### PR TITLE
Change every #ifdef WIN32 to check for _WIN32

### DIFF
--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -12,7 +12,7 @@
 #ifndef INC__APPCOMMON_H
 #define INC__APPCOMMON_H
  
-#if WIN32
+#if _WIN32
 
 // Keep this below commented out.
 // This is for a case when you need cpp debugging on Windows.
@@ -117,7 +117,7 @@ static inline int inet_pton(int af, const char * src, void * dst)
 }
 #endif // __MINGW__
 
-#ifdef WIN32
+#ifdef _WIN32
 inline int SysError() { return ::GetLastError(); }
 #else
 inline int SysError() { return errno; }

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -17,7 +17,7 @@
 #include <vector>
 #include "../srtcore/srt.h" // Devel path
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "winsock2.h"
 #endif
 

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -264,7 +264,7 @@ int main( int argc, char** argv )
     }
 
 
-#ifdef WIN32
+#ifdef _WIN32
 
     if (timeout > 0)
     {

--- a/apps/srt-multiplex.cpp
+++ b/apps/srt-multiplex.cpp
@@ -33,7 +33,7 @@
 #include <logging.h>
 
 // Make the windows-nonexistent alarm an empty call
-#ifdef WIN32
+#ifdef _WIN32
 #define alarm(argument) (void)0
 #define signal_alarm(fn) (void)0
 #else

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -18,7 +18,7 @@
 #include <iterator>
 #include <map>
 #include <srt.h>
-#if !defined(WIN32)
+#if !defined(_WIN32)
 #include <sys/ioctl.h>
 #endif
 
@@ -854,7 +854,7 @@ protected:
         ::setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof yes);
 
         // set non-blocking mode
-#if defined(WIN32)
+#if defined(_WIN32)
         unsigned long ulyes = 1;
         if (ioctlsocket(m_sock, FIONBIO, &ulyes) == SOCKET_ERROR)
 #else
@@ -923,7 +923,7 @@ protected:
                 mreq_arg_ptr = &mreq;
             }
 
-#ifdef WIN32
+#ifdef _WIN32
             const char* mreq_arg = (const char*)mreq_arg_ptr;
             const auto status_error = SOCKET_ERROR;
 #else
@@ -931,7 +931,7 @@ protected:
             const auto status_error = -1;
 #endif
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
             // On Windows it somehow doesn't work when bind()
             // is called with multicast address. Write the address
             // that designates the network device here.
@@ -999,7 +999,7 @@ protected:
 
     ~UdpCommon()
     {
-#ifdef WIN32
+#ifdef _WIN32
         if (m_sock != -1)
         {
            shutdown(m_sock, SD_BOTH);

--- a/examples/recvfile.cpp
+++ b/examples/recvfile.cpp
@@ -1,4 +1,4 @@
-#ifndef WIN32
+#ifndef _WIN32
    #include <arpa/inet.h>
    #include <netdb.h>
 #else

--- a/examples/sendfile.cpp
+++ b/examples/sendfile.cpp
@@ -1,4 +1,4 @@
-#ifndef WIN32
+#ifndef _WIN32
    #include <cstdlib>
    #include <netdb.h>
 #else
@@ -13,7 +13,7 @@
 
 using namespace std;
 
-#ifndef WIN32
+#ifndef _WIN32
 void* sendfile(void*);
 #else
 DWORD WINAPI sendfile(LPVOID);
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
 
    // Windows UDP issue
    // For better performance, modify HKLM\System\CurrentControlSet\Services\Afd\Parameters\FastSendDatagramThreshold
-#ifdef WIN32
+#ifdef _WIN32
    int mss = 1052;
    srt_setsockopt(serv, 0, SRTO_MSS, &mss, sizeof(int));
 #endif
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
       getnameinfo((sockaddr *)&clientaddr, addrlen, clienthost, sizeof(clienthost), clientservice, sizeof(clientservice), NI_NUMERICHOST|NI_NUMERICSERV);
       cout << "new connection: " << clienthost << ":" << clientservice << endl;
 
-      #ifndef WIN32
+      #ifndef _WIN32
          pthread_t filethread;
          pthread_create(&filethread, NULL, sendfile, new SRTSOCKET(fhandle));
          pthread_detach(filethread);
@@ -116,7 +116,7 @@ int main(int argc, char* argv[])
    return 0;
 }
 
-#ifndef WIN32
+#ifndef _WIN32
 void* sendfile(void* usocket)
 #else
 DWORD WINAPI sendfile(LPVOID usocket)
@@ -177,7 +177,7 @@ DWORD WINAPI sendfile(LPVOID usocket)
 
    //ifs.close();
 
-   #ifndef WIN32
+   #ifndef _WIN32
       return NULL;
    #else
       return 0;

--- a/examples/suflip.cpp
+++ b/examples/suflip.cpp
@@ -86,7 +86,7 @@ protected:
             ip_mreq mreq;
             mreq.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
             mreq.imr_interface.s_addr = maddr.sin_addr.s_addr;
-#ifdef WIN32
+#ifdef _WIN32
             int res = setsockopt(m_sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, (const char *)&mreq, sizeof(mreq));
             if ( res == SOCKET_ERROR || res == -1 )
             {
@@ -122,7 +122,7 @@ protected:
 
     ~UdpCommon()
     {
-#ifdef WIN32
+#ifdef _WIN32
         if (m_sock != -1)
         {
            shutdown(m_sock, SD_BOTH);

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 // setup exports
-#if defined WIN32 && !defined __MINGW__
+#if defined _WIN32 && !defined __MINGW__
 #ifdef HAICRYPT_DYNAMIC
 #ifdef HAICRYPT_EXPORTS
 #define HAICRYPT_API __declspec(dllexport)

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -22,7 +22,7 @@ written by
 #include <stdio.h>	/* snprintf */
 #include <stdlib.h>	/* NULL, malloc, free */
 #include <string.h>	/* memcpy, memset */
-#ifdef WIN32
+#ifdef _WIN32
     #include <winsock2.h>
     #include <ws2tcpip.h>
 #else

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -29,7 +29,7 @@ written by
 
 #include <sys/types.h>
 
-#ifdef WIN32
+#ifdef _WIN32
    #include <winsock2.h>
    #include <ws2tcpip.h>
    #if defined(_MSC_VER)

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -20,7 +20,7 @@ written by
 *****************************************************************************/
 
 #include <string.h>		/* memcpy */
-#ifdef WIN32
+#ifdef _WIN32
     #include <winsock2.h>
     #include <ws2tcpip.h>
     #include <win/wintime.h>

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -22,7 +22,7 @@ written by
 #include <sys/types.h>
 #include <stdlib.h>     /* NULL */
 #include <string.h>     /* memcpy */
-#ifdef WIN32
+#ifdef _WIN32
     #include <winsock2.h>
     #include <ws2tcpip.h>
     #include <stdint.h>
@@ -47,7 +47,7 @@ int HaiCrypt_Tx_GetBuf(HaiCrypt_Handle hhc, size_t data_len, unsigned char **in_
 			return(-1);
 		}
 	} else {
-#ifndef WIN32
+#ifndef _WIN32
 		ASSERT(crypto->inbuf != NULL);
 #endif
 		size_t in_len = crypto->msg_info->pfx_len + hcryptMsg_PaddedLen(data_len, pad_factor);

--- a/haicrypt/hcrypt_ut.c
+++ b/haicrypt/hcrypt_ut.c
@@ -22,7 +22,7 @@ written by
 #include <haicrypt.h>
 #include "hcrypt.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 
 /* RFC6070 PBKDF2 Tests Vectors */
 
@@ -221,4 +221,4 @@ int main(int argc, char *argv[])
 	return(nbe);
 }
 
-#endif // WIN32
+#endif // _WIN32

--- a/haicrypt/hcrypt_xpt_srt.c
+++ b/haicrypt/hcrypt_xpt_srt.c
@@ -18,7 +18,7 @@ written by
 *****************************************************************************/
 
 #include <string.h>			/* memset, memcpy */
-#ifdef WIN32
+#ifdef _WIN32
     #include <winsock2.h>
     #include <ws2tcpip.h>
 #else

--- a/haicrypt/hcrypt_xpt_sta.c
+++ b/haicrypt/hcrypt_xpt_sta.c
@@ -20,7 +20,7 @@ written by
 *****************************************************************************/
 
 #include <string.h>			/* memset, memcpy */
-#ifdef WIN32
+#ifdef _WIN32
     #include <winsock2.h>
     #include <ws2tcpip.h>
 #else

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -63,7 +63,7 @@ modified by
 #include "threadname.h"
 #include "srt.h"
 
-#ifdef WIN32
+#ifdef _WIN32
    #include <win/wintime.h>
 #endif
 
@@ -190,7 +190,7 @@ int CUDTUnited::startup()
       return 0;
 
    // Global initialization code
-   #ifdef WIN32
+   #ifdef _WIN32
       WORD wVersionRequested;
       WSADATA wsaData;
       wVersionRequested = MAKEWORD(2, 2);
@@ -240,7 +240,7 @@ int CUDTUnited::cleanup()
    // the application cleanup section, this can be temporarily
    // tolerated with simply exit the application without cleanup,
    // counting on that the system will take care of it anyway.
-#ifndef WIN32
+#ifndef _WIN32
    pthread_mutex_destroy(&m_GCStopLock);
    pthread_cond_destroy(&m_GCStopCond);
 #endif
@@ -248,7 +248,7 @@ int CUDTUnited::cleanup()
    m_bGCStatus = false;
 
    // Global destruction code
-   #ifdef WIN32
+   #ifdef _WIN32
       WSACleanup();
    #endif
 
@@ -1807,7 +1807,7 @@ void* CUDTUnited::garbageCollect(void* p)
        INCREMENT_THREAD_ITERATIONS();
        self->checkBrokenSockets();
 
-       //#ifdef WIN32
+       //#ifdef _WIN32
        //      self->checkTLSValue();
        //#endif
 

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -38,7 +38,7 @@ written by
    Yunhong Gu, last updated 05/05/2009
 *****************************************************************************/
 
-#ifdef WIN32
+#ifdef _WIN32
    #include <winsock2.h>
    #include <ws2tcpip.h>
 #endif

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -50,7 +50,7 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifndef WIN32
+#ifndef _WIN32
    #if __APPLE__
       #include "TargetConditionals.h"
    #endif
@@ -80,11 +80,11 @@ modified by
 #include "logging.h"
 #include "utilities.h"
 
-#ifdef WIN32
+#ifdef _WIN32
     typedef int socklen_t;
 #endif
 
-#ifndef WIN32
+#ifndef _WIN32
    #define NET_ERROR errno
 #else
    #define NET_ERROR WSAGetLastError()
@@ -131,7 +131,7 @@ void CChannel::open(const sockaddr* addr)
    // construct an socket
    m_iSocket = ::socket(m_iIPversion, SOCK_DGRAM, 0);
 
-   #ifdef WIN32
+   #ifdef _WIN32
       if (INVALID_SOCKET == m_iSocket)
    #else
       if (m_iSocket < 0)
@@ -242,7 +242,7 @@ void CChannel::setUDPSockOpt()
       int opts = ::fcntl(m_iSocket, F_GETFL);
       if (-1 == ::fcntl(m_iSocket, F_SETFL, opts | O_NONBLOCK))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-   #elif defined(WIN32)
+   #elif defined(_WIN32)
       DWORD ot = 1; //milliseconds
       if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVTIMEO, (char *)&ot, sizeof(DWORD)))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
@@ -255,7 +255,7 @@ void CChannel::setUDPSockOpt()
 
 void CChannel::close() const
 {
-   #ifndef WIN32
+   #ifndef _WIN32
       ::close(m_iSocket);
    #else
       ::closesocket(m_iSocket);
@@ -403,7 +403,7 @@ int CChannel::sendto(const sockaddr* addr, CPacket& packet) const
       ++ p;
    }
 
-   #ifndef WIN32
+   #ifndef _WIN32
       msghdr mh;
       mh.msg_name = (sockaddr*)addr;
       mh.msg_namelen = m_iSockAddrSize;
@@ -444,7 +444,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
 {
     EReadStatus status = RST_OK;
 
-#ifndef WIN32
+#ifndef _WIN32
     msghdr mh;   
     mh.msg_name = addr;
     mh.msg_namelen = m_iSockAddrSize;

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -51,7 +51,7 @@ modified by
 *****************************************************************************/
 
 
-#ifndef WIN32
+#ifndef _WIN32
    #include <cstring>
    #include <cerrno>
    #include <unistd.h>
@@ -124,7 +124,7 @@ void CTimer::rdtsc(uint64_t &x)
       asm ("rdtsc" : "=a" (lval), "=d" (hval));
       x = hval;
       x = (x << 32) | lval;
-   #elif defined(WIN32)
+   #elif defined(_WIN32)
       //HANDLE hCurThread = ::GetCurrentThread(); 
       //DWORD_PTR dwOldMask = ::SetThreadAffinityMask(hCurThread, 1); 
       BOOL ret = QueryPerformanceCounter((LARGE_INTEGER *)&x);
@@ -155,7 +155,7 @@ uint64_t CTimer::readCPUFrequency()
 
       // CPU clocks per microsecond
       frequency = (t2 - t1) / 100000;
-   #elif defined(WIN32)
+   #elif defined(_WIN32)
       int64_t ccf;
       if (QueryPerformanceFrequency((LARGE_INTEGER *)&ccf))
          frequency = ccf / 1000000;
@@ -290,7 +290,7 @@ CTimer::EWait CTimer::waitForEvent()
 
 void CTimer::sleep()
 {
-   #ifndef WIN32
+   #ifndef _WIN32
       usleep(10);
    #else
       Sleep(1);
@@ -373,7 +373,7 @@ m_iMajor(major),
 m_iMinor(minor)
 {
    if (err == -1)
-      #ifndef WIN32
+      #ifndef _WIN32
          m_iErrno = errno;
       #else
          m_iErrno = GetLastError();
@@ -601,7 +601,7 @@ const char* CUDTException::getErrorMessage()
    }
 
    // period
-   #ifndef WIN32
+   #ifndef _WIN32
    m_strMsg += ".";
    #endif
 
@@ -847,7 +847,7 @@ std::string logging::FormatTime(uint64_t time)
     struct tm tm = SysLocalTime(tt);
 
     char tmp_buf[512];
-#ifdef WIN32
+#ifdef _WIN32
     strftime(tmp_buf, 512, "%Y-%m-%d.", &tm);
 #else
     strftime(tmp_buf, 512, "%T.", &tm);
@@ -896,7 +896,7 @@ void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
         //
         // XXX Consider using %X everywhere, as it should work
         // on both systems.
-#ifdef WIN32
+#ifdef _WIN32
         strftime(tmp_buf, 512, "%X.", &tm);
 #else
         strftime(tmp_buf, 512, "%T.", &tm);

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -56,7 +56,7 @@ modified by
 #define _CRT_SECURE_NO_WARNINGS 1 // silences windows complaints for sscanf
 
 #include <cstdlib>
-#ifndef WIN32
+#ifndef _WIN32
    #include <sys/time.h>
    #include <sys/uio.h>
 #else

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -50,7 +50,7 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifndef WIN32
+#ifndef _WIN32
    #include <unistd.h>
    #include <netdb.h>
    #include <arpa/inet.h>
@@ -4657,7 +4657,7 @@ void CUDT::close()
             return;
          }
 
-         #ifndef WIN32
+         #ifndef _WIN32
             timespec ts;
             ts.tv_sec = 0;
             ts.tv_nsec = 1000000;

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -22,7 +22,7 @@ written by
 #include <set>
 #include <sstream>
 #include <cstdarg>
-#ifdef WIN32
+#ifdef _WIN32
 #include "win/wintime.h"
 #include <sys/timeb.h>
 #else

--- a/srtcore/logging_api.h
+++ b/srtcore/logging_api.h
@@ -25,7 +25,7 @@ written by
 #endif
 
 #include <pthread.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include "win/syslog_defs.h"
 #else
 #include <syslog.h>

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -58,7 +58,7 @@ modified by
 #include "common.h"
 #include "utilities.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 
 // XXX REFACTOR THIS.
 

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -10,7 +10,7 @@
 #ifndef INC__PLATFORM_SYS_H
 #define INC__PLATFORM_SYS_H
 
-#ifdef WIN32
+#ifdef _WIN32
    #include <winsock2.h>
    #include <ws2tcpip.h>
    #include <ws2ipdef.h>

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -50,7 +50,7 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifdef WIN32
+#ifdef _WIN32
    #include <winsock2.h>
    #include <ws2tcpip.h>
 #endif

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -35,7 +35,7 @@ written by
 //use -D_WIN32_WINNT=0x0501
 
 
-#ifdef WIN32
+#ifdef _WIN32
    #ifndef __MINGW__
       // Explicitly define 32-bit and 64-bit numbers
       typedef __int32 int32_t;
@@ -95,7 +95,7 @@ extern "C" {
 
 typedef int SRTSOCKET; // SRTSOCKET is a typedef to int anyway, and it's not even in UDT namespace :)
 
-#ifdef WIN32
+#ifdef _WIN32
    #ifndef __MINGW__
       typedef SOCKET SYSSOCKET;
    #else

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -26,7 +26,7 @@ written by
 #include <features.h>
 #endif
 
-#if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
@@ -61,7 +61,7 @@ extern const char * SysStrError(int errnum, char * buf, size_t buflen)
 
     buf[0] = '\0';
 
-#if defined(_WIN32) || defined(WIN32)
+#if defined(_WIN32)
     const char* lpMsgBuf;
 
     // Note: Intentionally the "fixed char size" types are used despite using

--- a/srtcore/srt_compat.h
+++ b/srtcore/srt_compat.h
@@ -21,7 +21,7 @@ written by
 #include <time.h>
 
 #ifndef SRT_API
-#ifdef WIN32
+#ifdef _WIN32
    #ifndef __MINGW__
       #ifdef SRT_DYNAMIC
          #ifdef SRT_EXPORTS
@@ -40,7 +40,7 @@ written by
 #endif
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
    // https://msdn.microsoft.com/en-us/library/tcxf1dw6.aspx
    // printf() Format for ssize_t
    #if !defined(PRIzd)
@@ -88,7 +88,7 @@ inline struct tm SysLocalTime(time_t tt)
 {
     struct tm tms;
     memset(&tms, 0, sizeof tms);
-#ifdef WIN32
+#ifdef _WIN32
 	errno_t rr = localtime_s(&tms, &tt);
 	if (rr == 0)
 		return tms;

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -54,7 +54,7 @@ modified by
 #define __UDT_WINDOW_H__
 
 
-#ifndef WIN32
+#ifndef _WIN32
    #include <sys/time.h>
    #include <time.h>
 #endif

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -344,7 +344,7 @@ int main( int argc, char** argv )
     }
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #define alarm(argument) (void)0
 
     if (stoptime != 0)

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -19,7 +19,7 @@
 #include <iterator>
 #include <map>
 #include <srt.h>
-#if !defined(WIN32)
+#if !defined(_WIN32)
 #include <sys/ioctl.h>
 #endif
 
@@ -1025,7 +1025,7 @@ protected:
             ip_mreq mreq;
             mreq.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
             mreq.imr_interface.s_addr = maddr.sin_addr.s_addr;
-#ifdef WIN32
+#ifdef _WIN32
             const char* mreq_arg = (const char*)&mreq;
             const auto status_error = SOCKET_ERROR;
 #else
@@ -1033,7 +1033,7 @@ protected:
             const auto status_error = -1;
 #endif
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
             // On Windows it somehow doesn't work when bind()
             // is called with multicast address. Write the address
             // that designates the network device here.
@@ -1104,7 +1104,7 @@ protected:
 
     ~UdpCommon()
     {
-#ifdef WIN32
+#ifdef _WIN32
         if (m_sock != -1)
         {
             shutdown(m_sock, SD_BOTH);


### PR DESCRIPTION
_WIN32 is the correct pre-defined macro according to Microsoft, and also
works for MinGW, to check for a compiler targetting Windows 32/64-bit ARM/x86/x64.

c.f. https://msdn.microsoft.com/en-us/library/b0084kay.aspx

Replacement was done with `git grep -Pl '#.*\bWIN32\b' | xargs sed -ri 's;(#.*)\bWIN32\b;\1_WIN32;g'`.

This fixes compilation with programs depending on libsrt that don't set WIN32 explicitely (like FFmpeg).