### PR TITLE
Fixed broken crosscompiler support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if ( USE_GNUTLS )
 else()
 	set (SSL_REQUIRED_MODULES "openssl libcrypto zlib")
 
-	if (LINUX)
+	if (USE_OPENSSL_PC)
 
 		pkg_check_modules(SSL REQUIRED ${SSL_REQUIRED_MODULES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,10 +140,35 @@ if ( USE_GNUTLS )
 	message(STATUS "SSL Dependency: using GNUTLS with Nettle, as requested")
 else()
 	set (SSL_REQUIRED_MODULES "openssl libcrypto zlib")
-	find_package(OpenSSL REQUIRED)
-	set (SSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
-	set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
 
+	if (LINUX)
+
+		pkg_check_modules(SSL REQUIRED ${SSL_REQUIRED_MODULES})
+
+		# We have some cases when pkg-config is improperly configured
+		# When it doesn't ship the -L and -I options, and the CMAKE_PREFIX_PATH
+		# is set (also through `configure`), then we have this problem. If so,
+		# set forcefully the -I and -L contents to prefix/include and
+		# prefix/lib.
+
+		if ("${SSL_LIBRARY_DIRS}" STREQUAL "")
+		if (NOT "${CMAKE_PREFIX_PATH}" STREQUAL "")
+			message(STATUS "WARNING: pkg-config has incorrect prefix - enforcing target path prefix: ${CMAKE_PREFIX_PATH}")
+			set (SSL_LIBRARY_DIRS ${CMAKE_PREFIX_PATH}/lib)
+			set (SSL_INCLUDE_DIRS ${CMAKE_PREFIX_PATH}/include)
+		endif()
+		endif()
+
+		link_directories(
+			${SSL_LIBRARY_DIRS}
+		)
+		message(STATUS "SSL REPORT: -L ${SSL_LIBRARY_DIRS} -I ${SSL_INCLUDE_DIRS} -l;${SSL_LIBRARIES}")
+	else()
+
+		find_package(OpenSSL REQUIRED)
+		set (SSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
+		set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
+	endif()
 	add_definitions(
 		-DHAICRYPT_USE_OPENSSL_EVP=1
 		-DHAICRYPT_USE_OPENSSL_AES

--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -119,6 +119,7 @@ proc preprocess {} {
 	if { [info exists ::optval(--with-target-path)] } {
 		set ::target_path $::optval(--with-target-path)
 		unset ::optval(--with-target-path)
+		puts "NOTE: Explicit target path: $::target_path"
 	} 
 
 #	# Now finally turn --with-compiler-prefix into cmake-c-compiler etc.
@@ -302,10 +303,11 @@ proc postprocess {} {
 			return no
 		}
 
-		if { ![info exists ::target_path)] } {
+		if { ![info exists ::target_path] } {
 			# Try to autodetect the target path by having the basic 3 directories.
 			set target_path ""
 			set compiler_prefix [file dirname $compiler_path] ;# strip 'bin' directory
+			puts "NOTE: no --with-target-path found, will try to autodetect at $compiler_path"
 			foreach path [list $compiler_path $compiler_prefix/$target] {
 				if { [check-target-path $path] } {
 					set target_path $path
@@ -326,9 +328,6 @@ proc postprocess {} {
 				exit 1
 			}
 			puts "NOTE: Using explicit target path: $target_path"
-
-			# Prevent --with-target-path from being translated
-			unset ::optval(--with-target-path)
 		}
 
 		# Add this for cmake, should it need for something
@@ -337,9 +336,13 @@ proc postprocess {} {
 		# Add explicitly the path for pkg-config
 		# which lib
 		if { [file isdir $target_path/lib64/pkgconfig] } {
-			set env(PKG_CONFIG_PATH) $target_path/lib64/pkgconfig
+			set ::env(PKG_CONFIG_PATH) $target_path/lib64/pkgconfig
+			puts "PKG_CONFIG_PATH: Found pkgconfig in lib64 for '$target_path' - using it"
 		} elseif { [file isdir $target_path/lib/pkgconfig] } {
-			set env(PKG_CONFIG_PATH) $target_path/lib/pkgconfig
+			set ::env(PKG_CONFIG_PATH) $target_path/lib/pkgconfig
+			puts "PKG_CONFIG_PATH: Found pkgconfig in lib for '$target_path' - using it"
+		} else {
+			puts "PKG_CONFIG_PATH: NOT changed, no pkgconfig in '$target_path'"
 		}
 		# Otherwise don't set PKG_CONFIG_PATH and we'll see.
 	}


### PR DESCRIPTION
Fixed broken --with-target-path handling: the configure-data.tcl script did not handle it properly at all.

Changed OpenSSL detection on linux to handle broken cross-compiler pkg-config. This handles the found case of a crosscompiler, which uses /usr prefix for in openssl.pc, making this way the values for `-I` and `-L` options to be reported incorrectly.

Also, the autodetection of OpenSSL, although it works perfectly in most of the cases, doesn't behave as required when a crosscompiler-specific version should be found. Therefore, when `--use-openssl-pc` flag is set (turns into `-DUSE_OPENSSL_PC=1` for cmake), the autodetection is made always through pkg-config. And when so, additionally, if the `CMAKE_PREFIX_PATH` is set (which is done by configure-data.tcl), it is expected that the resulting `SSL_LIBRARY_DIRS` is also set - if it turns out to be empty, this is probably incorrect pkg-config configuration, so the paths to `-L` and `-I` are set forcefully as based on `CMAKE_PREFIX_PATH`.

(The description was changed to reflect the further changes here since the beginning)

This fixes #227