### PR TITLE
Fix potential crash in CCache::update

### DIFF
--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -51,7 +51,7 @@ using namespace std;
 
 CInfoBlock& CInfoBlock::operator=(const CInfoBlock& obj)
 {
-   std::copy(obj.m_piIP, obj.m_piIP + 3, m_piIP);
+   std::copy(obj.m_piIP, obj.m_piIP + 4, m_piIP);
    m_iIPversion = obj.m_iIPversion;
    m_ullTimeStamp = obj.m_ullTimeStamp;
    m_iRTT = obj.m_iRTT;
@@ -85,7 +85,7 @@ CInfoBlock* CInfoBlock::clone()
 {
    CInfoBlock* obj = new CInfoBlock;
 
-   std::copy(m_piIP, m_piIP + 3, obj->m_piIP);
+   std::copy(m_piIP, m_piIP + 4, obj->m_piIP);
    obj->m_iIPversion = m_iIPversion;
    obj->m_ullTimeStamp = m_ullTimeStamp;
    obj->m_iRTT = m_iRTT;

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -169,12 +169,12 @@ public:
          T* last_data = m_StorageList.back();
          int last_key = last_data->getKey() % m_iHashSize;
 
-         item_list = m_vHashPtr[last_key];
-         for (typename ItemPtrList::iterator i = item_list.begin(); i != item_list.end(); ++ i)
+         ItemPtrList& last_item_list = m_vHashPtr[last_key];
+         for (typename ItemPtrList::iterator i = last_item_list.begin(); i != last_item_list.end(); ++ i)
          {
             if (*last_data == ***i)
             {
-               item_list.erase(i);
+               last_item_list.erase(i);
                break;
             }
          }


### PR DESCRIPTION
I found a potential crash point in CCache::update.

See codes there:
```
      ++ m_iCurrSize;
      if (m_iCurrSize >= m_iMaxSize)
      {
         // Cache overflow, remove oldest entry.
         T* last_data = m_StorageList.back();
         int last_key = last_data->getKey() % m_iHashSize;

         item_list = m_vHashPtr[last_key];
         for (typename ItemPtrList::iterator i = item_list.begin(); i != item_list.end(); ++ i)
         {
            if (*last_data == ***i)
            {
               item_list.erase(i);
               break;
            }
         }

         last_data->release();
         delete last_data;
         m_StorageList.pop_back();
         -- m_iCurrSize;
      }
```

`item_list` is a reference to `m_vHashPtr[key]`, so
`item_list = m_vHashPtr[last_key];`
will copy list from `m_vHashPtr[last_key]` to `m_vHashPtr[key]`, which is not we expected.