### PR TITLE
Add support nettle AES cryptographic.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
           osx_image: xcode7.3
           env: BUILD_TYPE=Debug
           before_install: brew update
-          install: brew install openssl
+          install: brew install openssl gnutls nettle
         - os: osx
           osx_image: xcode7.3
           before_install: brew update
-          install: brew install openssl
+          install: brew install openssl gnutls nettle
           env: BUILD_TYPE=Release
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,15 @@ set_if(LINUX ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # find OpenSSL
 if ( USE_GNUTLS )
-	message (FATAL_ERROR "Not yet implemented")
+	pkg_check_modules (SSL REQUIRED gnutls nettle)
+
+	add_definitions(
+		-DUSE_GNUTLS=1
+	)
+
+	link_directories(
+		${SSL_LIBRARY_DIRS}
+	)
 else()
 	find_package(OpenSSL REQUIRED)
 	set (SSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
@@ -234,7 +242,7 @@ endif()
 # Completing sources and installable headers. Flag settings will follow.
 # ---
 if ( USE_GNUTLS )
-	message (FATAL_ERROR "Not yet implemented")
+	set (HAICRYPT_FILELIST_MAF "haicrypt/filelist-gnutls.maf")
 else()
 	set (HAICRYPT_FILELIST_MAF "haicrypt/filelist.maf")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(ENABLE_LOGGING "Should logging be enabled" ${ENABLE_LOGGING_DEFAULT})
 option(ENABLE_SHARED "Should libsrt be built as a shared library" ON)
 option(ENABLE_SEPARATE_HAICRYPT "Should haicrypt be built as a separate library file" OFF)
 option(ENABLE_SUFLIP "Shuld suflip tool be built" OFF)
+option(USE_GNUTLS "Should use gnutls instead of openssl" OFF)
 
 # Always turn logging on if the build type is debug
 if (ENABLE_DEBUG)
@@ -87,8 +88,20 @@ set_if(DARWIN ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 set_if(LINUX ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # find OpenSSL
-find_package(OpenSSL REQUIRED)
-message (STATUS "OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+if ( USE_GNUTLS )
+	message (FATAL_ERROR "Not yet implemented")
+else()
+	find_package(OpenSSL REQUIRED)
+	set (SSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+	set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
+
+	add_definitions(
+		-DHAICRYPT_USE_OPENSSL_EVP=1
+		-DHAICRYPT_USE_OPENSSL_AES
+	)
+endif()
+
+message (STATUS "SSL libraries: ${SSL_LIBRARIES}")
 
 # Detect if the compiler is GNU compatable for flags
 set(HAVE_COMPILER_GNU_COMPAT 0)
@@ -172,8 +185,6 @@ add_definitions(
    -D_GNU_SOURCE
    -DHAI_PATCH=1
    -DHAI_ENABLE_SRT=1
-   -DHAICRYPT_USE_OPENSSL_EVP=1
-   -DHAICRYPT_USE_OPENSSL_AES
    -DSRT_VERSION="${SRT_VERSION}"
 )
 
@@ -222,7 +233,13 @@ endif()
 # Target: haicrypt.
 # Completing sources and installable headers. Flag settings will follow.
 # ---
-MafRead(haicrypt/filelist.maf
+if ( USE_GNUTLS )
+	message (FATAL_ERROR "Not yet implemented")
+else()
+	set (HAICRYPT_FILELIST_MAF "haicrypt/filelist.maf")
+endif()
+
+MafRead(${HAICRYPT_FILELIST_MAF}
 	SOURCES SOURCES_haicrypt_indir
 	PUBLIC_HEADERS HEADERS_haicrypt_indir
 	PROTECTED_HEADERS HEADERS_haicrypt_indir
@@ -327,13 +344,13 @@ add_library(${TARGET_srt} ${srt_libspec} ${SOURCES_srt} ${SOURCES_srt_extra})
 
 
 target_include_directories(${TARGET_haicrypt}
-	PRIVATE  ${OPENSSL_INCLUDE_DIR}
+	PRIVATE  ${SSL_INCLUDE_DIRS}
 	PUBLIC ${SRT_SRC_HAICRYPT_DIR}
 )
 
 set_target_properties (${TARGET_haicrypt} PROPERTIES VERSION ${SRT_VERSION} SOVERSION ${SRT_VERSION_MAJOR})
-target_link_libraries(${TARGET_haicrypt} PRIVATE ${OPENSSL_LIBRARIES})
-set (SRT_LIBS_PRIVATE ${OPENSSL_LIBRARIES})
+target_link_libraries(${TARGET_haicrypt} PRIVATE ${SSL_LIBRARIES})
+set (SRT_LIBS_PRIVATE ${SSL_LIBRARIES})
 if (WIN32)
 	target_link_libraries(${TARGET_haicrypt} PRIVATE ws2_32.lib)
 	set (SRT_LIBS_PRIVATE ${SRT_LIBS_PRIVATE} ws2_32.lib)

--- a/haicrypt/filelist-gnutls.maf
+++ b/haicrypt/filelist-gnutls.maf
@@ -1,0 +1,25 @@
+# This file is currently reserved for future refactoring, when all headers
+# are going to be moved here. This is the list of headers considered to be
+# attached to the installation package. Once possible, please move the below
+# header files from ../include back to this directory.
+PUBLIC HEADERS
+haicrypt.h
+hcrypt_ctx.h
+hcrypt_msg.h
+
+PRIVATE HEADERS
+hcrypt.h
+hcrypt-gnutls.h
+
+SOURCES
+hc_nettle_aes.c
+hcrypt.c
+hcrypt-gnutls.c
+hcrypt_ctx_rx.c
+hcrypt_ctx_tx.c
+hcrypt_rx.c
+hcrypt_sa.c
+hcrypt_tx.c
+hcrypt_ut.c
+hcrypt_xpt_srt.c
+hcrypt_xpt_sta.c

--- a/haicrypt/hc_nettle_aes.c
+++ b/haicrypt/hc_nettle_aes.c
@@ -125,7 +125,7 @@ hcNettle_AES_Open (size_t max_len)
   unsigned char *membuf;
   size_t memsiz, padded_len = hcryptMsg_PaddedLen (max_len, 128 / 8);
 
-  HCRYPT_LOG (LOG_DEBUG, "%s", "Using OpenSSL AES\n");
+  HCRYPT_LOG (LOG_DEBUG, "%s", "Using Nettle AES\n");
 
   memsiz = sizeof (*aes_data) + (HCRYPT_OPENSSL_OUTMSGMAX * padded_len);
   aes_data = malloc (memsiz);

--- a/haicrypt/hc_nettle_aes.c
+++ b/haicrypt/hc_nettle_aes.c
@@ -1,0 +1,448 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ *     Author: Justin Kim <justin.kim@collabora.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include "hcrypt.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct tag_hcNettle_AES_data
+{
+  AES_KEY aes_key[2];           /* even/odd SEK */
+
+#define	HCRYPT_OPENSSL_OUTMSGMAX		6
+  uint8_t *outbuf;              /* output circle buffer */
+  size_t outbuf_ofs;            /* write offset in circle buffer */
+  size_t outbuf_siz;            /* circle buffer size */
+} hcNettle_AES_data;
+
+static const unsigned char default_iv[] = {
+  0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
+};
+
+int
+hcrypt_WrapKey (AES_KEY * key, unsigned char *out,
+    const unsigned char *in, unsigned int inlen)
+{
+  unsigned char *A, B[16], *R;
+  unsigned int i, j, t;
+  if ((inlen & 0x7) || (inlen < 8))
+    return -1;
+  A = B;
+  t = 1;
+  memcpy (out + 8, in, inlen);
+  memcpy (A, default_iv, 8);
+
+  for (j = 0; j < 6; j++) {
+    R = out + 8;
+    for (i = 0; i < inlen; i += 8, t++, R += 8) {
+      memcpy (B + 8, R, 8);
+      aes_encrypt(key, sizeof(B), B, B);
+      A[7] ^= (unsigned char) (t & 0xff);
+      if (t > 0xff) {
+        A[6] ^= (unsigned char) ((t >> 8) & 0xff);
+        A[5] ^= (unsigned char) ((t >> 16) & 0xff);
+        A[4] ^= (unsigned char) ((t >> 24) & 0xff);
+      }
+      memcpy (R, B + 8, 8);
+    }
+  }
+  memcpy (out, A, 8);
+  return inlen + 8;
+}
+
+int
+hcrypt_UnwrapKey (AES_KEY * key, unsigned char *out,
+    const unsigned char *in, unsigned int inlen)
+{
+  unsigned char *A, B[16], *R;
+  unsigned int i, j, t;
+  inlen -= 8;
+  if (inlen & 0x7)
+    return -1;
+  if (inlen < 8)
+    return -1;
+  A = B;
+  t = 6 * (inlen >> 3);
+  memcpy (A, in, 8);
+  memcpy (out, in + 8, inlen);
+  for (j = 0; j < 6; j++) {
+    R = out + inlen - 8;
+    for (i = 0; i < inlen; i += 8, t--, R -= 8) {
+      A[7] ^= (unsigned char) (t & 0xff);
+      if (t > 0xff) {
+        A[6] ^= (unsigned char) ((t >> 8) & 0xff);
+        A[5] ^= (unsigned char) ((t >> 16) & 0xff);
+        A[4] ^= (unsigned char) ((t >> 24) & 0xff);
+      }
+      memcpy (B + 8, R, 8);
+      aes_decrypt(key, sizeof(B), B, B);
+      memcpy (R, B + 8, 8);
+    }
+  }
+  if (memcmp (A, default_iv, 8) != 0) {
+    memset (out, 0, inlen);
+    return 0;
+  }
+  return inlen;
+}
+
+static unsigned char *
+hcNettle_AES_GetOutbuf (hcNettle_AES_data * aes_data, size_t pfx_len,
+    size_t out_len)
+{
+  unsigned char *out_buf;
+
+  if ((pfx_len + out_len) > (aes_data->outbuf_siz - aes_data->outbuf_ofs)) {
+    /* Not enough room left, circle buffers */
+    aes_data->outbuf_ofs = 0;
+  }
+  out_buf = &aes_data->outbuf[aes_data->outbuf_ofs];
+  aes_data->outbuf_ofs += (pfx_len + out_len);
+  return (out_buf);
+}
+
+static hcrypt_CipherData *
+hcNettle_AES_Open (size_t max_len)
+{
+  hcNettle_AES_data *aes_data;
+  unsigned char *membuf;
+  size_t memsiz, padded_len = hcryptMsg_PaddedLen (max_len, 128 / 8);
+
+  HCRYPT_LOG (LOG_DEBUG, "%s", "Using OpenSSL AES\n");
+
+  memsiz = sizeof (*aes_data) + (HCRYPT_OPENSSL_OUTMSGMAX * padded_len);
+  aes_data = malloc (memsiz);
+  if (NULL == aes_data) {
+    HCRYPT_LOG (LOG_ERR, "malloc(%zd) failed\n", memsiz);
+    return (NULL);
+  }
+  membuf = (unsigned char *) aes_data;
+  membuf += sizeof (*aes_data);
+
+  aes_data->outbuf = membuf;
+  aes_data->outbuf_siz = HCRYPT_OPENSSL_OUTMSGMAX * padded_len;
+  aes_data->outbuf_ofs = 0;
+//      membuf += aes_data->outbuf_siz;
+
+  return ((hcrypt_CipherData *) aes_data);
+}
+
+static int
+hcNettle_AES_Close (hcrypt_CipherData * cipher_data)
+{
+  if (NULL != cipher_data) {
+    free (cipher_data);
+  }
+  return (0);
+}
+
+static int
+hcNettle_AES_SetKey (hcrypt_CipherData * cipher_data, hcrypt_Ctx * ctx,
+    unsigned char *key, size_t key_len)
+{
+  hcNettle_AES_data *aes_data = (hcNettle_AES_data *) cipher_data;
+  AES_KEY *aes_key = &aes_data->aes_key[hcryptCtx_GetKeyIndex (ctx)];   /* Ctx tells if it's for odd or even key */
+
+  if ((ctx->flags & HCRYPT_CTX_F_ENCRYPT)       /* Encrypt key */
+      ||(ctx->mode == HCRYPT_CTX_MODE_AESCTR)) {        /* CTR mode decrypts using encryption methods */
+    if (hcrypt_aes_set_encrypt_key (key, key_len * 8, aes_key)) {
+      HCRYPT_LOG (LOG_ERR, "%s", "AES_set_encrypt_key(sek) failed\n");
+      return (-1);
+    }
+  } else {                      /* Decrypt key */
+    if (hcrypt_aes_set_decrypt_key (key, key_len * 8, aes_key)) {
+      HCRYPT_LOG (LOG_ERR, "%s", "AES_set_decrypt_key(sek) failed\n");
+      return (-1);
+    }
+  }
+  return (0);
+}
+
+static int
+hcNettle_AES_Encrypt (hcrypt_CipherData * cipher_data,
+    hcrypt_Ctx * ctx,
+    hcrypt_DataDesc * in_data, int nbin,
+    void *out_p[], size_t out_len_p[], int *nbout_p)
+{
+  hcNettle_AES_data *aes_data = (hcNettle_AES_data *) cipher_data;
+  unsigned char *out_msg;
+  int out_len = 0;              //payload size
+  int pfx_len;
+
+  ASSERT (NULL != ctx);
+  ASSERT (NULL != aes_data);
+  ASSERT ((NULL != in_data) || (1 == nbin));    //Only one in_data[] supported
+
+  /* 
+   * Get message prefix length
+   * to reserve room for unencrypted message header in output buffer
+   */
+  pfx_len = ctx->msg_info->pfx_len;
+
+  /* Get buffer room from the internal circular output buffer */
+  out_msg = hcNettle_AES_GetOutbuf (aes_data, pfx_len, in_data[0].len);
+
+  if (NULL != out_msg) {
+    switch (ctx->mode) {
+      case HCRYPT_CTX_MODE_AESCTR:     /* Counter mode */
+      {
+        /* Get current key (odd|even) from context */
+        AES_KEY *aes_key = &aes_data->aes_key[hcryptCtx_GetKeyIndex (ctx)];
+        unsigned char ctr[AES_BLOCK_SIZE];
+        unsigned char iv[AES_BLOCK_SIZE];
+
+        /* Get input packet index (in network order) */
+        hcrypt_Pki pki = hcryptMsg_GetPki (ctx->msg_info, in_data[0].pfx, 1);
+
+        /*
+         * Compute the Initial Vector
+         * IV (128-bit):
+         *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         * |                   0s                  |      pki      |  ctr  |
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         *                            XOR                         
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         * |                         nonce                         +
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         *
+         * pki    (32-bit): packet index
+         * ctr    (16-bit): block counter
+         * nonce (112-bit): number used once (salt)
+         */
+        memset (&ctr[0], 0, sizeof (ctr));
+        hcrypt_SetCtrIV ((unsigned char *) &pki, ctx->salt, iv);
+
+        /* Encrypt packet payload in output message buffer */
+        ctr_crypt (aes_key,        /* ctx */
+                   aes_encrypt, /* nettle_cipher_func */
+                   AES_BLOCK_SIZE, /* cipher blocksize */
+                   iv,             /* iv */
+                   in_data[0].len, /* length */
+                   &out_msg[pfx_len],   /* dest */
+                   in_data[0].payload   /* src */);
+
+        /* Prepend packet prefix (clear text) in output buffer */
+        memcpy (out_msg, in_data[0].pfx, pfx_len);
+        /* CTR mode output length is same as input, no padding */
+        out_len = in_data[0].len;
+
+        break;
+      }
+      case HCRYPT_CTX_MODE_AESECB:     /* Electronic Codebook mode (VF-AES) */
+      {
+        int i;
+        int nb = in_data[0].len / AES_BLOCK_SIZE;
+        int nmore = in_data[0].len % AES_BLOCK_SIZE;
+        AES_KEY *aes_key = &aes_data->aes_key[hcryptCtx_GetKeyIndex (ctx)];
+
+        /* Encrypt packet payload, block by block, in output buffer */
+        for (i = 0; i < nb; i++) {
+          aes_encrypt (aes_key, AES_BLOCK_SIZE, 
+                          &out_msg[pfx_len + (i*AES_BLOCK_SIZE)],
+                          &in_data[0].payload[(i*AES_BLOCK_SIZE)]);
+        }
+        /* Encrypt last incomplete block */
+        if (0 < nmore) {
+          unsigned char intxt[AES_BLOCK_SIZE];
+          memcpy (intxt, &in_data[0].payload[(nb * AES_BLOCK_SIZE)], nmore);
+          memset (intxt + nmore, 0, AES_BLOCK_SIZE - nmore);
+          aes_encrypt (aes_key, AES_BLOCK_SIZE, 
+                          &out_msg[pfx_len + (nb*AES_BLOCK_SIZE)],
+                          intxt);
+          nb++;
+          //VF patch: pass padding size in pki
+          ctx->msg_info->setPki (out_msg, 16 - nmore);
+        }
+        /* Prepend packet prefix (clear text) in output message buffer */
+        memcpy (out_msg, in_data[0].pfx, pfx_len);
+        /* ECB mode output length is on AES block (128 bits) boundary */
+        out_len = nb * AES_BLOCK_SIZE;
+        break;
+      }
+      case HCRYPT_CTX_MODE_CLRTXT:     /* Clear text mode (transparent mode for tests) */
+        memcpy (&out_msg[pfx_len], in_data[0].payload, in_data[0].len);
+        memcpy (out_msg, in_data[0].pfx, pfx_len);
+        out_len = in_data[0].len;
+        break;
+      default:
+        /* Unsupported cipher mode */
+        return (-1);
+    }
+  } else {
+    /* input data too big */
+    return (-1);
+  }
+
+  if (out_len > 0) {
+    /* Encrypted messages have been produced */
+    if (NULL == out_p) {
+      /* 
+       * Application did not provided output buffer, 
+       * so copy encrypted message back in input buffer
+       */
+      memcpy (in_data[0].pfx, out_msg, pfx_len);
+      memcpy (in_data[0].payload, &out_msg[pfx_len], out_len);
+      in_data[0].len = out_len;
+    } else {
+      /*
+       * Set output buffer array to internal circular buffers
+       */
+      out_p[0] = out_msg;
+      out_len_p[0] = pfx_len + out_len;
+      *nbout_p = 1;
+    }
+  } else {
+    /*
+     * Nothing out
+     * This is not an error for implementations using deferred/async processing
+     * with co-processor, DSP, crypto hardware, etc.
+     * Submitted input data could be returned encrypted in a next call.
+     */
+    if (nbout_p != NULL)
+      *nbout_p = 0;
+    return (-1);
+  }
+  return (0);
+}
+
+
+
+static int
+hcNettle_AES_Decrypt (hcrypt_CipherData * cipher_data, hcrypt_Ctx * ctx,
+    hcrypt_DataDesc * in_data, int nbin, void *out_p[], size_t out_len_p[],
+    int *nbout_p)
+{
+  hcNettle_AES_data *aes_data = (hcNettle_AES_data *) cipher_data;
+  unsigned char *out_txt;
+  int out_len;
+  int iret = 0;
+
+  ASSERT (NULL != aes_data);
+  ASSERT (NULL != ctx);
+  ASSERT ((NULL != in_data) || (1 == nbin));    //Only one in_data[] supported
+
+  /* Reserve output buffer (w/no header) */
+  out_txt = hcNettle_AES_GetOutbuf (aes_data, 0, in_data[0].len);
+
+  if (NULL != out_txt) {
+    switch (ctx->mode) {
+      case HCRYPT_CTX_MODE_AESCTR:
+      {
+        /* Get current key (odd|even) from context */
+        AES_KEY *aes_key = &aes_data->aes_key[hcryptCtx_GetKeyIndex (ctx)];
+        unsigned char ctr[AES_BLOCK_SIZE];
+        unsigned char iv[AES_BLOCK_SIZE];
+
+        /* Get input message index (in network order) */
+        hcrypt_Pki pki = hcryptMsg_GetPki (ctx->msg_info, in_data[0].pfx, 1);
+
+        /*
+         * Compute the Initial Vector
+         * IV (128-bit):
+         *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         * |                   0s                  |      pki      |  ctr  |
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         *                            XOR                         
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         * |                         nonce                         +
+         * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+         *
+         * pki    (32-bit): packet index
+         * ctr    (16-bit): block counter
+         * nonce (112-bit): number used once (salt)
+         */
+        memset (&ctr[0], 0, sizeof (ctr));
+        hcrypt_SetCtrIV ((unsigned char *) &pki, ctx->salt, iv);
+
+        /* Decrypt message (same as encrypt for CTR mode) */
+        ctr_crypt (aes_key,        /* ctx */
+                   aes_encrypt, /* nettle_cipher_func */
+                   AES_BLOCK_SIZE, /* cipher blocksize */
+                   iv,             /* iv */
+                   in_data[0].len, /* length */
+                   out_txt,             /* dest */
+                   in_data[0].payload   /* src */);
+
+        out_len = in_data[0].len;
+        break;
+      }
+      case HCRYPT_CTX_MODE_AESECB:
+      {
+        int i;
+        int nb = in_data[0].len / AES_BLOCK_SIZE;
+        unsigned nbpad = ctx->msg_info->getPki (in_data[0].pfx, 0);     //Patch
+        AES_KEY *aes_key = &aes_data->aes_key[hcryptCtx_GetKeyIndex (ctx)];
+
+        /* Decrypt message (same as encrypt for CTR mode) */
+        for (i = 0; i < nb; i++) {
+          aes_encrypt (aes_key, AES_BLOCK_SIZE, 
+                          &out_txt[i*AES_BLOCK_SIZE],
+                          &in_data[0].payload[(i*AES_BLOCK_SIZE)]);
+        }
+        out_len = in_data[0].len - nbpad;
+        break;
+      }
+      case HCRYPT_CTX_MODE_CLRTXT:
+        memcpy (out_txt, in_data[0].payload, in_data[0].len);
+        out_len = in_data[0].len;
+        break;
+      default:
+        return (-1);
+    }
+  } else {
+    return (-1);
+  }
+
+  if (out_len > 0) {
+    if (NULL == out_p) {
+      /* Decrypt in-place (in input buffer) */
+      memcpy (in_data[0].payload, out_txt, out_len);
+      in_data[0].len = out_len;
+    } else {
+      out_p[0] = out_txt;
+      out_len_p[0] = out_len;
+      *nbout_p = 1;
+    }
+    iret = 0;
+  } else {
+    if (NULL != nbout_p)
+      *nbout_p = 0;
+    iret = -1;
+  }
+
+  return (iret);
+}
+
+
+static hcrypt_Cipher hcNettle_AES_cipher;
+
+HaiCrypt_Cipher
+HaiCryptCipher_Get_Instance (void)
+{
+  hcNettle_AES_cipher.open = hcNettle_AES_Open;
+  hcNettle_AES_cipher.close = hcNettle_AES_Close;
+  hcNettle_AES_cipher.setkey = hcNettle_AES_SetKey;
+  hcNettle_AES_cipher.encrypt = hcNettle_AES_Encrypt;
+  hcNettle_AES_cipher.decrypt = hcNettle_AES_Decrypt;
+
+  return ((HaiCrypt_Cipher) & hcNettle_AES_cipher);
+}

--- a/haicrypt/hcrypt-gnutls.c
+++ b/haicrypt/hcrypt-gnutls.c
@@ -1,0 +1,49 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ *     Author: Justin Kim <justin.kim@collabora.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ */
+#include "hcrypt-gnutls.h"
+
+int
+hcrypt_aes_set_encrypt_key (const uint8_t *key,
+                            unsigned bits,
+                            struct aes_ctx *ctx)
+{
+  size_t key_length = bits / 8;
+
+  if (!(key_length == 16 || key_length == 24 || key_length == 32)) {
+    return -1;
+  }
+
+  aes_set_encrypt_key (ctx, bits / 8, key);
+  return 0;
+}
+
+int
+hcrypt_aes_set_decrypt_key (const uint8_t *key,
+                            unsigned bits,
+                            struct aes_ctx *ctx)
+{
+  size_t key_length = bits / 8;
+
+  if (!(key_length == 16 || key_length == 24 || key_length == 32)) {
+    return -1;
+  }
+
+  aes_set_decrypt_key (ctx, bits / 8, key);
+  return 0;
+}

--- a/haicrypt/hcrypt-gnutls.h
+++ b/haicrypt/hcrypt-gnutls.h
@@ -1,0 +1,46 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2017 Haivision Systems Inc.
+ *     Author: Justin Kim <justin.kim@collabora.com>
+ * 
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; If not, see <http://www.gnu.org/licenses/>
+ */
+#ifndef __HCRYPT_GNUTLS_H__
+#define __HCRYPT_GNUTLS_H__
+
+#include <gnutls/gnutls.h>
+#include <gnutls/crypto.h>
+
+#include <nettle/aes.h>
+#include <nettle/ctr.h>
+#include <nettle/pbkdf2.h>
+
+typedef struct aes_ctx AES_KEY;
+
+#define hcrypt_Prng(rn,len) (gnutls_rnd(GNUTLS_RND_KEY,(rn),(len)) < 0 ? -1 : 0)
+
+#define hcrypt_pbkdf2_hmac_sha1(p,p_len,sa,sa_len,itr,out_len,out) \
+   pbkdf2_hmac_sha1(p_len,(const uint8_t *)p,itr,sa_len,sa,out_len,out)
+
+int hcrypt_aes_set_encrypt_key (const uint8_t *key, unsigned bits, struct aes_ctx *ctx);
+int hcrypt_aes_set_decrypt_key (const uint8_t *key, unsigned bits, struct aes_ctx *ctx);
+
+int hcrypt_WrapKey (AES_KEY *key, unsigned char *out,
+                    const unsigned char *in, unsigned int inlen);
+
+int hcrypt_UnwrapKey (AES_KEY *key, unsigned char *out,
+                      const unsigned char *in, unsigned int inlen);
+
+#endif /* __HCRYPT_GNUTLS_H__ */
+

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -50,9 +50,13 @@ written by
 
 #include "haicrypt.h"
 #include "hcrypt_msg.h"
-#if !defined(USE_GNUTLS)
+
+#if defined(USE_GNUTLS)
+#include "hcrypt-gnutls.h"
+#else
 #include "hcrypt-openssl.h"
 #endif
+
 #include "hcrypt_ctx.h"
 
 //#define HCRYPT_DEV 1  /* Development: should not be defined in committed code */

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2895,6 +2895,8 @@ int epoll_wait(
    }
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 // Trial version, not yet used :)
 static inline void set_result(
    set<UDTSOCKET>* val,
@@ -2915,6 +2917,7 @@ static inline void set_result(
         fds[count ++] = *it;
     }
 }
+#pragma GCC diagnostic pop
 
 int epoll_wait2(
    int eid, UDTSOCKET* readfds,


### PR DESCRIPTION
To replace OpenSSL, a `hc_nettle_aes` backend is added.
This backend can be selected by using `--with-gnutls` option of `configure`.

```
 $ ./configure --with-gnutls
```