### PR TITLE
Threadcheck and threadname fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,14 @@ if (ENABLE_LOGGING)
     list(APPEND SRT_EXTRA_CFLAGS "-DENABLE_LOGGING=1")
 endif()
 
+if (ENABLE_THREAD_CHECK)
+      add_definitions(
+               -DSRT_ENABLE_THREADCHECK=1
+               -DFUGU_PLATFORM=1
+               -I${WITH_THREAD_CHECK_INCLUDEDIR}
+        )
+endif()
+
 if (${ENABLE_PROFILE} AND HAVE_COMPILER_GNU_COMPAT)
     # They are actually cflags, not definitions, but CMake is stupid enough.
     add_definitions(-g -pg)

--- a/common/threadname.h
+++ b/common/threadname.h
@@ -51,7 +51,7 @@ public:
 
     ThreadName(const char* name)
     {
-        if ( get(old_name) )
+        if ( (good = get(old_name)) )
         {
             snprintf(new_name, 127, "%s", name);
             new_name[127] = 0;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1804,7 +1804,7 @@ void* CUDTUnited::garbageCollect(void* p)
 {
    CUDTUnited* self = (CUDTUnited*)p;
 
-   THREAD_STATE_INIT("SRT Collector");
+   THREAD_STATE_INIT("SRT:GC");
 
    CGuard gcguard(self->m_GCStopLock);
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3717,7 +3717,7 @@ void* CUDT::tsbpd(void* param)
 {
    CUDT* self = (CUDT*)param;
 
-   THREAD_STATE_INIT("SRT Packet Delivery");
+   THREAD_STATE_INIT("SRT:TsbPd");
 
    CGuard::enterCS(self->m_RecvLock);
    self->m_bTsbPdAckWakeup = true;

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -517,7 +517,7 @@ void* CSndQueue::worker(void* param)
 {
     CSndQueue* self = (CSndQueue*)param;
 
-    THREAD_STATE_INIT("SRT Tx Queue");
+    THREAD_STATE_INIT("SRT:SndQ:worker");
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
     CTimer::rdtsc(self->m_ullDbgTime);
@@ -1049,7 +1049,7 @@ void* CRcvQueue::worker(void* param)
    sockaddr_any sa ( self->m_UnitQueue.m_iIPversion );
    int32_t id;
 
-   THREAD_STATE_INIT("SRT Rx Queue");
+   THREAD_STATE_INIT("SRT:RcvQ:worker");
 
    CUnit* unit = 0;
    EConnectStatus cst = CONN_AGAIN;


### PR DESCRIPTION
Fixed ThreadName constructor to restore old thread name in destructor (issue #202).
Added CMake options to map THREADHCHECK macros to application's functions.
Synched THREADCHECK and prctl thread names.