### PR TITLE
Added support for -v:2 for verbose to stderr and make -v stdout by default

### DIFF
--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -260,7 +260,34 @@ int main( int argc, char** argv )
         transmit_chunk_size = chunk;
     }
 
-    Verbose::on = Option("no", "v", "verbose") != "no";
+    string verbose_val = Option("no", "v", "verbose");
+    int verbch = 1; // default cerr
+    if (verbose_val != "no")
+    {
+        Verbose::on = true;
+        try
+        {
+            verbch = stoi(verbose_val);
+        }
+        catch (...)
+        {
+            verbch = 1;
+        }
+        if (verbch != 1)
+        {
+            if (verbch != 2)
+            {
+                cerr << "-v or -v:1 (default) or -v:2 only allowed\n";
+                return 1;
+            }
+            Verbose::cverb = &std::cerr;
+        }
+        else
+        {
+            Verbose::cverb = &std::cout;
+        }
+    }
+
     bool crashonx = Option("no", "k", "crash") != "no";
     string loglevel = Option("error", "loglevel");
     string logfa = Option("general", "logfa");

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -333,7 +333,28 @@ int main( int argc, char** argv )
 
    string verbo = Option<OutString>(params, "no", o_verbose);
    if ( verbo == "" || !false_names.count(verbo) )
+   {
        Verbose::on = true;
+       int verboch = atoi(verbo.c_str());
+       if (verboch <= 0)
+       {
+           verboch = 1;
+       }
+       else if (verboch > 2)
+       {
+           cerr << "ERROR: -v option accepts value 1 (stdout, default) or 2 (stderr)\n";
+           return 1;
+       }
+
+       if (verboch == 1)
+       {
+           Verbose::cverb = &std::cout;
+       }
+       else
+       {
+           Verbose::cverb = &std::cerr;
+       }
+   }
 
     string srt_endpoint = args[0];
 

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -91,7 +91,6 @@ protected:
         ConnectClient(host, port);
     }
 
-
     virtual ~SrtCommon();
 };
 


### PR DESCRIPTION
This makes two changes that restore old behavior for two *testing* applications only: `srt-test-live` and `srt-test-relay`:
- make the default channel for `-v` option stdout (unlike `apps` applications)
- allow for setting verbose to stderr by `-v:2`
