### PR TITLE
expose a real socket descriptor

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -184,6 +184,7 @@ public:
    UDTSOCKET accept(const UDTSOCKET listen, sockaddr* addr, int* addrlen);
    int connect(const UDTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
    int close(const UDTSOCKET u);
+   int getfd(const UDTSOCKET u, SRT_SOCKFDTYPE fdtype);
    int getpeername(const UDTSOCKET u, sockaddr* name, int* namelen);
    int getsockname(const UDTSOCKET u, sockaddr* name, int* namelen);
    int select(ud_set* readfds, ud_set* writefds, ud_set* exceptfds, const timeval* timeout);

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -478,3 +478,8 @@ Return_error:
     packet.setLength(-1);
     return -1;
 }
+
+UDPSOCKET CChannel::getFD() const
+{
+  return m_iSocket;
+}

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -164,6 +164,8 @@ public:
    int getIpToS() const;
 #endif
 
+   int getFD() const;
+
 private:
    void setUDPSockOpt();
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -177,6 +177,7 @@ public: //API
    static UDTSOCKET accept(UDTSOCKET u, sockaddr* addr, int* addrlen);
    static int connect(UDTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
    static int close(UDTSOCKET u);
+   static int getfd(UDTSOCKET u, SRT_SOCKFDTYPE fdtype);
    static int getpeername(UDTSOCKET u, sockaddr* name, int* namelen);
    static int getsockname(UDTSOCKET u, sockaddr* name, int* namelen);
    static int getsockopt(UDTSOCKET u, int level, UDT_SOCKOPT optname, void* optval, int* optlen);

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -167,6 +167,7 @@ SRT_API extern int srt_cleanup(void);
 
 // socket operations
 SRT_API extern SRTSOCKET srt_socket(int af, int type, int protocol);
+SRT_API extern int srt_socket_get_fd(SRTSOCKET u, SRT_SOCKFDTYPE fdtype);
 SRT_API extern int srt_bind(SRTSOCKET u, const struct sockaddr* name, int namelen);
 SRT_API extern int srt_bind_peerof(SRTSOCKET u, UDPSOCKET udpsock);
 SRT_API extern int srt_listen(SRTSOCKET u, int backlog);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -35,6 +35,7 @@ extern "C" {
 int srt_startup() { return UDT::startup(); }
 int srt_cleanup() { return UDT::cleanup(); }
 UDTSOCKET srt_socket(int af, int type, int protocol) { return UDT::socket(af, type, protocol); }
+int srt_socket_get_fd(UDTSOCKET u, SRT_SOCKFDTYPE fdtype) { return UDT::getfd(u, fdtype); }
 int srt_bind(UDTSOCKET u, const struct sockaddr * name, int namelen) { return UDT::bind(u, name, namelen); }
 int srt_bind_peerof(UDTSOCKET u, UDPSOCKET udpsock) { return UDT::bind2(u, udpsock); }
 int srt_listen(UDTSOCKET u, int backlog) { return UDT::listen(u, backlog); }

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -272,6 +272,12 @@ enum UDT_SOCKOPT
 /* Binary backward compatibility obsolete options */
 #define SRT_NAKREPORT   SRT_RCVNAKREPORT
 
+typedef enum SRT_SOCKFDTYPE {
+    SRTF_RECEIVER = 0, 
+    SRTF_SENDER,
+    SRTF_UNKNOWN = -1,
+} SRT_SOCKFDTYPE;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct CPerfMon
@@ -670,6 +676,7 @@ UDT_API int listen(UDTSOCKET u, int backlog);
 UDT_API UDTSOCKET accept(UDTSOCKET u, struct sockaddr* addr, int* addrlen);
 UDT_API int connect(UDTSOCKET u, const struct sockaddr* name, int namelen);
 UDT_API int close(UDTSOCKET u);
+UDT_API int getfd(UDTSOCKET u, SRT_SOCKFDTYPE fdtype);
 UDT_API int getpeername(UDTSOCKET u, struct sockaddr* name, int* namelen);
 UDT_API int getsockname(UDTSOCKET u, struct sockaddr* name, int* namelen);
 UDT_API int getsockopt(UDTSOCKET u, int level, SOCKOPT optname, void* optval, int* optlen);


### PR DESCRIPTION
In a certain condition, the application should be able to interrupt SRT's thread. On Linux and Mac OS, this could be possible somewhat by the combination of  `srt_epoll_wait` and `pipe`. However, on Windows, there's  no suitable APIs.

The basic idea of this patch is to expose a real socket descriptor, then monitoring by `poll` in an application because `poll` can be used platform-independently.
