### PR TITLE
Build with debug information for lldb on iOS platform

### DIFF
--- a/scripts/iOS.cmake
+++ b/scripts/iOS.cmake
@@ -52,7 +52,7 @@ if (NOT DEFINED IOS_DISABLE_BITCODE)
 	set (EMBED_OPTIONS "-fembed-bitcode")
 endif(NOT DEFINED IOS_DISABLE_BITCODE)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR ENABLE_DEBUG)
 	set(IOS_DEBUG_OPTIONS "-glldb -gmodules")
 else()
 	set(IOS_DEBUG_OPTIONS "-fvisibility=hidden -fvisibility-inlines-hidden")

--- a/scripts/iOS.cmake
+++ b/scripts/iOS.cmake
@@ -52,9 +52,14 @@ if (NOT DEFINED IOS_DISABLE_BITCODE)
 	set (EMBED_OPTIONS "-fembed-bitcode")
 endif(NOT DEFINED IOS_DISABLE_BITCODE)
 
-# Hidden visibilty is required for cxx on iOS 
-set (CMAKE_C_FLAGS_INIT "${EMBED_OPTIONS}")
-set (CMAKE_CXX_FLAGS_INIT "-fvisibility=hidden -fvisibility-inlines-hidden ${EMBED_OPTIONS}")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+	set(IOS_DEBUG_OPTIONS "-glldb -gmodules")
+else()
+	set(IOS_DEBUG_OPTIONS "-fvisibility=hidden -fvisibility-inlines-hidden")
+endif()	
+
+set (CMAKE_C_FLAGS_INIT "${IOS_DEBUG_OPTIONS} ${EMBED_OPTIONS}")
+set (CMAKE_CXX_FLAGS_INIT "${IOS_DEBUG_OPTIONS} ${EMBED_OPTIONS}")
 
 set (CMAKE_C_LINK_FLAGS "-Wl,-search_paths_first ${EMBED_OPTIONS} ${CMAKE_C_LINK_FLAGS}")
 set (CMAKE_CXX_LINK_FLAGS "-Wl,-search_paths_first ${EMBED_OPTIONS} ${CMAKE_CXX_LINK_FLAGS}")


### PR DESCRIPTION
Add debug information for lldb (Xcode debugger) if `--enable-debug` or `--cmake-build-type=Debug` options were provided.