### PR TITLE
Small fixes for build and installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil)
 
+
 set (SRT_VERSION "1.2.0")
 
 set (NAME_haisrt haisrt)
@@ -387,8 +388,11 @@ if ( LINUX )
 	set (IFNEEDED_SRT_LDFLAGS "${IFNEEDED_SRT_LDFLAGS} -lstdc++ -lm")
 endif()
 
+# haisrt.pc left temporarily for backward compatibility. To be removed in future!
 configure_file(scripts/haisrt.pc.in haisrt.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/haisrt.pc DESTINATION lib/pkgconfig)
+configure_file(scripts/haisrt.pc.in srt.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/srt.pc DESTINATION lib/pkgconfig)
 
 # Applications
 

--- a/scripts/haisrt.pc.in
+++ b/scripts/haisrt.pc.in
@@ -6,6 +6,6 @@ includedir=${prefix}/include
 Name: haisrt
 Description: SRT library set
 Version: @SRT_VERSION@
-Libs: -L${libdir} -l@NAME_haisrt@ -l@NAME_haicrypt@ @IFNEEDED_HAISRTBASE@ @IFNEEDED_HAISRT_LDFLAGS@
+Libs: -L${libdir} -l@NAME_haisrt@ -l@NAME_haicrypt@ @IFNEEDED_SRTBASE@ @IFNEEDED_SRT_LDFLAGS@
 Cflags: -I${includedir}
 


### PR DESCRIPTION
This fixes the name of a variable used in haisrt.pc.in, it was named differently in CMakeLists. Also added an alternative name `srt.pc` to the `haisrt.pc` - this wasn't an intention since the very beginning to use `haisrt.pc` name, it should be `srt.pc`. But we have to leave it currently with old name as well, for backward compatibility. It will be removed at some point in future.