### PR TITLE
stransmit cleanup stats and print sender

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -61,12 +61,14 @@ int main( int argc, char** argv )
         o_buffer = {"b", "buffer" },
         o_verbose = {"v", "verbose" },
         o_noflush = {"s", "skipflush" },
-        o_fullstats = {"f", "full-stats" };
+        o_fullstats = {"f", "fullstats" };
 
     // Options that expect no arguments (ARG_NONE) need not be mentioned.
     vector<OptionScheme> optargs = {
         { o_loglevel, OptionScheme::ARG_ONE },
-        { o_buffer, OptionScheme::ARG_ONE }
+        { o_buffer, OptionScheme::ARG_ONE },
+        { o_noflush, OptionScheme::ARG_NONE },
+        { o_fullstats, OptionScheme::ARG_NONE }
     };
     options_t params = ProcessOptions(argv, argc, optargs);
 

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -60,7 +60,8 @@ int main( int argc, char** argv )
         o_loglevel = { "ll", "loglevel" },
         o_buffer = {"b", "buffer" },
         o_verbose = {"v", "verbose" },
-        o_noflush = {"s", "skipflush" };
+        o_noflush = {"s", "skipflush" },
+        o_fullstats = {"f", "full-stats" };
 
     // Options that expect no arguments (ARG_NONE) need not be mentioned.
     vector<OptionScheme> optargs = {
@@ -104,6 +105,10 @@ int main( int argc, char** argv )
     string sf = Option<OutString>(params, "no", o_noflush);
     if (sf == "" || !false_names.count(sf))
         ::g_skip_flushing = true;
+
+    string sfull = Option<OutString>(params, "no", o_fullstats);
+    if (sfull == "" || !false_names.count(sfull))
+        ::total_stats = true;
 
     string source = args[0];
     string target = args[1];

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -108,7 +108,7 @@ int main( int argc, char** argv )
 
     string sfull = Option<OutString>(params, "no", o_fullstats);
     if (sfull == "" || !false_names.count(sfull))
-        ::total_stats = true;
+        ::transmit_total_stats = true;
 
     string source = args[0];
     string target = args[1];

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -253,6 +253,7 @@ int main( int argc, char** argv )
         cerr << "\t-s:<stats-report-freq=0> - frequency of status report\n";
         cerr << "\t-k - crash on error (aka developer mode)\n";
         cerr << "\t-v - verbose mode (prints also size of every data packet passed)\n";
+        cerr << "\t-f - full counters (prints total statistics without reset)\n";
         return 1;
     }
 
@@ -274,6 +275,7 @@ int main( int argc, char** argv )
     string logfile = Option("", "logfile");
     bool internal_log = Option("no", "loginternal") != "no";
     bool skip_flushing = Option("no", "S", "skipflush") != "no";
+    total_stats = Option("no", "f", "full-stats") != "no";
 
     // Options that require integer conversion
     unsigned long bandwidth;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -247,13 +247,15 @@ int main( int argc, char** argv )
     {
         cerr << "Usage: " << argv[0] << " [options] <input-uri> <output-uri>\n";
         cerr << "\t-t:<timeout=0> - connection timeout\n";
+        cerr << "\t-d:<stoptime=0> - connection stop time\n";
         cerr << "\t-c:<chunk=1316> - max size of data read in one step\n";
         cerr << "\t-b:<bandwidth> - set SRT bandwidth\n";
         cerr << "\t-r:<report-frequency=0> - bandwidth report frequency\n";
         cerr << "\t-s:<stats-report-freq=0> - frequency of status report\n";
+        cerr << "\t-f - full counters in stats-report (prints total statistics)\n";
+        cerr << "\t-S - skip flushing\n";
         cerr << "\t-k - crash on error (aka developer mode)\n";
         cerr << "\t-v - verbose mode (prints also size of every data packet passed)\n";
-        cerr << "\t-f - full counters (prints total statistics without reset)\n";
         return 1;
     }
 
@@ -275,7 +277,7 @@ int main( int argc, char** argv )
     string logfile = Option("", "logfile");
     bool internal_log = Option("no", "loginternal") != "no";
     bool skip_flushing = Option("no", "S", "skipflush") != "no";
-    transmit_total_stats = Option("no", "f", "full-stats") != "no";
+    transmit_total_stats = Option("no", "f", "fullstats") != "no";
 
     // Options that require integer conversion
     unsigned long bandwidth;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -257,7 +257,7 @@ int main( int argc, char** argv )
     }
 
     int timeout = stoi(Option("30", "t", "to", "timeout"), 0, 0);
-    size_t chunk = stoul(Option("0", "c", "chunk"), 0, 0);
+    unsigned long chunk = stoul(Option("0", "c", "chunk"), 0, 0);
     if ( chunk == 0 )
     {
         chunk = SRT_LIVE_DEF_PLSIZE;
@@ -276,14 +276,14 @@ int main( int argc, char** argv )
     bool skip_flushing = Option("no", "S", "skipflush") != "no";
 
     // Options that require integer conversion
-    size_t bandwidth;
-    size_t stoptime;
+    unsigned long bandwidth;
+    unsigned long stoptime;
 
     try
     {
         bandwidth = stoul(Option("0", "b", "bandwidth", "bitrate"));
         transmit_bw_report = stoul(Option("0", "r", "report", "bandwidth-report", "bitrate-report"));
-        transmit_stats_report = stoi(Option("0", "s", "stats", "stats-report-frequency"));
+        transmit_stats_report = stoul(Option("0", "s", "stats", "stats-report-frequency"));
         stoptime = stoul(Option("0", "d", "stoptime"));
     }
     catch (std::invalid_argument)

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -275,7 +275,7 @@ int main( int argc, char** argv )
     string logfile = Option("", "logfile");
     bool internal_log = Option("no", "loginternal") != "no";
     bool skip_flushing = Option("no", "S", "skipflush") != "no";
-    total_stats = Option("no", "f", "full-stats") != "no";
+    transmit_total_stats = Option("no", "f", "full-stats") != "no";
 
     // Options that require integer conversion
     unsigned long bandwidth;

--- a/common/transmitbase.hpp
+++ b/common/transmitbase.hpp
@@ -9,7 +9,7 @@
 
 typedef std::vector<char> bytevector;
 extern bool transmit_verbose;
-extern bool total_stats;
+extern bool transmit_total_stats;
 extern volatile bool transmit_throw_on_interrupt;
 extern unsigned long transmit_bw_report;
 extern unsigned long transmit_stats_report;

--- a/common/transmitbase.hpp
+++ b/common/transmitbase.hpp
@@ -10,10 +10,10 @@
 typedef std::vector<char> bytevector;
 extern bool transmit_verbose;
 extern volatile bool transmit_throw_on_interrupt;
-extern int transmit_bw_report;
-extern unsigned transmit_stats_report;
+extern unsigned long transmit_bw_report;
+extern unsigned long transmit_stats_report;
 extern std::ostream* transmit_cverb;
-extern size_t transmit_chunk_size;
+extern unsigned long transmit_chunk_size;
 
 static const struct VerboseLogNoEol { VerboseLogNoEol() {} } VerbNoEOL;
 

--- a/common/transmitbase.hpp
+++ b/common/transmitbase.hpp
@@ -9,6 +9,7 @@
 
 typedef std::vector<char> bytevector;
 extern bool transmit_verbose;
+extern bool total_stats;
 extern volatile bool transmit_throw_on_interrupt;
 extern unsigned long transmit_bw_report;
 extern unsigned long transmit_stats_report;

--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -21,6 +21,8 @@
 using namespace std;
 
 bool transmit_verbose = false;
+bool total_stats = false;
+bool clear_stats = false;
 std::ostream* transmit_cverb = nullptr;
 volatile bool transmit_throw_on_interrupt = false;
 unsigned long transmit_bw_report = 0;
@@ -715,15 +717,16 @@ bytevector SrtSource::Read(size_t chunk)
         data.resize(chunk);
 
     CBytePerfMon perf;
-    srt_bstats(m_sock, &perf, true);
+    srt_bstats(m_sock, &perf, clear_stats);
+    clear_stats = false;
     if ( transmit_bw_report && (counter % transmit_bw_report) == transmit_bw_report - 1 )
     {
         cout << "+++/+++SRT BANDWIDTH: " << perf.mbpsBandwidth << endl;
     }
-
     if ( transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1)
     {
         PrintSrtStats(m_sock, perf);
+        clear_stats = !total_stats;
     }
 
     ++counter;
@@ -770,15 +773,16 @@ void SrtTarget::Write(const bytevector& data)
         Error(UDT::getlasterror(), "srt_sendmsg");
 
     CBytePerfMon perf;
-    srt_bstats(m_sock, &perf, true);
+    srt_bstats(m_sock, &perf, clear_stats);
+    clear_stats = false;
     if ( transmit_bw_report && (counter % transmit_bw_report) == transmit_bw_report - 1 )
     {
         cout << "+++/+++SRT BANDWIDTH: " << perf.mbpsBandwidth << endl;
     }
-
     if ( transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1)
     {
         PrintSrtStats(m_sock, perf);
+        clear_stats = !total_stats;
     }
 
     ++counter;

--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -21,7 +21,7 @@
 using namespace std;
 
 bool transmit_verbose = false;
-bool total_stats = false;
+bool transmit_total_stats = false;
 bool clear_stats = false;
 std::ostream* transmit_cverb = nullptr;
 volatile bool transmit_throw_on_interrupt = false;
@@ -726,7 +726,7 @@ bytevector SrtSource::Read(size_t chunk)
     if ( transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1)
     {
         PrintSrtStats(m_sock, perf);
-        clear_stats = !total_stats;
+        clear_stats = !transmit_total_stats;
     }
 
     ++counter;
@@ -754,7 +754,7 @@ int SrtTarget::ConfigurePre(SRTSOCKET sock)
 
 void SrtTarget::Write(const bytevector& data) 
 {
-	static unsigned long counter = 1;
+    static unsigned long counter = 1;
 
     ::transmit_throw_on_interrupt = true;
 
@@ -782,7 +782,7 @@ void SrtTarget::Write(const bytevector& data)
     if ( transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1)
     {
         PrintSrtStats(m_sock, perf);
-        clear_stats = !total_stats;
+        clear_stats = !transmit_total_stats;
     }
 
     ++counter;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5332,9 +5332,19 @@ void CUDT::sample(CPerfMon* perf, bool clear)
 
    if (clear)
    {
+      m_iTraceSndDrop        = 0;
+      m_iTraceRcvDrop        = 0;
+      m_ullTraceSndBytesDrop = 0;
+      m_ullTraceRcvBytesDrop = 0;
+      m_iTraceRcvUndecrypt        = 0;
+      m_ullTraceRcvBytesUndecrypt = 0;
+      //new>
+      m_ullTraceBytesSent = m_ullTraceBytesRecv = m_ullTraceBytesRetrans = 0;
+      //<
       m_llTraceSent = m_llTraceRecv = m_iTraceSndLoss = m_iTraceRcvLoss = m_iTraceRetrans = m_iSentACK = m_iRecvACK = m_iSentNAK = m_iRecvNAK = 0;
       m_llSndDuration = 0;
       m_iTraceRcvRetrans = 0;
+      m_iTraceRcvBelated = 0;
       m_LastSampleTime = currtime;
    }
 }
@@ -5510,6 +5520,7 @@ void CUDT::bstats(CBytePerfMon* perf, bool clear)
       m_llTraceSent = m_llTraceRecv = m_iTraceSndLoss = m_iTraceRcvLoss = m_iTraceRetrans = m_iSentACK = m_iRecvACK = m_iSentNAK = m_iRecvNAK = 0;
       m_llSndDuration = 0;
       m_iTraceRcvRetrans = 0;
+	  m_iTraceRcvBelated = 0;
       m_LastSampleTime = currtime;
    }
 }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5360,6 +5360,7 @@ void CUDT::bstats(CBytePerfMon* perf, bool clear)
    perf->pktSndLoss = m_iTraceSndLoss;
    perf->pktRcvLoss = m_iTraceRcvLoss;
    perf->pktRetrans = m_iTraceRetrans;
+   perf->pktRcvRetrans = m_iTraceRcvRetrans;
    perf->pktSentACK = m_iSentACK;
    perf->pktRecvACK = m_iRecvACK;
    perf->pktSentNAK = m_iSentNAK;
@@ -5508,6 +5509,7 @@ void CUDT::bstats(CBytePerfMon* perf, bool clear)
       //<
       m_llTraceSent = m_llTraceRecv = m_iTraceSndLoss = m_iTraceRcvLoss = m_iTraceRetrans = m_iSentACK = m_iRecvACK = m_iSentNAK = m_iRecvNAK = 0;
       m_llSndDuration = 0;
+      m_iTraceRcvRetrans = 0;
       m_LastSampleTime = currtime;
    }
 }


### PR DESCRIPTION
Hi,

This patch has some cleanups of the stats prints in the "stransmit" tool. Futhermore, it adds the functionality for printing the STATS in the SENDER (and not only in the RECEIVER). Now, the STATS are more Human Readable.

The problem of incorrect/fake STAT values will be corrected in the future.
