### PR TITLE
Fix typo in srtcore/udt.h

### DIFF
--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -194,7 +194,7 @@ typedef std::set<SRTSOCKET> ud_set;
 #define BROKEN       SRTS_BROKEN
 #define CLOSING      SRTS_CLOSING
 #define CLOSED       SRTS_CLOSED
-#define NONEXIST     SRTS_NONEXIS
+#define NONEXIST     SRTS_NONEXIST
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
SRTS_NONEXIS define meant to be SRTS_NONEXIST
