### PR TITLE
do not treat WSAECONNRESET as a fatal error (#468)

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -544,7 +544,6 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
         // These below errors are treated as "fatal", all others are treated as "again".
         static const int fatals [] =
         {
-            WSAECONNRESET,
             WSAEFAULT,
             WSAEINVAL,
             WSAENETDOWN,

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -472,7 +472,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
     // reported by recvmsg():
 
     // 1. Temporary error, can't get the data, but you can try again.
-    // Codes: EAGAIN/EWOULDBLOCK, EINTR
+    // Codes: EAGAIN/EWOULDBLOCK, EINTR, ECONNREFUSED
     // Return: RST_AGAIN.
     //
     // 2. Problems that should never happen due to unused configurations.
@@ -492,7 +492,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
     if (res == -1)
     {
         int err = NET_ERROR;
-        if (err == EAGAIN || err == EINTR) // For EAGAIN, this isn't an error, just a useless call.
+        if (err == EAGAIN || err == EINTR || err == ECONNREFUSED) // For EAGAIN, this isn't an error, just a useless call.
         {
             status = RST_AGAIN;
         }


### PR DESCRIPTION
treating WSAECONNRESET as a fatal error for UDP socket causes IPE when e.g. trying to connect to not responding SRT peer. 