### PR TITLE
Make MAF files dependencies of CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -663,10 +663,9 @@ endmacro()
 if ( ENABLE_CXX11 )
 
 	# Make a virtual library of all shared app files
-	MafRead(apps/support.maf
-		SOURCES SOURCES_support_indir
+	MafReadDir(apps support.maf
+		SOURCES SOURCES_support
 	)
-	adddirname(apps "${SOURCES_support_indir}" SOURCES_support)
 
 	# A special trick that makes the shared application sources
 	# to be compiled once for all applications. Maybe this virtual
@@ -724,8 +723,7 @@ if ( ENABLE_CXX11 )
 			#
 			# For testing applications, every application has its exclusive
 			# list of source files in its own Manifest file.
-			MafRead(testing/${name}.maf SOURCES SOURCES_app_indir)
-			adddirname(testing "${SOURCES_app_indir}" SOURCES_app)
+			MafReadDir(testing ${name}.maf SOURCES SOURCES_app)
 			srt_add_program(${name} ${SOURCES_app})
 		endmacro()
 

--- a/scripts/haiUtil.cmake
+++ b/scripts/haiUtil.cmake
@@ -53,7 +53,9 @@ macro(srt_install_symlink filepath sympath)
     install(CODE "message(\"-- Created symlink: ${sympath} -> ${filepath}\")")
 endmacro(srt_install_symlink)
 
+# LEGACY. PLEASE DON'T USE ANYMORE.
 MACRO(MafRead maffile)
+	message(WARNING "MafRead is deprecated. Please use MafReadDir instead")
 	# ARGN contains the extra "section-variable" pairs
 	# If empty, return nothing
 	set (MAFREAD_TAGS
@@ -148,6 +150,12 @@ MACRO(MafReadDir directory maffile)
 	FILE(READ ${directory}/${maffile} MAFREAD_CONTENTS)
 	STRING(REGEX REPLACE ";" "\\\\;" MAFREAD_CONTENTS "${MAFREAD_CONTENTS}")
 	STRING(REGEX REPLACE "\n" ";" MAFREAD_CONTENTS "${MAFREAD_CONTENTS}")
+
+	# Once correctly read, declare this file as dependency of the build file.
+	# Normally you should use cmake_configure_depends(), but this is
+	# available only since 3.0 version.
+	configure_file(${directory}/${maffile} dummy_${maffile}.cmake.out)
+	file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/dummy_${maffile}.cmake.out)
 
     #message("DEBUG: MAF FILE CONTENTS: ${MAFREAD_CONTENTS}")
     #message("DEBUG: PASSED VARIABLES:")


### PR DESCRIPTION
* Now changes in MAF files are tracked and reconfigure step is done
* Minor change: removed the use of MafRead (legacy) so that the change can be done directly in MafReadDir