### PR TITLE
Restored old behavior when parties declare encryption differently.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4651,12 +4651,6 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
         throw CUDTException(MJ_NOTSUP, MN_XSIZE, 0);
     }
 
-    if (!m_pCryptoControl->sendingAllowed())
-    {
-        LOGC(dlog.Error) << "Sending disabled due to security reasons";
-        throw CUDTException(MJ_SETUP, MN_SECURITY, 0);
-    }
-
     CGuard sendguard(m_SendLock);
 
     if (m_pSndBuffer->getCurrBufSize() == 0)

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -78,6 +78,23 @@ private:
 
 public:
 
+    bool sendingAllowed()
+    {
+        // This function is called to state as to whether the
+        // crypter allows the packet to be sent over the link.
+        // This is possible in two cases:
+        // - when Agent didn't set a password, no matter the crypto state
+        if (m_KmSecret.len == 0)
+            return true;
+        // - when Agent did set a password and the crypto state is SECURED.
+        if (m_KmSecret.len > 0 && m_iSndKmState == SRT_KM_S_SECURED
+                // && m_iRcvPeerKmState == SRT_KM_S_SECURED ?
+           )
+            return true;
+
+        return false;
+    }
+
 private:
 
     void regenCryptoKm(bool sendit, bool bidirectional);


### PR DESCRIPTION
The so far behavior with HSv5 was such that if parties declare encryption differently (which is the same with wrong password, as well as only one side declares encryption), the connection was rejected.

This fix makes the connection accepted also under this condition, and additionally the side that declares no encryption is still capable of sending the - unencrypted, obviously - data. Sending the data is also accepted, if a party declares encryption, and its peer does not or sets wrong password, just the receiver is unable to retrieve anything.