### PR TITLE
Workaround for a hangup during cleanup (proper fix required)

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -239,8 +239,17 @@ int CUDTUnited::cleanup()
    m_bClosing = true;
    pthread_cond_signal(&m_GCStopCond);
    pthread_join(m_GCThread, NULL);
+   
+   // XXX There's some weird bug here causing this
+   // to hangup on Windows. This might be either something
+   // bigger, or some problem in pthread-win32. As this is
+   // the application cleanup section, this can be temporarily
+   // tolerated with simply exit the application without cleanup,
+   // counting on that the system will take care of it anyway.
+#ifndef WIN32
    pthread_mutex_destroy(&m_GCStopLock);
    pthread_cond_destroy(&m_GCStopCond);
+#endif
 
    m_bGCStatus = false;
 


### PR DESCRIPTION
This simply turns off destruction of a condition variable in `CUDTUnited::cleanup()`, which is actually executed from within the global destructor, if not called manually.

The true reason as to why this destruction causes a hangup should be further studied. Currently this is simply blocked on Windows, which isn't the proper solution, but as this is a global object, destroyed just before the program exits, it can be temporarily tolerated.