### PR TITLE
Do not build the unit test in the main library

### DIFF
--- a/haicrypt/filelist-gnutls.maf
+++ b/haicrypt/filelist-gnutls.maf
@@ -20,6 +20,5 @@ hcrypt_ctx_tx.c
 hcrypt_rx.c
 hcrypt_sa.c
 hcrypt_tx.c
-hcrypt_ut.c
 hcrypt_xpt_srt.c
 hcrypt_xpt_sta.c

--- a/haicrypt/filelist.maf
+++ b/haicrypt/filelist.maf
@@ -21,6 +21,5 @@ hcrypt_ctx_tx.c
 hcrypt_rx.c
 hcrypt_sa.c
 hcrypt_tx.c
-hcrypt_ut.c
 hcrypt_xpt_srt.c
 hcrypt_xpt_sta.c


### PR DESCRIPTION
It may cause runtime problems on non-windows platforms
depending on the linker.