### PR TITLE
Timedwait fix

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -297,7 +297,7 @@ void CTimer::sleep()
    #endif
 }
 
-int CTimer::condTimedWait(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay) {
+int CTimer::condTimedWaitUS(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay) {
     timeval now;
     gettimeofday(&now, 0);
     uint64_t time_us = now.tv_sec * 1000000 + now.tv_usec + delay;

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -297,6 +297,17 @@ void CTimer::sleep()
    #endif
 }
 
+int CTimer::condTimedWait(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay) {
+    timeval now;
+    gettimeofday(&now, 0);
+    uint64_t time_us = now.tv_sec * 1000000 + now.tv_usec + delay;
+    timespec timeout;
+    timeout.tv_sec = time_us / 1000000;
+    timeout.tv_nsec = (time_us % 1000000) * 1000;
+    
+    return pthread_cond_timedwait(cond, mutex, &timeout);
+}
+
 
 // Automatically lock in constructor
 CGuard::CGuard(pthread_mutex_t& lock, bool shouldwork):

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -490,7 +490,7 @@ public:
       /// @retval 0 Wait was successfull
       /// @retval ETIMEDOUT The wait timed out
 
-   static int condTimedWait(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay);
+   static int condTimedWaitUS(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay);
 
 private:
    uint64_t getTimeInMicroSec();

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -482,6 +482,9 @@ public:
       /// sleep for a short interval. exact sleep time does not matter
 
    static void sleep();
+   
+      /// Wait for condition with timeout 
+   static int condTimedWait(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay);
 
 private:
    uint64_t getTimeInMicroSec();

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -484,6 +484,12 @@ public:
    static void sleep();
    
       /// Wait for condition with timeout 
+      /// @param [in] cond Condition variable to wait for
+      /// @param [in] mutex locked mutex associated with the condition variable
+      /// @param [in] delay timeout in microseconds
+      /// @retval 0 Wait was successfull
+      /// @retval ETIMEDOUT The wait timed out
+
    static int condTimedWait(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay);
 
 private:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3870,6 +3870,7 @@ void* CUDT::tsbpd(void* param)
    {
       int32_t current_pkt_seq = 0;
       uint64_t tsbpdtime = 0;
+      int64_t timediff = 0;
       bool rxready = false;
 
       CGuard::enterCS(self->m_AckLock);
@@ -3918,14 +3919,12 @@ void* CUDT::tsbpd(void* param)
 
                 self->m_iRcvLastSkipAck = skiptoseqno;
 
+                 uint64_t now = CTimer::getTime();
+                 if ( tsbpdtime )
+                     timediff = int64_t(now) - int64_t(tsbpdtime);
 #if ENABLE_LOGGING
-                uint64_t now = CTimer::getTime();
-
 #if ENABLE_HEAVY_LOGGING
-                int64_t timediff = 0;
-                if ( tsbpdtime )
-                    timediff = int64_t(now) - int64_t(tsbpdtime);
-
+             
                 HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: DROPSEQ: up to seq=" << CSeqNo::decseq(skiptoseqno)
                     << " (" << seqlen << " packets) playable at " << logging::FormatTime(tsbpdtime) << " delayed "
                     << (timediff/1000) << "." << (timediff%1000) << " ms");
@@ -3978,12 +3977,9 @@ void* CUDT::tsbpd(void* param)
          */
           self->m_bTsbPdAckWakeup = false;
           THREAD_PAUSED();
-          timespec locktime;
-          locktime.tv_sec = tsbpdtime / 1000000;
-          locktime.tv_nsec = (tsbpdtime % 1000000) * 1000;
           HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: FUTURE PACKET seq=" << current_pkt_seq
-              << " T=" << logging::FormatTime(tsbpdtime) << " - waiting " << ((tsbpdtime - CTimer::getTime())/1000.0) << "ms");
-          pthread_cond_timedwait(&self->m_RcvTsbPdCond, &self->m_RecvLock, &locktime);
+              << " T=" << logging::FormatTime(tsbpdtime) << " - waiting " << (timediff/1000.0) << "ms");
+          CTimer::condTimedWait(&self->m_RcvTsbPdCond, &self->m_RecvLock, timediff);
           THREAD_RESUMED();
       }
       else
@@ -4624,24 +4620,15 @@ int CUDT::receiveBuffer(char* data, int len)
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
                 {
                     //Do not block forever, check connection status each 1 sec.
-                    uint64_t exptime = CTimer::getTime() + 1000000ULL;
-                    timespec locktime;
-
-                    locktime.tv_sec = exptime / 1000000;
-                    locktime.tv_nsec = (exptime % 1000000) * 1000;
-                    pthread_cond_timedwait(&m_RecvDataCond, &m_RecvLock, &locktime);
+                    CTimer::condTimedWait(&m_RecvDataCond, &m_RecvLock, 1000000ULL);
                 }
             }
             else
             {
                 uint64_t exptime = CTimer::getTime() + m_iRcvTimeOut * 1000;
-                timespec locktime;
-                locktime.tv_sec = exptime / 1000000;
-                locktime.tv_nsec = (exptime % 1000000) * 1000;
-
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
                 {
-                    pthread_cond_timedwait(&m_RecvDataCond, &m_RecvLock, &locktime);
+                    CTimer::condTimedWait(&m_RecvDataCond, &m_RecvLock, m_iRcvTimeOut * 1000);
                     if (CTimer::getTime() >= exptime)
                         break;
                 }
@@ -4878,16 +4865,12 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
                 else
                 {
                     uint64_t exptime = CTimer::getTime() + m_iSndTimeOut * 1000ULL;
-                    timespec locktime;
-
-                    locktime.tv_sec = exptime / 1000000;
-                    locktime.tv_nsec = (exptime % 1000000) * 1000;
 
                     while (stillConnected()
                             && sndBuffersLeft() < minlen
                             && m_bPeerHealth
                             && exptime > CTimer::getTime())
-                        pthread_cond_timedwait(&m_SendBlockCond, &m_SendBlockLock, &locktime);
+                        CTimer::condTimedWait(&m_SendBlockCond, &m_SendBlockLock, m_iSndTimeOut * 1000ULL);
                 }
             }
 
@@ -5129,12 +5112,7 @@ int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
             do
             {
-                uint64_t exptime = CTimer::getTime() + (recvtmo * 1000ULL);
-                timespec locktime;
-
-                locktime.tv_sec = exptime / 1000000;
-                locktime.tv_nsec = (exptime % 1000000) * 1000;
-                if (pthread_cond_timedwait(&m_RecvDataCond, &m_RecvLock, &locktime) == ETIMEDOUT)
+                if (CTimer::condTimedWait(&m_RecvDataCond, &m_RecvLock, recvtmo * 1000ULL) == ETIMEDOUT)
                 {
                     if (!(m_iRcvTimeOut < 0))
                         timeout = true;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3978,7 +3978,7 @@ void* CUDT::tsbpd(void* param)
           THREAD_PAUSED();
           HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: FUTURE PACKET seq=" << current_pkt_seq
               << " T=" << logging::FormatTime(tsbpdtime) << " - waiting " << (timediff/1000.0) << "ms");
-          CTimer::condTimedWait(&self->m_RcvTsbPdCond, &self->m_RecvLock, timediff);
+          CTimer::condTimedWaitUS(&self->m_RcvTsbPdCond, &self->m_RecvLock, timediff);
           THREAD_RESUMED();
       }
       else
@@ -4619,7 +4619,7 @@ int CUDT::receiveBuffer(char* data, int len)
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
                 {
                     //Do not block forever, check connection status each 1 sec.
-                    CTimer::condTimedWait(&m_RecvDataCond, &m_RecvLock, 1000000ULL);
+                    CTimer::condTimedWaitUS(&m_RecvDataCond, &m_RecvLock, 1000000ULL);
                 }
             }
             else
@@ -4627,7 +4627,7 @@ int CUDT::receiveBuffer(char* data, int len)
                 uint64_t exptime = CTimer::getTime() + m_iRcvTimeOut * 1000;
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
                 {
-                    CTimer::condTimedWait(&m_RecvDataCond, &m_RecvLock, m_iRcvTimeOut * 1000);
+                    CTimer::condTimedWaitUS(&m_RecvDataCond, &m_RecvLock, m_iRcvTimeOut * 1000);
                     if (CTimer::getTime() >= exptime)
                         break;
                 }
@@ -4869,7 +4869,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
                             && sndBuffersLeft() < minlen
                             && m_bPeerHealth
                             && exptime > CTimer::getTime())
-                        CTimer::condTimedWait(&m_SendBlockCond, &m_SendBlockLock, m_iSndTimeOut * 1000ULL);
+                        CTimer::condTimedWaitUS(&m_SendBlockCond, &m_SendBlockLock, m_iSndTimeOut * 1000ULL);
                 }
             }
 
@@ -5111,7 +5111,7 @@ int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
             do
             {
-                if (CTimer::condTimedWait(&m_RecvDataCond, &m_RecvLock, recvtmo * 1000ULL) == ETIMEDOUT)
+                if (CTimer::condTimedWaitUS(&m_RecvDataCond, &m_RecvLock, recvtmo * 1000ULL) == ETIMEDOUT)
                 {
                     if (!(m_iRcvTimeOut < 0))
                         timeout = true;

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1379,13 +1379,7 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
 
    if (i == m_mBuffer.end())
    {
-       uint64_t now = CTimer::getTime();
-       timespec timeout;
-
-       timeout.tv_sec = now / 1000000 + 1;
-       timeout.tv_nsec = (now % 1000000) * 1000;
-
-       pthread_cond_timedwait(&m_PassCond, &m_PassLock, &timeout);
+      CTimer::condTimedWait(&m_PassCond, &m_PassLock, 1000000ULL);
 
       i = m_mBuffer.find(id);
       if (i == m_mBuffer.end())

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1379,7 +1379,7 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
 
    if (i == m_mBuffer.end())
    {
-      CTimer::condTimedWait(&m_PassCond, &m_PassLock, 1000000ULL);
+      CTimer::condTimedWaitUS(&m_PassCond, &m_PassLock, 1000000ULL);
 
       i = m_mBuffer.find(id);
       if (i == m_mBuffer.end())


### PR DESCRIPTION
Fixed regression after #291
Created `CTimer::condTimedWaitUS` - wrapper for pthread_cond_timedwait using relative time to avoid dependency on getTime() value.