### PR TITLE
[RFC] epoll: Add epoll-like support for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,9 @@ if (${ENABLE_PROFILE} AND HAVE_COMPILER_GNU_COMPAT)
 	link_libraries(-g -pg)
 endif()
 
+if (WIN32)
+list(APPEND SRT_EXTRA_CFLAGS "-fpermissive")
+endif()
 
 if (NOT MINGW)
 # find pthread

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -68,6 +68,13 @@ modified by
 #include <set>
 #include "udt.h"
 
+#if defined(WIN32)
+typedef struct _CEPollFD {
+  SYSSOCKET fd;
+  short events;
+  short revents;
+} CEPollFD;
+#endif
 
 struct CEPollDesc
 {
@@ -77,7 +84,11 @@ struct CEPollDesc
    std::set<UDTSOCKET> m_sUDTSocksEx;        // set of UDT sockets waiting for exceptions
 
    int m_iLocalID;                           // local system epoll ID
+#if defined(WIN32)
+   std::map<SYSSOCKET, CEPollFD> m_mLocals;   // map of local (non-UDT) descriptors
+#else
    std::set<SYSSOCKET> m_sLocals;            // set of local (non-UDT) descriptors
+#endif
 
    std::set<UDTSOCKET> m_sUDTWrites;         // UDT sockets ready for write
    std::set<UDTSOCKET> m_sUDTReads;          // UDT sockets ready for read


### PR DESCRIPTION
Please note that this is a request for comments.

Win32 API doesn't have `FD_SET` or `FD_ISSET` like function to know some information from a descriptor.
In this PR, I defined `sturct pollfd` like structure for internal use, and I'd like to know whether this approach 
fits for the roadmap of SRT for Windows support.

Please review this PR. Thanks.