### PR TITLE
Fixed potential problem with non-NUL-termination of error message string.

### DIFF
--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -42,8 +42,7 @@ written by
 
 static inline const char* SysStrError_Fallback(int errnum, char* buf, size_t buflen)
 {
-    snprintf(buf, buflen-1, "ERROR CODE %d", errnum);
-    buf[buflen-1] = 0;
+    snprintf(buf, buflen, "ERROR CODE %d", errnum);
     return buf;
 }
 

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -96,6 +96,7 @@ extern const char * SysStrError(int errnum, char * buf, size_t buflen)
     if (strerror_r(errnum, buf, buflen) != 0)
     {
         snprintf(buf, buflen-1, "Unknown error %d", errnum);
+        buf[buflen-1] = 0;
     }
     return buf;
 #else


### PR DESCRIPTION
The value to be passed as the last argument to `strncpy` is the maximum number of characters to be copied. This must include the spare size of one character for zero termination.

Also added a "fallback message" when the XSI-compliant function returns an error.