### PR TITLE
Add instructions for CentOS 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ sudo yum install tcl pkgconfig openssl-devel cmake gcc gcc-c++ make automake
 ./configure
 make
 ```
+## CentOS 6
+```
+sudo yum update
+sudo yum install tcl pkgconfig openssl-devel cmake gcc gcc-c++ make automake
+sudo yum install centos-release-scl-rh devtoolset-3-gcc devtoolset-3-gcc-c++
+scl enable devtoolset-3 bash
+./configure --use-static-libstdc++ --with-compiler-prefix=/opt/rh/devtoolset-3/root/usr/bin/
+make
+```
+
 
 For Mac (Darwin, iOS):
 =====================


### PR DESCRIPTION
Compiling on CentOS 6 requires the newer gcc libs provided by the SCL devtoolset chain since sample app requires C++11.

Running on CentOS 6 requires libstdc++ to be statically linked on compile, otherwise stransmit will fail to run with the following errors:

```
stransmit: /usr/lib64/libstdc++.so.6: version 'GLIBCXX_3.4.20' not found (required by stransmit)
stransmit: /usr/lib64/libstdc++.so.6: version 'GLIBCXX_3.4.19' not found (required by stransmit)
stransmit: /usr/lib64/libstdc++.so.6: version 'GLIBCXX_3.4.15' not found (required by stransmit)
```