### PR TITLE
Fixed correctly flushing send buffers on closing a socket.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -983,7 +983,16 @@ int CUDTUnited::close(const SRTSOCKET u)
            // The socket is either in m_ClosedSockets or is already gone.
 
            // Done the other way, but still done. You can stop waiting.
-           if ( m_ClosedSockets.count(id) == 0 || !s->m_pUDT->m_bOpened )
+           bool isgone = false;
+           {
+               CGuard manager_cg(m_ControlLock);
+               isgone = m_ClosedSockets.count(id) == 0;
+           }
+           if (!isgone)
+           {
+               isgone = !s->m_pUDT->m_bOpened;
+           }
+           if (isgone)
            {
                LOGC(mglog.Debug) << "%" << id << " GLOBAL CLOSING: ... gone in the meantime, whatever. Exiting close().";
                break;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -887,7 +887,9 @@ int CUDTUnited::close(const SRTSOCKET u)
 
    LOGC(mglog.Debug) << s->m_pUDT->CONID() << " CLOSING (removing from listening, closing CUDT)";
 
-   bool synch_close = s->m_pUDT->m_bSynSending;
+   bool synch_close_snd = s->m_pUDT->m_bSynSending;
+   //bool synch_close_rcv = s->m_pUDT->m_bSynRecving;
+
    int id = s->m_SocketID;
 
    if (s->m_Status == SRTS_LISTENING)
@@ -953,16 +955,33 @@ int CUDTUnited::close(const SRTSOCKET u)
 
    // Check if the ID is still in closed sockets before you access it
    // (the last triggerEvent could have deleted it).
-   if ( synch_close )
+   if ( synch_close_snd )
    {
 #if SRT_ENABLE_CLOSE_SYNCH
 
-       // Ok, now you are keeping GC thread hands off the internal data.
-       // You can check then if it has already deleted the socket or not.
-       // The socket is either in m_ClosedSockets or is already gone.
-       LOGC(mglog.Debug) << "%" << id << " GLOBAL CLOSING: sync-waiting for releasing socket resources...";
+       LOGC(mglog.Debug) << "%" << id << " GLOBAL CLOSING: sync-waiting for releasing sender resources...";
        for (;;)
        {
+           CSndBuffer* sb = s->m_pUDT->m_pSndBuffer;
+
+           // Disconnected from buffer - nothing more to check.
+           if (!sb)
+           {
+               LOGC(mglog.Debug) << "%" << id << " GLOBAL CLOSING: sending buffer disconnected. Allowed to close.";
+               break;
+           }
+
+           // Sender buffer empty
+           if (sb->getCurrBufSize() == 0)
+           {
+               LOGC(mglog.Debug) << "%" << id << " GLOBAL CLOSING: sending buffer depleted. Allowed to close.";
+               break;
+           }
+
+           // Ok, now you are keeping GC thread hands off the internal data.
+           // You can check then if it has already deleted the socket or not.
+           // The socket is either in m_ClosedSockets or is already gone.
+
            // Done the other way, but still done. You can stop waiting.
            if ( m_ClosedSockets.count(id) == 0 || !s->m_pUDT->m_bOpened )
            {
@@ -970,35 +989,37 @@ int CUDTUnited::close(const SRTSOCKET u)
                break;
            }
 
-           // If so, we can then take out the control lock and let GC do its job.
-           // It means that the thing to be done by CUDT::close() is not yet complete,
-           // so we have to wait.
+           LOGC(mglog.Debug) << "%" << id << " GLOBAL CLOSING: ... still waiting for any update.";
+           CTimer::EWait wt = CTimer::waitForEvent();
 
-           // This below will unlock the control lock and wait for the signal.
-
-           // Do a 0.20s rolling, just for safety, when we missed the signal.
-           timeval now;
-           timespec timeout;
-           gettimeofday(&now, 0);
-           timeout.tv_sec = now.tv_sec;
-           timeout.tv_nsec = (now.tv_usec + 200000) * 1000;
-
-           int st = pthread_cond_timedwait(&s->m_pUDT->m_CloseSynchCond, &m_ControlLock, &timeout);
-
-           // In case of whatever error, jump back to checking the condition.
-           // One of the errors that MIGHT happen is that the condition object
-           // has been deleted while waiting. This will cause this function to return
-           // error code. But if this happened, then surely it was deleted together with
-           // the whole object and so the socket has been removed from m_ClosedSockets.
-           // This way, the entry condition in this loop will be false and the loop breaks.
-           if ( st == 0 )
+           if ( wt == CTimer::WT_ERROR )
            {
-               LOGC(mglog.Debug) << "GLOBAL CLOSING: ... synch-closed. Exiting close().";
+               LOGC(mglog.Debug) << "GLOBAL CLOSING: ... ERROR WHEN WAITING FOR EVENT. Exiting close() to prevent hangup.";
                break;
            }
+
+           // Continue waiting in case when an event happened or 1s waiting time passed for checkpoint.
        }
 #endif
    }
+
+   /*
+      This code is PUT ASIDE for now.
+      Most likely this will be never required.
+      It had to hold the closing activity until the time when the receiver buffer is depleted.
+      However the closing of the socket should only happen when the receiver has received
+      an information about that the reading is no longer possible (error report from recv/recvfile).
+      When this happens, the receiver buffer is definitely depleted already and there's no need to check
+      anything.
+
+      Should there appear any other conditions in future under which the closing process should be
+      delayed until the receiver buffer is empty, this code can be filled here.
+
+   if ( synch_close_rcv )
+   {
+   ...
+   }
+   */
 
    return 0;
 }

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -988,7 +988,7 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, 
     // be also capable of checking if the next available packet, if it is
     // there, is the next sequence packet or not. Retrieving this exactly
     // packet would be most useful, as the test for play-readiness and
-    // "monotonicness" can be done on it directly.
+    // sequentiality can be done on it directly.
     //
     // When done so, the below loop would be completely unnecessary.
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4284,11 +4284,6 @@ void CUDT::close()
    m_lMinimumPeerSrtVersion = SRT_VERSION_MAJ1;
    m_ullRcvPeerStartTime = 0;
 
-   LOGC(mglog.Debug) << "CLOSING %" << m_SocketID << " - sync signal";
-   //pthread_mutex_lock(&m_CloseSynchLock);
-   pthread_cond_broadcast(&m_CloseSynchCond);
-   //pthread_mutex_unlock(&m_CloseSynchLock);
-   // CLOSED.
    m_bOpened = false;
 }
 
@@ -5439,9 +5434,6 @@ void CUDT::initSynch()
       pthread_mutex_init(&m_ConnectionLock, NULL);
       memset(&m_RcvTsbPdThread, 0, sizeof m_RcvTsbPdThread);
       pthread_cond_init(&m_RcvTsbPdCond, NULL);
-
-      pthread_mutex_init(&m_CloseSynchLock, NULL);
-      pthread_cond_init(&m_CloseSynchCond, NULL);
 }
 
 void CUDT::destroySynch()
@@ -5457,8 +5449,6 @@ void CUDT::destroySynch()
       pthread_mutex_destroy(&m_ConnectionLock);
       pthread_cond_destroy(&m_RcvTsbPdCond);
 
-      pthread_mutex_destroy(&m_CloseSynchLock);
-      pthread_cond_destroy(&m_CloseSynchCond);
 }
 
 void CUDT::releaseSynch()

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -659,13 +659,6 @@ private: // synchronization: mutexes and conditions
 
     pthread_mutex_t m_RcvLossLock;               // Protects the receiver loss list (access: CRcvQueue::worker, CUDT::tsbpd)
 
-    // This is required to synchronize the background part of the closing socket process
-    // with the call of srt_close(). The condition is broadcast at the end regardless of
-    // the settings. The srt_close() function is blocked from exiting until this signal
-    // is received when the socket is set SRTO_SNDSYN.
-    pthread_mutex_t m_CloseSynchLock;
-    pthread_cond_t m_CloseSynchCond;
-
     void initSynch();
     void destroySynch();
     void releaseSynch();

--- a/srtcore/srt4udt.h
+++ b/srtcore/srt4udt.h
@@ -76,6 +76,6 @@ written by
 #define SRT_ENABLE_IPOPTS 1
 
 
-#define SRT_ENABLE_CLOSE_SYNCH 0
+#define SRT_ENABLE_CLOSE_SYNCH 1
 
 #endif /* SRT4UDT_H */


### PR DESCRIPTION
This removes the previous trial implementation of preventing too early closing the socket and an extra mutex. This was experimental and blocked. The old implementation has been removed, the new one applies only closing when the send buffer is empty, updating the checks on `waitForEvent`.