### PR TITLE
Made SockaddrToString use only numeric string by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ option(ENABLE_HEAVY_LOGGING "Should heavy debug logging be enabled" ${ENABLE_HEA
 option(ENABLE_SHARED "Should libsrt be built as a shared library" ON)
 option(ENABLE_STATIC "Should libsrt be built as a static library" ON)
 option(ENABLE_SUFLIP "Should suflip tool be built" OFF)
+option(ENABLE_GETNAMEINFO "In-logs sockaddr-to-string should do rev-dns" OFF)
 option(USE_GNUTLS "Should use gnutls instead of openssl" OFF)
 option(ENABLE_C_DEPS "Extra library dependencies in srt.pc for C language" OFF)
 option(USE_STATIC_LIBSTDCXX "Should use static rather than shared libstdc++" OFF)
@@ -294,6 +295,10 @@ if (ENABLE_LOGGING)
 	if (ENABLE_HEAVY_LOGGING)
 		list(APPEND SRT_EXTRA_CFLAGS "-DENABLE_HEAVY_LOGGING=1")
 	endif()
+endif()
+
+if (ENABLE_GETNAMEINFO)
+	list(APPEND SRT_EXTRA_CFLAGS "-DENABLE_GETNAMEINFO=1")
 endif()
 
 if (ENABLE_THREAD_CHECK)

--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -53,7 +53,7 @@ set cmake_options {
     enable-shared "Should libsrt be built as a shared library (default: ON)"
     enable-static "Should libsrt be built as a static library (default: ON)"
     enable-suflip "Shuld suflip tool be built (default: OFF)"
-	enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
+    enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
     enable-thread-check "Enable #include <threadcheck.h> that implements THREAD_* macros"
     openssl-crypto-library=<filepath> "Path to a library."
     openssl-include-dir=<path> "Path to a file."

--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -53,6 +53,7 @@ set cmake_options {
     enable-shared "Should libsrt be built as a shared library (default: ON)"
     enable-static "Should libsrt be built as a static library (default: ON)"
     enable-suflip "Shuld suflip tool be built (default: OFF)"
+	enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
     enable-thread-check "Enable #include <threadcheck.h> that implements THREAD_* macros"
     openssl-crypto-library=<filepath> "Path to a library."
     openssl-include-dir=<path> "Path to a file."

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -280,11 +280,14 @@ inline std::string SockaddrToString(const sockaddr* sadr)
 
     std::ostringstream output;
     char hostbuf[1024];
+
+#if ENABLE_GETNAMEINFO
     if (!getnameinfo(sadr, sizeof(*sadr), hostbuf, 1024, NULL, 0, NI_NAMEREQD))
     {
         output << hostbuf;
     }
     else
+#endif
     {
         if (inet_ntop(sadr->sa_family, addr, hostbuf, 1024) == NULL)
         {

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1242,7 +1242,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
         CGuard cg(m_LSLock);
         if (m_pListener)
         {
-            LOGC(mglog.Note, log << "... PASSING request from: " << SockaddrToString(addr) << " to agent:" << m_pListener->socketID());
+            LOGC(mglog.Note, log << "PASSING request from: " << SockaddrToString(addr) << " to agent:" << m_pListener->socketID());
             listener_ret = m_pListener->processConnectRequest(addr, unit->m_Packet);
             // XXX This returns some very significant return value, which
             // is completely ignored here.
@@ -1277,7 +1277,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
 
     if ( have_listener ) // That is, the above block with m_pListener->processConnectRequest was executed
     {
-        LOGC(mglog.Note, log << CONID() << "listener managed the connection request from: " << SockaddrToString(addr)
+        LOGC(mglog.Note, log << CONID() << "Listener managed the connection request from: " << SockaddrToString(addr)
             << " result:" << RequestTypeStr(UDTRequestType(listener_ret)));
         return (listener_ret >= URQ_FAILURE_TYPES ? CONN_REJECT : CONN_CONTINUE);
     }


### PR DESCRIPTION
Displaying the rev-resolved hostname requires `--enable-getnameinfo` option.