### PR TITLE
Remove OpenSSL specific functions and definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ matrix:
         - os: osx
           osx_image: xcode7.3
           env: BUILD_TYPE=Debug
+          before_install: brew update
           install: brew install openssl
         - os: osx
           osx_image: xcode7.3
+          before_install: brew update
           install: brew install openssl
           env: BUILD_TYPE=Release
 

--- a/haicrypt/filelist.maf
+++ b/haicrypt/filelist.maf
@@ -9,6 +9,7 @@ hcrypt_msg.h
 
 PRIVATE HEADERS
 hcrypt.h
+hcrypt-openssl.h
 
 SOURCES
 hc_openssl_aes.c

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -58,6 +58,8 @@ extern "C" {
 
 typedef void *HaiCrypt_Cipher;
 
+HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_Get_Instance (void);     /* Return a efault cipher instance */
+
 HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP(void);       /* OpenSSL EVP interface (default to EVP_CTR) */
 HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CBC(void);   /* OpenSSL EVP interface for AES-CBC */
 HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CTR(void);   /* OpenSSL EVP interface for AES-CTR */

--- a/haicrypt/hc_openssl_evp_ctr.c
+++ b/haicrypt/hc_openssl_evp_ctr.c
@@ -340,4 +340,9 @@ HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP(void)
 	return(HaiCryptCipher_OpenSSL_EVP_CTR());
 }
 
+HaiCrypt_Cipher HaiCryptCipher_Get_Instance(void) 
+{
+	return(HaiCryptCipher_OpenSSL_EVP_CTR());
+}
+
 #endif /* HAICRYPT_USE_OPENSSL_EVP_CTR */

--- a/haicrypt/hcrypt-openssl.h
+++ b/haicrypt/hcrypt-openssl.h
@@ -1,0 +1,81 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ */
+#ifndef __HCRYPT_OPENSSL_H__
+#define __HCRYPT_OPENSSL_H__
+
+#ifdef HAICRYPT_USE_OPENSSL_AES
+#include <openssl/opensslv.h>   /* OPENSSL_VERSION_NUMBER  */
+#include <openssl/evp.h>        /* PKCS5_ */
+#include <openssl/rand.h>       /* RAND_bytes */
+#include <openssl/aes.h>        /* AES_ */
+
+#define hcrypt_Prng(rn, len)    (RAND_bytes(rn, len) <= 0 ? -1 : 0)
+
+#if     (OPENSSL_VERSION_NUMBER < 0x0090808fL) //0.9.8h
+        /*
+        * AES_wrap_key()/AES_unwrap_key() introduced in openssl 0.9.8h
+        * Use internal implementation (in hc_openssl_aes.c) for earlier versions
+        */
+int     AES_wrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out,
+            const unsigned char *in, unsigned int inlen);
+int     AES_unwrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out,
+            const unsigned char *in, unsigned int inlen);
+#endif  /* OPENSSL_VERSION_NUMBER */
+
+#define hcrypt_WrapKey(kek, wrap, key, keylen) (((int)(keylen + HAICRYPT_WRAPKEY_SIGN_SZ) \
+        == AES_wrap_key(kek, NULL, wrap, key, keylen)) ? 0 : -1)
+#define hcrypt_UnwrapKey(kek, key, wrap, wraplen)   (((int)(wraplen - HAICRYPT_WRAPKEY_SIGN_SZ) \
+        == AES_unwrap_key(kek, NULL, key, wrap, wraplen)) ? 0 : -1)
+
+#else   /* HAICRYPT_USE_OPENSSL_AES */
+#error  No Prng and key wrapper defined
+
+#endif  /* HAICRYPT_USE_OPENSSL_AES */
+
+#ifdef  HAICRYPT_USE_OPENSSL_EVP
+#include <openssl/opensslv.h>   // OPENSSL_VERSION_NUMBER 
+
+#define HAICRYPT_USE_OPENSSL_EVP_CTR 1
+        /*
+        * CTR mode is the default mode for HaiCrypt (standalone and SRT)
+        */
+#ifdef  HAICRYPT_USE_OPENSSL_EVP_CTR
+#if     (OPENSSL_VERSION_NUMBER < 0x10001000L)
+        /*
+        * CTR mode for EVP API introduced in openssl 1.0.1
+        * Implement it using ECB mode for earlier versions
+        */
+#define HAICRYPT_USE_OPENSSL_EVP_ECB4CTR 1  
+#endif
+        HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CTR(void);
+#endif
+
+//undef HAICRYPT_USE_OPENSSL_EVP_CBC 1  /* CBC mode (for crypto engine tests) */
+        /*
+        * CBC mode for crypto engine tests
+        * Default CTR mode not supported on Linux cryptodev (API to hardware crypto engines)
+        * Not officially support nor interoperable with any haicrypt peer
+        */
+#ifdef  HAICRYPT_USE_OPENSSL_EVP_CBC
+        HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CBC(void);
+#endif /* HAICRYPT_USE_OPENSSL_EVP_CBC */
+
+#endif /* HAICRYPT_USE_OPENSSL_EVP */
+
+
+#endif /* __HCRYPT_OPENSSL_H__ */

--- a/haicrypt/hcrypt-openssl.h
+++ b/haicrypt/hcrypt-openssl.h
@@ -77,5 +77,7 @@ int     AES_unwrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out
 
 #endif /* HAICRYPT_USE_OPENSSL_EVP */
 
+#define hcrypt_pbkdf2_hmac_sha1(p,p_len,sa,sa_len,itr,out_len,out) \
+   PKCS5_PBKDF2_HMAC_SHA1(p,p_len,sa,sa_len,itr,out_len,out)
 
 #endif /* __HCRYPT_OPENSSL_H__ */

--- a/haicrypt/hcrypt-openssl.h
+++ b/haicrypt/hcrypt-openssl.h
@@ -79,5 +79,7 @@ int     AES_unwrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out
 
 #define hcrypt_pbkdf2_hmac_sha1(p,p_len,sa,sa_len,itr,out_len,out) \
    PKCS5_PBKDF2_HMAC_SHA1(p,p_len,sa,sa_len,itr,out_len,out)
+#define hcrypt_aes_set_encrypt_key AES_set_encrypt_key
+#define hcrypt_aes_set_decrypt_key AES_set_decrypt_key
 
 #endif /* __HCRYPT_OPENSSL_H__ */

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -50,6 +50,9 @@ written by
 
 #include "haicrypt.h"
 #include "hcrypt_msg.h"
+#if !defined(USE_GNUTLS)
+#include "hcrypt-openssl.h"
+#endif
 #include "hcrypt_ctx.h"
 
 //#define HCRYPT_DEV 1  /* Development: should not be defined in committed code */
@@ -110,7 +113,6 @@ typedef struct {
 #define ASSERT(c)   assert(c)
 #endif
 
-#include "hcrypt-openssl.h"
 
 /* HaiCrypt-TP CTR mode IV (128-bit):
  *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -110,66 +110,7 @@ typedef struct {
 #define ASSERT(c)   assert(c)
 #endif
 
-#ifdef HAICRYPT_USE_OPENSSL_AES
-#include <openssl/opensslv.h>   /* OPENSSL_VERSION_NUMBER  */
-#include <openssl/evp.h>        /* PKCS5_ */
-#include <openssl/rand.h>       /* RAND_bytes */
-#include <openssl/aes.h>        /* AES_ */
-
-#define hcrypt_Prng(rn, len)    (RAND_bytes(rn, len) <= 0 ? -1 : 0)
-
-#if     (OPENSSL_VERSION_NUMBER < 0x0090808fL) //0.9.8h
-        /*
-        * AES_wrap_key()/AES_unwrap_key() introduced in openssl 0.9.8h
-        * Use internal implementation (in hc_openssl_aes.c) for earlier versions
-        */
-int     AES_wrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out,
-            const unsigned char *in, unsigned int inlen);
-int     AES_unwrap_key(AES_KEY *key, const unsigned char *iv, unsigned char *out,
-            const unsigned char *in, unsigned int inlen);
-#endif  /* OPENSSL_VERSION_NUMBER */
-
-#define hcrypt_WrapKey(kek, wrap, key, keylen) (((int)(keylen + HAICRYPT_WRAPKEY_SIGN_SZ) \
-        == AES_wrap_key(kek, NULL, wrap, key, keylen)) ? 0 : -1)
-#define hcrypt_UnwrapKey(kek, key, wrap, wraplen)   (((int)(wraplen - HAICRYPT_WRAPKEY_SIGN_SZ) \
-        == AES_unwrap_key(kek, NULL, key, wrap, wraplen)) ? 0 : -1)
-
-#else   /* HAICRYPT_USE_OPENSSL_AES */
-#error  No Prng and key wrapper defined
-
-#endif  /* HAICRYPT_USE_OPENSSL_AES */
-
-
-#ifdef  HAICRYPT_USE_OPENSSL_EVP
-#include <openssl/opensslv.h>   // OPENSSL_VERSION_NUMBER 
-
-#define HAICRYPT_USE_OPENSSL_EVP_CTR 1
-        /*
-        * CTR mode is the default mode for HaiCrypt (standalone and SRT)
-        */
-#ifdef  HAICRYPT_USE_OPENSSL_EVP_CTR
-#if     (OPENSSL_VERSION_NUMBER < 0x10001000L)
-        /*
-        * CTR mode for EVP API introduced in openssl 1.0.1
-        * Implement it using ECB mode for earlier versions
-        */
-#define HAICRYPT_USE_OPENSSL_EVP_ECB4CTR 1  
-#endif
-        HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CTR(void);
-#endif
-
-//undef HAICRYPT_USE_OPENSSL_EVP_CBC 1  /* CBC mode (for crypto engine tests) */
-        /*
-        * CBC mode for crypto engine tests
-        * Default CTR mode not supported on Linux cryptodev (API to hardware crypto engines)
-        * Not officially support nor interoperable with any haicrypt peer
-        */
-#ifdef  HAICRYPT_USE_OPENSSL_EVP_CBC
-        HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CBC(void);
-#endif /* HAICRYPT_USE_OPENSSL_EVP_CBC */
-
-#endif /* HAICRYPT_USE_OPENSSL_EVP */
-
+#include "hcrypt-openssl.h"
 
 /* HaiCrypt-TP CTR mode IV (128-bit):
  *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -31,7 +31,7 @@ written by
 #define HCRYPT_CTX_H
 
 #include <sys/types.h>
-#include <openssl/aes.h>		//AES_KEY for kek
+#include "hcrypt.h"
 
 #if !defined(HAISRT_VERSION_INT)
 #include "haicrypt.h"

--- a/haicrypt/hcrypt_sa.c
+++ b/haicrypt/hcrypt_sa.c
@@ -88,7 +88,7 @@ int hcryptCtx_GenSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx)
 	int iret;
 	(void)crypto;
 
-	PKCS5_PBKDF2_HMAC_SHA1(ctx->cfg.pwd, ctx->cfg.pwd_len, 
+	hcrypt_pbkdf2_hmac_sha1(ctx->cfg.pwd, ctx->cfg.pwd_len, 
 		&ctx->salt[ctx->salt_len - pbkdf_salt_len], pbkdf_salt_len, 
 		HAICRYPT_PBKDF2_ITER_CNT, kek_len, kek);
 

--- a/haicrypt/hcrypt_sa.c
+++ b/haicrypt/hcrypt_sa.c
@@ -45,9 +45,9 @@ int hcryptCtx_SetSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx, HaiCrypt_Secret
 		ctx->cfg.pwd_len = 0;
 		/* KEK: Key Encrypting Key */
 		if (HCRYPT_CTX_F_ENCRYPT & ctx->flags) {
-			iret = AES_set_encrypt_key(secret->str, secret->len * 8, &ctx->aes_kek);
+			iret = hcrypt_aes_set_encrypt_key(secret->str, secret->len * 8, &ctx->aes_kek);
 		} else {
-			iret = AES_set_decrypt_key(secret->str, secret->len * 8, &ctx->aes_kek);
+			iret = hcrypt_aes_set_decrypt_key(secret->str, secret->len * 8, &ctx->aes_kek);
 		}			
 		if (0 > iret) {
 		HCRYPT_LOG(LOG_ERR, "AES_set_%s_key(kek[%zd]) failed (rc=%d)\n", 
@@ -97,12 +97,12 @@ int hcryptCtx_GenSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx)
 	
 	/* KEK: Key Encrypting Key */
 	if (HCRYPT_CTX_F_ENCRYPT & ctx->flags) {
-		if (0 > (iret = AES_set_encrypt_key(kek, kek_len * 8, &ctx->aes_kek))) {
+		if (0 > (iret = hcrypt_aes_set_encrypt_key(kek, kek_len * 8, &ctx->aes_kek))) {
 		HCRYPT_LOG(LOG_ERR, "AES_set_encrypt_key(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
 			return(-1);
 		}
 	} else {
-		if (0 > (iret = AES_set_decrypt_key(kek, kek_len * 8, &ctx->aes_kek))) {
+		if (0 > (iret = hcrypt_aes_set_decrypt_key(kek, kek_len * 8, &ctx->aes_kek))) {
 		HCRYPT_LOG(LOG_ERR, "AES_set_decrypt_key(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
 			return(-1);
 		}

--- a/haicrypt/hcrypt_ut.c
+++ b/haicrypt/hcrypt_ut.c
@@ -175,7 +175,7 @@ int hc_ut_encrypt_ctr_speed(void)
 #ifdef HAICRYPT_USE_OPENSSL_EVP_CBC
 	crypto_cfg.cipher = HaiCryptCipher_OpenSSL_EVP_CBC();
 #else
-	crypto_cfg.cipher = HaiCryptCipher_OpenSSL_EVP();
+	crypto_cfg.cipher = HaiCryptCipher_Get_Instance();
 #endif
 	crypto_cfg.key_len = (size_t)128/8;
 	crypto_cfg.data_max_len = HAICRYPT_DEF_DATA_MAX_LENGTH;    //MTU

--- a/haicrypt/hcrypt_ut.c
+++ b/haicrypt/hcrypt_ut.c
@@ -128,7 +128,7 @@ static int hc_ut_pbkdf2(unsigned verbose)
 			gettimeofday(&tstart, NULL);
 		}	
 
-		PKCS5_PBKDF2_HMAC_SHA1(tv[i].pwd, tv[i].pwd_len, 
+		hcrypt_pbkdf2_hmac_sha1(tv[i].pwd, tv[i].pwd_len, 
 			tv[i].salt, tv[i].salt_len, 
 			tv[i].cnt, tv[i].dk_len, dk);
 

--- a/haicrypt/hcrypt_ut.c
+++ b/haicrypt/hcrypt_ut.c
@@ -26,6 +26,7 @@ written by
 *****************************************************************************/
 
 #include <string.h>				/* memcpy */
+#include <stdio.h>
 #include <haicrypt.h>
 #include "hcrypt.h"
 

--- a/srtcore/csrtcc.cpp
+++ b/srtcore/csrtcc.cpp
@@ -835,7 +835,7 @@ HaiCrypt_Handle CSRTCC::createCryptoCtx(int keylen, int tx)
 
         crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (tx ? HAICRYPT_CFG_F_TX : 0);
         crypto_cfg.xport = HAICRYPT_XPT_SRT;
-        crypto_cfg.cipher = HaiCryptCipher_OpenSSL_EVP();
+        crypto_cfg.cipher = HaiCryptCipher_Get_Instance();
         crypto_cfg.key_len = (size_t)keylen;
         crypto_cfg.data_max_len = HAICRYPT_DEF_DATA_MAX_LENGTH;    //MTU
         crypto_cfg.km_tx_period_ms = 0;//No HaiCrypt KM inject period, handled in SRT;


### PR DESCRIPTION
SRT designed to support multiple SSLs, but the implementation still have OpenSSL specific function and macros. It makes little hard to add alternative of OpenSSL. Before adding the other SSL, I created these patches to make it more portable.