### PR TITLE
Fix multicast binding problem on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ if ( ENABLE_CXX11 )
 		${CMAKE_SOURCE_DIR}/common/socketoptions.cpp
 		${CMAKE_SOURCE_DIR}/common/logsupport.cpp
 		${CMAKE_SOURCE_DIR}/common/transmitmedia.cpp
+		${CMAKE_SOURCE_DIR}/common/srt_compat.c
 	)
 
 	add_executable(srt-live-transmit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,10 @@ if ( ENABLE_CXX11 )
 		${CMAKE_SOURCE_DIR}/common/transmitmedia.cpp
 		${CMAKE_SOURCE_DIR}/common/srt_compat.c
 	)
+	# Enforce interpreting this file as C++ so that C++ compiler is used to compile it.
+	# This should result in exactly the same as when it was compiled as C, with the
+	# exception that the compiler with accept any C++-only COMPILE_FLAGS (e.g. -std=c++11).
+	set_source_files_properties(${CMAKE_SOURCE_DIR}/common/srt_compat.c PROPERTIES LANGUAGE CXX )
 
 	add_executable(srt-live-transmit
 		${CMAKE_SOURCE_DIR}/apps/srt-live-transmit.cpp

--- a/common/appcommon.hpp
+++ b/common/appcommon.hpp
@@ -125,6 +125,12 @@ static inline int inet_pton(int af, const char * src, void * dst)
 }
 #endif // __MINGW__
 
+#ifdef WIN32
+inline int SysError() { return ::GetLastError(); }
+#else
+inline int SysError() { return errno; }
+#endif
+
 inline sockaddr_in CreateAddrInet(const std::string& name, unsigned short port)
 {
     sockaddr_in sa;

--- a/common/srt_compat.c
+++ b/common/srt_compat.c
@@ -49,6 +49,10 @@ written by
 #include <mach/mach_time.h>
 #include <AvailabilityMacros.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 int OSX_clock_gettime(clockid_t clock_id, struct timespec * ts)
 {
@@ -137,8 +141,15 @@ int OSX_clock_gettime(clockid_t clock_id, struct timespec * ts)
    return result;
 }
 
+#ifdef __cplusplus
+} // extern C
+#endif
+
 #endif // (__MACH__)
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern const char * SysStrError(int errnum, char * buf, size_t buflen)
 {
@@ -202,3 +213,8 @@ extern const char * SysStrError(int errnum, char * buf, size_t buflen)
    }
 #endif
 }
+
+
+#ifdef __cplusplus
+} // extern C
+#endif

--- a/common/srt_compat.h
+++ b/common/srt_compat.h
@@ -26,6 +26,7 @@ written by
 #define HAISRT_COMPAT_H__
 
 #include <stddef.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -36,7 +37,6 @@ extern "C" {
 #if defined(__MACH__)
 
 #include <AvailabilityMacros.h>
-#include <time.h>
 #include <errno.h>
 #include <pthread.h>
 #include <string.h>
@@ -187,7 +187,6 @@ inline struct tm LocalTime(time_t tt)
 }
 
 
-
-#endif
+#endif // defined C++
 
 #endif // HAISRT_COMPAT_H__

--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -925,6 +925,7 @@ protected:
             if ( adapter == "" )
             {
                 Verb() << "Multicast: home address: INADDR_ANY:" << port;
+                maddr.sin_family = AF_INET;
                 maddr.sin_addr.s_addr = htonl(INADDR_ANY);
                 maddr.sin_port = htons(port); // necessary for temporary use
             }

--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -916,6 +916,9 @@ protected:
         if (m_sock == -1)
             Error(SysError(), "UdpCommon::Setup: socket");
 
+        int yes = 1;
+        ::setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof yes);
+
         sadr = CreateAddrInet(host, port);
 
         if ( attr.count("multicast") )


### PR DESCRIPTION
This fixes the problem with reading from UDP multicast on Windows, which was using the multicast IP address for the call to `bind()`. This works on Linux, but somehow doesn't work on Windows. Specifically for Windows, the IP address that designates the network device (INADDR_ANY by default, or the address specified in `adapter` attribute) is used for binding, not the IP address of the multicast group. Note that subscription to the multicast group includes both the IGMP address and the adapter address, and it works on Linux without change, so the fix is provided for Windows and Cygwin only.

The problem was reported in issue #101 