### PR TITLE
Add ThreadName implementation for windows

### DIFF
--- a/srtcore/threadname.h
+++ b/srtcore/threadname.h
@@ -66,6 +66,57 @@ public:
     }
 };
 
+#elif defined WIN32
+
+// https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code
+//  
+// Usage: SetThreadName ((DWORD)-1, "MainThread");  
+//  
+#include <windows.h>  
+const DWORD MS_VC_EXCEPTION = 0x406D1388;  
+#pragma pack(push,8)  
+typedef struct tagTHREADNAME_INFO  
+{  
+	DWORD dwType; // Must be 0x1000.  
+	LPCSTR szName; // Pointer to name (in user addr space).  
+	DWORD dwThreadID; // Thread ID (-1=caller thread).  
+	DWORD dwFlags; // Reserved for future use, must be zero.  
+} THREADNAME_INFO;  
+#pragma pack(pop)  
+inline void SetThreadName(DWORD dwThreadID, const char* threadName) {  
+	THREADNAME_INFO info;  
+	info.dwType = 0x1000;  
+	info.szName = threadName;  
+	info.dwThreadID = dwThreadID;  
+	info.dwFlags = 0;  
+#pragma warning(push)  
+#pragma warning(disable: 6320 6322)  
+	__try{  
+		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);  
+	}  
+	__except (EXCEPTION_EXECUTE_HANDLER){  
+	}
+#pragma warning(pop)  
+}
+
+class ThreadName
+{
+public:
+
+	// this isn't exposed, see https://stackoverflow.com/questions/9366722/how-to-get-the-name-of-a-win32-thread
+	static bool get(char*) { return false; }
+
+	ThreadName(const char* name)
+	{
+		SetThreadName(GetCurrentThreadId(), name);
+	}
+
+	~ThreadName()
+	{
+	}
+};
+
+
 #else
 
 // Fake class, which does nothing. You can also take a look how


### PR DESCRIPTION
It isn't totally the same as the unix implementation because you can't get the thread name.

Tell me if that's a problem. 