### PR TITLE
s_UDTUnited.lookup throw CUDTException but CUDT::getUDTHandle handle …

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2341,7 +2341,7 @@ CUDT* CUDT::getUDTHandle(UDTSOCKET u)
    {
       return s_UDTUnited.lookup(u);
    }
-   catch (std::exception& ee)
+   catch (...)
    {
       return NULL;
    }


### PR DESCRIPTION
…std::exceptoion

It's easy to break any program using SRT if you setup non-blocking sender and close sender socket just after calling sendmsg. Here is an example of sender unit test(google gtest is used).

```
    int yes = 1;
    int no = 0;

    SRTSOCKET m_client_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
    ASSERT_NE(m_client_sock, SRT_ERROR);

    ASSERT_NE(srt_setsockopt(m_client_sock, 0, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
    ASSERT_NE(srt_setsockopt(m_client_sock, 0, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
    ASSERT_NE(srt_setsockflag(m_client_sock, SRTO_SENDER, &yes, sizeof yes), SRT_ERROR);

    int epoll_out = SRT_EPOLL_OUT;
    srt_epoll_add_usock(client_pollid, m_client_sock, &epoll_out);

    sockaddr_in sa;
    memset(&sa, 0, sizeof sa);
    sa.sin_family = AF_INET;
    sa.sin_port = htons(9999);

    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr), 1);

    sockaddr* psa = (sockaddr*)&sa;

    ASSERT_NE(srt_connect(m_client_sock, psa, sizeof sa), SRT_ERROR);


    // Socket readiness for connection is checked by polling on WRITE allowed sockets.

    {
	    int wlen = 2;
	    SRTSOCKET write[2];

        ASSERT_NE(srt_epoll_wait(client_pollid, 0, 0,
	                                     write, &wlen,
	                                     -1, // -1 is set for debuging purpose.
	                                         // in case of production we need to set appropriate value
	                                     0, 0, 0, 0), SRT_ERROR);


	    ASSERT_EQ(wlen, 1); // get exactly one write event without reads
	    ASSERT_EQ(write[0], m_client_sock); // for our client socket
    }

    char buffer[1316] = {1, 2, 3, 4};

    ASSERT_NE(srt_sendmsg(m_client_sock, buffer, sizeof buffer,
    							  -1, // infinit ttl
                                  true // in order must be set to true
                                  ),
    	      SRT_ERROR);

 // system will abort after this call. Checking callstack you can
 // see CUDTUnited::lookup throws CUDTException because socket status is UDT_CLOSED.

    str_close(m_client_sock);

```

  if ((i == m_Sockets.end()) || (i->second->m_Status == UDT_CLOSED))
      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);



Current version of UDT https://sourceforge.net/projects/udt/files/udt/4.11/ also catch all exceptions in
CUDT* CUDT::getUDTHandle(UDTSOCKET u) function using (...) to handle all exception types.