### PR TITLE
Fixes for initial and refreshing KMX process

### DIFF
--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -131,6 +131,7 @@ int CCryptoControl::processSrtMsg_KMREQ(const uint32_t* srtdata, size_t bytelen,
 #define KMREQ_RESULT_REJECTION() { srtlen = 1; goto HSv4_ErrorReport; }
 
     int rc = HAICRYPT_OK; // needed before 'goto' run from KMREQ_RESULT_REJECTION macro
+    bool SRT_ATR_UNUSED wasb4 = false;
     size_t sek_len = 0;
 
     // What we have to do:
@@ -178,6 +179,7 @@ int CCryptoControl::processSrtMsg_KMREQ(const uint32_t* srtdata, size_t bytelen,
         m_RcvKmState = SRT_KM_S_NOSECRET;
         KMREQ_RESULT_REJECTION();
     }
+    wasb4 = m_hRcvCrypto;
 
     if (!createCryptoCtx(Ref(m_hRcvCrypto), m_iRcvKmKeyLen, HAICRYPT_CRYPTO_DIR_RX))
     {
@@ -186,16 +188,9 @@ int CCryptoControl::processSrtMsg_KMREQ(const uint32_t* srtdata, size_t bytelen,
         KMREQ_RESULT_REJECTION();
     }
 
-    HLOGC(mglog.Debug, log << "processSrtMsg_KMREQ: created also RX ENC with KeyLen=" << m_iRcvKmKeyLen);
-    if (bidirectional)
+    if (!wasb4)
     {
-        if (!createCryptoCtx(Ref(m_hSndCrypto), m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX))
-        {
-            LOGC(mglog.Error, log << "processSrtMsg_KMREQ: Can't create SND CRYPTO CTX - must reject...");
-            m_RcvKmState = SRT_KM_S_NOSECRET;
-            KMREQ_RESULT_REJECTION();
-        }
-        HLOGC(mglog.Debug, log << "processSrtMsg_KMREQ: created also TX ENC with KeyLen=" << m_iSndKmKeyLen);
+        HLOGC(mglog.Debug, log << "processSrtMsg_KMREQ: created RX ENC with KeyLen=" << m_iRcvKmKeyLen);
     }
 
     // We have both sides set with password, so both are pending for security
@@ -231,16 +226,37 @@ int CCryptoControl::processSrtMsg_KMREQ(const uint32_t* srtdata, size_t bytelen,
 
     // Configure the sender context also, if it succeeded to configure the
     // receiver context and we are using bidirectional mode.
-    if (m_RcvKmState == SRT_KM_S_SECURED && bidirectional )
+    if ( bidirectional )
     {
-        m_iSndKmKeyLen = m_iRcvKmKeyLen;
-        if (HaiCrypt_Clone(m_hRcvCrypto, HAICRYPT_CRYPTO_DIR_TX, &m_hSndCrypto))
+        // Note: 'bidirectional' means that we want a bidirectional key update,
+        // which happens only and exclusively with HSv5 handshake - not when the
+        // usual key update through UMSG_EXT+SRT_CMD_KMREQ was done (which is used
+        // in HSv4 versions also to initialize the first key, unlike HSv5).
+        if (m_RcvKmState == SRT_KM_S_SECURED )
         {
-            LOGC(mglog.Error, log << "processSrtMsg_KMREQ: Can't create SND CRYPTO CTX - WILL NOT SEND-ENCRYPT correctly!");
-            m_SndKmState = SRT_KM_S_NOSECRET;
-        }
+            m_iSndKmKeyLen = m_iRcvKmKeyLen;
+            if (HaiCrypt_Clone(m_hRcvCrypto, HAICRYPT_CRYPTO_DIR_TX, &m_hSndCrypto))
+            {
+                LOGC(mglog.Error, log << "processSrtMsg_KMREQ: Can't create SND CRYPTO CTX - WILL NOT SEND-ENCRYPT correctly!");
+                if (hasPassphrase())
+                    m_SndKmState = SRT_KM_S_BADSECRET;
+                else
+                    m_SndKmState = SRT_KM_S_NOSECRET;
+            }
 
-        LOGC(mglog.Note, log << FormatKmMessage("processSrtMsg_KMREQ", SRT_CMD_KMREQ, bytelen) << " SndKeyLen=" << m_iSndKmKeyLen);
+            LOGC(mglog.Note, log << FormatKmMessage("processSrtMsg_KMREQ", SRT_CMD_KMREQ, bytelen)
+                    << " SndKeyLen=" << m_iSndKmKeyLen
+                    << " TX CRYPTO CTX CLONED FROM RX"
+                    );
+        }
+        else
+        {
+            HLOGP(mglog.Debug, "processSrtMsg_KMREQ: NOT SECURED - not replaying failed security association to TX CRYPTO CTX");
+        }
+    }
+    else
+    {
+        HLOGC(mglog.Debug, log << "processSrtMsg_KMREQ: NOT REPLAYING the key update to TX CRYPTO CTX.");
     }
 
     return SRT_CMD_KMRSP;
@@ -316,7 +332,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
         if (key1 || key2)
         {
             m_SndKmState = m_RcvKmState = SRT_KM_S_SECURED;
-            HLOGC(mglog.Debug, log << "processSrtMsg_KMRSP: KM response matches key " << (key1 ? 1 : 2));
+            HLOGC(mglog.Debug, log << "processSrtMsg_KMRSP: KM response matches " << (key1 ? "EVEN" : "ODD") << " key");
         }
         else
         {
@@ -340,9 +356,13 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
 
 void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen)
 {
-    // XXX This must be done somehow differently for bidi
-    if ( !m_hSndCrypto )
+    if ( !m_hSndCrypto || m_SndKmState == SRT_KM_S_UNSECURED)
+    {
+        HLOGC(mglog.Debug, log << "sendKeysToPeer: NOT sending/regenerating keys: "
+                << (m_hSndCrypto ? "CONNECTION UNSECURED" : "NO TX CRYPTO CTX created"));
         return;
+    }
+
     uint64_t now;
     /*
      * Crypto Key Distribution to peer:
@@ -370,7 +390,10 @@ void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen)
     }
 
     if (regen)
-        regenCryptoKm(true, m_parent->handshakeVersion() > CUDT::HS_VERSION_UDT4); // regenerate and send
+        regenCryptoKm(
+                true, // send UMSG_EXT + SRT_CMD_KMREQ to the peer, if regenerated the key
+                false // Do not apply the regenerated key to the to the receiver context
+                ); // regenerate and send
 }
 
 void CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
@@ -394,22 +417,25 @@ void CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
          * Send to peer
          */
         // XXX Need to make it clearer and less hardcoded values
-        int ki = hcryptMsg_KM_GetKeyIndex((unsigned char *)(out_p[i])) & 0x1;
+        int kix = hcryptMsg_KM_GetKeyIndex((unsigned char *)(out_p[i]));
+        int ki = kix & 0x1;
         if ((out_len_p[i] != m_SndKmMsg[ki].MsgLen)
                 ||  (0 != memcmp(out_p[i], m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen))) 
         {
 
             uint8_t* oldkey SRT_ATR_UNUSED = m_SndKmMsg[ki].Msg;
-            HLOGF(mglog.Debug, "new key[%d] len=%zd,%zd msg=%0x,%0x\n", 
-                    ki, out_len_p[i], m_SndKmMsg[ki].MsgLen,
-                    *(int32_t *)out_p[i],
-                    *(int32_t *)oldkey);
+            HLOGC(mglog.Debug, log << "new key[" << ki << "] index=" << kix
+                    << " OLD=[" << m_SndKmMsg[ki].MsgLen << "]"
+                    << FormatBinaryString(m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen)
+                    << " NEW=[" << out_len_p[i] << "]"
+                    << FormatBinaryString((const uint8_t*)out_p[i], out_len_p[i]));
+
             /* New Keying material, send to peer */
             memcpy(m_SndKmMsg[ki].Msg, out_p[i], out_len_p[i]);
             m_SndKmMsg[ki].MsgLen = out_len_p[i];
             m_SndKmMsg[ki].iPeerRetry = SRT_MAX_KMRETRY;  
 
-            if (bidirectional)
+            if (bidirectional && !sendit)
             {
                 // "Send" this key also to myself, just to be applied to the receiver crypto,
                 // exactly the same way how this key is interpreted on the peer side into its receiver crypto
@@ -424,9 +450,19 @@ void CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
 
             if (sendit)
             {
+                HLOGC(mglog.Debug, log << "regenCryptoKm: SENDING ki=" << ki << " len=" << m_SndKmMsg[ki].MsgLen
+                        << " retry(updated)=" << m_SndKmMsg[ki].iPeerRetry);
                 m_parent->sendSrtMsg(SRT_CMD_KMREQ, (uint32_t *)m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen/sizeof(uint32_t));
                 sent++;
             }
+        }
+        else if (out_len_p[i] == 0)
+        {
+            HLOGC(mglog.Debug, log << "no key[" << ki << "] index=" << kix << ": not generated");
+        }
+        else
+        {
+            HLOGC(mglog.Debug, log << "no key[" << ki << "] index=" << kix << ": key unchanged");
         }
     }
 
@@ -506,7 +542,10 @@ bool CCryptoControl::init(HandshakeSide side, bool bidirectional)
                 return false;
             }
 
-            regenCryptoKm(false, bidirectional); // regen, but don't send.
+            regenCryptoKm(
+                    false,  // Do not send the key (will be attached it to the HSv5 handshake)
+                    bidirectional // replicate the key to the receiver context, if bidirectional
+                    );
         }
         else
         {


### PR DESCRIPTION
1. Made sure that the KMX refresh process works as initiated by the sender also when the connection is established with HSv5, and the agent is responder.
2. Fixed a memory leak due to creating the Sender Crypto (TXC) in the handler of KMREQ message, and then overwriting the pointer keeping it with a new Crypto object created by `HaiCrypt_Clone`.
3. Fixed the case of key refreshing when the key refreshment applied first to the Sender Crypto is applied also to Receiver Crypto, when the key was generated by refreshed key, not during the HSv5 handshake.
4. Changed the method of cloning the Sender Crypto out of Receiver Crypto by initializing it the same method as freshly created one, with the configuration object first extracted from the Receiver Crypto.