### PR TITLE
Fix compile error seen with gcc version 4.4.1

### DIFF
--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -181,7 +181,7 @@ public:
 #if ENABLE_LOGGING
 
     struct Proxy;
-    friend Proxy;
+    friend struct Proxy;
 
     Proxy operator()();
 #else


### PR DESCRIPTION
Fix compile error seen with gcc version 4.4.1:
 
```
srtcore/logging.h:184: error: a class-key must be used when declaring a friend
srtcore/logging.h:184: error: friend declaration does not name a class or function
```