### PR TITLE
Added information about maximum payload size

### DIFF
--- a/docs/live-streaming.md
+++ b/docs/live-streaming.md
@@ -24,7 +24,10 @@ transport unit size for SRT, and it is also often used when sending MPEG-TS over
 Note that SRT isn't limited to MPEG-TS -- it can be applied to any "live streaming" data 
 transmission (as long as you use Live mode, which is the SRT default mode). You can use 
 any other suitable data format, and any intermediate protocol on top of MPEG-TS with 
-an extra header (you still have an extra 140 bytes per unit for that purpose). 
+an extra header (if you want to do this - as people often try this with RTP - note
+that 1316 is the default maximum payload size, which can be changed using
+`SRTO_PAYLOADSIZE` option to no more than 1456).
+
 However, the transmission must still satisfy the Live Streaming Requirements.
 
 

--- a/docs/live-streaming.md
+++ b/docs/live-streaming.md
@@ -24,8 +24,8 @@ transport unit size for SRT, and it is also often used when sending MPEG-TS over
 Note that SRT isn't limited to MPEG-TS -- it can be applied to any "live streaming" data 
 transmission (as long as you use Live mode, which is the SRT default mode). You can use 
 any other suitable data format, and any intermediate protocol on top of MPEG-TS with 
-an extra header (if you want to do this - as people often try this with RTP - note
-that 1316 is the default maximum payload size, which can be changed using
+an extra header (this is an option that people often try with RTP) - note that
+1316 is the default maximum payload size, which can be changed using the
 `SRTO_PAYLOADSIZE` option to no more than 1456).
 
 However, the transmission must still satisfy the Live Streaming Requirements.


### PR DESCRIPTION
People get often confused about the maximum payload size in SRT when trying to send RTP over SRT; this could be at least as a reference information what to be aware of in this case.