### PR TITLE
Removed srt_compat from app sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,12 +438,16 @@ if ( ENABLE_CXX11 )
 		${CMAKE_SOURCE_DIR}/common/socketoptions.cpp
 		${CMAKE_SOURCE_DIR}/common/logsupport.cpp
 		${CMAKE_SOURCE_DIR}/common/transmitmedia.cpp
-		${CMAKE_SOURCE_DIR}/common/srt_compat.c
+		#${CMAKE_SOURCE_DIR}/common/srt_compat.c
 	)
+	# XXX This fix was never necessary, srt_compat.c is
+	# included in the SRT library. This was motivated by some error report
+	# from some CI system, so leaving the commented-out parts for historical reasons.
+	
 	# Enforce interpreting this file as C++ so that C++ compiler is used to compile it.
 	# This should result in exactly the same as when it was compiled as C, with the
 	# exception that the compiler with accept any C++-only COMPILE_FLAGS (e.g. -std=c++11).
-	set_source_files_properties(${CMAKE_SOURCE_DIR}/common/srt_compat.c PROPERTIES LANGUAGE CXX )
+	#set_source_files_properties(${CMAKE_SOURCE_DIR}/common/srt_compat.c PROPERTIES LANGUAGE CXX )
 
 	add_executable(srt-live-transmit
 		${CMAKE_SOURCE_DIR}/apps/srt-live-transmit.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,9 +361,9 @@ if ( LINUX )
 endif()
 
 
-target_compile_definitions(${TARGET_srt} PRIVATE -DUDT_EXPORTS )
+target_compile_definitions(${TARGET_srt} PRIVATE -DSRT_EXPORTS )
 if (ENABLE_SHARED)
-	target_compile_definitions(${TARGET_srt} PUBLIC -DUDT_DYNAMIC) 
+	target_compile_definitions(${TARGET_srt} PUBLIC -DSRT_DYNAMIC) 
 endif()
 
 if ( WIN32 )

--- a/common/srt_compat.h
+++ b/common/srt_compat.h
@@ -28,6 +28,24 @@ written by
 #include <stddef.h>
 #include <time.h>
 
+#ifdef WIN32
+   #ifndef __MINGW__
+	#ifdef SRT_DYNAMIC
+      #ifdef SRT_EXPORTS
+         #define SRT_API __declspec(dllexport)
+      #else
+         #define SRT_API __declspec(dllimport)
+      #endif
+	#else
+		#define SRT_API
+	#endif
+   #else
+      #define SRT_API
+   #endif
+#else
+   #define SRT_API __attribute__ ((visibility("default")))
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -156,7 +174,7 @@ static inline size_t SysStrnlen(const char * s, size_t maxlen)
 #endif
 
 /* Ensures that we store the error in the buffer and return the bufer. */
-const char * SysStrError(int errnum, char * buf, size_t buflen);
+SRT_API const char * SysStrError(int errnum, char * buf, size_t buflen);
 
 #ifdef __cplusplus
 } // extern C

--- a/common/srt_compat.h
+++ b/common/srt_compat.h
@@ -30,15 +30,15 @@ written by
 
 #ifdef WIN32
    #ifndef __MINGW__
-	#ifdef SRT_DYNAMIC
-      #ifdef SRT_EXPORTS
-         #define SRT_API __declspec(dllexport)
+      #ifdef SRT_DYNAMIC
+         #ifdef SRT_EXPORTS
+            #define SRT_API __declspec(dllexport)
+         #else
+            #define SRT_API __declspec(dllimport)
+         #endif
       #else
-         #define SRT_API __declspec(dllimport)
+         #define SRT_API
       #endif
-	#else
-		#define SRT_API
-	#endif
    #else
       #define SRT_API
    #endif

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -55,8 +55,8 @@ written by
          typedef __int64 uint64_t;
       #endif
 
-	#ifdef UDT_DYNAMIC
-      #ifdef UDT_EXPORTS
+	#ifdef SRT_DYNAMIC
+      #ifdef SRT_EXPORTS
          #define SRT_API __declspec(dllexport)
       #else
          #define SRT_API __declspec(dllimport)


### PR DESCRIPTION
There was a fix some time ago that added `srt_compat.c` to apps due to reported linker error. The reason was rather mysterious and the need of it wasn't confirmed on Mac OS X 10.12.6. This is also impossible because the symbols provided there should be already provided through the SRT library.