### PR TITLE
Fix Visual Studio compilation issue for Windows

### DIFF
--- a/srtcore/CMakeLists.txt
+++ b/srtcore/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PUBLIC_HEADERS_haisrt
 # HaiSRT: SRT library (UDT API only)
 add_library(${NAME_haisrt} ${srt_libspec} ${SOURCES_haisrt} ${PUBLIC_HEADERS_haisrt})
 
+# to avoid redefinition of 'timespec' structure causing compilation errors when MSVC is used
 if ( WIN32 )
 	add_definitions(-DHAVE_STRUCT_TIMESPEC)
 endif()

--- a/srtcore/CMakeLists.txt
+++ b/srtcore/CMakeLists.txt
@@ -33,6 +33,9 @@ set(PUBLIC_HEADERS_haisrt
 # HaiSRT: SRT library (UDT API only)
 add_library(${NAME_haisrt} ${srt_libspec} ${SOURCES_haisrt} ${PUBLIC_HEADERS_haisrt})
 
+if ( WIN32 )
+	add_definitions(-DHAVE_STRUCT_TIMESPEC)
+endif()
 
 target_link_libraries (${NAME_haisrt} PUBLIC ${PTHREAD_LIBRARY} ${NAME_haicrypt})
 target_include_directories(${NAME_haisrt} PUBLIC ${PTHREAD_INCLUDE_DIR} ${SRT_SRC_SRTCORE_DIR})


### PR DESCRIPTION
without this option we have following issue on MSVC 2014

external\srt\pthreads-w32\Pre-built.2\include\pthread.h(320): error C2011: 'timespec': 'struct' type redefinition [C:\workshop\nimble\external\srt\srt\srtcore\haisrt.vcxproj]