### PR TITLE
Add supporting nettle/gnutls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
           osx_image: xcode7.3
           env: BUILD_TYPE=Debug
           before_install: brew update
-          install: brew install openssl
+          install: brew install openssl gnutls nettle
         - os: osx
           osx_image: xcode7.3
           before_install: brew update
-          install: brew install openssl
+          install: brew install openssl gnutls nettle
           env: BUILD_TYPE=Release
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ matrix:
         - os: osx
           osx_image: xcode7.3
           env: BUILD_TYPE=Debug
+          before_install: brew update
           install: brew install openssl
         - os: osx
           osx_image: xcode7.3
+          before_install: brew update
           install: brew install openssl
           env: BUILD_TYPE=Release
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(ENABLE_LOGGING "Should logging be enabled" ${ENABLE_LOGGING_DEFAULT})
 option(ENABLE_SHARED "Should libsrt be built as a shared library" ON)
 option(ENABLE_SEPARATE_HAICRYPT "Should haicrypt be built as a separate library file" OFF)
 option(ENABLE_SUFLIP "Shuld suflip tool be built" OFF)
+option(USE_NETTLE "Should use nettle instead of openssl" OFF)
 
 # Always turn logging on if the build type is debug
 if (ENABLE_DEBUG)
@@ -87,8 +88,20 @@ set_if(DARWIN ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 set_if(LINUX ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # find OpenSSL
-find_package(OpenSSL REQUIRED)
-message (STATUS "OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+if ( USE_NETTLE )
+	pkg_search_module(NETTLE nettle)
+	set(NETTLE_DEFINITIONS ${NETTLE_CFLAGS_OTHER})
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_NETTLE=1")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_NETTLE=1")
+	message (STATUS "Detected nettle version: ${NETTLE_VERSION}")
+
+	pkg_search_module(GNUTLS gnutls)
+	set(OPENSSL_INCLUDES ${NETTLE_INCLUDES} ${GNUTLS_INCLUDES})
+	set(OPENSSL_LIBRARIES ${NETTLE_LIBRARIES} ${GNUTLS_LIBRARIES})
+else()
+	find_package(OpenSSL)
+	message (STATUS "OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+endif()
 
 # Detect if the compiler is GNU compatable for flags
 set(HAVE_COMPILER_GNU_COMPAT 0)
@@ -172,7 +185,6 @@ add_definitions(
    -D_GNU_SOURCE
    -DHAI_PATCH=1
    -DHAI_ENABLE_SRT=1
-   -DHAICRYPT_USE_OPENSSL_EVP=1
    -DHAICRYPT_USE_OPENSSL_AES
    -DSRT_VERSION="${SRT_VERSION}"
 )
@@ -230,6 +242,15 @@ MafRead(haicrypt/filelist.maf
 
 adddirname(haicrypt "${SOURCES_haicrypt_indir}" SOURCES_haicrypt)
 adddirname(haicrypt "${HEADERS_haicrypt_indir}" HEADERS_haicrypt)
+
+
+if ( USE_NETTLE )
+	list(APPEND SOURCES_haicrypt "haicrypt/cryptographic-internal.c")
+else ()
+	add_definitions(
+   		-DHAICRYPT_USE_OPENSSL_EVP=1
+	)
+endif ()
 
 if (WIN32)
 	MafRead(common/filelist_win32.maf

--- a/haicrypt/cryptographic-internal.c
+++ b/haicrypt/cryptographic-internal.c
@@ -1,0 +1,38 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ *   Author: Justin Kim <justin.kim@collabora.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "cryptographic-internal.h"
+
+int
+AES_set_encrypt_key (const uint8_t *key,
+                     unsigned bits GNUC_UNUSED,
+                     AES_KEY *aeskey)
+{
+  aes128_set_encrypt_key(aeskey, key);
+  return 0;
+}
+
+int
+AES_set_decrypt_key (const uint8_t *key,
+                     unsigned bits GNUC_UNUSED,
+                     AES_KEY *aeskey)
+{
+  aes128_set_decrypt_key(aeskey, key);
+  return 0;
+}

--- a/haicrypt/cryptographic-internal.h
+++ b/haicrypt/cryptographic-internal.h
@@ -1,0 +1,76 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ *   Author: Justin Kim <justin.kim@collabora.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef __CRYPTOGRAPHIC_INTERNAL_H__
+#define __CRYPTOGRAPHIC_INTERNAL_H__
+
+#if !defined(USE_NETTLE)
+
+/* By default, SRT uses OpenSSL */
+#include <openssl/aes.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>	/* PKCS5_xxx() */
+#include <openssl/modes.h>	/* CRYPTO_xxx() */
+#include <openssl/opensslv.h>   /* OPENSSL_VERSION_NUMBER  */
+#include <openssl/rand.h>       /* RAND_bytes */
+
+#if (OPENSSL_VERSION_NUMBER < 0x0090808fL) //0.9.8h
+#include <openssl/bio.h>
+#endif
+
+#else // !defined(USE_NETTLE)
+
+#include <gnutls/gnutls.h>
+#include <gnutls/crypto.h>
+
+#include <nettle/aes.h>
+#include <nettle/ctr.h>
+#include <nettle/hmac.h>
+#include <nettle/pbkdf2.h>
+
+#undef OPENSSL_VERSION_NUMBER
+#define OPENSSL_VERSION_NUMBER 0L
+
+#if     __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ > 4)
+#define GNUC_UNUSED                           \
+  __attribute__((__unused__))
+#else
+#define GNUC_UNUSED
+#endif
+
+typedef struct aes128_ctx AES_KEY;
+
+int AES_set_encrypt_key(const uint8_t *key, unsigned bits, AES_KEY *aeskey);
+
+int AES_set_decrypt_key(const uint8_t *key, unsigned bits, AES_KEY *aeskey);
+
+typedef void (*block128_f) (struct aes_ctx *ctx, unsigned length, uint8_t *dst, const uint8_t *src);
+
+#define OPENSSL_cleanse(p,l)
+#define RAND_bytes(d,s) gnutls_rnd(GNUTLS_RND_KEY,(d),(s))
+#define PKCS5_PBKDF2_HMAC(p,p_l,sa,sa_l,iter,digest,k_l,d)
+
+
+void AES_ecb_encrypt(const unsigned char *in, unsigned char *out, const AES_KEY *key, const int enc);
+
+#define AES_ecb_encrypt(s,d,key,enc)
+
+
+#endif // !defined(USE_NETTLE)
+#endif // __CRYPTOGRAPHIC_INTERNAL_H__

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -48,6 +48,7 @@ written by
    #include <sys/time.h>
 #endif
 
+#include "cryptographic-internal.h"
 #include "haicrypt.h"
 #include "hcrypt_msg.h"
 #include "hcrypt_ctx.h"
@@ -111,10 +112,6 @@ typedef struct {
 #endif
 
 #ifdef HAICRYPT_USE_OPENSSL_AES
-#include <openssl/opensslv.h>   /* OPENSSL_VERSION_NUMBER  */
-#include <openssl/evp.h>        /* PKCS5_ */
-#include <openssl/rand.h>       /* RAND_bytes */
-#include <openssl/aes.h>        /* AES_ */
 
 #define hcrypt_Prng(rn, len)    (RAND_bytes(rn, len) <= 0 ? -1 : 0)
 
@@ -141,7 +138,6 @@ int     AES_unwrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out
 
 
 #ifdef  HAICRYPT_USE_OPENSSL_EVP
-#include <openssl/opensslv.h>   // OPENSSL_VERSION_NUMBER 
 
 #define HAICRYPT_USE_OPENSSL_EVP_CTR 1
         /*

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -31,7 +31,6 @@ written by
 #define HCRYPT_CTX_H
 
 #include <sys/types.h>
-#include <openssl/aes.h>		//AES_KEY for kek
 
 #if !defined(HAISRT_VERSION_INT)
 #include "haicrypt.h"

--- a/srtcore/csrtcc.cpp
+++ b/srtcore/csrtcc.cpp
@@ -835,7 +835,11 @@ HaiCrypt_Handle CSRTCC::createCryptoCtx(int keylen, int tx)
 
         crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (tx ? HAICRYPT_CFG_F_TX : 0);
         crypto_cfg.xport = HAICRYPT_XPT_SRT;
+#if !defined(USE_NETTLE)
+#ifdef  HAICRYPT_USE_OPENSSL_EVP
         crypto_cfg.cipher = HaiCryptCipher_OpenSSL_EVP();
+#endif
+#endif
         crypto_cfg.key_len = (size_t)keylen;
         crypto_cfg.data_max_len = HAICRYPT_DEF_DATA_MAX_LENGTH;    //MTU
         crypto_cfg.km_tx_period_ms = 0;//No HaiCrypt KM inject period, handled in SRT;


### PR DESCRIPTION
OpenSSL has non-GPL compatibility problem.
For GPLed software, Nettle and GnuTLS can provide
alternative.

Signed-off-by: Justin Kim <justin.kim@collabora.com>