### PR TITLE
Create and bundle binaries for Win32

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,7 @@ build_script:
 after_build:
 - cmd: >-
     gather-package.bat
-        7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\package
+        7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\package\*
         appveyor PushArtifact SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip
 
 on_finish:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,6 @@
+init:
+ #-ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+ 
 configuration:
   - Release
   - Debug
@@ -23,3 +26,12 @@ build_script:
   - ps: if ( $VS_VERSION -eq "2013" ) { $CMAKE_GENERATOR = "Visual Studio 12 2013 Win64" } else { $CMAKE_GENERATOR = "Visual Studio 14 2015 Win64" }
   - ps: cmake . -G"$CMAKE_GENERATOR" -DCMAKE_BUILD_TYPE=$Env:CONFIGURATION
   - ps: msbuild SRT.sln /p:Configuration=$Env:CONFIGURATION /p:Platform=x64
+  
+after_build:
+- cmd: >-
+    copy C:\OpenSSL-Win64\bin\libeay32.dll %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
+        7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.*
+        appveyor PushArtifact SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip
+
+on_finish:
+  #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,5 @@
 init:
- -ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+ # -ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
  
 configuration:
   - Release
@@ -34,4 +34,4 @@ after_build:
         appveyor PushArtifact SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip
 
 on_finish:
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+ # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,8 +29,8 @@ build_script:
   
 after_build:
 - cmd: >-
-    copy C:\OpenSSL-Win64\bin\libeay32.dll %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
-        7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.*
+    gather-package.bat
+        7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\package
         appveyor PushArtifact SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-%APPVEYOR_BUILD_VERSION%.zip
 
 on_finish:

--- a/gather-package.bat
+++ b/gather-package.bat
@@ -20,5 +20,5 @@ copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\packa
 copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\package\lib\
 
 rem gather 3rd party elements
-(robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0
 (robocopy c:\openssl-win64\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win64 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0
+(robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/gather-package.bat
+++ b/gather-package.bat
@@ -20,5 +20,5 @@ copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\packa
 copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\package\lib\
 
 rem gather 3rd party elements
-robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e
-robocopy c:\openssl-win64\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win64 /s /e
+(robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0
+(robocopy c:\openssl-win64\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win64 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0

--- a/gather-package.bat
+++ b/gather-package.bat
@@ -1,0 +1,23 @@
+rem Create empty directories for package bundle
+
+md %APPVEYOR_BUILD_FOLDER%\package
+md %APPVEYOR_BUILD_FOLDER%\package\include
+md %APPVEYOR_BUILD_FOLDER%\package\include\win
+md %APPVEYOR_BUILD_FOLDER%\package\bin        
+md %APPVEYOR_BUILD_FOLDER%\package\lib
+md %APPVEYOR_BUILD_FOLDER%\package\pthread-win32
+md %APPVEYOR_BUILD_FOLDER%\package\openssl-win64
+
+rem Gather SRT includes, binaries and libs
+copy %APPVEYOR_BUILD_FOLDER%\srtcore\*.h %APPVEYOR_BUILD_FOLDER%\package\include\
+copy %APPVEYOR_BUILD_FOLDER%\haicrypt\*.h %APPVEYOR_BUILD_FOLDER%\package\include\
+copy %APPVEYOR_BUILD_FOLDER%\common\*.h %APPVEYOR_BUILD_FOLDER%\package\include\
+copy %APPVEYOR_BUILD_FOLDER%\common\win\*.h %APPVEYOR_BUILD_FOLDER%\package\include\win\
+copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.exe %APPVEYOR_BUILD_FOLDER%\package\bin\
+copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.dll %APPVEYOR_BUILD_FOLDER%\package\bin\
+copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\package\lib\
+copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\package\lib\
+
+rem gather 3rd party elements
+robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e
+robocopy c:\openssl-win64\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win64 /s /e

--- a/gather-package.bat
+++ b/gather-package.bat
@@ -1,4 +1,5 @@
 rem Create empty directories for package bundle
+@echo off
 
 md %APPVEYOR_BUILD_FOLDER%\package
 md %APPVEYOR_BUILD_FOLDER%\package\include

--- a/gather-package.bat
+++ b/gather-package.bat
@@ -20,5 +20,6 @@ copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\packa
 copy %APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\package\lib\
 
 rem gather 3rd party elements
-(robocopy c:\openssl-win64\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win64 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0
-(robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e) ^& IF %ERRORLEVEL% LEQ 1 exit 0
+(robocopy c:\openssl-win64\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win64 /s /e) ^& IF %ERRORLEVEL% GTR 1 exit %ERRORLEVEL%
+(robocopy c:\pthread-win32\ %APPVEYOR_BUILD_FOLDER%\package\pthread-win32 /s /e) ^& IF %ERRORLEVEL% GTR 1 exit %ERRORLEVEL%
+exit 0


### PR DESCRIPTION
I added steps to catch resulting files from build process into Zip files for Win32 build.

This is useful, since it then provides correct pre-compiled SRT binaries without variances from local build changes or OpenSSL versions.

It also makes utilities like 'stransmit' available pre-compiled.

I also scrape up the OpenSSL and PThreads binaries, and all headers and lib files that might be needed by anyone then trying to use srt.dll in any other app from one easy pack.

Now, there might be a good reason nobody did this before - but I find it incredibly useful - and if it was merged, it actually makes my life easier to test fixes to builds without risking any variances from building patches. So I offer this request, and stand ready to answer any questions!

