### PR TITLE
Fix interop with SRT 1.1.x peer: …

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3361,10 +3361,6 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
             return CONN_REJECT;
     }
 
-    // XXX Probably redundant - processSrtMsg_HSRSP should do it in both
-    // HSv4 and HSv5 modes.
-    handshakeDone();
-
     CInfoBlock ib;
     ib.m_iIPversion = m_iIPversion;
     CInfoBlock::convert(m_pPeerAddr, m_iIPversion, ib.m_piIP);


### PR DESCRIPTION
removed call to handshakeDone in postConnect preventing HSv4 to proceed. Symptoms: Latency=0 and PeerSrtVersion=0 when connected. Lost packet recovery impossible.