### PR TITLE
pkg-config: Change to libsrt-1.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,11 +409,13 @@ endif()
 
 join_arguments(SRT_LIBS_PRIVATE ${SRT_LIBS_PRIVATE})
 
+configure_file(scripts/libsrt-${SRT_VERSION_MAJOR}.pc.in libsrt-${SRT_VERSION_MAJOR}.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libsrt-${SRT_VERSION_MAJOR}.pc DESTINATION lib/pkgconfig)
 # haisrt.pc left temporarily for backward compatibility. To be removed in future!
+configure_file(scripts/srt.pc.in srt.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/srt.pc DESTINATION lib/pkgconfig)
 configure_file(scripts/haisrt.pc.in haisrt.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/haisrt.pc DESTINATION lib/pkgconfig)
-configure_file(scripts/haisrt.pc.in srt.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/srt.pc DESTINATION lib/pkgconfig)
 
 # Applications
 

--- a/scripts/libsrt-1.pc.in
+++ b/scripts/libsrt-1.pc.in
@@ -1,0 +1,11 @@
+prefix=@INSTALLDIR@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libsrt-@SRT_VERSION_MAJOR@
+Description: SRT library set
+Version: @SRT_VERSION@
+Libs: -L${libdir} -l@TARGET_srt@ @IFNEEDED_LINK_HAICRYPT@ @IFNEEDED_SRTBASE@ @IFNEEDED_SRT_LDFLAGS@
+Libs.private: @SRT_LIBS_PRIVATE@
+Cflags: -I${includedir}

--- a/scripts/srt.pc.in
+++ b/scripts/srt.pc.in
@@ -3,7 +3,7 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/lib
 includedir=${prefix}/include
 
-Name: haisrt
+Name: srt
 Description: SRT library set
 Version: @SRT_VERSION@
 Requires: libsrt-@SRT_VERSION_MAJOR@


### PR DESCRIPTION
According to Debian policy[0] and guide[1], they recommends using `lib`
prefixed package name for shared libraries. In addition, gnome also
recommend using ABI version to satisfy Parallel Installability[2]
This patch suggests a starting point to follow the standard by
chainging `.pc` file name.

[0] https://www.debian.org/doc/debian-policy/#document-ch-sharedlibs
[1] https://www.debian.org/doc/manuals/maint-guide/advanced.en.html#library
[2] https://developer.gnome.org/programming-guidelines/unstable/parallel-installability.html.en

Signed-off-by: Justin Kim <justin.kim@collabora.com>