### PR TITLE
Refactored the use of ref_t. Also fixes a crash.

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -168,8 +168,8 @@ void ExtractPath(string path, ref_t<string> dir, ref_t<string> fname)
         directory = wd + "/" + directory;
     }
 
-    dir = directory;
-    fname = filename;
+    *dir = directory;
+    *fname = filename;
 }
 
 bool DoUpload(UriParser& ut, string path, string filename)

--- a/common/srt_compat.h
+++ b/common/srt_compat.h
@@ -192,16 +192,26 @@ inline std::string SysStrError(int errnum)
 
 inline struct tm LocalTime(time_t tt)
 {
-	struct tm tm = {};
-#ifdef WIN32
-	errno_t rr = localtime_s(&tm, &tt);
-	if (rr == 0)
-		return tm;
+#ifdef __cplusplus
+    // As a POD, in C++ tm will be zero-initialized
+    // with explicit default initializer. No warns.
+    tm tms = tm();
 #else
-	tm = *localtime_r(&tt, &tm);
+    // This will issue a warning in C, but still
+    // it will do the same as memset(&tms, 0...).
+    // Using a zero-list is a portability risk.
+    // Using one zero becuase {} is not C99 standard.
+	struct tm tms = {0};
+#endif
+#ifdef WIN32
+	errno_t rr = localtime_s(&tms, &tt);
+	if (rr == 0)
+		return tms;
+#else
+	tms = *localtime_r(&tt, &tms);
 #endif
 
-    return tm;
+    return tms;
 }
 
 

--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -800,7 +800,7 @@ void SrtModel::Establish(ref_t<std::string> name)
         if (name.get() != "")
         {
             Verb() << "Connect with requesting stream [" << name.get() << "]";
-            UDT::setstreamid(m_sock, name);
+            UDT::setstreamid(m_sock, +name);
         }
         else
         {
@@ -843,7 +843,7 @@ void SrtModel::Establish(ref_t<std::string> name)
         Verb() << "Accepting a client...";
         AcceptNewClient();
         // This rewrites m_sock with a new SRT socket ("accepted" socket)
-        name = UDT::getstreamid(m_sock);
+        *name = UDT::getstreamid(m_sock);
         Verb() << "... GOT CLIENT for stream [" << name.get() << "]";
     }
 }

--- a/common/utilities.h
+++ b/common/utilities.h
@@ -246,16 +246,16 @@ template <class T>
 struct ref_t: public std::reference_wrapper<T>
 {
     typedef std::reference_wrapper<T> base;
-    ref_t() {}
+    explicit ref_t(const T& i): base(i) {}
     ref_t(const ref_t& i): base(i) {}
     ref_t(const base& i): base(i) {}
 
     ref_t& operator=(const ref_t&) = default;
 
-    void operator=(const T& i)
-    {
-        this->get() = i;
-    }
+    T& operator*() { return this->get(); }
+    T operator+() { return this->get(); }
+
+    operator T&() = delete;
 
     T operator->() const
     { return this->get(); }
@@ -358,20 +358,17 @@ public:
         : m_data(inref.m_data)
     { }
 
+    // This *REBINDS* the reference, not
+    // assigns a value. 
     void operator=(const ref_t<Type>& inref)
     {
         m_data = inref.m_data;
     }
 
-    void operator=(const Type& src)
-    {
-        *m_data = src;
-    }
+    Type& operator*() { return *m_data; }
+    Type operator+() { return *m_data; }
 
-    operator Type&() const
-    { return this->get(); }
-
-    Type& get() const 
+    Type& get() const
     { return *m_data; }
 
     Type operator->() const

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -152,88 +152,90 @@ CSndBuffer::~CSndBuffer()
 
 void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint64_t srctime, ref_t<int32_t> r_msgno)
 {
-   int size = len / m_iMSS;
-   if ((len % m_iMSS) != 0)
-      size ++;
+    int32_t& msgno = *r_msgno;
 
-   LOGC(mglog.Debug) << "addBuffer: size=" << m_iCount << " reserved=" << m_iSize << " needs=" << size << " buffers for " << len << " bytes";
+    int size = len / m_iMSS;
+    if ((len % m_iMSS) != 0)
+        size ++;
 
-   // dynamically increase sender buffer
-   while (size + m_iCount >= m_iSize)
-   {
-      LOGC(mglog.Debug) << "addBuffer: ... still lacking " << (size + m_iCount - m_iSize) << " buffers...";
-      increase();
-   }
+    LOGC(mglog.Debug) << "addBuffer: size=" << m_iCount << " reserved=" << m_iSize << " needs=" << size << " buffers for " << len << " bytes";
 
-   uint64_t time = CTimer::getTime();
-   int32_t inorder = order ? MSGNO_PACKET_INORDER::mask : 0;
+    // dynamically increase sender buffer
+    while (size + m_iCount >= m_iSize)
+    {
+        LOGC(mglog.Debug) << "addBuffer: ... still lacking " << (size + m_iCount - m_iSize) << " buffers...";
+        increase();
+    }
 
-   LOGC(dlog.Debug) << CONID() << "addBuffer: adding "
-       << size << " packets (" << len << " bytes) to send, msgno=" << m_iNextMsgNo
-       << (inorder ? "" : " NOT") << " in order";
+    uint64_t time = CTimer::getTime();
+    int32_t inorder = order ? MSGNO_PACKET_INORDER::mask : 0;
 
-   Block* s = m_pLastBlock;
-   r_msgno = m_iNextMsgNo;
-   for (int i = 0; i < size; ++ i)
-   {
-      int pktlen = len - i * m_iMSS;
-      if (pktlen > m_iMSS)
-         pktlen = m_iMSS;
+    LOGC(dlog.Debug) << CONID() << "addBuffer: adding "
+        << size << " packets (" << len << " bytes) to send, msgno=" << m_iNextMsgNo
+        << (inorder ? "" : " NOT") << " in order";
 
-      LOGC(dlog.Debug) << "addBuffer: spreading from=" << (i*m_iMSS) << " size=" << pktlen << " TO BUFFER:" << (void*)s->m_pcData;
-      memcpy(s->m_pcData, data + i * m_iMSS, pktlen);
-      s->m_iLength = pktlen;
+    Block* s = m_pLastBlock;
+    msgno = m_iNextMsgNo;
+    for (int i = 0; i < size; ++ i)
+    {
+        int pktlen = len - i * m_iMSS;
+        if (pktlen > m_iMSS)
+            pktlen = m_iMSS;
 
-      s->m_iMsgNoBitset = m_iNextMsgNo | inorder;
-      if (i == 0)
-         s->m_iMsgNoBitset |= PacketBoundaryBits(PB_FIRST);
-      if (i == size - 1)
-         s->m_iMsgNoBitset |= PacketBoundaryBits(PB_LAST);
-      // NOTE: if i is neither 0 nor size-1, it resuls with PB_SUBSEQUENT.
-      //       if i == 0 == size-1, it results with PB_SOLO. 
-      // Packets assigned to one message can be:
-      // [PB_FIRST] [PB_SUBSEQUENT] [PB_SUBSEQUENT] [PB_LAST] - 4 packets per message
-      // [PB_FIRST] [PB_LAST] - 2 packets per message
-      // [PB_SOLO] - 1 packet per message
+        LOGC(dlog.Debug) << "addBuffer: spreading from=" << (i*m_iMSS) << " size=" << pktlen << " TO BUFFER:" << (void*)s->m_pcData;
+        memcpy(s->m_pcData, data + i * m_iMSS, pktlen);
+        s->m_iLength = pktlen;
 
-      s->m_ullSourceTime_us = srctime;
-      s->m_ullOriginTime_us = time;
-      s->m_iTTL = ttl;
+        s->m_iMsgNoBitset = m_iNextMsgNo | inorder;
+        if (i == 0)
+            s->m_iMsgNoBitset |= PacketBoundaryBits(PB_FIRST);
+        if (i == size - 1)
+            s->m_iMsgNoBitset |= PacketBoundaryBits(PB_LAST);
+        // NOTE: if i is neither 0 nor size-1, it resuls with PB_SUBSEQUENT.
+        //       if i == 0 == size-1, it results with PB_SOLO. 
+        // Packets assigned to one message can be:
+        // [PB_FIRST] [PB_SUBSEQUENT] [PB_SUBSEQUENT] [PB_LAST] - 4 packets per message
+        // [PB_FIRST] [PB_LAST] - 2 packets per message
+        // [PB_SOLO] - 1 packet per message
 
-      // XXX unchecked condition: s->m_pNext == NULL.
-      // Should never happen, as the call to increase() should ensure enough buffers.
-      s = s->m_pNext;
-   }
-   m_pLastBlock = s;
+        s->m_ullSourceTime_us = srctime;
+        s->m_ullOriginTime_us = time;
+        s->m_iTTL = ttl;
 
-   CGuard::enterCS(m_BufLock);
-   m_iCount += size;
+        // XXX unchecked condition: s->m_pNext == NULL.
+        // Should never happen, as the call to increase() should ensure enough buffers.
+        s = s->m_pNext;
+    }
+    m_pLastBlock = s;
 
-   m_iBytesCount += len;
+    CGuard::enterCS(m_BufLock);
+    m_iCount += size;
+
+    m_iBytesCount += len;
 #ifdef SRT_ENABLE_CBRTIMESTAMP
-   m_ullLastOriginTime_us = srctime;
+    m_ullLastOriginTime_us = srctime;
 #else
-   m_ullLastOriginTime_us = time;
+    m_ullLastOriginTime_us = time;
 #endif /* SRT_ENABLE_CBRTIMESTAMP */
 
-   updInputRate(time, size, len);
+    updInputRate(time, size, len);
 
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
-   updAvgBufSize(time);
+    updAvgBufSize(time);
 #endif
 
-   CGuard::leaveCS(m_BufLock);
+    CGuard::leaveCS(m_BufLock);
 
 
-   // MSGNO_SEQ::mask has a form: 00000011111111...
-   // At least it's known that it's from some index inside til the end (to bit 0).
-   // If this value has been reached in a step of incrementation, it means that the
-   // maximum value has been reached. Casting to int32_t to ensure the same sign
-   // in comparison, although it's far from reaching the sign bit.
+    // MSGNO_SEQ::mask has a form: 00000011111111...
+    // At least it's known that it's from some index inside til the end (to bit 0).
+    // If this value has been reached in a step of incrementation, it means that the
+    // maximum value has been reached. Casting to int32_t to ensure the same sign
+    // in comparison, although it's far from reaching the sign bit.
 
-   m_iNextMsgNo ++;
-   if (m_iNextMsgNo == int32_t(MSGNO_SEQ::mask))
-      m_iNextMsgNo = 1;
+    m_iNextMsgNo ++;
+    if (m_iNextMsgNo == int32_t(MSGNO_SEQ::mask))
+        m_iNextMsgNo = 1;
 }
 
 void CSndBuffer::setInputRateSmpPeriod(int period)
@@ -269,31 +271,33 @@ void CSndBuffer::updInputRate(uint64_t time, int pkts, int bytes)
    }
 }
 
-int CSndBuffer::getInputRate(ref_t<int> payloadsz, ref_t<int> period)
+int CSndBuffer::getInputRate(ref_t<int> r_payloadsz, ref_t<int> r_period)
 {
-   uint64_t time = CTimer::getTime();
+    int& payloadsz = *r_payloadsz;
+    int& period = *r_period;
+    uint64_t time = CTimer::getTime();
 
-   if ((m_InRatePeriod != 0)
-   &&  (m_InRateStartTime != 0) 
-   &&  ((time - m_InRateStartTime) > m_InRatePeriod))
-   {
-      //Packet size with headers
-      if (m_iInRatePktsCount == 0)
-          m_iAvgPayloadSz = 0;
-      else
-          m_iAvgPayloadSz = m_iInRateBytesCount / m_iInRatePktsCount;
+    if ((m_InRatePeriod != 0)
+            &&  (m_InRateStartTime != 0) 
+            &&  ((time - m_InRateStartTime) > m_InRatePeriod))
+    {
+        //Packet size with headers
+        if (m_iInRatePktsCount == 0)
+            m_iAvgPayloadSz = 0;
+        else
+            m_iAvgPayloadSz = m_iInRateBytesCount / m_iInRatePktsCount;
 
-      //include packet headers: SRT + UDP + IP
-      int64_t llBytesCount = (int64_t)m_iInRateBytesCount + (m_iInRatePktsCount * (CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE));
-      //Byte/sec rate
-      m_iInRateBps = (int)((llBytesCount * 1000000) / (time - m_InRateStartTime));
-      m_iInRatePktsCount = 0;
-      m_iInRateBytesCount = 0;
-      m_InRateStartTime = time;
-   }
-   payloadsz = m_iAvgPayloadSz;
-   period = (int)m_InRatePeriod;
-   return(m_iInRateBps);
+        //include packet headers: SRT + UDP + IP
+        int64_t llBytesCount = (int64_t)m_iInRateBytesCount + (m_iInRatePktsCount * (CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE));
+        //Byte/sec rate
+        m_iInRateBps = (int)((llBytesCount * 1000000) / (time - m_InRateStartTime));
+        m_iInRatePktsCount = 0;
+        m_iInRateBytesCount = 0;
+        m_InRateStartTime = time;
+    }
+    payloadsz = m_iAvgPayloadSz;
+    period = (int)m_InRatePeriod;
+    return(m_iInRateBps);
 }
 
 int CSndBuffer::addBufferFromFile(fstream& ifs, int len)
@@ -508,16 +512,18 @@ int CSndBuffer::getCurrBufSize() const
 
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
 
-int CSndBuffer::getAvgBufSize(ref_t<int> bytes, ref_t<int> timespan)
+int CSndBuffer::getAvgBufSize(ref_t<int> r_bytes, ref_t<int> r_tsp)
 {
-   CGuard bufferguard(m_BufLock); /* Consistency of pkts vs. bytes vs. spantime */
+    int& bytes = *r_bytes;
+    int& timespan = *r_tsp;
+    CGuard bufferguard(m_BufLock); /* Consistency of pkts vs. bytes vs. spantime */
 
-   /* update stats in case there was no add/ack activity lately */
-   updAvgBufSize(CTimer::getTime());
+    /* update stats in case there was no add/ack activity lately */
+    updAvgBufSize(CTimer::getTime());
 
-   bytes = m_iBytesCountMAvg;
-   timespan = m_TimespanMAvg;
-   return(m_iCountMAvg);
+    bytes = m_iBytesCountMAvg;
+    timespan = m_TimespanMAvg;
+    return(m_iCountMAvg);
 }
 
 void CSndBuffer::updAvgBufSize(uint64_t now)
@@ -560,16 +566,16 @@ void CSndBuffer::updAvgBufSize(uint64_t now)
 
 int CSndBuffer::getCurrBufSize(ref_t<int> bytes, ref_t<int> timespan)
 {
-   bytes = m_iBytesCount;
+   *bytes = m_iBytesCount;
    /* 
    * Timespan can be less then 1000 us (1 ms) if few packets. 
    * Also, if there is only one pkt in buffer, the time difference will be 0.
    * Therefore, always add 1 ms if not empty.
    */
 #ifdef SRT_ENABLE_CBRTIMESTAMP
-   timespan = 0 < m_iCount ? int((m_ullLastOriginTime_us - m_pFirstBlock->m_ullSourceTime_us) / 1000) + 1 : 0;
+   *timespan = 0 < m_iCount ? int((m_ullLastOriginTime_us - m_pFirstBlock->m_ullSourceTime_us) / 1000) + 1 : 0;
 #else
-   timespan = 0 < m_iCount ? int((m_ullLastOriginTime_us - m_pFirstBlock->m_ullOriginTime_us) / 1000) + 1 : 0;
+   *timespan = 0 < m_iCount ? int((m_ullLastOriginTime_us - m_pFirstBlock->m_ullOriginTime_us) / 1000) + 1 : 0;
 #endif
 
    return m_iCount;
@@ -932,8 +938,10 @@ void CRcvBuffer::skipData(int len)
       m_iMaxPos = 0;
 }
 
-bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, ref_t<int32_t> skipseqno, ref_t<int32_t> r_curpktseq)
+bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passack, ref_t<int32_t> r_skipseqno, ref_t<int32_t> r_curpktseq)
 {
+    int32_t& skipseqno = *r_skipseqno;
+    bool& passack = *r_passack;
     skipseqno = -1;
     passack = false;
     // tsbpdtime will be retrieved by the below call
@@ -945,11 +953,11 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, 
     // - @return: whether the reported packet is ready to play
 
     /* Check the acknowledged packets */
-    if (getRcvReadyMsg(tsbpdtime, r_curpktseq))
+    if (getRcvReadyMsg(r_tsbpdtime, r_curpktseq))
     {
         return true;
     }
-    else if (tsbpdtime != 0)
+    else if (+r_tsbpdtime != 0)
     {
         return false;
     }
@@ -967,7 +975,7 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, 
      * Check the not yet acked packets that may be stuck by missing packet(s).
      */
     bool haslost = false;
-    tsbpdtime = 0; // redundant, for clarity
+    *r_tsbpdtime = 0; // redundant, for clarity
     passack = true;
 
     // XXX SUSPECTED ISSUE with this algorithm:
@@ -1008,8 +1016,8 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, 
         else
         {
             /* We got the 1st valid packet */
-            tsbpdtime = getPktTsbPdTime(m_pUnit[i]->m_Packet.getMsgTimeStamp());
-            if (tsbpdtime <= CTimer::getTime())
+            *r_tsbpdtime = getPktTsbPdTime(m_pUnit[i]->m_Packet.getMsgTimeStamp());
+            if (+r_tsbpdtime <= CTimer::getTime())
             {
                 /* Packet ready to play */
                 if (haslost)
@@ -1019,7 +1027,7 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, 
                      * Tell 1st valid packet seqno so caller can skip (drop) the missing packets.
                      */
                     skipseqno = m_pUnit[i]->m_Packet.m_iSeqNo;
-                    r_curpktseq = skipseqno.get();
+                    *r_curpktseq = skipseqno;
                 }
 
                 // NOTE: if haslost is not set, it means that this is the VERY FIRST
@@ -1043,55 +1051,69 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> tsbpdtime, ref_t<bool> passack, 
 
 bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpktseq)
 {
-   tsbpdtime = 0;
-   int rmpkts = 0; 
-   int rmbytes = 0;
-   for (int i = m_iStartPos, n = m_iLastAckPos; i != n; i = (i + 1) % m_iSize)
-   {
-      bool freeunit = false;
+    *tsbpdtime = 0;
+    int rmpkts = 0; 
+    int rmbytes = 0;
 
-      /* Skip any invalid skipped/dropped packets */
-      if (m_pUnit[i] == NULL)
-      {
-         if (++ m_iStartPos == m_iSize)
-            m_iStartPos = 0;
-         continue;
-      }
+    string reason = "NOT RECEIVED";
+    for (int i = m_iStartPos, n = m_iLastAckPos; i != n; i = (i + 1) % m_iSize)
+    {
+        bool freeunit = false;
 
-      curpktseq = m_pUnit[i]->m_Packet.getSeqNo();
+        /* Skip any invalid skipped/dropped packets */
+        if (m_pUnit[i] == NULL)
+        {
+            if (++ m_iStartPos == m_iSize)
+                m_iStartPos = 0;
+            continue;
+        }
 
-      if (m_pUnit[i]->m_iFlag != CUnit::GOOD)
-      {
-         freeunit = true;
-      }
-      else
-      {
-        tsbpdtime = getPktTsbPdTime(m_pUnit[i]->m_Packet.getMsgTimeStamp());
-        if (tsbpdtime > CTimer::getTime())
-            return false;
+        *curpktseq = m_pUnit[i]->m_Packet.getSeqNo();
 
-        if (m_pUnit[i]->m_Packet.getMsgCryptoFlags() != EK_NOENC)
-            freeunit = true; /* packet not decrypted */
+        if (m_pUnit[i]->m_iFlag != CUnit::GOOD)
+        {
+            freeunit = true;
+        }
         else
-            return true;
-      }
+        {
+            *tsbpdtime = getPktTsbPdTime(m_pUnit[i]->m_Packet.getMsgTimeStamp());
+            int64_t towait = (+tsbpdtime - CTimer::getTime());
+            if (towait > 0)
+            {
+                LOGC(mglog.Debug) << "getRcvReadyMsg: found packet, but not ready to play (only in " << (towait/1000.0) << "ms)";
+                return false;
+            }
 
-      if (freeunit)
-      {
-         CUnit* tmp = m_pUnit[i];
-         m_pUnit[i] = NULL;
-         rmpkts++;
-         rmbytes += tmp->m_Packet.getLength();
-         tmp->m_iFlag = CUnit::FREE;
-         --m_pUnitQueue->m_iCount;
+            if (m_pUnit[i]->m_Packet.getMsgCryptoFlags() != EK_NOENC)
+            {
+                reason = "DECRYPTION FAILED";
+                freeunit = true; /* packet not decrypted */
+            }
+            else
+            {
+                LOGC(mglog.Debug) << "getRcvReadyMsg: packet seq=" << curpktseq.get() << " ready to play (delayed " << (-towait/1000.0) << "ms)";
+                return true;
+            }
+        }
 
-         if (++m_iStartPos == m_iSize)
-            m_iStartPos = 0;
-      }
-   }
-   /* removed skipped, dropped, undecryptable bytes from rcv buffer */
-   countBytes(-rmpkts, -rmbytes, true);
-   return false;
+        if (freeunit)
+        {
+            CUnit* tmp = m_pUnit[i];
+            m_pUnit[i] = NULL;
+            rmpkts++;
+            rmbytes += tmp->m_Packet.getLength();
+            tmp->m_iFlag = CUnit::FREE;
+            --m_pUnitQueue->m_iCount;
+
+            if (++m_iStartPos == m_iSize)
+                m_iStartPos = 0;
+        }
+    }
+
+    LOGC(mglog.Debug) << "getRcvReadyMsg: nothing to deliver: " << reason;
+    /* removed skipped, dropped, undecryptable bytes from rcv buffer */
+    countBytes(-rmpkts, -rmbytes, true);
+    return false;
 }
 
 
@@ -1107,7 +1129,7 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
 */
 bool CRcvBuffer::isRcvDataReady(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpktseq)
 {
-   tsbpdtime = 0;
+   *tsbpdtime = 0;
 
    if (m_bTsbPdMode)
    {
@@ -1119,9 +1141,9 @@ bool CRcvBuffer::isRcvDataReady(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
             * Only say ready if time to deliver.
             * Report the timestamp, ready or not.
             */
-            curpktseq = pkt->getSeqNo();
-            tsbpdtime = getPktTsbPdTime(pkt->getMsgTimeStamp());
-            if (tsbpdtime <= CTimer::getTime())
+            *curpktseq = pkt->getSeqNo();
+            *tsbpdtime = getPktTsbPdTime(pkt->getMsgTimeStamp());
+            if (+tsbpdtime <= CTimer::getTime())
                return true;
        }
        return false;
@@ -1501,18 +1523,18 @@ int CRcvBuffer::readMsg(char* data, int len)
 
 int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 {
-    SRT_MSGCTRL& msgctl = r_msgctl;
+    SRT_MSGCTRL& msgctl = *r_msgctl;
     int p, q;
     bool passack;
     bool empty = true;
-    uint64_t& r_tsbpdtime = msgctl.srctime;
+    uint64_t& rplaytime = msgctl.srctime;
 
     if (m_bTsbPdMode)
     {
         passack = false;
-      int seq = 0;
+        int seq = 0;
 
-      if (getRcvReadyMsg(Ref(r_tsbpdtime), Ref(seq)))
+        if (getRcvReadyMsg(Ref(rplaytime), Ref(seq)))
         {
             empty = false;
 
@@ -1523,12 +1545,12 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 
 #ifdef SRT_DEBUG_TSBPD_OUTJITTER
             uint64_t now = CTimer::getTime();
-            if ((now - r_tsbpdtime)/10 < 10)
-                m_ulPdHisto[0][(now - r_tsbpdtime)/10]++;
-            else if ((now - r_tsbpdtime)/100 < 10)
-                m_ulPdHisto[1][(now - r_tsbpdtime)/100]++;
-            else if ((now - r_tsbpdtime)/1000 < 10)
-                m_ulPdHisto[2][(now - r_tsbpdtime)/1000]++;
+            if ((now - rplaytime)/10 < 10)
+                m_ulPdHisto[0][(now - rplaytime)/10]++;
+            else if ((now - rplaytime)/100 < 10)
+                m_ulPdHisto[1][(now - rplaytime)/100]++;
+            else if ((now - rplaytime)/1000 < 10)
+                m_ulPdHisto[2][(now - rplaytime)/1000]++;
             else
                 m_ulPdHisto[3][1]++;
 #endif   /* SRT_DEBUG_TSBPD_OUTJITTER */
@@ -1536,7 +1558,7 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
     }
     else
     {
-        r_tsbpdtime = 0;
+        rplaytime = 0;
         if (scanMsg(Ref(p), Ref(q), Ref(passack)))
             empty = false;
 
@@ -1615,11 +1637,17 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 }
 
 
-bool CRcvBuffer::scanMsg(ref_t<int> p, ref_t<int> q, ref_t<bool> passack)
+bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
 {
+    int& p = *r_p;
+    int& q = *r_q;
+
     // empty buffer
     if ((m_iStartPos == m_iLastAckPos) && (m_iMaxPos <= 0))
+    {
+        LOGC(mglog.Debug) << "scanMsg: empty buffer";
         return false;
+    }
 
     int rmpkts = 0;
     int rmbytes = 0;
@@ -1697,7 +1725,7 @@ bool CRcvBuffer::scanMsg(ref_t<int> p, ref_t<int> q, ref_t<bool> passack)
 
     p = -1;                  // message head
     q = m_iStartPos;         // message tail
-    passack = m_iStartPos == m_iLastAckPos;
+    *passack = m_iStartPos == m_iLastAckPos;
     bool found = false;
 
     // looking for the first message
@@ -1746,7 +1774,7 @@ bool CRcvBuffer::scanMsg(ref_t<int> p, ref_t<int> q, ref_t<bool> passack)
                 break;
 
             case PB_SUBSEQUENT:
-                ; // do nothing
+                ; // do nothing (caught first, rolling for last)
             }
         }
         else
@@ -1760,8 +1788,11 @@ bool CRcvBuffer::scanMsg(ref_t<int> p, ref_t<int> q, ref_t<bool> passack)
         if (found)
         {
             // the msg has to be ack'ed or it is allowed to read out of order, and was not read before
-            if (!passack || !m_pUnit[q]->m_Packet.getMsgOrderFlag())
+            if (!+passack || !m_pUnit[q]->m_Packet.getMsgOrderFlag())
+            {
+                LOGC(mglog.Debug) << "scanMsg: found next-to-broken message, delivering OUT OF ORDER.";
                 break;
+            }
 
             found = false;
         }
@@ -1770,15 +1801,32 @@ bool CRcvBuffer::scanMsg(ref_t<int> p, ref_t<int> q, ref_t<bool> passack)
             q = 0;
 
         if (q == m_iLastAckPos)
-            passack = true;
+            *passack = true;
     }
 
     // no msg found
     if (!found)
     {
+        // NOTE:
+        // This situation may only happen if:
+        // - Found a packet with PB_FIRST, so p = q at the moment when it was found
+        // - Possibly found following components of that message up to shifted q
+        // - Found no terminal packet (PB_LAST) for that message.
+
         // if the message is larger than the receiver buffer, return part of the message
         if ((p != -1) && ((q + 1) % m_iSize == p))
+        {
+            LOGC(mglog.Debug) << "scanMsg: BUFFER FULL and message is INCOMPLETE. Returning PARTIAL MESSAGE.";
             found = true;
+        }
+        else
+        {
+            LOGC(mglog.Debug) << "scanMsg: PARTIAL or NO MESSAGE found: p=" << p << " q=" << q;
+        }
+    }
+    else
+    {
+        LOGC(mglog.Debug) << "scanMsg: extracted message p=" << p << " q=" << q << " (" << ((q-p+m_iSize+1)%m_iSize) << " packets)";
     }
 
     return found;

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -103,7 +103,7 @@ void CCryptoControl::updateKmState(int cmd, size_t srtlen)
 
 int CCryptoControl::processSrtMsg_KMREQ(const uint32_t* srtdata, size_t bytelen, uint32_t* srtdata_out, ref_t<size_t> r_srtlen, int hsv)
 {
-    size_t& srtlen = r_srtlen;
+    size_t& srtlen = *r_srtlen;
     //Receiver
     /* All 32-bit msg fields swapped on reception
      * But HaiCrypt expect network order message
@@ -508,7 +508,7 @@ bool CCryptoControl::createCryptoCtx(ref_t<HaiCrypt_Handle> hCrypto, size_t keyl
 {
     //HaiCrypt_Handle& hCrypto (rh);
 
-    if (hCrypto)
+    if (+hCrypto)
     {
         // XXX You can check here if the existing handle represents
         // a correctly defined crypto. But this doesn't seem to be
@@ -585,7 +585,7 @@ EncryptionStatus CCryptoControl::encrypt(ref_t<CPacket> r_packet)
     if ( getSndCryptoFlags() == EK_NOENC )
         return ENCS_CLEAR;
 
-    CPacket& packet = r_packet;
+    CPacket& packet = *r_packet;
     int rc = HaiCrypt_Tx_Data(m_hSndCrypto, (uint8_t*)packet.getHeader(), (uint8_t*)packet.m_pcData, packet.getLength());
     if (rc < 0)
     {
@@ -603,7 +603,7 @@ EncryptionStatus CCryptoControl::encrypt(ref_t<CPacket> r_packet)
 
 EncryptionStatus CCryptoControl::decrypt(ref_t<CPacket> r_packet)
 {
-    CPacket& packet = r_packet;
+    CPacket& packet = *r_packet;
 
     if (packet.getMsgCryptoFlags() == EK_NOENC)
     {

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -64,7 +64,7 @@ m_extension(false)
 
 int CHandShake::store_to(char* buf, ref_t<size_t> r_size)
 {
-   size_t& size = r_size;
+   size_t& size = *r_size;
    if (size < m_iContentSize)
       return -1;
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -861,7 +861,7 @@ void CRendezvousQueue::remove(const SRTSOCKET& id, bool should_lock)
 CUDT* CRendezvousQueue::retrieve(const sockaddr* addr, ref_t<SRTSOCKET> r_id)
 {
    CGuard vg(m_RIDVectorLock);
-   SRTSOCKET& id = r_id;
+   SRTSOCKET& id = *r_id;
 
    // TODO: optimize search
    for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++ i)
@@ -1173,7 +1173,7 @@ static string PacketInfo(const CPacket& pkt)
     return os.str();
 }
 
-EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> id, ref_t<CUnit*> unit, sockaddr* addr)
+EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_unit, sockaddr* addr)
 {
 #ifdef NO_BUSY_WAITING
     m_pTimer->tick();
@@ -1190,8 +1190,8 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> id, ref_t<CUnit*> unit
         }
     }
     // find next available slot for incoming packet
-    unit = m_UnitQueue.getNextAvailUnit();
-    if (!unit)
+    *r_unit = m_UnitQueue.getNextAvailUnit();
+    if (!+r_unit)
     {
         // no space, skip this packet
         CPacket temp;
@@ -1210,17 +1210,17 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> id, ref_t<CUnit*> unit
         return rst == RST_ERROR ? RST_ERROR : RST_AGAIN;
     }
 
-    unit->m_Packet.setLength(m_iPayloadSize);
+    r_unit->m_Packet.setLength(m_iPayloadSize);
 
     // reading next incoming packet, recvfrom returns -1 is nothing has been received
     THREAD_PAUSED();
-    EReadStatus rst = m_pChannel->recvfrom(addr, unit->m_Packet);
+    EReadStatus rst = m_pChannel->recvfrom(addr, r_unit->m_Packet);
     THREAD_RESUMED();
 
     if (rst == RST_OK)
     {
-        id = unit->m_Packet.m_iID;
-        LOGC(mglog.Debug) << "INCOMING PACKET: BOUND=" << SockaddrToString(m_pChannel->bindAddress()) << " " << PacketInfo(unit->m_Packet);
+        *r_id = r_unit->m_Packet.m_iID;
+        LOGC(mglog.Debug) << "INCOMING PACKET: BOUND=" << SockaddrToString(m_pChannel->bindAddress()) << " " << PacketInfo(r_unit->m_Packet);
     }
     return rst;
 }
@@ -1375,7 +1375,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
 int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
 {
    CGuard bufferlock(m_PassLock);
-   CPacket& packet = r_packet;
+   CPacket& packet = *r_packet;
 
    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -184,7 +184,7 @@ public:
        CGuard cg(m_lockPktWindow);
 
        int pktReplica[ASIZE];          // packet information window (inter-packet time)
-       return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, bytesps);
+       return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, *bytesps);
    }
 
    int getPktRcvSpeed() const


### PR DESCRIPTION
There was quite a mistake in the design of `ref_t` solution.

It was initially designed to make the arguments for a function call, that had to be references, passed with an **explicit** marking that these are references, not values, and not just pointers. The solution initially was done with the use of a C++11 type, `std::reference_wrapper`, so that the standard `std::ref` function can be used as the aforementioned marker, however this has been later changed in the standard to be able to accept a reference in a non-explicit constructor, which completely broke the intention. Therefore a new type has been defined, `ref_t`, which in C++11 version only derives from `std::reference_wrapper`, but applies also appropriate fixes. Still, due to interoperability problems between C++03 compiled SRT and C++11 compiled applications, the halfway solution was still to create a custom `Ref` function as a helper, which in C++11 version resolves to `std::ref`, but in C++03 version it's a custom function, and so `ref_t` is a custom class, although based on the sources of `std::reference_wrapper`.

The problematic intention of the `std::reference_wrapper`, however, is that the assignment operator is intended to **rebind the reference**, rather than **assign a value**. It has been a design flaw then to add an assignment operator for a value for the `ref_t` type because in this case the form of assignment to a `ref_t` variable from a designated type value and from another `ref_t` variable were two completely different and unrelated operations, while the second one did not copy the value, but rebound the reference instead.

Because of that, the design of `ref_t` has been changed so that the **direct access** to the designated reference is **no longer implicitly available**. It was earlier designed to use the `get()` method to access the designated reference, and so it remains, but the `operator Type&()` function has been removed (in C++11 version the derived method has been deleted). For convenience, the `operator*` method has been added so that the reference can be still obtained easily, but still also explicitly. This makes the whole solution look more like a pointer, but still as it is made impossible to create a `ref_t` value with no argument, it is ensured enough that a null pointer can't be passed by `ref_t` (or, better said, to make a null pointer passed here one must do it very intentionally and explicitly). There was also left the overloaded the `operator->` function, which allows an easier access to the pointer value, in case when the `ref_t` type variable wraps a pointer variable - this has been stated as not dangerous, as it still doesn't give a direct access to modifying the `ref_t` variable itself. **Might be further discussed, whether the implicit returning a value copy of the designated reference has some reason**; currently it's not added because it slightly violates the ideology of `ref_t` as per current design, where it **wraps** rather than just **designates** the referred variable.

For problems that might arise during value-or-reference resolution dilemmas, there's also added `operator+`, which returns a copy of the value held by the designated reference. This follows the general understanding of `operator+` where it simply returns the value that follows this operator.