### PR TITLE
Shifted locking around drift tracer to inside the function.

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1389,7 +1389,7 @@ void CRcvBuffer::printDriftOffset(int tsbPdOffset, int tsbPdDriftAvg)
 }
 #endif /* SRT_DEBUG_TSBPD_DRIFT */
 
-void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp)
+void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp, pthread_mutex_t& mutex_to_lock)
 {
     if (!m_bTsbPdMode) // Not checked unless in TSBPD mode
         return;
@@ -1412,6 +1412,9 @@ void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp)
     // either schedule time or a time supplied by the application).
 
     int64_t iDrift = CTimer::getTime() - (getTsbPdTimeBase(timestamp) + timestamp);
+
+    CGuard::enterCS(mutex_to_lock);
+
     bool updated = m_DriftTracer.update(iDrift);
 
 #ifdef SRT_DEBUG_TSBPD_DRIFT
@@ -1427,6 +1430,7 @@ void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp)
         m_ullTsbPdTimeBase += m_DriftTracer.overdrift();
     }
 
+    CGuard::leaveCS(mutex_to_lock);
 }
 
 int CRcvBuffer::readMsg(char* data, int len)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -362,7 +362,7 @@ public:
       /// Add packet timestamp for drift caclculation and compensation
       /// @param [in] timestamp packet time stamp
 
-   void addRcvTsbPdDriftSample(uint32_t timestamp);
+   void addRcvTsbPdDriftSample(uint32_t timestamp, pthread_mutex_t& mutex_to_lock);
 
 #ifdef SRT_DEBUG_TSBPD_DRIFT
    void printDriftHistogram(int64_t iDrift);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6111,9 +6111,13 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
 
       updateCC(TEV_ACKACK, ack);
 
-      CGuard::enterCS(m_RecvLock);
-      m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp());
-      CGuard::leaveCS(m_RecvLock);
+      // This function will put a lock on m_RecvLock by itself, as needed.
+      // It must be done inside because this function reads the current time
+      // and if waiting for the lock has caused a delay, the time will be
+      // inaccurate. Additionally it won't lock if TSBPD mode is off, and
+      // won't update anything. Note that if you set TSBPD mode and use
+      // srt_recvfile (which doesn't make any sense), you'll have e deadlock.
+      m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(), m_RecvLock);
 
       // update last ACK that has been received by the sender
       if (CSeqNo::seqcmp(ack, m_iRcvLastAckAck) > 0)


### PR DESCRIPTION
Also, locking is done only after the current time is read.

Per issue #113 