### PR TITLE
Fixes for compiling under Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,12 +219,17 @@ if(WIN32)
 	if (NOT DEFINED WITH_PTHREAD_LDFLAGS OR NOT DEFINED WITH_PTHREAD_INCLUDEDIR)
 		message(FATAL_ERROR "On Windows, PTHREAD library is 3rd party. WITH_PTHREAD_* variables must be specified.")
 	endif()
+
+    set (LDFLAGS_srt_STATIC ${WITH_PTHREAD_LDFLAGS})
 elseif(DARWIN)
     message( "DARWIN detected")
     add_definitions(-DOSX=1) 
 elseif(LINUX)
     add_definitions(-DLINUX=1)
     message( "LINUX detected" )
+elseif(CYGWIN)
+	add_definitions(-DCYGWIN=1)
+	message("CYGWIN (posix mode) detected")
 else()
     message(FATAL_ERROR "Unsupported system")
 endif()
@@ -272,7 +277,7 @@ set (HEADERS_haisrt
     ${SRT_SRC_SRTCORE_DIR}/udt.h
     ${SRT_SRC_SRTCORE_DIR}/srt4udt.h
 	${SRT_SRC_SRTCORE_DIR}/logging_api.h
-
+	${SRT_SRC_SRTCORE_DIR}/platform_sys.h
 )
 
 set (HEADERS_haicrypt
@@ -330,7 +335,9 @@ endif()
 
 if ( WIN32 )
     target_compile_definitions(${NAME_haisrt} PRIVATE -DUDT_EXPORTS)
-    link_libraries(Ws2_32.lib)
+	if (NOT CYGWIN)
+    	link_libraries(Ws2_32.lib)
+	endif()
     add_definitions(-DPTW32_STATIC_LIB)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,20 @@ The 64-bit devel package can be downloaded from here:
 
      http://slproweb.com/download/Win64OpenSSL-1_0_2a.exe
 
+(Note that the last letter or version number may be changed and older versions
+no longer available. If this isn't found, check here:
+http://slproweb.com/products/Win32OpenSSL.html
+)
+
 It's expected to be installed in `C:\OpenSSL-Win64` (see the above variables).
+
+Note that this version is compiled most likely for Visual Studio 2013. For
+other versions you better download and compile the sources by yourself,
+from: https://github.com/openssl/openssl
+
+The instruction for Windows:
+http://developer.covenanteyes.com/building-openssl-for-visual-studio/
+
 
 
 3. Compile and install Pthreads for Windows from this submodule:
@@ -109,6 +122,30 @@ e. Copy include files to `C:\pthread-win32\include` - the following ones:
 (They are in the toplevel directory, there are actually no meaningful subdirs here)
 (NOTE: the win32 is part of the project name. It will become 32 or 64 depending on selection)
 
+4. For the sake of cmake generation: When you want to have a 64-bit version,
+remember that cmake by some reason adds /machine:X86 to the linker options.
+There are about four variables ended with `_LINKER_FLAGS` in the `CMakeCache.txt`
+file (also available with Advanced checked in CMake GUI). Remove them, or change
+into /machine:X64.
+
+Also, just after you generated the project for MSVC (if you fail or forget to do
+that before the first compiling, you'll have to delete and regenerate all project
+files) then open Configuration Manager **exactly** after generation from cmake and
+setup x86 platform with requesting to generate this for every subproject.
+
+5. IMPORTANT FOR DEVELOPERS AND CONTRIBUTORS: If you make any changes that fix
+something in the Windows version, remember to keep the project working also for
+all other platforms. To simplify the verification if you just would like to do
+it on the Windows machine, please install Cygwin and make another build for Cygwin,
+for example (remember that 'configure' script requires tcl8.5 package):
+
+		mkdir build-cygwin
+		cd build-cygwin
+		../configure --prefix=install --cygwin-use-posix
+		make
+
+The Cygwin platform isn't any important target platform for this project, but it's
+very useful to check if the project wouldn't be build-broken on Linux.
 
 # Using the stransmit app
 

--- a/apps/stransmit.cpp
+++ b/apps/stransmit.cpp
@@ -1481,12 +1481,12 @@ void TestLogHandler(void* opaque, int level, const char* file, int line, const c
     time_t now;
     time(&now);
     char buf[1024];
-	struct tm local = LocalTime(now);
+    struct tm local = LocalTime(now);
     size_t pos = strftime(buf, 1024, "[%c ", &local);
 
 #ifdef _MSC_VER
-	// That's something weird that happens on Microsoft Visual Studio 2013
-	// Trying to keep portability, while every version of MSVS is a different plaform.
+    // That's something weird that happens on Microsoft Visual Studio 2013
+    // Trying to keep portability, while every version of MSVS is a different plaform.
     // On MSVS 2015 there's already a standard-compliant snprintf, whereas _snprintf
     // is available on backward compatibility and it doesn't work exactly the same way.
 #define snprintf _snprintf

--- a/apps/utility-test.cpp
+++ b/apps/utility-test.cpp
@@ -25,7 +25,7 @@
 #include <packet.h>
 #include <csrtcc.h>
 
-int main( int argc __attribute__((unused)), char** argv  __attribute__((unused)))
+int main()
 {
     using namespace std;
 

--- a/common/socketoptions.hpp
+++ b/common/socketoptions.hpp
@@ -7,6 +7,10 @@
 #include <vector>
 #include "../srtcore/srt.h" // Devel path
 
+#ifdef WIN32
+#include "winsock2.h"
+#endif
+
 struct OptionValue
 {
     std::string s;

--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -159,6 +159,12 @@ proc postprocess {} {
 		}
 	}
 
+	set cygwin_posix 0
+	if { "--cygwin-use-posix" in $all_options } {
+		# Will enforce OpenSSL autodetection
+		set cygwin_posix 1
+	}
+
 	if { $toolchain_changed } {
 		# Check characteristics of the compiler - in particular, whether the target is different
 		# than the current target.
@@ -220,7 +226,7 @@ proc postprocess {} {
 		}
 	}
 
-	if { $::HAVE_LINUX } {
+	if { $::HAVE_LINUX || $cygwin_posix } {
 		# Extract Openssl from pkg-config
 		if { !$have_openssl } {
 			set openssl_libs [pkg-config --libs-only-l --libs-only-other openssl]

--- a/include/srt_compat.h
+++ b/include/srt_compat.h
@@ -172,6 +172,22 @@ inline std::string SysStrError(int errnum)
     return SysStrError(errnum, buf, 1024);
 }
 
+inline struct tm LocalTime(time_t tt)
+{
+	struct tm tm = {};
+#ifdef WIN32
+	errno_t rr = localtime_s(&tm, &tt);
+	if (rr)
+		return tm;
+#else
+	tm = *localtime_r(&tt, &tm);
+#endif
+
+    return tm;
+}
+
+
+
 #endif
 
 #endif // HAISRT_COMPAT_H__

--- a/include/srt_compat.h
+++ b/include/srt_compat.h
@@ -174,7 +174,7 @@ inline std::string SysStrError(int errnum)
 
 inline struct tm LocalTime(time_t tt)
 {
-	struct tm tm = {};
+	struct tm tm;
 #ifdef WIN32
 	errno_t rr = localtime_s(&tm, &tt);
 	if (rr)

--- a/srtcore/HEADERS.maf
+++ b/srtcore/HEADERS.maf
@@ -6,3 +6,5 @@ udt.h
 logging_api.h
 PROTECTED HEADERS
 srt4udt.h
+platform_sys.h
+

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -63,18 +63,10 @@ modified by
 #include <exception>
 #include <stdexcept>
 #include <typeinfo>
+#include <iterator>
 
-#ifdef WIN32
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
-   #ifdef LEGACY_WIN32
-      #include <wspiapi.h>
-   #endif
-   #include <win/wintime.h>
-#else
-   #include <unistd.h>
-#endif
 #include <cstring>
+#include "platform_sys.h"
 #include "api.h"
 #include "core.h"
 #include "logging.h"

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -324,7 +324,7 @@ int CSndBuffer::addBufferFromFile(fstream& ifs, int len)
          pktlen = m_iMSS;
 
       ifs.read(s->m_pcData, pktlen);
-      if ((pktlen = ifs.gcount()) <= 0)
+      if ((pktlen = int(ifs.gcount())) <= 0)
          break;
 
       // currently file transfer is only available in streaming mode, message is always in order, ttl = infinite
@@ -545,9 +545,9 @@ int CSndBuffer::getCurrBufSize(int &bytes, int &timespan)
    * Therefore, always add 1 ms if not empty.
    */
 #ifdef SRT_ENABLE_CBRTIMESTAMP
-   timespan = 0 < m_iCount ? ((m_LastOriginTime - m_pFirstBlock->m_SourceTime) / 1000) + 1 : 0;
+   timespan = 0 < m_iCount ? int((m_LastOriginTime - m_pFirstBlock->m_SourceTime) / 1000) + 1 : 0;
 #else
-   timespan = 0 < m_iCount ? ((m_LastOriginTime - m_pFirstBlock->m_OriginTime) / 1000) + 1 : 0;
+   timespan = 0 < m_iCount ? int((m_LastOriginTime - m_pFirstBlock->m_OriginTime) / 1000) + 1 : 0;
 #endif
 
    return m_iCount;

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -41,9 +41,6 @@ written by
 #ifdef WIN32
    #include <winsock2.h>
    #include <ws2tcpip.h>
-   #ifdef LEGACY_WIN32
-      #include <wspiapi.h>
-   #endif
 #endif
 
 #include <cstring>

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -74,9 +74,6 @@ modified by
 #else
    #include <winsock2.h>
    #include <ws2tcpip.h>
-   #ifdef LEGACY_WIN32
-      #include <wspiapi.h>
-   #endif
    #include <win/wintime.h>
 #endif
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -70,15 +70,20 @@ modified by
 #else
    #include <winsock2.h>
    #include <ws2tcpip.h>
-   #ifdef LEGACY_WIN32
-      #include <wspiapi.h>
-   #endif
 #endif
 #include <cmath>
 #include <sstream>
 #include "queue.h"
 #include "core.h"
 #include "logging.h"
+
+// Again, just in case when some "smart guy" provided such a global macro
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
 
 #ifdef SRT_ENABLE_SRTCC_EMB
 #include "csrtcc.h"
@@ -351,7 +356,7 @@ static bool bool_int_value(const void* optval, int optlen)
 
     if ( optlen == sizeof(int) )
     {
-        return *(int*)optval;
+        return 0!=  *(int*)optval; // 0!= is a windows warning-killer int-to-bool conversion
     }
     return false;
 }
@@ -3681,7 +3686,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
       m_pSndQueue->m_pSndUList->update(this, false);
 
       size_t acksize = ctrlpkt.getLength(); // TEMPORARY VALUE FOR CHECKING
-      bool wrongsize = acksize % ACKD_FIELD_SIZE;
+      bool wrongsize = 0 != (acksize % ACKD_FIELD_SIZE);
       acksize = acksize / ACKD_FIELD_SIZE;  // ACTUAL VALUE
 
       if ( wrongsize )
@@ -4679,7 +4684,7 @@ int CUDT::processData(CUnit* unit)
    {
       unlose(packet); // was BELATED or RETRANSMITTED packet.
 #if SRT_BELATED_LOSSREPORT
-      was_orderly_sent = pktrexmitflag;
+      was_orderly_sent = 0!=  pktrexmitflag;
 #endif
    }
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -104,7 +104,7 @@ inline T CountIIR(T base, T newval, double factor)
         return newval;
 
     T diff = newval - base;
-    return base+(diff*factor);
+    return base+T(diff*factor);
 }
 
 // XXX Probably a better rework for that can be done - this can be
@@ -460,7 +460,7 @@ private: // Sending related data
    int32_t m_iSndLastAck2;                      // Last ACK2 sent back
    uint64_t m_ullSndLastAck2Time;               // The time when last ACK2 was sent back
 #ifdef SRT_ENABLE_CBRTIMESTAMP
-   int64_t m_ullSndLastCbrTime;                 // Last timestamp set in a data packet to send (usec)
+   uint64_t m_ullSndLastCbrTime;                 // Last timestamp set in a data packet to send (usec)
 #endif
 
    int32_t m_iISN;                              // Initial Sequence Number

--- a/srtcore/csrtcc.cpp
+++ b/srtcore/csrtcc.cpp
@@ -108,12 +108,17 @@ void CSRTCC::sendSrtMsg(int cmd, int32_t *srtdata_in, int srtlen_in)
 		}
 		else
 #endif
+        /*
+           XXX Do some version renegotiation if needed;
+           The "unknown version" may be used for something else,
+           currently not predicted to happen.
 		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_UNK)
 		{
 			// Some fallback...
 			srtdata[SRT_HS_VERSION] = 0; // Rejection
 		}
 		else
+        */
 		{
             /* Current version (1.x.x) SRT handshake */
             srtdata[SRT_HS_VERSION] = m_SrtVersion;  /* Required version */
@@ -146,29 +151,31 @@ void CSRTCC::sendSrtMsg(int cmd, int32_t *srtdata_in, int srtlen_in)
 
 
 #ifdef SRT_VERSION_MAJ2
-		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_MAJ1)
-		{
-			//>>duB: fix that to not set m_SrtVersion under normal operations (version downgrade)
-			//>>only set to test version handshake
-			//m_SrtVersion = SRT_VERSION_1XX; //highest compatible version 1
-			// move 1.x.x handshake code here when default becomes 2.x.x
-			//break; //>>fall through until 2.x.x implemented
-	    }
-		else
+        if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_MAJ1)
+        {
+            //>>duB: fix that to not set m_SrtVersion under normal operations (version downgrade)
+            //>>only set to test version handshake
+            //m_SrtVersion = SRT_VERSION_1XX; //highest compatible version 1
+            // move 1.x.x handshake code here when default becomes 2.x.x
+            //break; //>>fall through until 2.x.x implemented
+        }
+        else
 #endif
-		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_UNK)
-		{
-			// Some fallback...
-			srtdata[SRT_HS_VERSION] = 0; // Rejection
-		}
-		else
-		{
+        /*
+        if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_UNK)
+        {
+            // Some fallback...
+            srtdata[SRT_HS_VERSION] = 0; // Rejection
+        }
+        else
+        */
+        {
             /* Current version (1.x.x) SRT handshake */
             srtdata[SRT_HS_VERSION] = m_SrtVersion; /* Required version */
             if (0 != m_RcvPeerStartTime)
             {
                 /* 
-                * We got and transposed peer start time (HandShake request timestamp),
+                 * We got and transposed peer start time (HandShake request timestamp),
                 * we can support Timestamp-based Packet Delivery
                 */
                 srtdata[SRT_HS_FLAGS] |= SRT_OPT_TSBPDRCV;

--- a/srtcore/csrtcc.cpp
+++ b/srtcore/csrtcc.cpp
@@ -97,17 +97,24 @@ void CSRTCC::sendSrtMsg(int cmd, int32_t *srtdata_in, int srtlen_in)
     case SRT_CMD_HSREQ:
         memset(srtdata, 0, sizeof(srtdata));
 
-        switch(SRT_VERSION_MAJ(m_PeerSrtVersion)) {
-#ifdef SRT_VERSION_MAJ2  /* Whenever versions >= 2.0.0 implemented */
-        case SRT_VERSION_MAJ1:   /* Still supported older versions */
-            //>>duB: fix that to not set m_SrtVersion under normal operations (version downgrade)
-            //>>only set to test version handshake
-            //m_SrtVersion = SRT_VERSION_1XX; //highest compatible version 1
-            // move 1.x.x handshake code here when default becomes 2.x.x
-            //break; //>>fall through until 2.x.x implemented
+#ifdef SRT_VERSION_MAJ2
+		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_MAJ1)
+		{
+			//>>duB: fix that to not set m_SrtVersion under normal operations (version downgrade)
+			//>>only set to test version handshake
+			//m_SrtVersion = SRT_VERSION_1XX; //highest compatible version 1
+			// move 1.x.x handshake code here when default becomes 2.x.x
+			//break; //>>fall through until 2.x.x implemented
+		}
+		else
 #endif
-        case SRT_VERSION_UNK:           /* Unknown peer version: first attempt */
-        default:
+		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_UNK)
+		{
+			// Some fallback...
+			srtdata[SRT_HS_VERSION] = 0; // Rejection
+		}
+		else
+		{
             /* Current version (1.x.x) SRT handshake */
             srtdata[SRT_HS_VERSION] = m_SrtVersion;  /* Required version */
             if (m_bSndTsbPdMode)
@@ -131,23 +138,31 @@ void CSRTCC::sendSrtMsg(int cmd, int32_t *srtdata_in, int srtlen_in)
                 srtdata[SRT_HS_VERSION],
                 srtdata[SRT_HS_FLAGS],
                 SRT_HS_EXTRAS_LO::unwrap(srtdata[SRT_HS_EXTRAS]));
-            break;
         }
         break;
 
     case SRT_CMD_HSRSP:
         memset(srtdata, 0, sizeof(srtdata));
 
-        switch(SRT_VERSION_MAJ(m_PeerSrtVersion)) {
-#ifdef SRT_VERSION_MAJ2   /* Whenever versions >= 2.0.0 implemented */
-        case SRT_VERSION_MAJ1:   /* Still supported older versions */
-            //>>duB: fix that to not set m_SrtVersion under normal operations (version downgrade)
-            //>>only set to test version handshake
-            //m_SrtVersion = SRT_VERSION_1XX; //highest 1.x.x compatible version
-            // move 1.x.x handshake code here when default becomes 2.x.x
-            //break; //>>fall through until 2.x.x implemented
-#endif /* SRT_VERSION_MAJ2 */
-        default:
+
+#ifdef SRT_VERSION_MAJ2
+		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_MAJ1)
+		{
+			//>>duB: fix that to not set m_SrtVersion under normal operations (version downgrade)
+			//>>only set to test version handshake
+			//m_SrtVersion = SRT_VERSION_1XX; //highest compatible version 1
+			// move 1.x.x handshake code here when default becomes 2.x.x
+			//break; //>>fall through until 2.x.x implemented
+	    }
+		else
+#endif
+		if (SRT_VERSION_MAJ(m_PeerSrtVersion) == SRT_VERSION_UNK)
+		{
+			// Some fallback...
+			srtdata[SRT_HS_VERSION] = 0; // Rejection
+		}
+		else
+		{
             /* Current version (1.x.x) SRT handshake */
             srtdata[SRT_HS_VERSION] = m_SrtVersion; /* Required version */
             if (0 != m_RcvPeerStartTime)
@@ -195,11 +210,10 @@ void CSRTCC::sendSrtMsg(int cmd, int32_t *srtdata_in, int srtlen_in)
                 // version specification in the build configuration.
                 LOGC(mglog.Debug).form("HS RP1: I DO NOT UNDERSTAND REXMIT flag" );
             }
-            srtlen = 3;
+            srtlen = SRT_HS__SIZE;
 
             LOGC(mglog.Note).form( "sndSrtMsg: cmd=%d(HSRSP) len=%d vers=0x%x opts=0x%x delay=%d\n", 
                 cmd, (int)(srtlen * sizeof(int32_t)), srtdata[SRT_HS_VERSION], srtdata[SRT_HS_FLAGS], srtdata[SRT_HS_EXTRAS]);
-            break;
         }
         break;
 

--- a/srtcore/csrtcc.h
+++ b/srtcore/csrtcc.h
@@ -25,6 +25,8 @@ written by
 #ifndef CSRTCC_H
 #define CSRTCC_H
 
+#define _CRT_SECURE_NO_WARNINGS
+#include <cstdio>
 #include <cstring>
 #include <string>
 
@@ -61,8 +63,12 @@ inline int SrtVersion(int major, int minor, int patch)
 inline int32_t SrtParseVersion(const char* v)
 {
     int major, minor, patch;
+	// On Windows/MSC, ignore C4996 warning here.
+	// This warning states that sscanf is unsafe because the %s and %c conversions
+	// don't specify the size of the buffer. Just because of this fact, sscanf is
+	// considered unsafe - even though I don't use %s or %c here at all.
     int result = sscanf(v, "%d.%d.%d", &major, &minor, &patch);
-
+	
     if ( result != 3 )
     {
         fprintf(stderr, "Invalid version format for SRT_VERSION: %s - use m.n.p\n", v);
@@ -79,10 +85,9 @@ inline std::string SrtVersionString(int version)
     int patch = version % 0x100;
     int minor = (version/0x100)%0x100;
     int major = version/0x10000;
-
-    char buf[20];
-    sprintf(buf, "%d.%d.%d", major, minor, patch);
-    return buf;
+	std::ostringstream buf;
+	buf << major << "." << minor << "." << patch;
+	return buf.str();
 }
 
 enum SrtOptions

--- a/srtcore/csrtcc.h
+++ b/srtcore/csrtcc.h
@@ -63,12 +63,12 @@ inline int SrtVersion(int major, int minor, int patch)
 inline int32_t SrtParseVersion(const char* v)
 {
     int major, minor, patch;
-	// On Windows/MSC, ignore C4996 warning here.
-	// This warning states that sscanf is unsafe because the %s and %c conversions
-	// don't specify the size of the buffer. Just because of this fact, sscanf is
-	// considered unsafe - even though I don't use %s or %c here at all.
+    // On Windows/MSC, ignore C4996 warning here.
+    // This warning states that sscanf is unsafe because the %s and %c conversions
+    // don't specify the size of the buffer. Just because of this fact, sscanf is
+    // considered unsafe - even though I don't use %s or %c here at all.
     int result = sscanf(v, "%d.%d.%d", &major, &minor, &patch);
-	
+
     if ( result != 3 )
     {
         fprintf(stderr, "Invalid version format for SRT_VERSION: %s - use m.n.p\n", v);
@@ -85,9 +85,9 @@ inline std::string SrtVersionString(int version)
     int patch = version % 0x100;
     int minor = (version/0x100)%0x100;
     int major = version/0x10000;
-	std::ostringstream buf;
-	buf << major << "." << minor << "." << patch;
-	return buf.str();
+    std::ostringstream buf;
+    buf << major << "." << minor << "." << patch;
+    return buf.str();
 }
 
 enum SrtOptions

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -203,7 +203,16 @@ int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
    if (kevent(p->second.m_iLocalID, ke, num, NULL, 0, NULL) < 0)
       throw CUDTException();
 #else
+
+#ifdef _MSC_VER
+// Microsoft Visual Studio doesn't support the #warning directive - nonstandard anyway.
+// Use #pragma message with the same text.
+// All other compilers should be ok :)
+#pragma message("WARNING: Unsupported system for epoll. The epoll_add_ssock() API call won't work on this platform.")
+#else
 #warning "Unsupported system for epoll. The epoll_add_ssock() API call won't work on this platform."
+#endif
+
 #endif
 
    p->second.m_sLocals.insert(s);

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -241,6 +241,11 @@ struct CRcvFreshLoss
 
     CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_ttl);
 
+// Don't WTF when looking at this. The Windows system headers define
+// a publicly visible preprocessor macro with that name. REALLY!
+#ifdef DELETE
+#undef DELETE
+#endif
     enum Emod {
         NONE, //< the given sequence was not found in this range
         STRIPPED, //< it was equal to first or last, already taken care of

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -451,9 +451,9 @@ inline std::string FormatTime(uint64_t time)
 #else
     strftime(tmp_buf, 512, "%T.", &tm);
 #endif
-	ostringstream out;
-	out << tmp_buf << setfill('0') << setw(6) << usec;
-	return out.str();
+    ostringstream out;
+    out << tmp_buf << setfill('0') << setw(6) << usec;
+    return out.str();
 }
 
 inline void LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -31,7 +31,12 @@ written by
 #include <set>
 #include <sstream>
 #include <cstdarg>
+#ifdef WIN32
+#include "win/wintime.h"
+#include <sys/timeb.h>
+#else
 #include <sys/time.h>
+#endif
 #include <pthread.h>
 #if HAVE_CXX11
 #include <mutex>
@@ -40,6 +45,7 @@ written by
 #include "utilities.h"
 #include "threadname.h"
 #include "logging_api.h"
+#include "srt_compat.h"
 
 #ifdef __GNUC__
 #define PRINTF_LIKE __attribute__((format(printf,2,3)))
@@ -431,18 +437,23 @@ inline bool LogDispatcher::CheckEnabled()
 
 inline std::string FormatTime(uint64_t time)
 {
+    using namespace std;
+
     time_t sec = time/1000000;
     time_t usec = time%1000000;
 
     time_t tt = sec;
-    struct tm tm = *localtime(&tt);
+    struct tm tm = LocalTime(tt);
 
     char tmp_buf[512];
+#ifdef WIN32
+    strftime(tmp_buf, 512, "%Y-%m-%d.", &tm);
+#else
     strftime(tmp_buf, 512, "%T.", &tm);
-    std::string out = tmp_buf;
-    sprintf(tmp_buf, "%06ld", usec);
-    out += tmp_buf;
-    return out;
+#endif
+	ostringstream out;
+	out << tmp_buf << setfill('0') << setw(6) << usec;
+	return out.str();
 }
 
 inline void LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
@@ -456,7 +467,7 @@ inline void LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
         timeval tv;
         gettimeofday(&tv, 0);
         time_t t = tv.tv_sec;
-        struct tm tm = *localtime(&t);
+        struct tm tm = LocalTime(t);
         strftime(tmp_buf, 512, "%T.", &tm);
 
         serr << tmp_buf << setw(6) << setfill('0') << tv.tv_usec;

--- a/srtcore/logging_api.h
+++ b/srtcore/logging_api.h
@@ -34,7 +34,11 @@ written by
 #endif
 
 #include <pthread.h>
+#ifdef WIN32
+#include "win/syslog_defs.h"
+#else
 #include <sys/syslog.h>
+#endif
 
 // Syslog is included so that it provides log level names.
 // Haivision log standard requires the same names plus extra one:

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -25,8 +25,8 @@ written by
 #ifndef INC__NETINET_ANY_H
 #define INC__NETINET_ANY_H
 
-#include <netinet/in.h>
 #include <cstring>
+#include "platform_sys.h"
 
 // This is a smart structure that this moron who has designed BSD sockets
 // should have defined in the first place.

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -368,7 +368,7 @@ PacketBoundary CPacket::getMsgBoundary() const
 
 bool CPacket::getMsgOrderFlag() const
 {
-    return MSGNO_PACKET_INORDER::unwrap(m_nHeader[PH_MSGNO]);
+    return 0!=  MSGNO_PACKET_INORDER::unwrap(m_nHeader[PH_MSGNO]);
 }
 
 int32_t CPacket::getMsgSeq(bool has_rexmit) const
@@ -386,7 +386,7 @@ int32_t CPacket::getMsgSeq(bool has_rexmit) const
 bool CPacket::getRexmitFlag() const
 {
     // return false; //
-    return MSGNO_REXMIT::unwrap(m_nHeader[PH_MSGNO]);
+    return 0 !=  MSGNO_REXMIT::unwrap(m_nHeader[PH_MSGNO]);
 }
 
 EncryptionKeySpec CPacket::getMsgCryptoFlags() const

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -229,7 +229,9 @@ public:
    bool isControl() const
    {
        // read bit 0
-       return SEQNO_CONTROL::unwrap(m_nHeader[PH_SEQNO]);
+	   // This "0!=" is a "special Microsoft aware conversion to bool"
+	   // which gets rid of a warning.
+       return 0!=  SEQNO_CONTROL::unwrap(m_nHeader[PH_SEQNO]);
    }
 
       /// Read the extended packet type.

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -229,8 +229,8 @@ public:
    bool isControl() const
    {
        // read bit 0
-	   // This "0!=" is a "special Microsoft aware conversion to bool"
-	   // which gets rid of a warning.
+       // This "0!=" is a "special Microsoft aware conversion to bool"
+       // which gets rid of a warning.
        return 0!=  SEQNO_CONTROL::unwrap(m_nHeader[PH_SEQNO]);
    }
 

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -1,0 +1,24 @@
+#ifndef INC__PLATFORM_SYS_H
+#define INC__PLATFORM_SYS_H
+
+#ifdef WIN32
+   #include <winsock2.h>
+   #include <ws2tcpip.h>
+   #include <ws2ipdef.h>
+   #include <windows.h>
+   #include <inttypes.h>
+   #include <stdint.h>
+   #include <win/wintime.h>
+   #if defined(_MSC_VER)
+      #pragma warning(disable:4251)
+   #endif
+#else
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#endif
+
+#endif

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -63,9 +63,6 @@ modified by
 #ifdef WIN32
    #include <winsock2.h>
    #include <ws2tcpip.h>
-   #ifdef LEGACY_WIN32
-      #include <wspiapi.h>
-   #endif
 #endif
 #include <cstring>
 

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -22,6 +22,7 @@ written by
    Haivision Systems Inc.
  *****************************************************************************/
 
+#include <iterator>
 #if __APPLE__
    #include "TargetConditionals.h"
 #endif
@@ -69,7 +70,7 @@ int srt_setsockflag(UDTSOCKET u, SRT_SOCKOPT opt, const void* optval, int optlen
 
 int srt_send(UDTSOCKET u, const char * buf, int len, int flags) { return UDT::send(u, buf, len, flags); }
 int srt_recv(UDTSOCKET u, char * buf, int len, int flags) { return UDT::recv(u, buf, len, flags); }
-int srt_sendmsg(UDTSOCKET u, const char * buf, int len, int ttl, int inorder) { return UDT::sendmsg(u, buf, len, ttl, inorder); }
+int srt_sendmsg(UDTSOCKET u, const char * buf, int len, int ttl, int inorder) { return UDT::sendmsg(u, buf, len, ttl, 0!=  inorder); }
 int srt_recvmsg(UDTSOCKET u, char * buf, int len) { return UDT::recvmsg(u, buf, len); }
 
 int srt_sendmsg2(UDTSOCKET u, const char * buf, int len, SRT_MSGCTRL *mctrl)
@@ -116,8 +117,8 @@ void srt_clearlasterror()
     UDT::getlasterror().clear();
 }
 
-int srt_perfmon(UDTSOCKET u, SRT_TRACEINFO * perf, int clear) { return UDT::perfmon(u, perf, clear); }
-int srt_bstats(UDTSOCKET u, SRT_TRACEBSTATS * perf, int clear) { return UDT::bstats(u, perf, clear); }
+int srt_perfmon(UDTSOCKET u, SRT_TRACEINFO * perf, int clear) { return UDT::perfmon(u, perf, 0!=  clear); }
+int srt_bstats(UDTSOCKET u, SRT_TRACEBSTATS * perf, int clear) { return UDT::bstats(u, perf, 0!=  clear); }
 
 SRT_SOCKSTATUS srt_getsockstate(UDTSOCKET u) { return SRT_SOCKSTATUS((int)UDT::getsockstate(u)); }
 

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -100,21 +100,9 @@ modified by
 #endif
 #endif
 
-#ifndef WIN32
-   #include <sys/types.h>
-   #include <sys/socket.h>
-   #include <netinet/in.h>
-#else
-   #ifdef __MINGW__
-      #include <inttypes.h>
-      #include <stdint.h>
-      #include <winsock2.h>
-      #include <ws2tcpip.h>
-   #endif
-   #include <windows.h>
-   #if defined(_MSC_VER)
-      #pragma warning(disable:4251)
-   #endif
+// This is a "protected header"; should include all required
+// system headers, as required on particular platform.
+#include "platform_sys.h"
 #endif
 
 #ifdef __cplusplus

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -103,7 +103,6 @@ modified by
 // This is a "protected header"; should include all required
 // system headers, as required on particular platform.
 #include "platform_sys.h"
-#endif
 
 #ifdef __cplusplus
 #include <fstream>

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -407,10 +407,10 @@ public:
 
 struct CIPAddress
 {
-   static bool ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver = AF_INET);
-   static void ntop(const sockaddr* addr, uint32_t ip[4], int ver = AF_INET);
-   static void pton(sockaddr* addr, const uint32_t ip[4], int ver = AF_INET);
-   static std::string show(const sockaddr* adr);
+   static bool ipcmp(const struct sockaddr* addr1, const struct sockaddr* addr2, int ver = AF_INET);
+   static void ntop(const struct sockaddr* addr, uint32_t ip[4], int ver = AF_INET);
+   static void pton(struct sockaddr* addr, const uint32_t ip[4], int ver = AF_INET);
+   static std::string show(const struct sockaddr* adr);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -259,7 +259,7 @@ public:
        int64_t timediff = m_CurrArrTime - m_ProbeTime;
        int64_t timediff_times_pl_size = timediff * (1500 - SRT_DATA_PKTHDR_SIZE);
 
-       m_aProbeWindow[m_iProbeWindowPtr] = pktsz ? timediff_times_pl_size / pktsz : int(timediff);
+       m_aProbeWindow[m_iProbeWindowPtr] = pktsz ? int(timediff_times_pl_size / pktsz) : int(timediff);
 
        // OLD CODE BEFORE BSTATS:
        // record the probing packets interval

--- a/srtcore/windows/win_time.cpp
+++ b/srtcore/windows/win_time.cpp
@@ -79,51 +79,6 @@ void timeradd(struct timeval *a, struct timeval *b, struct timeval *result)
     }
 }
 
-
-/*
-int gettimeofday(struct timeval *tv, struct timezone *tz)
-{
-    FILETIME ft;
-    unsigned __int64 tmpres = 0;
-    static int tzflag;
-    long timezone = 0;
-    int daylight = 0;
-
-    if (NULL != tv)
-    {
-        GetSystemTimeAsFileTime(&ft);
- 
-        tmpres |= ft.dwHighDateTime;
-        tmpres <<= 32;
-        tmpres |= ft.dwLowDateTime;
- 
-        // converting file time to unix epoch
-        tmpres -= DELTA_EPOCH_IN_MICROSECS; 
-        tmpres /= 10;  //convert into microseconds
-        tv->tv_sec  = (long)(tmpres / 1000000UL);
-        tv->tv_usec = (long)(tmpres % 1000000UL);
-    }
- 
-    if (NULL != tz)
-    {
-        if (!tzflag)
-        {
-            _tzset();
-            tzflag++;
-        }
-
-        _get_timezone(&timezone);
-        _get_daylight(&daylight);
-
-        tz->tz_minuteswest = timezone / 60;
-        tz->tz_dsttime     = daylight;
-    }
- 
-    return 0;
-}
-*/
-
-
 int gettimeofday(struct timeval* tp, struct timezone* tz)
 {
     static LARGE_INTEGER tickFrequency, epochOffset;


### PR DESCRIPTION
This fixes compile problems on Windows. Uses some ideas hinted by @russelltg. As it comes for system includes, the solution is radical - there's one include file that gets all required system headers in appropriate set and appropriate order. This may still required further testing; I have successfully compiled this on MSVS 2013 and then on Cygwin (to test if Linux isn't broken). There are some problems on MSVS 2015, also the OpenSSL in the version as described won't work with this compiler (requires manually compiled OpenSSL).