### PR TITLE
Fixed bug: incorrect data type for maxbw option

### DIFF
--- a/common/socketoptions.hpp
+++ b/common/socketoptions.hpp
@@ -150,7 +150,7 @@ inline bool SocketOption::apply(int socket, std::string value) const
 
 namespace {
 SocketOption srt_options [] {
-    { "maxbw", 0, SRTO_MAXBW, SocketOption::INT, SocketOption::PRE },
+    { "maxbw", 0, SRTO_MAXBW, SocketOption::INT64, SocketOption::PRE },
     { "pbkeylen", 0, SRTO_PBKEYLEN, SocketOption::INT, SocketOption::PRE },
     { "passphrase", 0, SRTO_PASSPHRASE, SocketOption::STRING, SocketOption::PRE },
 


### PR DESCRIPTION
This was detected during development of congestion control restoration. The type of SRTO_MAXBW option handling in `CUDT::setOpt` is `int64_t`, this was an overlook. Applications using `setsockopt` with SRTO_MAXBW are not affected, although they will suffer the same problem unless they use the correct data type - `int64_t`.