### PR TITLE
Support win32 by MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ else()
 endif()
 
 else()
-set (PTHREAD_LIBRARY -lpthreadGC2)
+find_library(PTHREAD_LIBRARY NAMES pthread pthreadGC2 pthreadGC)
 endif() # if (NOT MINGW)
 
 # This is required in some projects that add some other sources
@@ -371,7 +371,7 @@ target_include_directories(${TARGET_haicrypt}
 set_target_properties (${TARGET_haicrypt} PROPERTIES VERSION ${SRT_VERSION} SOVERSION ${SRT_VERSION_MAJOR})
 target_link_libraries(${TARGET_haicrypt} PRIVATE ${SRT_LIBS_PRIVATE} ${SSL_LIBRARIES})
 
-if ( WIN32 AND (NOT MINGW AND NOT CYGWIN) )
+if ( WIN32 AND NOT CYGWIN )
 	target_link_libraries(${TARGET_haicrypt} PRIVATE ws2_32.lib)
 	set (SRT_LIBS_PRIVATE ${SRT_LIBS_PRIVATE} ws2_32.lib)
 endif()

--- a/common/srt_compat.h
+++ b/common/srt_compat.h
@@ -177,10 +177,16 @@ inline struct tm LocalTime(time_t tt)
 {
 	struct tm tm;
 #ifdef WIN32
+#if defined(_MSC_VER) && (_MSC_VER>=1500)
 	errno_t rr = localtime_s(&tm, &tt);
 	if (rr)
 		return tm;
+
 #else
+	tm = *localtime(&tt);
+#endif // _MSC_VER
+
+#else // WIN32
 	tm = *localtime_r(&tt, &tm);
 #endif
 

--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -4,7 +4,6 @@
 #include <winsock2.h>
 #include <windows.h>
 #include <time.h>
-#include "haicrypt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,7 +33,7 @@ struct timezone
 
 void timeradd(struct timeval *a, struct timeval *b, struct timeval *result);
 
-HAICRYPT_API int gettimeofday(struct timeval* tp, struct timezone* tz);
+int gettimeofday(struct timeval* tp, struct timezone* tz);
 
 #ifdef __cplusplus
 }

--- a/scripts/haisrt.pc.in
+++ b/scripts/haisrt.pc.in
@@ -8,5 +8,5 @@ Description: SRT library set
 Version: @SRT_VERSION@
 Libs: -L${libdir} -l@TARGET_srt@ @IFNEEDED_LINK_HAICRYPT@ @IFNEEDED_SRTBASE@ @IFNEEDED_SRT_LDFLAGS@
 Libs.private: @SRT_LIBS_PRIVATE@
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/srt
 Requires.private: @SSL_REQUIRED_MODULES@

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -8,7 +8,7 @@
    #include <windows.h>
    #include <inttypes.h>
    #include <stdint.h>
-   #include <win/wintime.h>
+   #include "win/wintime.h"
    #if defined(_MSC_VER)
       #pragma warning(disable:4251)
    #endif


### PR DESCRIPTION
This PR is created to support MinGW version 4 and 5,  and VLC and GStreamer on Win32.
 - `localtime_s` function is missing in MinGW 4, but MinGW 5 has the function.
 - Using different implementations of pthread. 
 - Fixing windows-specific header location

  