### PR TITLE
Fixed passing the chunk size by transmit to SRTO_PAYLOADSIZE option

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -82,10 +82,6 @@
 #include <srt.h>
 #include <logging.h>
 
-// The length of the SRT payload used in srt_recvmsg call.
-// So far, this function must be used and up to this length of payload.
-const size_t DEFAULT_CHUNK = 1316;
-
 using namespace std;
 
 
@@ -240,7 +236,14 @@ int main( int argc, char** argv )
     int timeout = stoi(Option("30", "t", "to", "timeout"), 0, 0);
     size_t chunk = stoul(Option("0", "c", "chunk"), 0, 0);
     if ( chunk == 0 )
-        chunk = DEFAULT_CHUNK;
+    {
+        chunk = SRT_LIVE_DEF_PLSIZE;
+    }
+    else
+    {
+        transmit_chunk_size = chunk;
+    }
+
     size_t bandwidth = stoul(Option("0", "b", "bandwidth", "bitrate"), 0, 0);
     transmit_bw_report = stoul(Option("0", "r", "report", "bandwidth-report", "bitrate-report"), 0, 0);
     transmit_verbose = Option("no", "v", "verbose") != "no";
@@ -285,6 +288,7 @@ int main( int argc, char** argv )
             UDT::setlogstream(logfile_stream);
         }
     }
+
 
 #ifdef WIN32
 #define alarm(argument) (void)0

--- a/common/transmitbase.hpp
+++ b/common/transmitbase.hpp
@@ -12,6 +12,7 @@ extern volatile bool transmit_throw_on_interrupt;
 extern int transmit_bw_report;
 extern unsigned transmit_stats_report;
 extern std::ostream* transmit_cverb;
+extern size_t transmit_chunk_size;
 
 static const struct VerboseLogNoEol { VerboseLogNoEol() {} } VerbNoEOL;
 


### PR DESCRIPTION
The new feature introduced to SRT is such that the default payload size is 1316, and the live payload size may be increased up to 1456, but it must be predeclared by SRTO_PAYLOADSIZE if it's not default, and when trying to send more than the payloadsize, srt_send* functions report an error. The chunk size in stransmit could be customized by `-c` option, but the application didn't undergo necessary readjustment after introducing this rule, that is, this nondefault chunk size should be passed to SRTO_PAYLOADSIZE option.

Fixes #130