### PR TITLE
Fixed problems in handshake handling

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -172,7 +172,7 @@ CUDTUnited::~CUDTUnited()
     delete m_pCache;
 }
 
-std::string CUDTUnited::CONID(SRTSOCKET sock) const
+std::string CUDTUnited::CONID(SRTSOCKET sock)
 {
     if ( sock == 0 )
         return "";

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -128,7 +128,7 @@ public:
 
 public:
 
-   std::string CONID(SRTSOCKET sock) const;
+   static std::string CONID(SRTSOCKET sock);
 
       /// initialize the UDT library.
       /// @return 0 if success, otherwise -1 is returned.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2983,6 +2983,8 @@ bool CUDT::processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const
         */
     }
 
+    HLOGC(mglog.Debug, log << "processAsyncConnectRequest: sending request packet, setting REQ-TIME HIGH.");
+    m_llLastReqTime = CTimer::getTime();
     m_pSndQueue->sendto(serv_addr, request);
     return status;
 }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3123,16 +3123,27 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
         }
         else
         {
-            // This is a periodic handshake update, so you need to extract the KM data from the
-            // first message, provided that it is there.
-            kmdatasize = m_pCryptoControl->getKmMsg_size(0);
-            if (kmdatasize == 0)
+            // If the last CONCLUSION message didn't contain the KMX extension, there's
+            // no key recorded yet, so it can't be extracted. Mark this kmdatasize empty though.
+            int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
+            if (IsSet(hs_flags, CHandShake::HS_EXT_KMREQ))
             {
-                LOGC(mglog.Error, log << "processRendezvous: IPE: PERIODIC HS: NO KMREQ RECORDED.");
-                return CONN_REJECT;
+                // This is a periodic handshake update, so you need to extract the KM data from the
+                // first message, provided that it is there.
+                kmdatasize = m_pCryptoControl->getKmMsg_size(0);
+                if (kmdatasize == 0)
+                {
+                    LOGC(mglog.Error, log << "processRendezvous: IPE: PERIODIC HS: NO KMREQ RECORDED.");
+                    return CONN_REJECT;
+                }
+                HLOGC(mglog.Debug, log << "processRendezvous: getting KM DATA from the fore-recorded KMX from KMREQ");
+                memcpy(kmdata, m_pCryptoControl->getKmMsg_data(0), kmdatasize);
             }
-            HLOGC(mglog.Debug, log << "processRendezvous: getting KMDATA from the fore-recorded KMX from KMREQ");
-            memcpy(kmdata, m_pCryptoControl->getKmMsg_data(0), kmdatasize);
+            else
+            {
+                HLOGC(mglog.Debug, log << "processRendezvous: no KMX flag - not extracting KM data for KMRSP");
+                kmdatasize = 0;
+            }
         }
 
         // No matter the value of needs_extension, the extension is always needed
@@ -6775,7 +6786,22 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
                  }
                  else
                  {
-                     initdata.m_extension = true;
+                     // Extensions are added only in case of CONCLUSION (not AGREEMENT).
+                     // Actually what is expected here is that this may either process the
+                     // belated-repeated handshake from a caller (and then it's CONCLUSION,
+                     // and should be added with HSRSP/KMRSP), or it's a belated handshake
+                     // of Rendezvous when it has already considered itself connected.
+                     // Sanity check - according to the rules, there should be no such situation
+                     if (m_bRendezvous && m_SrtHsSide == HSD_RESPONDER)
+                     {
+                         LOGC(mglog.Error, log << "processCtrl/HS: IPE???: RESPONDER should receive all its handshakes in handshake phase.");
+                     }
+
+                     // The 'extension' flag will be set from this variable; set it to false
+                     // in case when the AGREEMENT response is to be sent.
+                     have_hsreq = initdata.m_iReqType == URQ_CONCLUSION;
+                     HLOGC(mglog.Debug, log << "processCtrl/HS: processing ok, reqtype="
+                             << RequestTypeStr(initdata.m_iReqType) << " kmdatasize=" << kmdatasize);
                  }
              }
              else

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3264,7 +3264,9 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
 
    // This is required in HSv5 rendezvous, in which it should send the URQ_AGREEMENT message to
    // the peer, however switch to connected state. 
-   HLOGC(mglog.Debug, log << "processConnectResponse: TYPE:" << MessageTypeStr(response.getType(), response.getExtendedType()));
+   HLOGC(mglog.Debug, log << "processConnectResponse: TYPE:" <<
+           (response.isControl() ?  MessageTypeStr(response.getType(), response.getExtendedType())
+            : string("DATA")));
    //ConnectStatus res = CONN_REJECT; // used later for status - must be declared here due to goto POST_CONNECT.
 
    // For HSv4, the data sender is INITIATOR, and the data receiver is RESPONDER,
@@ -3500,7 +3502,9 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
         // however in this case the HSREQ extension will not be attached,
         // so it will simply go the "old way".
         bool ok = prepareConnectionObjects(m_ConnRes, m_SrtHsSide, eout);
-        if ( ok )
+        // May happen that 'response' contains a data packet that was sent in rendezvous mode.
+        // In this situation the interpretation of handshake was already done earlier.
+        if (ok && response.isControl())
         {
             ok = interpretSrtHandshake(m_ConnRes, response, 0, 0);
             if (!ok && eout)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -305,7 +305,7 @@ private:
     /// @retval 1 Connection in progress (m_ConnReq turned into RESPONSE)
     /// @retval -1 Connection failed
 
-    EConnectStatus processConnectResponse(const CPacket& pkt, CUDTException* eout, bool synchro) ATR_NOEXCEPT;
+    SRT_ATR_NODISCARD EConnectStatus processConnectResponse(const CPacket& pkt, CUDTException* eout, bool synchro) ATR_NOEXCEPT;
 
 
     // This function works in case of HSv5 rendezvous. It changes the state
@@ -317,28 +317,28 @@ private:
     // - RETURNED VALUE: if true, it means a URQ_CONCLUSION message was received with HSRSP/KMRSP extensions and needs HSRSP/KMRSP.
     bool rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> needs_extension);
     void cookieContest();
-    EConnectStatus processRendezvous(ref_t<CPacket> reqpkt, const CPacket &response, const sockaddr* serv_addr, bool synchro);
-    bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
-    EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro);
+    SRT_ATR_NODISCARD EConnectStatus processRendezvous(ref_t<CPacket> reqpkt, const CPacket &response, const sockaddr* serv_addr, bool synchro);
+    SRT_ATR_NODISCARD bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
+    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro);
     void applyResponseSettings();
-    EConnectStatus processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT;
-    bool processAsyncConnectRequest(EConnectStatus cst, const CPacket& response, const sockaddr* serv_addr);
+    SRT_ATR_NODISCARD EConnectStatus processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT;
+    SRT_ATR_NODISCARD bool processAsyncConnectRequest(EConnectStatus cst, const CPacket& response, const sockaddr* serv_addr);
 
     void checkUpdateCryptoKeyLen(const char* loghdr, int32_t typefield);
 
-    size_t fillSrtHandshake_HSREQ(uint32_t* srtdata, size_t srtlen, int hs_version);
-    size_t fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t srtlen, int hs_version);
-    size_t fillSrtHandshake(uint32_t* srtdata, size_t srtlen, int msgtype, int hs_version);
+    SRT_ATR_NODISCARD size_t fillSrtHandshake_HSREQ(uint32_t* srtdata, size_t srtlen, int hs_version);
+    SRT_ATR_NODISCARD size_t fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t srtlen, int hs_version);
+    SRT_ATR_NODISCARD size_t fillSrtHandshake(uint32_t* srtdata, size_t srtlen, int msgtype, int hs_version);
 
-    bool createSrtHandshake(ref_t<CPacket> reqpkt, ref_t<CHandShake> hs,
+    SRT_ATR_NODISCARD bool createSrtHandshake(ref_t<CPacket> reqpkt, ref_t<CHandShake> hs,
             int srths_cmd, int srtkm_cmd, const uint32_t* data, size_t datalen);
 
-    size_t prepareSrtHsMsg(int cmd, uint32_t* srtdata, size_t size);
+    SRT_ATR_NODISCARD size_t prepareSrtHsMsg(int cmd, uint32_t* srtdata, size_t size);
 
-    bool processSrtMsg(const CPacket *ctrlpkt);
-    int processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv);
-    int processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv);
-    bool interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uint32_t* out_data, size_t* out_len);
+    SRT_ATR_NODISCARD bool processSrtMsg(const CPacket *ctrlpkt);
+    SRT_ATR_NODISCARD int processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv);
+    SRT_ATR_NODISCARD int processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv);
+    SRT_ATR_NODISCARD bool interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uint32_t* out_data, size_t* out_len);
 
     void updateAfterSrtHandshake(int srt_cmd, int hsv);
 
@@ -362,7 +362,7 @@ private:
     /// @param len [in] The size of the data block.
     /// @return Actual size of data sent.
 
-    int send(const char* data, int len)
+    SRT_ATR_NODISCARD int send(const char* data, int len)
     {
         return sendmsg(data, len, -1, false, 0);
     }
@@ -372,7 +372,7 @@ private:
     /// @param len [in] The desired size of data to be received.
     /// @return Actual size of data received.
 
-    int recv(char* data, int len);
+    SRT_ATR_NODISCARD int recv(char* data, int len);
 
     /// send a message of a memory block "data" with size of "len".
     /// @param data [out] data received.
@@ -382,20 +382,20 @@ private:
     /// @param srctime [in] Time when the data were ready to send.
     /// @return Actual size of data sent.
 
-    int sendmsg(const char* data, int len, int ttl, bool inorder, uint64_t srctime);
+    SRT_ATR_NODISCARD int sendmsg(const char* data, int len, int ttl, bool inorder, uint64_t srctime);
     /// Receive a message to buffer "data".
     /// @param data [out] data received.
     /// @param len [in] size of the buffer.
     /// @return Actual size of data received.
 
-    int sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> m);
+    SRT_ATR_NODISCARD int sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> m);
 
-    int recvmsg(char* data, int len, uint64_t& srctime);
+    SRT_ATR_NODISCARD int recvmsg(char* data, int len, uint64_t& srctime);
 
-    int recvmsg2(char* data, int len, ref_t<SRT_MSGCTRL> m);
+    SRT_ATR_NODISCARD int recvmsg2(char* data, int len, ref_t<SRT_MSGCTRL> m);
 
-    int receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> m);
-    int receiveBuffer(char* data, int len);
+    SRT_ATR_NODISCARD int receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> m);
+    SRT_ATR_NODISCARD int receiveBuffer(char* data, int len);
 
     /// Request UDT to send out a file described as "fd", starting from "offset", with size of "size".
     /// @param ifs [in] The input file stream.
@@ -404,7 +404,7 @@ private:
     /// @param block [in] size of block per read from disk
     /// @return Actual size of data sent.
 
-    int64_t sendfile(std::fstream& ifs, int64_t& offset, int64_t size, int block = 366000);
+    SRT_ATR_NODISCARD int64_t sendfile(std::fstream& ifs, int64_t& offset, int64_t size, int block = 366000);
 
     /// Request UDT to receive data into a file described as "fd", starting from "offset", with expected size of "size".
     /// @param ofs [out] The output file stream.
@@ -413,7 +413,7 @@ private:
     /// @param block [in] size of block per write to disk
     /// @return Actual size of data received.
 
-    int64_t recvfile(std::fstream& ofs, int64_t& offset, int64_t size, int block = 7320000);
+    SRT_ATR_NODISCARD int64_t recvfile(std::fstream& ofs, int64_t& offset, int64_t size, int block = 7320000);
 
     /// Configure UDT options.
     /// @param optName [in] The enum name of a UDT option.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -317,12 +317,21 @@ private:
     // - RETURNED VALUE: if true, it means a URQ_CONCLUSION message was received with HSRSP/KMRSP extensions and needs HSRSP/KMRSP.
     bool rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> needs_extension);
     void cookieContest();
-    SRT_ATR_NODISCARD EConnectStatus processRendezvous(ref_t<CPacket> reqpkt, const CPacket &response, const sockaddr* serv_addr, bool synchro);
+
+    /// Interpret the incoming handshake packet in order to perform appropriate
+    /// rendezvous FSM state transition if needed, and craft the response, serialized
+    /// into the packet to be next sent.
+    /// @param reqpkt Packet to be written with handshake data
+    /// @param response incoming handshake response packet to be interpreted
+    /// @param serv_addr incoming packet's address
+    /// @param synchro True when this function was called in blocking mode
+    /// @param rst Current read status to know if the HS packet was freshly received from the peer, or this is only a periodic update (RST_AGAIN)
+    SRT_ATR_NODISCARD EConnectStatus processRendezvous(ref_t<CPacket> reqpkt, const CPacket &response, const sockaddr* serv_addr, bool synchro, EReadStatus);
     SRT_ATR_NODISCARD bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
     SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro);
     void applyResponseSettings();
     SRT_ATR_NODISCARD EConnectStatus processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT;
-    SRT_ATR_NODISCARD bool processAsyncConnectRequest(EConnectStatus cst, const CPacket& response, const sockaddr* serv_addr);
+    SRT_ATR_NODISCARD bool processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const CPacket& response, const sockaddr* serv_addr);
 
     void checkUpdateCryptoKeyLen(const char* loghdr, int32_t typefield);
 

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -57,8 +57,8 @@ using namespace std;
 
 
 CHandShake::CHandShake():
-m_iVersion(AF_UNSPEC),
-m_iType(UDT_UNDEFINED),
+m_iVersion(0),
+m_iType(0), // Universal: UDT_UNDEFINED or no flags
 m_iISN(0),
 m_iMSS(0),
 m_iFlightFlagSize(0),

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1151,6 +1151,7 @@ void* CRcvQueue::worker(void* param)
            }
            else
            {
+               HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << " SOCKET broken, REMOVING FROM RCV QUEUE/MAP.");
                // the socket must be removed from Hash table first, then RcvUList
                self->m_pHash->remove(u->m_SocketID);
                self->m_pRcvUList->remove(u);
@@ -1217,6 +1218,7 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_
         CUDT* ne = getNewEntry();
         if (ne)
         {
+            HLOGC(mglog.Debug, log << CUDTUnited::CONID(ne->m_SocketID) << " SOCKET pending for connection - ADDING TO RCV QUEUE/MAP");
             m_pRcvUList->insert(ne);
             m_pHash->insert(ne->m_SocketID, ne);
         }
@@ -1397,7 +1399,61 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
         // appropriate mutex lock - which can't be done here because it's intentionally private.
         // OTOH it can't be applied to processConnectResponse because the synchronous
         // call to this method applies the lock by itself, and same-thread-double-locking is nonportable (crashable).
-        return u->processAsyncConnectResponse(unit->m_Packet);
+        EConnectStatus cst = u->processAsyncConnectResponse(unit->m_Packet);
+
+        // It might be that this is a data packet, which has turned the connection
+        // into "connected" state, removed the connector (so since now every next packet
+        // will land directly in the queue), but this data packet shall still be delivered.
+        if (cst == CONN_ACCEPT && !unit->m_Packet.isControl())
+        {
+            // The process as called through processAsyncConnectResponse() should have put the
+            // socket into the pending queue for pending connection (don't ask me, this is so).
+            // This pending queue is being purged every time in the beginning of this loop, so
+            // currently the socket is in the pending queue, but not yet in the connection queue.
+            // It will be done at the next iteration of the reading loop, but it will be too late,
+            // we have a pending data packet now and we must either dispatch it to an already connected
+            // socket or disregard it, and rather prefer the former. So do this transformation now
+            // that we KNOW (by the cst == CONN_ACCEPT result) that the socket should be inserted
+            // into the pending anteroom.
+
+            CUDT* ne = getNewEntry(); // This function actuall removes the entry and returns it.
+            // This **should** now always return a non-null value, but check it first
+            // because if this accidentally isn't true, the call to worker_ProcessAddressedPacket will
+            // result in redirecting it to here and so on until the call stack overflow. In case of
+            // this "accident" simply disregard the packet from any further processing, it will be later
+            // loss-recovered.
+            // XXX (Probably the old contents of UDT's CRcvQueue::worker should be shaped a little bit
+            // differently throughout the functions).
+            if (ne)
+            {
+                HLOGC(mglog.Debug, log << CUDTUnited::CONID(ne->m_SocketID) << " SOCKET pending for connection - ADDING TO RCV QUEUE/MAP");
+                m_pRcvUList->insert(ne);
+                m_pHash->insert(ne->m_SocketID, ne);
+
+                // The current situation is that this has passed processAsyncConnectResponse, but actually
+                // this packet *SHOULD HAVE BEEN* handled by worker_ProcessAddressedPacket, however the
+                // connection state wasn't completed at the moment when dispatching this packet. This has
+                // been now completed inside the call to processAsyncConnectResponse, but this is still a
+                // data packet that should have expected the connection to be already established. Therefore
+                // redirect it once again into worker_ProcessAddressedPacket here.
+
+                HLOGC(mglog.Debug, log << "AsyncOrRND: packet SWITCHED TO CONNECTED with ID=" << id
+                        << " -- passing to worker_ProcessAddressedPacket");
+
+                // Theoretically we should check if m_pHash->lookup(ne->m_SocketID) returns 'ne', but this
+                // has been just added to m_pHash, so the check would be extremely paranoid here.
+                cst = worker_ProcessAddressedPacket(id, unit, addr);
+                if (cst == CONN_REJECT)
+                    return cst;
+                return CONN_ACCEPT; // this function usually will return CONN_CONTINUE, which doesn't represent current situation.
+            }
+            else
+            {
+                LOGC(mglog.Error, log << "IPE: AsyncOrRND: packet SWITCHED TO CONNECTED, but ID=" << id
+                        << " is still not present in the socket ID dispatch hash - DISREGARDING");
+            }
+        }
+        return cst;
     }
     HLOGC(mglog.Debug, log << "AsyncOrRND: packet RESOLVED TO ID=" << id << " -- continuing through CENTRAL PACKET QUEUE");
     // This is where also the packets for rendezvous connection will be landing,
@@ -1514,6 +1570,7 @@ void CRcvQueue::removeConnector(const SRTSOCKET& id, bool should_lock)
 
 void CRcvQueue::setNewEntry(CUDT* u)
 {
+   HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
    CGuard listguard(m_IDLock);
    m_vNewEntry.push_back(u);
 }

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -868,117 +868,127 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr* addr, ref_t<SRTSOCKET> r_id)
 
 void CRendezvousQueue::updateConnStatus(EConnectStatus cst, const CPacket& response)
 {
-   CGuard vg(m_RIDVectorLock);
+    CGuard vg(m_RIDVectorLock);
 
-   if (m_lRendezvousID.empty())
-      return;
+    if (m_lRendezvousID.empty())
+        return;
 
-   int debug_nupd = 0;
-   int debug_nrun = 0;
+    HLOGC(mglog.Debug, log << "updateConnStatus: updating after getting pkt id=" << response.m_iID << " status: " << ConnectStatusStr(cst));
 
-   HLOGC(mglog.Debug, log << "updateConnStatus: updating after getting pkt id=" << response.m_iID << " status: " << ConnectStatusStr(cst));
+#if ENABLE_HEAVY_LOGGING
+    int debug_nupd = 0;
+    int debug_nrun = 0;
+    int debug_nfail = 0;
+#endif
 
-   list<CRL>::iterator i = m_lRendezvousID.begin();
-   while (i != m_lRendezvousID.end())
-   {
-       // NOTE: This is a SAFE LOOP.
-       // Incrementation will be done at the end, after the processing did not
-       // REMOVE the currently processed element. When the element was removed,
-       // the iterator value for the next iteration will be taken from erase()'s result.
+    for (list<CRL>::iterator i = m_lRendezvousID.begin(), i_next = i; i != m_lRendezvousID.end(); i = i_next)
+    {
+        ++i_next;
+        // NOTE: This is a SAFE LOOP.
+        // Incrementation will be done at the end, after the processing did not
+        // REMOVE the currently processed element. When the element was removed,
+        // the iterator value for the next iteration will be taken from erase()'s result.
 
-      // CONN_AGAIN happens in case when the last attempt to read a packet from the UDP
-      // socket has read nothing. In this case it would be a repeated update, while
-      // still waiting for a response from the peer. When we have any other state here
-      // (most expectably CONN_CONTINUE or CONN_RENDEZVOUS, which means that a packet has
-      // just arrived in this iteration), send the response immediately.
-      uint64_t then = i->m_pUDT->m_llLastReqTime;
-      uint64_t now = CTimer::getTime();
-      bool nowstime = true;
-      if (cst == CONN_AGAIN)
-      {
-          // If no packet has been received from the peer,
-          // avoid sending too many requests, at most 1 request per 250ms
-          HLOGC(mglog.Debug, log << "RID:%" << i->m_iID << " then=" << then << " now=" << now << " passed=" << (now-then)
-                  <<  "<=> 250000 -- now's " << (nowstime ? "" : "NOT ") << "the time");
-          nowstime = (now - then) > 250000;
-      }
-      else
-      {
-          HLOGC(mglog.Debug, log << "RID:%" << i->m_iID << " cst=" << ConnectStatusStr(cst) << " -- sending update NOW.");
-      }
+        // CONN_AGAIN happens in case when the last attempt to read a packet from the UDP
+        // socket has read nothing. In this case it would be a repeated update, while
+        // still waiting for a response from the peer. When we have any other state here
+        // (most expectably CONN_CONTINUE or CONN_RENDEZVOUS, which means that a packet has
+        // just arrived in this iteration), send the response immediately.
+        uint64_t then = i->m_pUDT->m_llLastReqTime;
+        uint64_t now = CTimer::getTime();
+        bool nowstime = true;
 
+        // Use "slow" cyclic responding in case when
+        // - CONN_AGAIN (no packet was received for whichever socket)
+        // - a packet was received, but not for THIS socket
+        if (cst == CONN_AGAIN || i->m_iID != response.m_iID)
+        {
+            // If no packet has been received from the peer,
+            // avoid sending too many requests, at most 1 request per 250ms
+            nowstime = (now - then) > 250000;
+            HLOGC(mglog.Debug, log << "RID:%" << i->m_iID << " then=" << then << " now=" << now << " passed=" << (now-then)
+                    <<  "<=> 250000 -- now's " << (nowstime ? "" : "NOT ") << "the time");
+        }
+        else
+        {
+            HLOGC(mglog.Debug, log << "RID:%" << i->m_iID << " cst=" << ConnectStatusStr(cst) << " -- sending update NOW.");
+        }
 
-       ++debug_nrun;
-      if (nowstime)
-      {
-          // XXX This guy... has created a loop that rolls in infinity without any
-          // sleeps inside and makes it once per about 50 calls send a hs conclusion
-          // for a randomly sampled rendezvous ID of a socket out of the list.
-          // Ok, probably the rendezvous ID should be just one so not much to
-          // sample from, but if so, why the container?
-          //
-          // This must be somehow fixed!
-         if (CTimer::getTime() >= i->m_ullTTL)
-         {
-            HLOGC(mglog.Debug, log << "RendezvousQueue: EXPIRED. removing from queue");
-            // connection timer expired, acknowledge app via epoll
-            i->m_pUDT->m_bConnecting = false;
-            CUDT::s_UDTUnited.m_EPoll.update_events(i->m_iID, i->m_pUDT->m_sPollID, UDT_EPOLL_ERR, true);
-            /*
-            * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
-            * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
-            * and may crash here on next pass.
-            */
-            if (AF_INET == i->m_iIPversion)
-               delete (sockaddr_in*)i->m_pPeerAddr;
-            else
-               delete (sockaddr_in6*)i->m_pPeerAddr;
+#if ENABLE_HEAVY_LOGGING
+        ++debug_nrun;
+#endif
+        if (nowstime)
+        {
+            // XXX This guy... has created a loop that rolls in infinity without any
+            // sleeps inside and makes it once per about 50 calls send a hs conclusion
+            // for a randomly sampled rendezvous ID of a socket out of the list.
+            // Ok, probably the rendezvous ID should be just one so not much to
+            // sample from, but if so, why the container?
+            //
+            // This must be somehow fixed!
+            if (CTimer::getTime() >= i->m_ullTTL)
+            {
+                HLOGC(mglog.Debug, log << "RendezvousQueue: EXPIRED. removing from queue");
+                // connection timer expired, acknowledge app via epoll
+                i->m_pUDT->m_bConnecting = false;
+                CUDT::s_UDTUnited.m_EPoll.update_events(i->m_iID, i->m_pUDT->m_sPollID, UDT_EPOLL_ERR, true);
+                /*
+                 * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
+                 * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
+                 * and may crash here on next pass.
+                 */
+                if (AF_INET == i->m_iIPversion)
+                    delete (sockaddr_in*)i->m_pPeerAddr;
+                else
+                    delete (sockaddr_in6*)i->m_pPeerAddr;
 
-            i = m_lRendezvousID.erase(i);
-            continue;
-         }
+                // i_next was preincremented, but this is guaranteed to point to
+                // the element next to erased one.
+                i_next = m_lRendezvousID.erase(i);
+                continue;
+            }
 
-         // This queue is used only in case of Rendezvous or Async mode caller-listener.
-         // Synchronous connection requests are handled in startConnect() completely.
-         //if (cst != CONN_AGAIN && (i->m_pUDT->m_bRendezvous || !i->m_pUDT->m_bSynRecving))
-         if (!i->m_pUDT->m_bSynRecving)
-         {
-             ++debug_nupd;
-             list<CRL>::iterator i_next = i;
-             ++i_next;
+            // This queue is used only in case of Async mode Rendezvous or caller-listener.
+            // Synchronous connection requests are handled in startConnect() completely.
+            //if (cst != CONN_AGAIN && (i->m_pUDT->m_bRendezvous || !i->m_pUDT->m_bSynRecving))
+            if (!i->m_pUDT->m_bSynRecving)
+            {
+#if ENABLE_HEAVY_LOGGING
+                ++debug_nupd;
+#endif
 
-             // IMPORTANT INFORMATION.
-             // In the legacy UDT code there was no attempt to interpret any incoming data.
-             // All data from the incoming packet were considered to be already deployed into
-             // m_ConnRes field, and m_ConnReq field was considered at this time accordingly updated.
-             // Therefore this procedure did only one thing: craft a new handshake packet and send it.
-             // In SRT this may also interpret extra data (extensions in case when Agent is Responder)
-             // and the `response` packet may sometimes contain no data, which can be recognized by
-             // `response.getLength() == -1u` condition.
-             //
-             // In the below call, only the underlying `processRendezvous` function will be attempting
-             // to interpret these data (for caller-listener this was already done by `processConnectRequest`
-             // before calling this function), and it checks for the data presence.
-             if (i->m_pUDT->processAsyncConnectRequest(cst, response, i->m_pPeerAddr))
-             {
-                 // This has been processed and most likely removed.
-                 i = i_next;
-                 continue;
-             }
-         }
-         /*
-            This debug log is blocked because it is sent multiple times in a millisecond without a good reason.
-         else
-         {
-             HLOGC(mglog.Debug, log << "updateConnStatus: RendezvousQueue not to send CONCLUSION for the non-rdv sokket.");
-         }
-         // */
-      }
+                // IMPORTANT INFORMATION.
+                // In the legacy UDT code there was no attempt to interpret any incoming data.
+                // All data from the incoming packet were considered to be already deployed into
+                // m_ConnRes field, and m_ConnReq field was considered at this time accordingly updated.
+                // Therefore this procedure did only one thing: craft a new handshake packet and send it.
+                // In SRT this may also interpret extra data (extensions in case when Agent is Responder)
+                // and the `response` packet may sometimes contain no data, which can be recognized by
+                // `response.getLength() == -1u` condition.
+                //
+                // In the below call, only the underlying `processRendezvous` function will be attempting
+                // to interpret these data (for caller-listener this was already done by `processConnectRequest`
+                // before calling this function), and it checks for the data presence.
+                if (!i->m_pUDT->processAsyncConnectRequest(cst, response, i->m_pPeerAddr))
+                {
+                    LOGC(mglog.Error, log << "RendezvousQueue: processAsyncConnectRequest FAILED. Setting TTL as EXPIRED.");
+                    i->m_ullTTL = 0; // Make it expire right now, will be picked up at the next iteration
+#if ENABLE_HEAVY_LOGGING
+                    ++debug_nfail;
+#endif
+                }
 
-      i++;
-   }
+                // NOTE: safe loop, the incrementation was done before the loop body,
+                // so the `i' node can be safely deleted. Just the body must end here.
+                continue;
+            }
+        }
+    }
 
-   HLOGC(mglog.Debug, log << "updateConnStatus: total of " << debug_nupd << " sockets updated, the loop ran " << (debug_nrun-debug_nupd) << " uselessly.");
+    HLOGC(mglog.Debug,
+            log << "updateConnStatus: " << debug_nupd << "/" << debug_nrun << " sockets updated ("
+            << (debug_nrun-debug_nupd) << " useless). REMOVED " << debug_nfail << " sockets."
+         );
 }
 
 //
@@ -1152,7 +1162,8 @@ void* CRcvQueue::worker(void* param)
 
        if ( have_received )
        {
-           HLOGC(mglog.Debug, log << "worker: updateConnStatus (after received packet from the party)");
+           HLOGC(mglog.Debug, log << "worker: RECEIVED PACKET --> updateConnStatus. cst=" << ConnectStatusStr(cst)
+                   << " id=" << id << " pkt-payload-size=" << unit->m_Packet.getLength());
        }
 
        // Check connection requests status for all sockets in the RendezvousQueue.
@@ -1162,6 +1173,9 @@ void* CRcvQueue::worker(void* param)
        // CUDT::processAsyncConnectResponse --->
        // CUDT::processConnectResponse 
        self->m_pRendezvousQueue->updateConnStatus(cst, unit->m_Packet);
+
+       // XXX updateConnStatus may have removed the connector from the list,
+       // however there's still m_mBuffer in CRcvQueue for that socket to care about.
    }
 
    THREAD_EXIT();
@@ -1473,6 +1487,7 @@ void CRcvQueue::removeListener(const CUDT* u)
 
 void CRcvQueue::registerConnector(const SRTSOCKET& id, CUDT* u, int ipv, const sockaddr* addr, uint64_t ttl)
 {
+   HLOGC(mglog.Debug, log << "registerConnector: adding %" << id << " addr=" << SockaddrToString(addr) << " TTL=" << ttl);
    m_pRendezvousQueue->insert(id, u, ipv, addr, ttl);
 }
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -885,15 +885,8 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
     {
         ++i_next;
         // NOTE: This is a SAFE LOOP.
-        // Incrementation will be done at the end, after the processing did not
-        // REMOVE the currently processed element. When the element was removed,
-        // the iterator value for the next iteration will be taken from erase()'s result.
-
-        // CONN_AGAIN happens in case when the last attempt to read a packet from the UDP
-        // socket has read nothing. In this case it would be a repeated update, while
-        // still waiting for a response from the peer. When we have any other state here
-        // (most expectably CONN_CONTINUE or CONN_RENDEZVOUS, which means that a packet has
-        // just arrived in this iteration), send the response immediately.
+        // The next iterator is preincremented so that it points to the valid element,
+        // even if the processing inside deleted the node at `i`.
         uint64_t then = i->m_pUDT->m_llLastReqTime;
         uint64_t now = CTimer::getTime();
 
@@ -908,13 +901,16 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
 #endif
         if (nowstime)
         {
-            // XXX This guy... has created a loop that rolls in infinity without any
-            // sleeps inside and makes it once per about 50 calls send a hs conclusion
+            // XXX This looks like a loop that rolls in infinity without any sleeps
+            // inside and makes it once per about 50 calls send a hs conclusion
             // for a randomly sampled rendezvous ID of a socket out of the list.
             // Ok, probably the rendezvous ID should be just one so not much to
             // sample from, but if so, why the container?
             //
             // This must be somehow fixed!
+            //
+            // Maybe the time should be simply checked once and the whole loop not
+            // done when "it's not the time"?
             if (CTimer::getTime() >= i->m_ullTTL)
             {
                 HLOGC(mglog.Debug, log << "RendezvousQueue: EXPIRED. removing from queue");
@@ -937,23 +933,22 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
                 continue;
             }
 
-            // This queue is used only in case of Async mode Rendezvous or caller-listener.
+            // This queue is used only in case of Async mode (rendezvous or caller-listener).
             // Synchronous connection requests are handled in startConnect() completely.
-            //if (cst != CONN_AGAIN && (i->m_pUDT->m_bRendezvous || !i->m_pUDT->m_bSynRecving))
             if (!i->m_pUDT->m_bSynRecving)
             {
 #if ENABLE_HEAVY_LOGGING
                 ++debug_nupd;
 #endif
-
-                // IMPORTANT INFORMATION.
-                // In the legacy UDT code there was no attempt to interpret any incoming data.
+                // IMPORTANT INFORMATION concerning changes towards UDT legacy.
+                // In the UDT code there was no attempt to interpret any incoming data.
                 // All data from the incoming packet were considered to be already deployed into
                 // m_ConnRes field, and m_ConnReq field was considered at this time accordingly updated.
                 // Therefore this procedure did only one thing: craft a new handshake packet and send it.
                 // In SRT this may also interpret extra data (extensions in case when Agent is Responder)
-                // and the `response` packet may sometimes contain no data, which can be recognized by
-                // `response.getLength() == -1u` condition.
+                // and the `response` packet may sometimes contain no data. Therefore the passed `rst`
+                // must be checked to distinguish the call by periodic update (RST_AGAIN) from a call
+                // due to have received the packet (RST_OK).
                 //
                 // In the below call, only the underlying `processRendezvous` function will be attempting
                 // to interpret these data (for caller-listener this was already done by `processConnectRequest`

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -312,7 +312,7 @@ public:
    void remove(const SRTSOCKET& id, bool should_lock);
    CUDT* retrieve(const sockaddr* addr, ref_t<SRTSOCKET> id);
 
-   void updateConnStatus(EConnectStatus, const CPacket& response);
+   void updateConnStatus(EReadStatus rst, EConnectStatus, const CPacket& response);
 
 private:
    struct CRL

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -70,12 +70,23 @@ written by
 // You can use these constants with SRTO_MINVERSION option.
 #define SRT_VERSION_FEAT_HSv5 0x010300
 
-#ifdef __GNUG__
+// When compiling in C++17 mode, use the standard C++17 attributes
+// (out of these, only [[deprecated]] is supported in C++14, so
+// for all lesser standard use compiler-specific attributes).
+#if defined(__cplusplus) && __cplusplus > 201406
+#define SRT_ATR_UNUSED [[maybe_unused]]
+#define SRT_ATR_DEPRECATED [[deprecated]]
+#define SRT_ATR_NODISCARD [[nodiscard]]
+
+// GNUG is GNU C++; this syntax is also supported by Clang
+#elif defined( __GNUG__)
 #define SRT_ATR_UNUSED __attribute__((unused))
 #define SRT_ATR_DEPRECATED __attribute__((deprecated))
+#define SRT_ATR_NODISCARD __attribute__((warn_unused_result))
 #else
 #define SRT_ATR_UNUSED
 #define SRT_ATR_DEPRECATED
+#define SRT_ATR_NODISCARD
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes:
 - the rejection case in `startConnect` was catching a not possible behavior. The condition stayed, but it is turned into just an IPE error message.
 - added case when the processing ended with `CONN_REJECT` and was not properly handled - this adds the exception info
 - removed calls to `removeConnector` previously applied when the process gets broken due to rejection. Instead the removal is done only in case when this function is about to finish and throw exception due to any case of abnormal result.
 - in `processRendezvous` the "response" packet is checked if it contains data (otherwise payload size is set to -1). There were cases when a non-received payload packet was passed to this function and was interpreted as infinite-size content causing a crash
 - made the `updateConnStatus` respond anything only in asynchronous mode (this was probably allowed in synchronous mode in UDT because it was an accidental patch to a bug). Keeping this running in synchronous mode might in specific cases cause processing the incoming packet in two FAs and two threads separately in areas that weren't predicted to be protected against simultaneous access
 - fixed a problem when setting REQ-TIME LOW when no packet has arrived
 - passing the rst state down to processRendezvous so that it can distinguish after-packet call to periodic-update call
 - processRendezvous when called for periodic update (and is unable to get the data from KMREQ), crafts KMRSP from data recorded when doing reverse-KMX (WARNING: this makes this PR now depedent on #365)
