### PR TITLE
Flushing the output in case of buffered stream and no EOL requested

### DIFF
--- a/apps/verbose.cpp
+++ b/apps/verbose.cpp
@@ -21,6 +21,10 @@ namespace Verbose
     Log& Log::operator<<(LogNoEol)
     {
         noeol = true;
+        if (on)
+        {
+            (*cverb) << std::flush;
+        }
         return *this;
     }
 


### PR DESCRIPTION
This fixes a problem with that the expression like:

    Verb() << "Processing... " << VerbNoEOL;

is not printed at all because the stream used for verbose is occasionally line-buffered. With this fix, the buffer is forcefully flushed to make sure the destructor of `Verbose::Log` forces it printed.