### PR TITLE
cmake: fix linking with static GnuTLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,9 @@ if ( USE_GNUTLS )
 	endif()
  
 	pkg_check_modules (SSL REQUIRED ${SSL_REQUIRED_MODULES})
+	if(NOT ENABLE_SHARED OR NOT BUILD_SHARED_LIBS)
+		set (SSL_LIBRARIES ${SSL_LIBRARIES} ${SSL_STATIC_LIBRARIES})
+	endif()
 
 	add_definitions(
 		-DUSE_GNUTLS=1


### PR DESCRIPTION
For some reason static openssl works with just libssl and libcrypto.