### PR TITLE
Added -stoptime option. Improved exit predictability.

### DIFF
--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -542,7 +542,7 @@ void SrtCommon::Error(UDT::ERRORINFO& udtError, string src)
         cerr << "\nERROR #" << udtResult << ": " << message << endl;
 
     udtError.clear();
-    throw std::runtime_error("error: " + src + ": " + message);
+    throw TransmissionError("error: " + src + ": " + message);
 }
 
 void SrtCommon::OpenRendezvous(string adapter, string host, int port)
@@ -1053,7 +1053,7 @@ protected:
         else
             cerr << "\nERROR #" << err << ": " << message << endl;
 
-        throw std::runtime_error("error: " + src + ": " + message);
+        throw TransmissionError("error: " + src + ": " + message);
     }
 
     ~UdpCommon()

--- a/common/transmitmedia.hpp
+++ b/common/transmitmedia.hpp
@@ -3,11 +3,23 @@
 
 #include <string>
 #include <map>
+#include <stdexcept>
 
 #include "transmitbase.hpp"
 #include <udt.h> // Needs access to CUDTException
 
 using namespace std;
+
+// Trial version of an exception. Try to implement later an official
+// interruption mechanism in SRT using this.
+
+struct TransmissionError: public std::runtime_error
+{
+    TransmissionError(const std::string& arg):
+        std::runtime_error(arg)
+    {
+    }
+};
 
 class SrtCommon
 {


### PR DESCRIPTION
The following changes are done:

1. REQUEST INTERRUPT is printed when stransmit received SIGTERM or SIGINT. In this case there's also no error message printed (except possible log message, if turned on).
2. INTERRUPT ON TIMEOUT is printed when stransmit was interrupted on timeout, which may happen due to:
* Transmission inactivity through the timeout specified in `-t` option (default 30s, -1 turns off)
* Time elapsed as specified in `-d` option (alias: `-stoptime`), in which case `-t` option is ignored.

The new option `-d` allows to exit after given time, including the final 5s clean timeout if a transmission was started. So, for example `-d:30` causes that the application exit after 30s, although if the media included SRT in listener mode:
* it's waiting for connection and if a connection is made within the last 5 seconds, the application terminates immediately.
* If a connection is made after 10s, there remains 20s for the application, so the timer is set to 15s, which is spent for transmission, then there's the transmission interrupted, and then the last 5 seconds is for the cleanup check

This should improve testing capabilities.