### PR TITLE
Fix warning under MSVC

### DIFF
--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -45,7 +45,7 @@ struct sockaddr_any
     {
         memset(this, 0, sizeof *this);
         sa.sa_family = domain;
-        len = size();
+        len = static_cast<socklen_t>(size());
     }
 
     size_t size() const

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -45,15 +45,15 @@ struct sockaddr_any
     {
         memset(this, 0, sizeof *this);
         sa.sa_family = domain;
-        len = static_cast<socklen_t>(size());
+        len = size();
     }
 
-    size_t size() const
+    socklen_t size() const
     {
         switch (sa.sa_family)
         {
-        case AF_INET: return sizeof sin;
-        case AF_INET6: return sizeof sin6;
+        case AF_INET: return static_cast<socklen_t>(sizeof sin);
+        case AF_INET6: return static_cast<socklen_t>(sizeof sin6);
 
         default: return 0; // fallback, impossible
         }


### PR DESCRIPTION
Use an explicit static_cast in coverting a `size_t` to a `socklen_t`.

Before this fix, the warning
```
warning C4267: '=' : conversion from 'size_t' to 'socklen_t', possible loss of data
```
is produced, and now it's suppressed. This is problematic because this also produces a warning in code using SRT, which could have warnings set as errors.