### PR TITLE
Do not expose internals unneeded by the external API

### DIFF
--- a/common/filelist_win32.maf
+++ b/common/filelist_win32.maf
@@ -1,6 +1,5 @@
 
 PUBLIC HEADERS
-win/wintime.h
 win/syslog_defs.h
 #
 # These are included by platform_sys.h header contained in ../srtcore/filelist.maf

--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -9,18 +9,25 @@
 extern "C" {
 #endif
 
+#if !defined(_POSIX_TIMERS) || (_POSIX_TIMERS <= 0)
+// NOTE: These are defined in WinPThread and should not be redefined.
+
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 1
 #endif
 
-int clock_gettime(int X, struct timespec *ts);
+int SRTCompat_clock_gettime(int X, struct timespec *ts);
+static inline int clock_gettime(int X, struct timespec *ts)
+{
+   return SRTCompat_clock_gettime(X, ts);
+}
 
 #if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
     #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
 #else
     #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
- 
+#endif
 
 #ifndef _TIMEZONE_DEFINED /* also in sys/time.h */
 #define _TIMEZONE_DEFINED
@@ -29,13 +36,25 @@ struct timezone
     int tz_minuteswest; /* minutes W of Greenwich */
     int tz_dsttime;     /* type of dst correction */
 };
+
 #endif
 
-void timeradd(struct timeval *a, struct timeval *b, struct timeval *result);
-int gettimeofday(struct timeval* tp, struct timezone* tz);
+void SRTCompat_timeradd(
+      struct timeval *a, struct timeval *b, struct timeval *result);
+static inline void timeradd(
+      struct timeval *a, struct timeval *b, struct timeval *result)
+{
+   SRTCompat_timeradd(a, b, result);
+}
+
+int SRTCompat_gettimeofday(struct timeval* tp, struct timezone* tz);
+static inline int gettimeofday(struct timeval* tp, struct timezone* tz)
+{
+   return SRTCompat_gettimeofday(tp, tz);
+}
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif // INC__WIN_WINTIME

--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -10,7 +10,8 @@ extern "C" {
 #endif
 
 #if !defined(_POSIX_TIMERS) || (_POSIX_TIMERS <= 0)
-// NOTE: These are defined in WinPThread and should not be redefined.
+// NOTE: The availability of clock_gettime() is indicated that _POSIX_TIMERS
+// is defined and is greater than 0.
 
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 1

--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -38,6 +38,7 @@ SRTCOMPAT_WINTIME_STATIC_INLINE_DECL int clock_gettime(
 #else
     #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
 #endif
+
 #endif
 
 #ifndef _TIMEZONE_DEFINED /* also in sys/time.h */
@@ -47,7 +48,6 @@ struct timezone
     int tz_minuteswest; /* minutes W of Greenwich */
     int tz_dsttime;     /* type of dst correction */
 };
-
 #endif
 
 void SRTCompat_timeradd(

--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -17,30 +17,6 @@ extern "C" {
    #define SRTCOMPAT_WINTIME_STATIC_INLINE_DECL static
 #endif
 
-#if !defined(_POSIX_TIMERS) || (_POSIX_TIMERS <= 0)
-// NOTE: The clock_gettime() availability is indicated by _POSIX_TIMERS
-// being defined and greater than 0.
-
-#ifndef CLOCK_REALTIME
-#define CLOCK_REALTIME 1
-#endif
-
-int SRTCompat_clock_gettime(
-      int X, struct timespec *ts);
-SRTCOMPAT_WINTIME_STATIC_INLINE_DECL int clock_gettime(
-      int X, struct timespec *ts)
-{
-   return SRTCompat_clock_gettime(X, ts);
-}
-
-#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
-    #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
-#else
-    #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
-#endif
-
-#endif
-
 #ifndef _TIMEZONE_DEFINED /* also in sys/time.h */
 #define _TIMEZONE_DEFINED
 struct timezone 

--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -9,16 +9,26 @@
 extern "C" {
 #endif
 
+#if !defined(_MSC_VER)
+   #define SRTCOMPAT_WINTIME_STATIC_INLINE_DECL static inline
+#else
+   // NOTE: MVC Does not like static inline for C functions in some versions.
+   //    so just use static for MVC.
+   #define SRTCOMPAT_WINTIME_STATIC_INLINE_DECL static
+#endif
+
 #if !defined(_POSIX_TIMERS) || (_POSIX_TIMERS <= 0)
-// NOTE: The availability of clock_gettime() is indicated that _POSIX_TIMERS
-// is defined and is greater than 0.
+// NOTE: The clock_gettime() availability is indicated by _POSIX_TIMERS
+// being defined and greater than 0.
 
 #ifndef CLOCK_REALTIME
 #define CLOCK_REALTIME 1
 #endif
 
-int SRTCompat_clock_gettime(int X, struct timespec *ts);
-static inline int clock_gettime(int X, struct timespec *ts)
+int SRTCompat_clock_gettime(
+      int X, struct timespec *ts);
+SRTCOMPAT_WINTIME_STATIC_INLINE_DECL int clock_gettime(
+      int X, struct timespec *ts)
 {
    return SRTCompat_clock_gettime(X, ts);
 }
@@ -42,17 +52,21 @@ struct timezone
 
 void SRTCompat_timeradd(
       struct timeval *a, struct timeval *b, struct timeval *result);
-static inline void timeradd(
+SRTCOMPAT_WINTIME_STATIC_INLINE_DECL void timeradd(
       struct timeval *a, struct timeval *b, struct timeval *result)
 {
    SRTCompat_timeradd(a, b, result);
 }
 
-int SRTCompat_gettimeofday(struct timeval* tp, struct timezone* tz);
-static inline int gettimeofday(struct timeval* tp, struct timezone* tz)
+int SRTCompat_gettimeofday(
+      struct timeval* tp, struct timezone* tz);
+SRTCOMPAT_WINTIME_STATIC_INLINE_DECL int gettimeofday(
+      struct timeval* tp, struct timezone* tz)
 {
    return SRTCompat_gettimeofday(tp, tz);
 }
+
+#undef SRTCOMPAT_WINTIME_STATIC_INLINE_DECL
 
 #ifdef __cplusplus
 }

--- a/common/win_time.cpp
+++ b/common/win_time.cpp
@@ -13,13 +13,13 @@ written by
    Haivision Systems Inc.
  *****************************************************************************/
 
-#include <win/wintime.h>
+#include "win/wintime.h"
 #include <sys/timeb.h>
 
 #if 0
 // Temporarily blocked. Needs to be fixed.
 // Currently unused, but may be useful in future.
-int clock_gettime(int X, struct timespec *ts)
+int SRTCompat_clock_gettime(int X, struct timespec *ts)
 {
     LARGE_INTEGER           t;
     FILETIME            f;
@@ -58,7 +58,7 @@ int clock_gettime(int X, struct timespec *ts)
 }
 #endif
 
-void timeradd(struct timeval *a, struct timeval *b, struct timeval *result)
+void SRTCompat_timeradd(struct timeval *a, struct timeval *b, struct timeval *result)
 {
     result->tv_sec  = a->tv_sec + b->tv_sec;
     result->tv_usec = a->tv_usec + b->tv_usec;
@@ -69,7 +69,7 @@ void timeradd(struct timeval *a, struct timeval *b, struct timeval *result)
     }
 }
 
-int gettimeofday(struct timeval* tp, struct timezone* tz)
+int SRTCompat_gettimeofday(struct timeval* tp, struct timezone* tz)
 {
     static LARGE_INTEGER tickFrequency, epochOffset;
 
@@ -105,4 +105,3 @@ int gettimeofday(struct timeval* tp, struct timezone* tz)
     }
     return 0;
 }
-

--- a/common/win_time.cpp
+++ b/common/win_time.cpp
@@ -16,48 +16,6 @@ written by
 #include "win/wintime.h"
 #include <sys/timeb.h>
 
-#if 0
-// Temporarily blocked. Needs to be fixed.
-// Currently unused, but may be useful in future.
-int SRTCompat_clock_gettime(int X, struct timespec *ts)
-{
-    LARGE_INTEGER           t;
-    FILETIME            f;
-    double                  microseconds;
-    static LARGE_INTEGER    offset;
-    static double           frequencyToMicroseconds;
-    static int              initialized = 0;
-    static BOOL             usePerformanceCounter = 0;
-
-    if (!initialized) {
-        LARGE_INTEGER performanceFrequency;
-        initialized = 1;
-        usePerformanceCounter = QueryPerformanceFrequency(&performanceFrequency);
-        if (usePerformanceCounter) {
-            QueryPerformanceCounter(&offset);
-            frequencyToMicroseconds = (double)performanceFrequency.QuadPart / 1000000.;
-        } else {
-            offset = getFILETIMEoffset();
-            frequencyToMicroseconds = 10.;
-        }
-    }
-    if (usePerformanceCounter) QueryPerformanceCounter(&t);
-    else {
-        GetSystemTimeAsFileTime(&f);
-        t.QuadPart = f.dwHighDateTime;
-        t.QuadPart <<= 32;
-        t.QuadPart |= f.dwLowDateTime;
-    }
-
-    t.QuadPart -= offset.QuadPart;
-    microseconds = (double)t.QuadPart / frequencyToMicroseconds;
-    t.QuadPart = microseconds;
-    tv->tv_sec = t.QuadPart / 1000000;
-    tv->tv_usec = t.QuadPart % 1000000;
-    return (0);
-}
-#endif
-
 void SRTCompat_timeradd(struct timeval *a, struct timeval *b, struct timeval *result)
 {
     result->tv_sec  = a->tv_sec + b->tv_sec;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -63,6 +63,10 @@ modified by
 #include "threadname.h"
 #include "srt.h"
 
+#ifdef WIN32
+   #include <win/wintime.h>
+#endif
+
 using namespace std;
 
 extern logging::LogConfig srt_logger_config;

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -17,7 +17,6 @@
    #include <windows.h>
    #include <inttypes.h>
    #include <stdint.h>
-   #include "win/wintime.h"
    #if defined(_MSC_VER)
       #pragma warning(disable:4251)
    #endif


### PR DESCRIPTION
Do not expose internals unneeded by the external API. Also do not export global symbols in the SRT library with names like gettimeofday, clock_gettime, and timeradd as these are standard symbol names that may clash for the library user. This PR makes them static implementations to the library for internal use only and does not expose them to the public include and API. This also removes the wintime.h from the public API which may also, unnessarily cause clashes for the external library user.