### PR TITLE
OpenSSL 1.1 support

### DIFF
--- a/haicrypt/hc_openssl_aes.c
+++ b/haicrypt/hc_openssl_aes.c
@@ -33,6 +33,7 @@ written by
 #include <string.h>
 #include <openssl/evp.h>	/* PKCS5_xxx() */
 #include <openssl/aes.h>	/* AES_xxx() */
+#include <openssl/modes.h>	/* CRYPTO_xxx() */
 #include <openssl/rand.h>
 #include <openssl/err.h>
 
@@ -264,8 +265,14 @@ static int hcOpenSSL_AES_Encrypt(
 			hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
 
 			/* Encrypt packet payload in output message buffer */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+			CRYPTO_ctr128_encrypt(in_data[0].payload, &out_msg[pfx_len], 
+				in_data[0].len, aes_key, iv, ctr, &blk_ofs, (block128_f) AES_encrypt);
+#else
 			AES_ctr128_encrypt(in_data[0].payload, &out_msg[pfx_len], 
 				in_data[0].len, aes_key, iv, ctr, &blk_ofs);
+#endif
+
 
 			/* Prepend packet prefix (clear text) in output buffer */
 			memcpy(out_msg, in_data[0].pfx, pfx_len);
@@ -396,8 +403,13 @@ static int hcOpenSSL_AES_Decrypt(hcrypt_CipherData *cipher_data, hcrypt_Ctx *ctx
 			hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
 
 			/* Decrypt message (same as encrypt for CTR mode) */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+			CRYPTO_ctr128_encrypt(in_data[0].payload, out_txt, 
+				in_data[0].len, aes_key, iv, ctr, &blk_ofs, (block128_f) AES_encrypt);
+#else
 			AES_ctr128_encrypt(in_data[0].payload, out_txt, 
 				in_data[0].len, aes_key, iv, ctr, &blk_ofs);
+#endif
 			out_len = in_data[0].len;
 			break;
 		}


### PR DESCRIPTION
The current code doesn't bulid against OpenSSL 1.1 which is starting to be included as the default in newer Linux distributions. This patch fixes the little build issues, but I haven't done any testing.

This should resolve issue #68 