### PR TITLE
Fixed long times constant error

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -300,7 +300,7 @@ void CTimer::sleep()
 int CTimer::condTimedWaitUS(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay) {
     timeval now;
     gettimeofday(&now, 0);
-    uint64_t time_us = now.tv_sec * 1000000 + now.tv_usec + delay;
+    uint64_t time_us = now.tv_sec * 1000000ULL + now.tv_usec + delay;
     timespec timeout;
     timeout.tv_sec = time_us / 1000000;
     timeout.tv_nsec = (time_us % 1000000) * 1000;


### PR DESCRIPTION
There's currently an issue where the queue is not properly waiting for one second, and ends up spinning. This is because the now.tv_sec is of type long and it's being multiplied by a constant without ULL, as is done elsewhere in common.c