### PR TITLE
Add support cross compilation with mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,14 @@ set_if(LINUX ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # find OpenSSL
 if ( USE_GNUTLS )
-	pkg_check_modules (SSL REQUIRED gnutls nettle)
+	set (SSL_REQUIRED_MODULES "gnutls nettle")
+	if (WIN32)
+		if (MINGW)
+			set (SSL_REQUIRED_MODULES "${SSL_REQUIRED_MODULES} zlib")
+		endif()
+	endif()
+ 
+	pkg_check_modules (SSL REQUIRED ${SSL_REQUIRED_MODULES})
 
 	add_definitions(
 		-DUSE_GNUTLS=1
@@ -211,6 +218,7 @@ if (${ENABLE_PROFILE} AND HAVE_COMPILER_GNU_COMPAT)
 endif()
 
 
+if (NOT MINGW)
 # find pthread
 find_path(PTHREAD_INCLUDE_DIR pthread.h HINTS C:/pthread-win32/include)
 if (PTHREAD_INCLUDE_DIR)
@@ -225,6 +233,10 @@ if (PTHREAD_LIBRARY)
 else()
 	message(FATAL_ERROR "Failed to find pthread library. Specify PTHREAD_LIBRARY.")
 endif()
+
+else()
+set (PTHREAD_LIBRARY -lpthreadGC2)
+endif() # if (NOT MINGW)
 
 # This is required in some projects that add some other sources
 # to the SRT library to be compiled together (aka "virtual library").
@@ -359,7 +371,8 @@ target_include_directories(${TARGET_haicrypt}
 set_target_properties (${TARGET_haicrypt} PROPERTIES VERSION ${SRT_VERSION} SOVERSION ${SRT_VERSION_MAJOR})
 target_link_libraries(${TARGET_haicrypt} PRIVATE ${SSL_LIBRARIES})
 set (SRT_LIBS_PRIVATE ${SSL_LIBRARIES})
-if (WIN32)
+
+if ( WIN32 AND (NOT MINGW AND NOT CYGWIN) )
 	target_link_libraries(${TARGET_haicrypt} PRIVATE ws2_32.lib)
 	set (SRT_LIBS_PRIVATE ${SRT_LIBS_PRIVATE} ws2_32.lib)
 endif()
@@ -385,10 +398,8 @@ if (ENABLE_SHARED)
 	target_compile_definitions(${TARGET_srt} PUBLIC -DUDT_DYNAMIC) 
 endif()
 
-if ( WIN32 )
-	if (NOT CYGWIN)
+if ( WIN32 AND (NOT MINGW AND NOT CYGWIN) )
     	target_link_libraries(${TARGET_srt} PUBLIC Ws2_32.lib)
-	endif()
 endif()
 
 install(TARGETS ${TARGET_srt}
@@ -452,6 +463,9 @@ endif()
 
 if ( ENABLE_CXX11 )
 
+# FIXME: with MINGW, it fails to build stransmit
+# https://github.com/Haivision/srt/issues/177
+if ( NOT MINGW )
 	add_executable(stransmit
 		${CMAKE_SOURCE_DIR}/apps/stransmit.cpp
 		${CMAKE_SOURCE_DIR}/common/uriparser.cpp
@@ -467,6 +481,8 @@ if ( ENABLE_CXX11 )
 	target_link_libraries(utility-test ${TARGET_srt})
 	install(TARGETS stransmit RUNTIME DESTINATION bin)
 	install(PROGRAMS scripts/sfplay DESTINATION bin)
+
+endif() # if ( NOT MINGW )
 
 endif()
 

--- a/common/srt_compat.h
+++ b/common/srt_compat.h
@@ -26,6 +26,7 @@ written by
 #define HAISRT_COMPAT_H__
 
 #include <stddef.h>
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -282,7 +282,7 @@ inline std::string SockaddrToString(const sockaddr* sadr)
 
 	std::ostringstream output;
 	char hostbuf[1024];
-	if (inet_ntop(sadr->sa_family, addr, hostbuf, 1024))
+	if (!getnameinfo(sadr, sizeof(*sadr), hostbuf, 1024, NULL, 0, NI_NAMEREQD))
 	{
 		output << hostbuf;
 	}

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -75,6 +75,7 @@ modified by
 #else
    #include <winsock2.h>
    #include <ws2tcpip.h>
+   #include <mswsock.h>
 #endif
 
 #include <iostream>

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>


### PR DESCRIPTION
This patch is to support building with `mingw-w64` on linux.
Another side effect of this patch is that manual handling of `pthread-win32` is not required while building. If `mingw-w64` is installed on linux distribution, the building sequence is same as host build except for specifying toolchain.