### PR TITLE
Some Build Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,12 +148,12 @@ else()
 endif()
 
 
-set (SRT_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/common)
+set (SRT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common)
 
-set (SRT_SRC_HAICRYPT_DIR ${CMAKE_SOURCE_DIR}/haicrypt)
-set (SRT_SRC_SRTCORE_DIR ${CMAKE_SOURCE_DIR}/srtcore)
-set (SRT_SRC_COMMON_DIR ${CMAKE_SOURCE_DIR}/common)
-set (SRT_SRC_TOOLS_DIR ${CMAKE_SOURCE_DIR}/tools)
+set (SRT_SRC_HAICRYPT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/haicrypt)
+set (SRT_SRC_SRTCORE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/srtcore)
+set (SRT_SRC_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR}/common)
+set (SRT_SRC_TOOLS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tools)
 
 if(WIN32)
     add_definitions(-DWIN32=1 -DPTW32_STATIC_LIB)
@@ -435,11 +435,11 @@ endif()
 if ( ENABLE_CXX11 )
 
 	set (SOURCES_transmit 
-		${CMAKE_SOURCE_DIR}/common/uriparser.cpp
-		${CMAKE_SOURCE_DIR}/common/socketoptions.cpp
-		${CMAKE_SOURCE_DIR}/common/logsupport.cpp
-		${CMAKE_SOURCE_DIR}/common/transmitmedia.cpp
-		#${CMAKE_SOURCE_DIR}/common/srt_compat.c
+		${CMAKE_CURRENT_SOURCE_DIR}/common/uriparser.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/common/socketoptions.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/common/logsupport.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/common/transmitmedia.cpp
+		#${CMAKE_CURRENT_SOURCE_DIR}/common/srt_compat.c
 	)
 	# XXX This fix was never necessary, srt_compat.c is
 	# included in the SRT library. This was motivated by some error report
@@ -448,32 +448,32 @@ if ( ENABLE_CXX11 )
 	# Enforce interpreting this file as C++ so that C++ compiler is used to compile it.
 	# This should result in exactly the same as when it was compiled as C, with the
 	# exception that the compiler with accept any C++-only COMPILE_FLAGS (e.g. -std=c++11).
-	#set_source_files_properties(${CMAKE_SOURCE_DIR}/common/srt_compat.c PROPERTIES LANGUAGE CXX )
+	#set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/common/srt_compat.c PROPERTIES LANGUAGE CXX )
 
 	add_executable(srt-live-transmit
-		${CMAKE_SOURCE_DIR}/apps/srt-live-transmit.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/apps/srt-live-transmit.cpp
 		${SOURCES_transmit}
 	)
 
 	add_executable(srt-multiplex
-		${CMAKE_SOURCE_DIR}/apps/srt-multiplex.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/apps/srt-multiplex.cpp
 		${SOURCES_transmit}
 	)
 
 # srt-file-transmit must be temporarily blocked on Windows because it's not yet portable
 	if (NOT WIN32)
 	add_executable(srt-file-transmit
-		${CMAKE_SOURCE_DIR}/apps/srt-file-transmit.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/apps/srt-file-transmit.cpp
 		${SOURCES_transmit}
 	)
 	endif()
 
 	add_executable(sendfile
-		${CMAKE_SOURCE_DIR}/apps/legacy/sendfile.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/apps/legacy/sendfile.cpp
 	)
 
 	add_executable(recvfile
-		${CMAKE_SOURCE_DIR}/apps/legacy/recvfile.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/apps/legacy/recvfile.cpp
 	)
 	target_link_libraries(sendfile ${TARGET_srt} ${DEPENDS_srt})
 	target_link_libraries(recvfile ${TARGET_srt} ${DEPENDS_srt})
@@ -498,7 +498,7 @@ if ( ENABLE_CXX11 )
 	endif()
 
 	# Test programs
-	add_executable(utility-test ${CMAKE_SOURCE_DIR}/apps/utility-test.cpp)
+	add_executable(utility-test ${CMAKE_CURRENT_SOURCE_DIR}/apps/utility-test.cpp)
 
 	# We state that Darwin always uses CLANG compiler, which honors this flag the same way.
 	set_target_properties(srt-live-transmit PROPERTIES COMPILE_FLAGS "${CFLAGS_CXX_STANDARD} ${EXTRA_stransmit}" ${FORCE_RPATH})
@@ -537,8 +537,8 @@ endif()
 
 if ( ENABLE_SUFLIP )
 	set (SOURCES_suflip
-		${CMAKE_SOURCE_DIR}/apps/suflip.cpp
-		${CMAKE_SOURCE_DIR}/common/uriparser.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/apps/suflip.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/common/uriparser.cpp
 	)
 
 	set(LIBS_suflip ${TARGET_haicrypt} ${TARGET_srt})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ target_include_directories(${TARGET_srt} PUBLIC ${PTHREAD_INCLUDE_DIR} ${SRT_SRC
 # Not sure why it's required, but somehow only on Linux
 if ( LINUX )
 	target_link_libraries(${TARGET_srt} PUBLIC rt)
+	target_link_libraries(${TARGET_srt} PUBLIC dl)
 	set (IFNEEDED_SRT_LDFLAGS -pthread)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,11 @@ set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil)
 include(FindPkgConfig)
 
-set (SRT_VERSION 1.3.0)
+set(SRT_VERSION_MAJOR 1)
+set(SRT_VERSION_MINOR 3)
+set(SRT_VERSION_PATCH 0)
+
+set(SRT_VERSION "${SRT_VERSION_MAJOR}.${SRT_VERSION_MINOR}.${SRT_VERSION_PATCH}")
 set_version_variables(SRT_VERSION ${SRT_VERSION})
 
 if (NOT DEFINED ENABLE_DEBUG)
@@ -306,6 +310,11 @@ MafRead(srtcore/filelist.maf
 
 adddirname(srtcore "${SOURCES_srt_indir}" SOURCES_srt)
 adddirname(srtcore "${HEADERS_srt_indir}" HEADERS_srt)
+
+# Auto generated version file and add it to the HEADERS_srt list.
+configure_file("srtcore/version.h.in" "version.h" @ONLY)
+list(INSERT HEADERS_srt 0 "${CMAKE_CURRENT_BINARY_DIR}/version.h")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 # Manual handling of dependency on virtual library
 if (haicrypt_libspec STREQUAL VIRTUAL)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -25,6 +25,8 @@ written by
 #ifndef INC__SRTC_H
 #define INC__SRTC_H
 
+#include "version.h"
+
 #include "platform_sys.h"
 
 #include <string.h>
@@ -76,10 +78,6 @@ written by
 // For feature tests if you need.
 // You can use these constants with SRTO_MINVERSION option.
 #define SRT_VERSION_FEAT_HSv5 0x010300
-
-
-// To construct version value
-#define SRT_MAKE_VERSION(major, minor, patch) ((patch)+((minor)*0x100)+((major)*0x10000))
 
 #ifdef __GNUG__
 #define SRT_ATR_UNUSED __attribute__((unused))

--- a/srtcore/version.h.in
+++ b/srtcore/version.h.in
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ * 
+ *****************************************************************************/
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+ *****************************************************************************/
+
+#ifndef INC__SRT_VERSION_H
+#define INC__SRT_VERSION_H
+
+// To construct version value
+#define SRT_MAKE_VERSION(major, minor, patch) \
+   ((patch) + ((minor)*0x100) + ((major)*0x10000))
+#define SRT_MAKE_VERSION_VALUE SRT_MAKE_VERSION
+
+#define SRT_VERSION_MAJOR @SRT_VERSION_MAJOR@
+#define SRT_VERSION_MINOR @SRT_VERSION_MINOR@
+#define SRT_VERSION_PATCH @SRT_VERSION_PATCH@
+
+#define SRT_VERSION_STRING "@SRT_VERSION@"
+#define SRT_VERSION_VALUE \
+   SRT_MAKE_VERSION_VALUE( \
+      SRT_VERSION_MAJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH )
+
+#endif // INC__SRT_VERSION_H


### PR DESCRIPTION
Fixes Linux Static SRT build with Static OpenSSL library build.
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR in the CMake project to allow the project to be used as a add_subdirectory() subproject in a larger project.
Add an autogenerated version.h that is constructed automatically by the version definitions in the CMake project.