### PR TITLE
Changed FA selection imp to std::bitset. 

### DIFF
--- a/apps/srt-multiplex.cpp
+++ b/apps/srt-multiplex.cpp
@@ -37,7 +37,7 @@ using namespace std;
 const size_t DEFAULT_CHUNK = 1316;
 
 const logging::LogFA SRT_LOGFA_APP = 10;
-logging::Logger applog(SRT_LOGFA_APP, &srt_logger_config, "siplex");
+logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "siplex");
 
 volatile bool siplex_int_state = false;
 void OnINT_SetIntState(int)

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3063,21 +3063,28 @@ void setloglevel(logging::LogLevel::type ll)
 void addlogfa(logging::LogFA fa)
 {
     CGuard gg(srt_logger_config.mutex);
-    srt_logger_config.enabled_fa.insert(fa);
+    srt_logger_config.enabled_fa.set(fa, true);
 }
 
 void dellogfa(logging::LogFA fa)
 {
     CGuard gg(srt_logger_config.mutex);
-    srt_logger_config.enabled_fa.erase(fa);
+    srt_logger_config.enabled_fa.set(fa, false);
 }
 
 void resetlogfa(set<logging::LogFA> fas)
 {
     CGuard gg(srt_logger_config.mutex);
-    set<int> enfas;
-    copy(fas.begin(), fas.end(), std::inserter(enfas, enfas.begin()));
-    srt_logger_config.enabled_fa = enfas;
+    for (int i = 0; i <= SRT_LOGFA_LASTNONE; ++i)
+        srt_logger_config.enabled_fa.set(i, fas.count(i));
+}
+
+void resetlogfa(const int* fara, size_t fara_size)
+{
+    CGuard gg(srt_logger_config.mutex);
+    srt_logger_config.enabled_fa.reset();
+    for (const int* i = fara; i != fara + fara_size; ++i)
+        srt_logger_config.enabled_fa.set(*i, true);
 }
 
 void setlogstream(std::ostream& stream)

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -867,7 +867,7 @@ void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
     using namespace std;
 
     char tmp_buf[512];
-    if ( !flags(SRT_LOGF_DISABLE_TIME) )
+    if ( !isset(SRT_LOGF_DISABLE_TIME) )
     {
         // Not necessary if sending through the queue.
         timeval tv;
@@ -887,13 +887,13 @@ void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
     }
 
     string out_prefix;
-    if ( !flags(SRT_LOGF_DISABLE_SEVERITY) )
+    if ( !isset(SRT_LOGF_DISABLE_SEVERITY) )
     {
         out_prefix = prefix;
     }
 
     // Note: ThreadName::get needs a buffer of size min. ThreadName::BUFSIZE
-    if ( !flags(SRT_LOGF_DISABLE_THREADNAME) && ThreadName::get(tmp_buf) )
+    if ( !isset(SRT_LOGF_DISABLE_THREADNAME) && ThreadName::get(tmp_buf) )
     {
         serr << "/" << tmp_buf << out_prefix << ": ";
     }

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -851,7 +851,7 @@ logging::LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabl
 	{
         i_file = "";
         i_line = 0;
-        flags = that.flags;
+        flags = that.src_config->flags;
 		// Create logger prefix
 		that.CreateLogLinePrefix(os);
 	}
@@ -867,7 +867,7 @@ void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
     using namespace std;
 
     char tmp_buf[512];
-    if ( (flags & SRT_LOGF_DISABLE_TIME) == 0 )
+    if ( !flags(SRT_LOGF_DISABLE_TIME) )
     {
         // Not necessary if sending through the queue.
         timeval tv;
@@ -886,14 +886,14 @@ void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
         serr << tmp_buf << setw(6) << setfill('0') << tv.tv_usec;
     }
 
-    // Note: ThreadName::get needs a buffer of size min. ThreadName::BUFSIZE
     string out_prefix;
-    if ( (flags & SRT_LOGF_DISABLE_SEVERITY) == 0 )
+    if ( !flags(SRT_LOGF_DISABLE_SEVERITY) )
     {
         out_prefix = prefix;
     }
 
-    if ( (flags & SRT_LOGF_DISABLE_THREADNAME) == 0 && ThreadName::get(tmp_buf) )
+    // Note: ThreadName::get needs a buffer of size min. ThreadName::BUFSIZE
+    if ( !flags(SRT_LOGF_DISABLE_THREADNAME) && ThreadName::get(tmp_buf) )
     {
         serr << "/" << tmp_buf << out_prefix << ": ";
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -92,26 +92,26 @@ using namespace std;
 
 struct AllFaOn
 {
-    set<int> allfa;
+    logging::LogConfig::fa_bitset_t allfa;
 
     AllFaOn()
     {
-        allfa.insert(SRT_LOGFA_BSTATS);
-        allfa.insert(SRT_LOGFA_CONTROL);
-        allfa.insert(SRT_LOGFA_DATA);
-        allfa.insert(SRT_LOGFA_TSBPD);
-        allfa.insert(SRT_LOGFA_REXMIT);
+        allfa.set(SRT_LOGFA_BSTATS, true);
+        allfa.set(SRT_LOGFA_CONTROL, true);
+        allfa.set(SRT_LOGFA_DATA, true);
+        allfa.set(SRT_LOGFA_TSBPD, true);
+        allfa.set(SRT_LOGFA_REXMIT, true);
     }
 } logger_fa_all;
 
 logging::LogConfig srt_logger_config (logger_fa_all.allfa);
 
-logging::Logger glog(SRT_LOGFA_GENERAL, &srt_logger_config, "SRT.g");
-logging::Logger blog(SRT_LOGFA_BSTATS, &srt_logger_config, "SRT.b");
-logging::Logger mglog(SRT_LOGFA_CONTROL, &srt_logger_config, "SRT.c");
-logging::Logger dlog(SRT_LOGFA_DATA, &srt_logger_config, "SRT.d");
-logging::Logger tslog(SRT_LOGFA_TSBPD, &srt_logger_config, "SRT.t");
-logging::Logger rxlog(SRT_LOGFA_REXMIT, &srt_logger_config, "SRT.r");
+logging::Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
+logging::Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
+logging::Logger mglog(SRT_LOGFA_CONTROL, srt_logger_config, "SRT.c");
+logging::Logger dlog(SRT_LOGFA_DATA, srt_logger_config, "SRT.d");
+logging::Logger tslog(SRT_LOGFA_TSBPD, srt_logger_config, "SRT.t");
+logging::Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
 
 CUDTUnited CUDT::s_UDTUnited;
 

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -118,7 +118,7 @@ private:
     LogConfig* src_config;
     pthread_mutex_t mutex;
 
-    bool flags(int flg) { return (src_config->flags & flg) != 0; }
+    bool isset(int flg) { return (src_config->flags & flg) != 0; }
 
 public:
 
@@ -385,7 +385,7 @@ inline void LogDispatcher::PrintLogLine(const char* file ATR_UNUSED, int line AT
     CreateLogLinePrefix(serr);
     PrintArgs(serr, args...);
 
-    if ( !flags(SRT_LOGF_DISABLE_EOL) )
+    if ( !isset(SRT_LOGF_DISABLE_EOL) )
         serr << std::endl;
 
     // Not sure, but it wasn't ever used.
@@ -403,7 +403,7 @@ inline void LogDispatcher::PrintLogLine(const char* file ATR_UNUSED, int line AT
     CreateLogLinePrefix(serr);
     serr << arg;
 
-    if ( !flags( SRT_LOGF_DISABLE_EOL) )
+    if ( !isset(SRT_LOGF_DISABLE_EOL) )
         serr << std::endl;
 
     // Not sure, but it wasn't ever used.

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -458,7 +458,9 @@ static const SRT_ERRNO SRT_EISDGRAM  SRT_ATR_DEPRECATED = (SRT_ERRNO) MN(NOTSUP,
 #define SRT_LOGFA_TSBPD 4
 #define SRT_LOGFA_REXMIT 5
 
-#define SRT_LOGFA_LASTNONE 99
+// To make a typical int32_t size, although still use std::bitset.
+// C API will carry it over.
+#define SRT_LOGFA_LASTNONE 31
 
 enum SRT_KM_STATE
 {

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -307,9 +307,7 @@ void srt_dellogfa(int fa)
 
 void srt_resetlogfa(const int* fara, size_t fara_size)
 {
-    std::set<logging::LogFA> fas;
-    std::copy(fara, fara + fara_size, std::inserter(fas, fas.begin()));
-    UDT::resetlogfa(fas);
+    UDT::resetlogfa(fara, fara_size);
 }
 
 void srt_setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler)

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -400,6 +400,7 @@ UDT_API void setloglevel(logging::LogLevel::type ll);
 UDT_API void addlogfa(logging::LogFA fa);
 UDT_API void dellogfa(logging::LogFA fa);
 UDT_API void resetlogfa(std::set<logging::LogFA> fas);
+UDT_API void resetlogfa(const int* fara, size_t fara_size);
 UDT_API void setlogstream(std::ostream& stream);
 UDT_API void setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler);
 UDT_API void setlogflags(int flags);


### PR DESCRIPTION
This should speed up checking if log FA is enabled.

One of the improvements were also removed mutex-locking around checking the level and fa. The fields that are being read are considered read atomically (free of a risk of broken data consistency) because:
- level is implemented basing on 32-bit integer type internally
- FA bitset is set to be of explicit size = 32, which should make it a 32-bit integer

Note that writing to these variables is still protected by a mutex, so this solution is also free from the potential read-modify-write race conditions. The risk of reading a value that was simultaneously changed by the application thread is negligible - worst case scenario, it will apply the log filtering effectively a little bit later than the change has actually happen.

The FA symbols remain what they are, just the value of `SRT_LOGFA_LASTNONE` has been adjusted to 31 so that it makes the 32 size of the bitset.

Also there are some improvements internally in the logs. LogDispatcher now extracts the flags directly from the log config. Only the LogDispatcher::Proxy class caches this value, but this isn't dangerous, provided that this type is predicted to be used for temporary objects only. This removes the dependencies from the previous implementation, where the log enable flag was cached at the first use and the config pointer was "detached" (set to NULL) just after this check (which caused that logs could be configured only before the first log message was printed). Now that the logger config is permanent, the enabled state of particular LogDispatcher is checked every time a log is considered to be printed, and this improvement was to speed this up - here there's only one integer comparison and one bit mask check done.