### PR TITLE
Fixed bug when crafting HS response after received waveahand version 4

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2937,7 +2937,7 @@ bool CUDT::processAsyncConnectRequest(EConnectStatus cst, const CPacket& respons
     uint64_t now = CTimer::getTime();
     request.m_iTimeStamp = int(now - this->m_StartTime);
 
-    HLOGC(mglog.Debug, log << "processAsyncConnectRequest: REQ-TIME: HIGH. Should prevent too quick responses.");
+    HLOGC(mglog.Debug, log << "startConnect: REQ-TIME: HIGH. Should prevent too quick responses.");
     m_llLastReqTime = now;
     // ID = 0, connection request
     request.m_iID = !m_bRendezvous ? 0 : m_ConnRes.m_iID;


### PR DESCRIPTION
The following problems are solved:
- It could happen that the `CUDT::createSrtHandshake`, called from within `CUDT::updateConnStatus` when a new handshake packet comes in, did not made itself aware yet that the peer is HSv4. The recognition is added and for that case it is made sure that the handshake is crafted exclusively according to the HSv4 rules, that is:
   - Version is 4
   - Type is 2 (`UDT_DGRAM`), not a bit flag combination used for HSv5.
- Handling the `CONN_REJECT` case, which still is possible for various circumstances in which this function is being called
- Added a comment for prospective fix in future: the `m_ConnRes` field should be rather always filled by the incoming handshake and `m_ConnReq` by the handshake that is prepared to be send to the peer. This is currently not done in case of blocking-mode caller. This is not fixed as this doesn't change anything in the functionality, only may make the code more consistent.