### PR TITLE
Bump up SRT_VERSION to 1.2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil)
 include(FindPkgConfig)
 
-set (SRT_VERSION 1.2.0)
+set (SRT_VERSION 1.2.2)
 set_version_variables(SRT_VERSION ${SRT_VERSION})
 
 if (NOT DEFINED ENABLE_DEBUG)


### PR DESCRIPTION
The version 1.2.1 has been released, but `.pc` and soname still stay 1.2.0.
So I created one more bump-up version to fix the version string.