### PR TITLE
ctx_{rx,tx}: Invalidate only if {un}wrap_key returns negative

### DIFF
--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -164,7 +164,7 @@ int hcryptCtx_Rx_ParseKM(hcrypt_Session *crypto, unsigned char *km_msg, size_t m
 	}
 
 	/* Unwrap SEK(s) and set in context */
-	if (0 > hcrypt_UnwrapKey(&ctx->aes_kek, seks,
+	if (0 < hcrypt_UnwrapKey(&ctx->aes_kek, seks,
 		&km_msg[HCRYPT_MSG_KM_OFS_SALT + salt_len], 
 		(sek_cnt * sek_len) + HAICRYPT_WRAPKEY_SIGN_SZ)) {
 		HCRYPT_LOG(LOG_WARNING, "%s", "unwrap key failed\n");

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -262,7 +262,7 @@ int hcryptCtx_Tx_AsmKM(hcrypt_Session *crypto, hcrypt_Ctx *ctx, unsigned char *a
 	} else {
 		seks = ctx->sek;
 	}
-	if (0 > hcrypt_WrapKey(&ctx->aes_kek,
+	if (0 < hcrypt_WrapKey(&ctx->aes_kek,
 		&km_msg[HCRYPT_MSG_KM_OFS_SALT + ctx->salt_len],
 		seks, sek_cnt * ctx->sek_len)) {
 


### PR DESCRIPTION
According to the defined macros, `hcrypt_UnwrapKey` and
`hcrypt_WrapKey` are able to return only zero or -1.
It's impossible to have the return value which is greater than 0.

Issue: #151

Signed-off-by: Justin Kim <justin.kim@collabora.com>