### PR TITLE
Initialize srt_epoll for SrtTarget non-blocking

### DIFF
--- a/apps/stransmit.cpp
+++ b/apps/stransmit.cpp
@@ -1154,7 +1154,7 @@ public:
     {
         Init(host, port, par, true);
 	
-    if ( !m_blocking_mode )
+        if ( !m_blocking_mode )
         {
             srt_epoll = AddPoller(m_sock, SRT_EPOLL_OUT);
         }

--- a/apps/stransmit.cpp
+++ b/apps/stransmit.cpp
@@ -1153,6 +1153,11 @@ public:
     SrtTarget(string host, int port, const map<string,string>& par)
     {
         Init(host, port, par, true);
+	
+    if ( !m_blocking_mode )
+        {
+            srt_epoll = AddPoller(m_sock, SRT_EPOLL_OUT);
+        }
     }
 
     virtual int ConfigurePre(SRTSOCKET sock) override


### PR DESCRIPTION
Initialize srt_epoll in SrtTarget non-blocking mode to correct "Invalid epoll ID".