### PR TITLE
srt_startup call required in stransmit main function

### DIFF
--- a/apps/stransmit.cpp
+++ b/apps/stransmit.cpp
@@ -372,7 +372,18 @@ extern "C" void TestLogHandler(void* opaque, int level, const char* file, int li
 
 int main( int argc, char** argv )
 {
-    srt_startup();
+   #ifdef WIN32
+      WORD wVersionRequested;
+      WSADATA wsaData;
+      wVersionRequested = MAKEWORD(2, 2);
+
+      if (0 != WSAStartup(wVersionRequested, &wsaData))
+      {
+          cerr << "Failed to init socket library\n";
+          return 1;
+      }
+   #endif
+
     vector<string> args;
     copy(argv+1, argv+argc, back_inserter(args));
 
@@ -524,7 +535,9 @@ int main( int argc, char** argv )
 
         return 1;
     }
-    srt_cleanup();
+   #ifdef WIN32
+      WSACleanup();
+   #endif
     return 0;
 }
 

--- a/apps/stransmit.cpp
+++ b/apps/stransmit.cpp
@@ -372,6 +372,7 @@ extern "C" void TestLogHandler(void* opaque, int level, const char* file, int li
 
 int main( int argc, char** argv )
 {
+    srt_startup();
     vector<string> args;
     copy(argv+1, argv+argc, back_inserter(args));
 
@@ -523,7 +524,7 @@ int main( int argc, char** argv )
 
         return 1;
     }
-
+    srt_cleanup();
     return 0;
 }
 


### PR DESCRIPTION
srt_startup is necessary for proper stransmit work as WSAStartup called for Windows and many other things inited.
srt_cleanup also required