### PR TITLE
srt-live-transmit stability fixes and improvements

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -71,6 +71,7 @@
 #include <csignal>
 #include <chrono>
 #include <thread>
+#include <list>
 
 #include "appcommon.hpp"  // CreateAddrInet
 #include "uriparser.hpp"  // UriParser
@@ -86,7 +87,6 @@
 #include <logging.h>
 
 using namespace std;
-
 
 map<string,string> g_options;
 
@@ -123,18 +123,28 @@ volatile bool int_state = false;
 volatile bool timer_state = false;
 void OnINT_ForceExit(int)
 {
-    cerr << "\n-------- REQUESTED INTERRUPT!\n";
+    if (transmit_verbose)
+    {
+        cerr << "\n-------- REQUESTED INTERRUPT!\n";
+    }
+
     int_state = true;
-    if ( transmit_throw_on_interrupt )
-        throw ForcedExit("Requested exception interrupt");
 }
 
 void OnAlarm_Interrupt(int)
 {
-    cerr << "\n---------- INTERRUPT ON TIMEOUT!\n";
+    if (transmit_verbose)
+    {
+        cerr << "\n---------- INTERRUPT ON TIMEOUT!\n";
+    }
+
     int_state = false; // JIC
     timer_state = true;
-    throw AlarmExit("Watchdog bites hangup");
+
+    if ((false))
+    {
+        throw AlarmExit("Watchdog bites hangup");
+    }
 }
 
 struct BandwidthGuard
@@ -246,20 +256,19 @@ int main( int argc, char** argv )
     if ( params.size() != 2 )
     {
         cerr << "Usage: " << argv[0] << " [options] <input-uri> <output-uri>\n";
-        cerr << "\t-t:<timeout=0> - connection timeout\n";
-        cerr << "\t-d:<stoptime=0> - connection stop time\n";
+        cerr << "\t-t:<timeout=0> - exit timer in seconds\n";
         cerr << "\t-c:<chunk=1316> - max size of data read in one step\n";
         cerr << "\t-b:<bandwidth> - set SRT bandwidth\n";
         cerr << "\t-r:<report-frequency=0> - bandwidth report frequency\n";
         cerr << "\t-s:<stats-report-freq=0> - frequency of status report\n";
         cerr << "\t-f - full counters in stats-report (prints total statistics)\n";
-        cerr << "\t-S - skip flushing\n";
-        cerr << "\t-k - crash on error (aka developer mode)\n";
-        cerr << "\t-v - verbose mode (prints also size of every data packet passed)\n";
+        cerr << "\t-q - quiet mode, default no\n";
+        cerr << "\t-v - verbose mode, default no\n";
+        cerr << "\t-a - auto-reconnect mode, default yes, -a:no to disable\n";
         return 1;
     }
 
-    int timeout = stoi(Option("30", "t", "to", "timeout"), 0, 0);
+    int timeout = stoi(Option("0", "t", "to", "timeout"), 0, 0);
     unsigned long chunk = stoul(Option("0", "c", "chunk"), 0, 0);
     if ( chunk == 0 )
     {
@@ -271,24 +280,18 @@ int main( int argc, char** argv )
     }
 
     transmit_verbose = Option("no", "v", "verbose") != "no";
-    bool crashonx = Option("no", "k", "crash") != "no";
     string loglevel = Option("error", "loglevel");
     string logfa = Option("general", "logfa");
     string logfile = Option("", "logfile");
     bool internal_log = Option("no", "loginternal") != "no";
-    bool skip_flushing = Option("no", "S", "skipflush") != "no";
+    bool autoreconnect = Option("yes", "a", "auto") != "no";
+    bool quiet = Option("no", "q", "quiet") != "no";
     transmit_total_stats = Option("no", "f", "fullstats") != "no";
-
-    // Options that require integer conversion
-    unsigned long bandwidth;
-    unsigned long stoptime;
 
     try
     {
-        bandwidth = stoul(Option("0", "b", "bandwidth", "bitrate"));
         transmit_bw_report = stoul(Option("0", "r", "report", "bandwidth-report", "bitrate-report"));
         transmit_stats_report = stoul(Option("0", "s", "stats", "stats-report-frequency"));
-        stoptime = stoul(Option("0", "d", "stoptime"));
     }
     catch (std::invalid_argument)
     {
@@ -329,214 +332,340 @@ int main( int argc, char** argv )
 
 
 #ifdef WIN32
-#define alarm(argument) (void)0
 
-    if (stoptime != 0)
+    if (timeout != 0)
     {
-        cerr << "ERROR: The -stoptime option (-d) is not implemented on Windows\n";
+        cerr << "ERROR: The -timeout option (-t) is not implemented on Windows\n";
         return 1;
     }
 
 #else
-    signal(SIGALRM, OnAlarm_Interrupt);
+    if (timeout != 0)
+    {
+        signal(SIGALRM, OnAlarm_Interrupt);
+        if (!quiet)
+            cerr << "TIMEOUT: will interrupt after " << timeout << "s\n";
+        alarm(timeout);
+    }
 #endif
     signal(SIGINT, OnINT_ForceExit);
     signal(SIGTERM, OnINT_ForceExit);
 
-    time_t start_time { time(0) };
-    time_t end_time { -1 };
 
-    if (stoptime != 0)
+    if (!quiet)
     {
-        if (stoptime < 10)
-        {
-            cerr << "ERROR: -stoptime (-d) must be at least 10 seconds\n";
-            return 1;
-        }
-        alarm(stoptime);
-        cerr << "STOPTIME: will interrupt after " << stoptime << "s\n";
-        if (timeout != 30)
-        {
-            cerr << "WARNING: -timeout (-t) option ignored due to specified -stoptime (-d)\n";
-        }
+        cout << "Media path: '"
+            << params[0]
+            << "' --> '"
+            << params[1]
+            << "'\n";
     }
-
-    // XXX This could be also controlled by an option.
-    int final_delay = 5;
-
-    // In the beginning, set Alarm 
 
     unique_ptr<Source> src;
+    bool srcConnected = false;
     unique_ptr<Target> tar;
+    bool tarConnected = false;
 
-    try
+    int pollid = srt_epoll_create();
+    if ( pollid < 0 )
     {
-        src = Source::Create(params[0]);
-        tar = Target::Create(params[1]);
-    }
-    catch(std::exception& x)
-    {
-        if (::int_state)
-        {
-            // The application was terminated by SIGINT or SIGTERM.
-            // Don't print anything, just exit gently like ffmpeg.
-            cerr << "Exit on request.\n";
-            return 255;
-        }
-
-        if (stoptime != 0 && ::timer_state)
-        {
-            cerr << "Exit on timeout.\n";
-            return 0;
-        }
-
-        if ( transmit_verbose )
-        {
-            cout << "MEDIA CREATION FAILED: " << x.what() << " - exitting.\n";
-        }
-
-        // Don't speak anything when no -v option.
-        // (the "requested interrupt" will be printed anyway)
-        return 2;
-    }
-    catch (...)
-    {
-        cerr << "ERROR: UNKNOWN EXCEPTION\n";
-        return 2;
-    }
-
-    alarm(0);
-    end_time = time(0);
-
-    // Now loop until broken
-    BandwidthGuard bw(bandwidth);
-
-    if ( transmit_verbose )
-    {
-        cout << "STARTING TRANSMISSION: '" << params[0] << "' --> '" << params[1] << "'\n";
-    }
-
-    // After the time has been spent in the creation
-    // (including waiting for connection)
-    // rest of the time should be spent for transmission.
-    if (stoptime != 0)
-    {
-        int elapsed = end_time - start_time;
-        int remain = stoptime - elapsed;
-
-        if (remain <= final_delay)
-        {
-            cerr << "NOTE: remained too little time for cleanup: " << remain << "s - exitting\n";
-            return 0;
-        }
-
-        cerr << "NOTE: stoptime: remaining " << remain << " seconds (setting alarm to " << (remain - final_delay) << "s)\n";
-        alarm(remain - final_delay);
-    }
-
-    extern logging::Logger glog;
-    try
-    {
-        for (;;)
-        {
-            if (stoptime == 0 && timeout != -1 )
-            {
-                alarm(timeout);
-            }
-            const bytevector& data = src->Read(chunk);
-            if ( transmit_verbose )
-                cout << " << " << data.size() << "  ->  ";
-            if ( data.empty() && src->End() )
-            {
-                if ( transmit_verbose )
-                    cout << "EOS\n";
-                break;
-            }
-            tar->Write(data);
-            if (stoptime == 0 && timeout != -1 )
-            {
-                alarm(0);
-            }
-            if ( tar->Broken() )
-            {
-                if ( transmit_verbose )
-                    cout << " OUTPUT broken\n";
-                break;
-            }
-            if ( transmit_verbose )
-                cout << " sent\n";
-            if ( int_state )
-            {
-                cerr << "\n (interrupted on request)\n";
-                break;
-            }
-
-            bw.Checkpoint(chunk, transmit_bw_report);
-
-            if (stoptime != 0)
-            {
-                int elapsed = time(0) - end_time;
-                int remain = stoptime - final_delay - elapsed;
-                if (remain < 0)
-                {
-                    cerr << "\n (interrupted on timeout: elapsed " << elapsed << "s) - waiting " << final_delay << "s for cleanup\n";
-                    this_thread::sleep_for(chrono::seconds(final_delay));
-                    break;
-                }
-            }
-        }
-
-    } catch (Source::ReadEOF&) {
-        alarm(0);
-
-        if (!skip_flushing)
-        {
-            cerr << "(DEBUG) EOF when reading file. Looping until the sending bufer depletes.\n";
-            for (;;)
-            {
-                size_t still = tar->Still();
-                if (still == 0)
-                {
-                    cerr << "(DEBUG) DEPLETED. Done.\n";
-                    break;
-                }
-
-                cerr << "(DEBUG)... still " << still << " bytes (sleep 1s)\n";
-                this_thread::sleep_for(chrono::seconds(1));
-            }
-        }
-    } catch (std::exception& x) { // Catches TransmissionError and AlarmExit
-
-        if (stoptime != 0 && ::timer_state)
-        {
-            cerr << "Exit on timeout.\n";
-        }
-        else if (::int_state)
-        {
-            // Do nothing.
-        }
-        else
-        {
-            cerr << "STD EXCEPTION: " << x.what() << endl;
-        }
-
-        if (final_delay > 0)
-        {
-            cerr << "Waiting " << final_delay << "s for possible cleanup...\n";
-            this_thread::sleep_for(chrono::seconds(final_delay));
-        }
-        if (stoptime != 0 && ::timer_state)
-            return 0;
-
-        return 255;
-
-    } catch (...) {
-
-        cerr << "UNKNOWN type of EXCEPTION\n";
-        if ( crashonx )
-            throw;
-
+        cerr << "Can't initialize epoll";
         return 1;
+    }
+
+    size_t receivedBytes = 0;
+    size_t wroteBytes = 0;
+    size_t lostBytes = 0;
+    size_t lastReportedtLostBytes = 0;
+    std::time_t writeErrorLogTimer(std::time(nullptr));
+
+    try {
+        // Now loop until broken
+        while (!int_state && !timer_state)
+        {
+            if (!src.get())
+            {
+                src = Source::Create(params[0]);
+                if (!src.get())
+                {
+                    cerr << "Unsupported source type" << endl;
+                    return 1;
+                }
+                int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+                switch(src->uri.type())
+                {
+                case UriParser::SRT:
+                    if (srt_epoll_add_usock(pollid,
+                            src->GetSRTSocket(), &events))
+                    {
+                        cerr << "Failed to add SRT source to poll, "
+                            << src->GetSRTSocket() << endl;
+                        return 1;
+                    }
+                    break;
+                case UriParser::UDP:
+                    if (srt_epoll_add_ssock(pollid,
+                            src->GetSysSocket(), &events))
+                    {
+                        cerr << "Failed to add UDP source to poll, "
+                            << src->GetSysSocket() << endl;
+                        return 1;
+                    }
+                    break;
+                case UriParser::FILE:
+                    if (srt_epoll_add_ssock(pollid,
+                            src->GetSysSocket(), &events))
+                    {
+                        cerr << "Failed to add FILE source to poll, "
+                            << src->GetSysSocket() << endl;
+                        return 1;
+                    }
+                    break;
+                default:
+                    break;
+                }
+
+                receivedBytes = 0;
+            }
+
+            if (!tar.get())
+            {
+                tar = Target::Create(params[1]);
+                if (!src.get())
+                {
+                    cerr << "Unsupported target type" << endl;
+                    return 1;
+                }
+
+                // IN because we care for state transitions only
+                int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+                switch(tar->uri.type())
+                {
+                case UriParser::SRT:
+                    if (srt_epoll_add_usock(pollid,
+                            tar->GetSRTSocket(), &events))
+                    {
+                        cerr << "Failed to add SRT destination to poll, "
+                            << tar->GetSRTSocket() << endl;
+                        return 1;
+                    }
+                    break;
+                default:
+                    break;
+                }
+
+                wroteBytes = 0;
+                lostBytes = 0;
+                lastReportedtLostBytes = 0;
+            }
+
+            int srtrfdslen = 2;
+            SRTSOCKET srtrfds[2];
+            int sysrfdslen = 2;
+            SYSSOCKET sysrfds[2];
+            if (srt_epoll_wait(pollid,
+                &srtrfds[0], &srtrfdslen, 0, 0,
+                100,
+                &sysrfds[0], &sysrfdslen, 0, 0) >= 0)
+            {
+                if ((false))
+                {
+                    cout << "Event:"
+                        << " srtrfdslen " << srtrfdslen
+                        << " sysrfdslen " << sysrfdslen
+                        << endl;
+                }
+
+                bool doabort = false;
+                for (int i = 0; i < srtrfdslen; i++)
+                {
+                    bool issource = false;
+                    SRTSOCKET s = srtrfds[i];
+                    if (src->GetSRTSocket() == s)
+                    {
+                        issource = true;
+                    }
+                    else if (tar->GetSRTSocket() != s)
+                    {
+                        cerr << "Unexpected socket poll: " << s;
+                        doabort = true;
+                        break;
+                    }
+
+                    const char * dirstring = (issource)? "source" : "target";
+
+                    SRT_SOCKSTATUS status = srt_getsockstate(s);
+                    if ((false) && status != CONNECTED)
+                    {
+                        cout << dirstring << " status " << status << endl;
+                    }
+                    switch (status)
+                    {
+                        case LISTENING:
+                        {
+                            if ((false) && !quiet)
+                                cout << "New SRT client connection" << endl;
+
+                            bool res = (issource) ?
+                                src->AcceptNewClient() : tar->AcceptNewClient();
+                            if (!res)
+                            {
+                                cerr << "Failed to accept SRT connection"
+                                    << endl;
+                                doabort = true;
+                                break;
+                            }
+
+                            srt_epoll_remove_usock(pollid, s);
+
+                            SRTSOCKET ns = (issource) ?
+                                src->GetSRTSocket() : tar->GetSRTSocket();
+                            int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+                            if (srt_epoll_add_usock(pollid, ns, &events))
+                            {
+                                cerr << "Failed to add SRT client to poll, "
+                                    << ns << endl;
+                                doabort = true;
+                            }
+                            else
+                            {
+                                if (!quiet)
+                                {
+                                    cout << "Accepted SRT "
+                                        << dirstring
+                                        <<  " connection"
+                                        << endl;
+                                }
+                                if (issource)
+                                    srcConnected = true;
+                                else
+                                    tarConnected = true;
+                            }
+                        }
+                        break;
+                        case BROKEN:
+                        case NONEXIST:
+                        case CLOSED:
+                        {
+                            if (issource)
+                            {
+                                if (srcConnected)
+                                {
+                                    if (!quiet)
+                                    {
+                                        cout << "SRT source disconnected"
+                                            << endl;
+                                    }
+                                    srcConnected = false;
+                                }
+                            }
+                            else if (tarConnected)
+                            {
+                                if (!quiet)
+                                    cout << "SRT target disconnected" << endl;
+                                tarConnected = false;
+                            }
+
+                            if(!autoreconnect)
+                            {
+                                doabort = true;
+                            }
+                            else
+                            {
+                                // force re-connection
+                                srt_epoll_remove_usock(pollid, s);
+                                if (issource)
+                                    src.release();
+                                else
+                                    tar.release();
+                            }
+                        }
+                        break;
+                        case CONNECTED:
+                        {
+                            if (issource)
+                            {
+                                if (!srcConnected)
+                                {
+                                    if (!quiet)
+                                        cout << "SRT source connected" << endl;
+                                    srcConnected = true;
+                                }
+                            }
+                            else if (!tarConnected)
+                            {
+                                if (!quiet)
+                                    cout << "SRT target connected" << endl;
+                                tarConnected = true;
+                            }
+                        }
+
+                        default:
+                        {
+                            // No-Op
+                        }
+                        break;
+                    }
+                }
+
+                if (doabort)
+                {
+                    break;
+                }
+
+                // read a few chunks at a time in attempt to deplete
+                // read buffers as much as possible on each read event
+                // note that this implies live streams and does not
+                // work for cached/file sources
+                std::list<std::shared_ptr<bytevector>> dataqueue;
+                if (src.get() && (srtrfdslen || sysrfdslen))
+                {
+                    while (dataqueue.size() < 10)
+                    {
+                        std::shared_ptr<bytevector> pdata(
+                            new bytevector(chunk));
+                        if (!src->Read(chunk, *pdata) || (*pdata).empty())
+                        {
+                            break;
+                        }
+                        dataqueue.push_back(pdata);
+                        receivedBytes += (*pdata).size();
+                    }
+                }
+
+                // if no target, let received data fall to the floor
+                while (tar.get() && !dataqueue.empty())
+                {
+                    std::shared_ptr<bytevector> pdata = dataqueue.front();
+                    if (!tar->IsOpen() || !tar->Write(*pdata))
+                        lostBytes += (*pdata).size();
+
+                    else
+                        wroteBytes += (*pdata).size();
+
+                    dataqueue.pop_front();
+                }
+
+                if (!quiet && (lastReportedtLostBytes != lostBytes))
+                {
+                    std::time_t now(std::time(nullptr));
+                    if (std::difftime(now, writeErrorLogTimer) >= 5.0)
+                    {
+                        cout << lostBytes << " bytes lost, "
+                            << wroteBytes << " bytes sent, "
+                            << receivedBytes << " bytes received"
+                            << endl;
+                        writeErrorLogTimer = now;
+                        lastReportedtLostBytes = lostBytes;
+                    }
+                }
+            }
+        }
+    }
+    catch (std::exception& x)
+    {
+        cerr << "ERROR: " << x.what() << endl;
+        return 255;
     }
 
     return 0;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -495,13 +495,13 @@ int main( int argc, char** argv )
                     const char * dirstring = (issource)? "source" : "target";
 
                     SRT_SOCKSTATUS status = srt_getsockstate(s);
-                    if ((false) && status != CONNECTED)
+                    if ((false) && status != SRTS_CONNECTED)
                     {
                         cout << dirstring << " status " << status << endl;
                     }
                     switch (status)
                     {
-                        case LISTENING:
+                        case SRTS_LISTENING:
                         {
                             if ((false) && !quiet)
                                 cout << "New SRT client connection" << endl;
@@ -543,9 +543,9 @@ int main( int argc, char** argv )
                             }
                         }
                         break;
-                        case BROKEN:
-                        case NONEXIST:
-                        case CLOSED:
+                        case SRTS_BROKEN:
+                        case SRTS_NONEXIST:
+                        case SRTS_CLOSED:
                         {
                             if (issource)
                             {
@@ -581,7 +581,7 @@ int main( int argc, char** argv )
                             }
                         }
                         break;
-                        case CONNECTED:
+                        case SRTS_CONNECTED:
                         {
                             if (issource)
                             {

--- a/apps/srt-multiplex.cpp
+++ b/apps/srt-multiplex.cpp
@@ -45,8 +45,6 @@ void OnINT_SetIntState(int)
 {
     cerr << "\n-------- REQUESTED INTERRUPT!\n";
     siplex_int_state = true;
-    if ( transmit_throw_on_interrupt )
-        throw std::runtime_error("Requested exception interrupt");
 }
 
 volatile bool alarm_state = false;
@@ -112,7 +110,8 @@ struct MediumPair
             {
                 ostringstream sout;
                 alarm(1);
-                const bytevector& data = src->Read(chunk);
+                bytevector data;
+                src->Read(chunk, data);
                 alarm(0);
                 if (alarm_state)
                 {

--- a/common/transmitbase.hpp
+++ b/common/transmitbase.hpp
@@ -62,7 +62,7 @@ public:
 class Source: public Location
 {
 public:
-    virtual bytevector Read(size_t chunk) = 0;
+    virtual bool Read(size_t chunk, bytevector& data) = 0;
     virtual bool IsOpen() = 0;
     virtual bool End() = 0;
     static std::unique_ptr<Source> Create(const std::string& url);
@@ -76,18 +76,26 @@ public:
         {
         }
     };
+
+    virtual SRTSOCKET GetSRTSocket() { return SRT_INVALID_SOCK; };
+    virtual int GetSysSocket() { return -1; };
+    virtual bool AcceptNewClient() { return false; }
 };
 
 class Target: public Location
 {
 public:
-    virtual void Write(const bytevector& portion) = 0;
+    virtual bool Write(const bytevector& portion) = 0;
     virtual bool IsOpen() = 0;
     virtual bool Broken() = 0;
     virtual void Close() {}
     virtual size_t Still() { return 0; }
     static std::unique_ptr<Target> Create(const std::string& url);
     virtual ~Target() {}
+
+    virtual SRTSOCKET GetSRTSocket() { return SRT_INVALID_SOCK; }
+    virtual int GetSysSocket() { return -1; }
+    virtual bool AcceptNewClient() { return false; }
 };
 
 

--- a/common/transmitmedia.cpp
+++ b/common/transmitmedia.cpp
@@ -8,6 +8,9 @@
 #include <iterator>
 #include <map>
 #include <srt.h>
+#if !defined(WIN32)
+#include <sys/ioctl.h>
+#endif
 
 #include "netinet_any.h"
 #include "appcommon.hpp"
@@ -22,7 +25,6 @@ bool transmit_verbose = false;
 bool transmit_total_stats = false;
 bool clear_stats = false;
 std::ostream* transmit_cverb = nullptr;
-volatile bool transmit_throw_on_interrupt = false;
 unsigned long transmit_bw_report = 0;
 unsigned long transmit_stats_report = 0;
 unsigned long transmit_chunk_size = SRT_LIVE_DEF_PLSIZE;
@@ -39,17 +41,22 @@ public:
             throw std::runtime_error(path + ": Can't open file for reading");
     }
 
-    bytevector Read(size_t chunk) override
+    bool Read(size_t chunk, bytevector& data) override
     {
-        bytevector data(chunk);
+        if (data.size() < chunk)
+            data.resize(chunk);
+
         ifile.read(data.data(), chunk);
         size_t nread = ifile.gcount();
         if ( nread < data.size() )
             data.resize(nread);
 
         if ( data.empty() )
-            throw ReadEOF(filename_copy);
-        return data;
+        {
+            return false;
+        }
+
+        return true;
     }
 
     bool IsOpen() override { return bool(ifile); }
@@ -64,9 +71,10 @@ public:
 
     FileTarget(const string& path): ofile(path, ios::out | ios::trunc | ios::binary) {}
 
-    void Write(const bytevector& data) override
+    bool Write(const bytevector& data) override
     {
         ofile.write(data.data(), data.size());
+        return !(ofile.bad());
     }
 
     bool IsOpen() override { return !!ofile; }
@@ -136,7 +144,8 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
 
     par.erase("mode");
 
-    if ( par.count("blocking") )
+    // no blocking mode support at the moment
+    if ( ((false)) && par.count("blocking") )
     {
         m_blocking_mode = !false_names.count(par.at("blocking"));
         par.erase("blocking");
@@ -199,11 +208,6 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
     if ( stat == SRT_ERROR )
         Error(UDT::getlasterror(), "ConfigurePre");
 
-    if ( !m_blocking_mode )
-    {
-        srt_conn_epoll = AddPoller(m_bindsock, SRT_EPOLL_OUT);
-    }
-
     sockaddr_in sa = CreateAddrInet(host, port);
     sockaddr* psa = (sockaddr*)&sa;
     if ( transmit_verbose )
@@ -220,7 +224,7 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
 
     if ( transmit_verbose )
     {
-        cout << " listen... ";
+        cout << " listen..." << endl;
         cout.flush();
     }
     stat = srt_listen(m_bindsock, backlog);
@@ -228,29 +232,6 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
     {
         srt_close(m_bindsock);
         Error(UDT::getlasterror(), "srt_listen");
-    }
-
-    if ( transmit_verbose )
-    {
-        cout << " accept... ";
-        cout.flush();
-    }
-    ::transmit_throw_on_interrupt = true;
-
-    if ( !m_blocking_mode )
-    {
-        if ( transmit_verbose )
-            cout << "[ASYNC] " << flush;
-
-        int len = 2;
-        SRTSOCKET ready[2];
-        if ( srt_epoll_wait(srt_conn_epoll, 0, 0, ready, &len, -1, 0, 0, 0, 0) == -1 )
-            Error(UDT::getlasterror(), "srt_epoll_wait");
-
-        if ( transmit_verbose )
-        {
-            cout << "[EPOLL: " << len << " sockets] " << flush;
-        }
     }
 }
 
@@ -269,26 +250,43 @@ void SrtCommon::StealFrom(SrtCommon& src)
     src.m_sock = SRT_INVALID_SOCK; // STEALING
 }
 
-void SrtCommon::AcceptNewClient()
+bool SrtCommon::AcceptNewClient()
 {
     sockaddr_in scl;
     int sclen = sizeof scl;
+
+    if ( transmit_verbose )
+    {
+        cout << " accept... ";
+        cout.flush();
+    }
+
     m_sock = srt_accept(m_bindsock, (sockaddr*)&scl, &sclen);
     if ( m_sock == SRT_INVALID_SOCK )
     {
         srt_close(m_bindsock);
+        m_bindsock = SRT_INVALID_SOCK;
         Error(UDT::getlasterror(), "srt_accept");
+    }
+
+    if ((true))
+    {
+        // we do one client connection at a time,
+        // so close the listener.
+        srt_close(m_bindsock);
+        m_bindsock = SRT_INVALID_SOCK;
     }
 
     if ( transmit_verbose )
         cout << " connected.\n";
-    ::transmit_throw_on_interrupt = false;
 
     // ConfigurePre is done on bindsock, so any possible Pre flags
     // are DERIVED by sock. ConfigurePost is done exclusively on sock.
     int stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
         Error(UDT::getlasterror(), "ConfigurePost");
+
+    return true;
 }
 
 void SrtCommon::Init(string host, int port, map<string,string> par, bool dir_output)
@@ -311,15 +309,6 @@ void SrtCommon::Init(string host, int port, map<string,string> par, bool dir_out
     {
         throw std::invalid_argument("Invalid 'mode'. Use 'client' or 'server'");
     }
-}
-
-int SrtCommon::AddPoller(SRTSOCKET socket, int modes)
-{
-    int pollid = srt_epoll_create();
-    if ( pollid == -1 )
-        throw std::runtime_error("Can't create epoll in nonblocking mode");
-    srt_epoll_add_usock(pollid, socket, &modes);
-    return pollid;
 }
 
 int SrtCommon::ConfigurePost(SRTSOCKET sock)
@@ -449,41 +438,8 @@ void SrtCommon::PrepareClient()
     int stat = ConfigurePre(m_sock);
     if ( stat == SRT_ERROR )
         Error(UDT::getlasterror(), "ConfigurePre");
-
-    if ( !m_blocking_mode )
-    {
-        srt_conn_epoll = AddPoller(m_sock, SRT_EPOLL_OUT);
-    }
-
 }
 
-/*
- This may be used sometimes for testing, but it's nonportable.
-void SrtCommon::SpinWaitAsync()
-{
-    static string udt_status_names [] = {
-        "INIT" , "OPENED", "LISTENING", "CONNECTING", "CONNECTED", "BROKEN", "CLOSING", "CLOSED", "NONEXIST"
-    };
-
-    for (;;)
-    {
-        SRT_SOCKSTATUS state = srt_getsockstate(m_sock);
-        if ( int(state) < SRTS_CONNECTED )
-        {
-            if ( transmit_verbose )
-                cout << state << flush;
-            usleep(250000);
-            continue;
-        }
-        else if ( int(state) > SRTS_CONNECTED )
-        {
-            Error(UDT::getlasterror(), "UDT::connect status=" + udt_status_names[state]);
-        }
-
-        return;
-    }
-}
-*/
 
 void SrtCommon::ConnectClient(string host, int port)
 {
@@ -502,33 +458,14 @@ void SrtCommon::ConnectClient(string host, int port)
         Error(UDT::getlasterror(), "UDT::connect");
     }
 
-    // Wait for REAL connected state if nonblocking mode
-    if ( !m_blocking_mode )
+    if (transmit_verbose)
     {
-        if ( transmit_verbose )
-            cout << "[ASYNC] " << flush;
-
-        // SPIN-WAITING version. Don't use it unless you know what you're doing.
-        // SpinWaitAsync();
-
-        // Socket readiness for connection is checked by polling on WRITE allowed sockets.
-        int len = 2;
-        SRTSOCKET ready[2];
-        if ( srt_epoll_wait(srt_conn_epoll, 0, 0, ready, &len, -1, 0, 0, 0, 0) != -1 )
-        {
-            if ( transmit_verbose )
-            {
-                cout << "[EPOLL: " << len << " sockets] " << flush;
-            }
-        }
+        if ( m_blocking_mode)
+            cout << " connected.\n";
         else
-        {
-            Error(UDT::getlasterror(), "srt_epoll_wait");
-        }
+            cout << endl;
     }
 
-    if ( transmit_verbose )
-        cout << " connected.\n";
     stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
         Error(UDT::getlasterror(), "ConfigurePost");
@@ -560,11 +497,6 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
     if ( stat == SRT_ERROR )
         Error(UDT::getlasterror(), "ConfigurePre");
 
-    if ( !m_blocking_mode )
-    {
-        srt_conn_epoll = AddPoller(m_sock, SRT_EPOLL_OUT);
-    }
-
     sockaddr_in localsa = CreateAddrInet(adapter, port);
     sockaddr* plsa = (sockaddr*)&localsa;
     if ( transmit_verbose )
@@ -593,33 +525,13 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
         Error(UDT::getlasterror(), "srt_connect");
     }
 
-    // Wait for REAL connected state if nonblocking mode
-    if ( !m_blocking_mode )
+    if (transmit_verbose)
     {
-        if ( transmit_verbose )
-            cout << "[ASYNC] " << flush;
-
-        // SPIN-WAITING version. Don't use it unless you know what you're doing.
-        // SpinWaitAsync();
-
-        // Socket readiness for connection is checked by polling on WRITE allowed sockets.
-        int len = 2;
-        SRTSOCKET ready[2];
-        if ( srt_epoll_wait(srt_conn_epoll, 0, 0, ready, &len, -1, 0, 0, 0, 0) != -1 )
-        {
-            if ( transmit_verbose )
-            {
-                cout << "[EPOLL: " << len << " sockets] " << flush;
-            }
-        }
+        if ( m_blocking_mode && transmit_verbose )
+            cout << " connected." << endl;
         else
-        {
-            Error(UDT::getlasterror(), "srt_epoll_wait");
-        }
+            cout << endl;
     }
-
-    if ( transmit_verbose )
-        cout << " connected.\n";
 
     stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
@@ -657,28 +569,23 @@ SrtSource::SrtSource(string host, int port, const map<string,string>& par)
 {
     Init(host, port, par, false);
 
-    if ( !m_blocking_mode )
-    {
-        srt_epoll = AddPoller(m_sock, SRT_EPOLL_IN);
-    }
-
     ostringstream os;
     os << host << ":" << port;
     hostport_copy = os.str();
 }
 
-bytevector SrtSource::Read(size_t chunk)
+bool SrtSource::Read(size_t chunk, bytevector& data)
 {
     static unsigned long counter = 1;
 
-    bytevector data(chunk);
+    if (data.size() < chunk)
+        data.resize(chunk);
+
     bool ready = true;
     int stat;
     do
     {
-        ::transmit_throw_on_interrupt = true;
         stat = srt_recvmsg(m_sock, data.data(), chunk);
-        ::transmit_throw_on_interrupt = false;
         if ( stat == SRT_ERROR )
         {
             if ( !m_blocking_mode )
@@ -686,19 +593,8 @@ bytevector SrtSource::Read(size_t chunk)
                 // EAGAIN for SRT READING
                 if ( srt_getlasterror(NULL) == SRT_EASYNCRCV )
                 {
-                    Verb() << "AGAIN: - waiting for data by epoll...";
-                    // Poll on this descriptor until reading is available, indefinitely.
-                    int len = 2;
-                    SRTSOCKET sready[2];
-                    if ( srt_epoll_wait(srt_epoll, sready, &len, 0, 0, -1, 0, 0, 0, 0) != -1 )
-                    {
-                        if ( transmit_verbose )
-                        {
-                            cout << "... epoll reported ready " << len << " sockets\n";
-                        }
-                        continue;
-                    }
-                    // If was -1, then passthru.
+                    data.clear();
+                    return false;
                 }
             }
             Error(UDT::getlasterror(), "recvmsg");
@@ -730,7 +626,7 @@ bytevector SrtSource::Read(size_t chunk)
 
     ++counter;
 
-    return data;
+    return true;
 }
 
 int SrtTarget::ConfigurePre(SRTSOCKET sock)
@@ -751,25 +647,17 @@ int SrtTarget::ConfigurePre(SRTSOCKET sock)
     return 0;
 }
 
-void SrtTarget::Write(const bytevector& data) 
+bool SrtTarget::Write(const bytevector& data) 
 {
     static unsigned long counter = 1;
 
-    ::transmit_throw_on_interrupt = true;
-
-    // Check first if it's ready to write.
-    // If not, wait indefinitely.
-    if ( !m_blocking_mode )
-    {
-        int ready[2];
-        int len = 2;
-        if ( srt_epoll_wait(srt_epoll, 0, 0, ready, &len, -1, 0, 0, 0, 0) == SRT_ERROR )
-            Error(UDT::getlasterror(), "srt_epoll_wait");
-    }
-
     int stat = srt_sendmsg2(m_sock, data.data(), data.size(), nullptr);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "srt_sendmsg");
+    {
+        if (m_blocking_mode)
+            Error(UDT::getlasterror(), "srt_sendmsg");
+        return false;
+    }
 
     CBytePerfMon perf;
     srt_bstats(m_sock, &perf, clear_stats);
@@ -786,7 +674,7 @@ void SrtTarget::Write(const bytevector& data)
 
     ++counter;
 
-    ::transmit_throw_on_interrupt = false;
+    return true;
 }
 
 SrtModel::SrtModel(string host, int port, map<string,string> par)
@@ -800,7 +688,6 @@ SrtModel::SrtModel(string host, int port, map<string,string> par)
     m_host = host;
     m_port = port;
 }
-
 
 void SrtModel::Establish(ref_t<std::string> name)
 {
@@ -870,7 +757,6 @@ void SrtModel::Establish(ref_t<std::string> name)
 }
 
 
-
 template <class Iface> struct Srt;
 template <> struct Srt<Source> { typedef SrtSource type; };
 template <> struct Srt<Target> { typedef SrtTarget type; };
@@ -886,24 +772,30 @@ public:
     {
     }
 
-    bytevector Read(size_t chunk) override
+    bool Read(size_t chunk, bytevector& data) override
     {
-        bytevector data(chunk);
+        if (data.size() < chunk)
+            data.resize(chunk);
+
         bool st = cin.read(data.data(), chunk).good();
         chunk = cin.gcount();
         if ( chunk == 0 && !st )
-            return bytevector();
+        {
+            data.clear();
+            return false;
+        }
 
         if ( chunk < data.size() )
             data.resize(chunk);
         if ( data.empty() )
-            throw ReadEOF("CONSOLE device");
+            return false;
 
-        return data;
+        return true;
     }
 
     bool IsOpen() override { return cin.good(); }
     bool End() override { return cin.eof(); }
+    int GetSysSocket() { return 0; };
 };
 
 class ConsoleTarget: public Target
@@ -914,13 +806,15 @@ public:
     {
     }
 
-    void Write(const bytevector& data) override
+    bool Write(const bytevector& data) override
     {
         cout.write(data.data(), data.size());
+        return true;
     }
 
     bool IsOpen() override { return cout.good(); }
     bool Broken() override { return cout.eof(); }
+    int GetSysSocket() { return 0; };
 };
 
 template <class Iface> struct Console;
@@ -962,6 +856,20 @@ protected:
 
         int yes = 1;
         ::setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof yes);
+
+        if ((true))
+        {
+            // set non-blocking mode
+#if defined(WIN32)
+            unsigned long ulyes = 1;
+            if (ioctlsocket(m_sock, FIONBIO, &ulyes) == SOCKET_ERROR)
+#else
+            if (ioctl(m_sock, FIONBIO, (const char *)&yes) < 0)
+#endif
+            {
+                Error(SysError(), "UdpCommon::Setup: ioctl FIONBIO");
+            }
+        }
 
         sadr = CreateAddrInet(host, port);
 
@@ -1057,6 +965,7 @@ protected:
             if ( m_options.count(o.name) )
             {
                 string value = m_options.at(o.name);
+                cout << "set " << o.name;
                 bool ok = o.apply<SocketOption::SYSTEM>(m_sock, value);
                 if ( transmit_verbose && !ok )
                     cout << "WARNING: failed to set '" << o.name << "' to " << value << endl;
@@ -1107,30 +1016,33 @@ public:
         eof = false;
     }
 
-    bytevector Read(size_t chunk) override
+    bool Read(size_t chunk, bytevector& data) override
     {
-        bytevector data(chunk);
+        if (data.size() < chunk)
+            data.resize(chunk);
+
         sockaddr_in sa;
         socklen_t si = sizeof(sockaddr_in);
         int stat = recvfrom(m_sock, data.data(), chunk, 0, (sockaddr*)&sa, &si);
-        if ( stat == -1 )
-            Error(SysError(), "UDP Read/recvfrom");
-
         if ( stat < 1 )
         {
-            eof = true;
-            return bytevector();
+            if (SysError() != EWOULDBLOCK)
+                eof = true;
+            data.clear();
+            return false;
         }
 
         chunk = size_t(stat);
         if ( chunk < data.size() )
             data.resize(chunk);
 
-        return data;
+        return true;
     }
 
     bool IsOpen() override { return m_sock != -1; }
     bool End() override { return eof; }
+
+    int GetSysSocket() { return m_sock; };
 };
 
 class UdpTarget: public Target, public UdpCommon
@@ -1141,15 +1053,22 @@ public:
         Setup(host, port, attr);
     }
 
-    void Write(const bytevector& data) override
+    bool Write(const bytevector& data) override
     {
         int stat = sendto(m_sock, data.data(), data.size(), 0, (sockaddr*)&sadr, sizeof sadr);
         if ( stat == -1 )
-            Error(SysError(), "UDP Write/sendto");
+        {
+            if ((false))
+                Error(SysError(), "UDP Write/sendto");
+            return false;
+        }
+        return true;
     }
 
     bool IsOpen() override { return m_sock != -1; }
     bool Broken() override { return false; }
+
+    int GetSysSocket() { return m_sock; };
 };
 
 template <class Iface> struct Udp;
@@ -1175,7 +1094,8 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
     int iport = 0;
     switch ( u.type() )
     {
-    default: ; // do nothing, return nullptr
+    default:
+        break; // do nothing, return nullptr
     case UriParser::FILE:
         if ( u.host() == "con" || u.host() == "console" )
         {
@@ -1189,10 +1109,12 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
             }
             ptr.reset( CreateConsole<Base>() );
         }
+// Disable regular file support for the moment
+#if 0
         else
             ptr.reset( CreateFile<Base>(u.path()));
+#endif
         break;
-
 
     case UriParser::SRT:
         iport = atoi(u.port().c_str());
@@ -1217,7 +1139,9 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
 
     }
 
-    ptr->uri = move(u);
+    if (ptr.get())
+        ptr->uri = move(u);
+
     return ptr;
 }
 

--- a/common/transmitmedia.hpp
+++ b/common/transmitmedia.hpp
@@ -23,14 +23,10 @@ struct TransmissionError: public std::runtime_error
 
 class SrtCommon
 {
-    int srt_conn_epoll = -1;
-
-    void SpinWaitAsync();
-
 protected:
 
     bool m_output_direction = false; //< Defines which of SND or RCV option variant should be used, also to set SRT_SENDER for output
-    bool m_blocking_mode = true; //< enforces using SRTO_SNDSYN or SRTO_RCVSYN, depending on @a m_output_direction
+    bool m_blocking_mode = false; //< enforces using SRTO_SNDSYN or SRTO_RCVSYN, depending on @a m_output_direction
     int m_timeout = 0; //< enforces using SRTO_SNDTIMEO or SRTO_RCVTIMEO, depending on @a m_output_direction
     bool m_tsbpdmode = true;
     int m_outgoing_port = 0;
@@ -46,7 +42,7 @@ public:
     void InitParameters(string host, map<string,string> par);
     void PrepareListener(string host, int port, int backlog);
     void StealFrom(SrtCommon& src);
-    void AcceptNewClient();
+    bool AcceptNewClient();
 
     SRTSOCKET Socket() { return m_sock; }
     SRTSOCKET Listener() { return m_bindsock; }
@@ -57,7 +53,7 @@ protected:
 
     void Error(UDT::ERRORINFO& udtError, string src);
     void Init(string host, int port, map<string,string> par, bool dir_output);
-    int AddPoller(SRTSOCKET socket, int modes);
+
     virtual int ConfigurePost(SRTSOCKET sock);
     virtual int ConfigurePre(SRTSOCKET sock);
 
@@ -69,7 +65,10 @@ protected:
     void OpenServer(string host, int port)
     {
         PrepareListener(host, port, 1);
-        AcceptNewClient();
+        if (m_blocking_mode)
+        {
+            AcceptNewClient();
+        }
     }
 
     void OpenRendezvous(string adapter, string host, int port);
@@ -90,7 +89,7 @@ public:
         // Do nothing - create just to prepare for use
     }
 
-    bytevector Read(size_t chunk) override;
+    bool Read(size_t chunk, bytevector& data) override;
 
     /*
        In this form this isn't needed.
@@ -107,28 +106,30 @@ public:
     bool IsOpen() override { return IsUsable(); }
     bool End() override { return IsBroken(); }
     void Close() override { return SrtCommon::Close(); }
+
+    SRTSOCKET GetSRTSocket()
+    { 
+        SRTSOCKET socket = SrtCommon::Socket();
+        if (socket == SRT_INVALID_SOCK)
+            socket = SrtCommon::Listener();
+        return socket;
+    }
+    bool AcceptNewClient() { return SrtCommon::AcceptNewClient(); }
 };
 
 class SrtTarget: public Target, public SrtCommon
 {
-    int srt_epoll = -1;
 public:
 
     SrtTarget(std::string host, int port, const std::map<std::string,std::string>& par)
     {
         Init(host, port, par, true);
-
-        if ( !m_blocking_mode )
-        {
-            srt_epoll = AddPoller(m_sock, SRT_EPOLL_OUT);
-        }
-
     }
 
     SrtTarget() {}
 
     int ConfigurePre(SRTSOCKET sock) override;
-    void Write(const bytevector& data) override;
+    bool Write(const bytevector& data) override;
     bool IsOpen() override { return IsUsable(); }
     bool Broken() override { return IsBroken(); }
     void Close() override { return SrtCommon::Close(); }
@@ -142,6 +143,14 @@ public:
         return bytes;
     }
 
+    SRTSOCKET GetSRTSocket()
+    { 
+        SRTSOCKET socket = SrtCommon::Socket();
+        if (socket == SRT_INVALID_SOCK)
+            socket = SrtCommon::Listener();
+        return socket;
+    }
+    bool AcceptNewClient() { return SrtCommon::AcceptNewClient(); }
 };
 
 


### PR DESCRIPTION
The proposed changes in this PR are to:

    fix non-blocking API usage
    fix known stransit/srt-live-transmit hard crashes, particularly on shutdown
    fix exiting on signal
    fix timeout option
    disable blocking API usage, at least for the moment
    disable exceptions handling attempting to mask crashes
    disable file source/destinations except stdin/stdout
    disable bandwidth monitor/guard
    add non-verbose messaging to report high-level events by default
    add quiet mode, default normal reporting mode
    add auto-reconnect mode, on by default
    add simple periodic report on received/sent/lost data