### PR TITLE
Fixes for unusual rendezvous connection rejection cases

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -932,7 +932,9 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
             // done when "it's not the time"?
             if (CTimer::getTime() >= i->m_ullTTL)
             {
-                HLOGC(mglog.Debug, log << "RendezvousQueue: EXPIRED. removing from queue");
+                HLOGC(mglog.Debug, log << "RendezvousQueue: EXPIRED ("
+                        << (i->m_ullTTL ? "enforced on FAILURE" : "passed TTL")
+                        << ". removing from queue");
                 // connection timer expired, acknowledge app via epoll
                 i->m_pUDT->m_bConnecting = false;
                 CUDT::s_UDTUnited.m_EPoll.update_events(i->m_iID, i->m_pUDT->m_sPollID, UDT_EPOLL_ERR, true);
@@ -1114,6 +1116,11 @@ void* CRcvQueue::worker(void* param)
                cst = self->worker_ProcessAddressedPacket(id, unit, &sa);
            }
            HLOGC(mglog.Debug, log << self->CONID() << "worker: result for the unit: " << ConnectStatusStr(cst));
+           if (cst == CONN_AGAIN)
+           {
+               HLOGC(mglog.Debug, log << self->CONID() << "worker: packet not dispatched, continuing reading.");
+               continue;
+           }
            have_received = true;
        }
        else if (rst == RST_ERROR)
@@ -1337,8 +1344,8 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
         HLOGC(mglog.Debug, log << CONID() << "Packet for SID=" << id << " asoc with " << SockaddrToString(u->m_pPeerAddr)
             << " received from " << SockaddrToString(addr) << " (CONSIDERED ATTACK ATTEMPT)");
         // This came not from the address that is the peer associated
-        // with the socket. Reject.
-        return CONN_REJECT;
+        // with the socket. Ignore it.
+        return CONN_AGAIN;
     }
 
     if (!u->m_bConnected || u->m_bBroken || u->m_bClosing)
@@ -1378,19 +1385,29 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
     CUDT* u = m_pRendezvousQueue->retrieve(addr, Ref(id));
     if ( !u )
     {
-        // XXX this socket is then completely unknown to the system.
-        // May be nice to send some rejection info to the peer.
+        // this socket is then completely unknown to the system.
+        // Note that this situation may also happen at a very unfortunate
+        // coincidence that the socket is already bound, but the registerConnector()
+        // has not yet started. In case of rendezvous this may mean that the other
+        // side just started sending its handshake packets, the local side has already
+        // run the CRcvQueue::worker thread, and this worker thread is trying to dispatch
+        // the handshake packet too early, before the dispatcher has a chance to see
+        // this socket registerred in the RendezvousQueue, which causes the packet unable
+        // to be dispatched. Therefore simply treat every "out of band" packet (with socket
+        // not belonging to the connection and not registered as rendezvous) as "possible
+        // attach" and ignore it. This also should better protect the rendezvous socket
+        // against a rogue connector.
         if ( id == 0 )
         {
             HLOGC(mglog.Debug, log << CONID() << "AsyncOrRND: no sockets expect connection from "
-                << SockaddrToString(addr) << " - POSSIBLE ATTACK");
+                << SockaddrToString(addr) << " - POSSIBLE ATTACK, ignore packet");
         }
         else
         {
             HLOGC(mglog.Debug, log << CONID() << "AsyncOrRND: no sockets expect socket " << id << " from "
-                << SockaddrToString(addr) << " - POSSIBLE ATTACK");
+                << SockaddrToString(addr) << " - POSSIBLE ATTACK, ignore packet");
         }
-        return CONN_REJECT;
+        return CONN_AGAIN; // This means that the packet should be ignored.
     }
 
     // asynchronous connect: call connect here


### PR DESCRIPTION
This fixes the problem that arisen when the KMX process failed due to either no password set or bad password. The transmission should fail anyway, but the connection should be still set up correctly, and the transmission should send the packets - they shall be only unable to be decrypted. In the opposite direction the transmission should be allowed anyway. It should also show correct encryption state. This fixes the problem that in case when BADSECRET or NOSECRET situation the repeated handshake attempt was trying to extract the recorded key from previous KMREQ, which wasn't recorded due to that error, and it resulted in rejection instead of sending back the 1-word KMX failure status, if there's no key possible to be sent. The peer should receive the KMX failure, but only setup a failed encryption state on itself, not break the connection, and the transmission from a party that set no encryption should be anyway possible.

Another fix repairs the problem when a rendezvous handshake comes in when it is already received due to having bound socket, but before `registerConnector` was called (these things happen in two different threads), which means that in this period any packet incoming from peer has no chance to be dispatched and it's treated as a rogue packet. The incorrect reaction was to reject the handshake and cause the connection process to be broken. This, instead, ignores the packet, which means that the peer will simply send it again, this time most likely when the connector is already registerred and therefore the packet will be correctly dispatched.