### PR TITLE
Build fixes for Windows / MingW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,6 @@ endif()
 # will now apply to the dependent library.
 #list(APPEND SOURCES_srt ${SOURCES_haicrypt})
 set (VIRTUAL_srt $<TARGET_OBJECTS:srt_virtual> $<TARGET_OBJECTS:haicrypt_virtual>)
-set (HEADERS_srt ${HEADERS_srt} ${HEADERS_srt_win32})
 
 if (srt_libspec_shared)
 	add_library(${TARGET_srt}_shared SHARED ${VIRTUAL_srt})

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -270,19 +270,16 @@ inline std::string SockaddrToString(const sockaddr* sadr)
 
     std::ostringstream output;
     char hostbuf[1024];
+    int flags;
 
 #if ENABLE_GETNAMEINFO
-    if (!getnameinfo(sadr, sizeof(*sadr), hostbuf, 1024, NULL, 0, NI_NAMEREQD))
-    {
-        output << hostbuf;
-    }
-    else
+    flags = NI_NAMEREQD;
+#else
+    flags = NI_NUMERICHOST | NI_NUMERICSERV;
 #endif
+
+    if (!getnameinfo(sadr, sizeof(*sadr), hostbuf, 1024, NULL, 0, flags))
     {
-        if (inet_ntop(sadr->sa_family, addr, hostbuf, 1024) == NULL)
-        {
-            strcpy(hostbuf, "unknown");
-        }
         output << hostbuf;
     }
 

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -15,9 +15,9 @@
    #include <ws2tcpip.h>
    #include <ws2ipdef.h>
    #include <windows.h>
-   #include <inttypes.h>
    #include <stdint.h>
    #if defined(_MSC_VER)
+      #include <inttypes.h>
       #pragma warning(disable:4251)
    #endif
 #else

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -15,9 +15,9 @@
    #include <ws2tcpip.h>
    #include <ws2ipdef.h>
    #include <windows.h>
-   #include <stdint.h>
    #if defined(_MSC_VER)
-      #include <inttypes.h>
+      #include <win/stdint.h>
+      #include <win/inttypes.h>
       #pragma warning(disable:4251)
    #endif
 #else


### PR DESCRIPTION
Some small fixes.

Make sure the windows headers are only installed in win/ so as to not pollute the main namespace. Actually, I wonder if all the pbulic headers shouldn't be included as srt/.. and then you don't need to include -I/usr/include/srt at all.

Also removed the use of inet_ntop() for the more portable getnameinfo() with the numeric flags which does the same thing.

And only include the MSC headers when MSC is used to build. With those, I can build SRT 1.3.1 in the VLC Windows build, so I think they're all candidates for a 1.3.2