### PR TITLE
- fix valgrind reported error : conditional jump depends on initializ…

### DIFF
--- a/srtcore/threadname.h
+++ b/srtcore/threadname.h
@@ -50,12 +50,14 @@ public:
 
 
     ThreadName(const char* name)
+        : good(false)
     {
         if ( get(old_name) )
         {
             snprintf(new_name, 127, "%s", name);
             new_name[127] = 0;
             prctl(PR_SET_NAME, (unsigned long)new_name, 0, 0);
+            good = true;
         }
     }
 


### PR DESCRIPTION
…ed value

valgrind reported the following error:

```
Binding a server on 127.0.0.1:6666 ...==13772== Conditional jump or move depends on uninitialised value(s)
==13772==    at 0x4E9A891: ThreadName::~ThreadName() (threadname.h:64)
==13772==    by 0x4EDB040: CSndQueue::init(CChannel*, CTimer*) (queue.cpp:496)
==13772==    by 0x4E913DE: CUDTUnited::updateMux(CUDTSocket*, sockaddr const*, int const*) (api.cpp:1620)
==13772==    by 0x4E8D6D7: CUDTUnited::bind(int, sockaddr const*, int) (api.cpp:551)
==13772==    by 0x4E9225D: CUDT::bind(int, sockaddr const*, int) (api.cpp:1788)
==13772==    by 0x4E9904E: UDT::bind(int, sockaddr const*, int) (api.cpp:2609)
==13772==    by 0x4EE3EC1: srt_bind (srt_c_api.cpp:38)
==13772==    by 0x434EB2: SrtCommon::OpenServer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int) (stransmit.cpp:907)
==13772==    by 0x4339B1: SrtCommon::Init(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >, bool) (stransmit.cpp:684)
==13772==    by 0x435AF6: SrtSource::SrtSource(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (stransmit.cpp:1042)
==13772==    by 0x43B3A5: Source* CreateSrt<Source>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&) (in /usr/local/bin/stransmit)
==13772==    by 0x4380A0: std::unique_ptr<Source, std::default_delete<Source> > CreateMedium<Source>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (stransmit.cpp:1472)
==13772== 
````