### PR TITLE
Fix windows build when only building the static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,8 +520,10 @@ if (ENABLE_SHARED)
 	target_compile_definitions(haicrypt_virtual PRIVATE -DHAICRYPT_EXPORTS)
 endif()
 
+if (srt_libspec_shared)
 if (MICROSOFT)
     target_link_libraries(${TARGET_srt}_shared PUBLIC Ws2_32.lib)
+endif()
 endif()
 
 # Cygwin installs the *.dll libraries in bin directory and uses PATH.


### PR DESCRIPTION
Fix windows build when only building the static library. In which case ${TARGET_srt}_shared is not a valid target and CMake generates an error.