### PR TITLE
Made WinSock non-blocking #383

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -243,9 +243,9 @@ void CChannel::setUDPSockOpt()
       if (-1 == ::fcntl(m_iSocket, F_SETFL, opts | O_NONBLOCK))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
    #elif defined(_WIN32)
-      DWORD ot = 1; //milliseconds
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVTIMEO, (char *)&ot, sizeof(DWORD)))
-         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+      u_long nonBlocking = 1;
+      if (0 != ioctlsocket (m_iSocket, FIONBIO, &nonBlocking))
+         throw CUDTException (MJ_SETUP, MN_NORES, NET_ERROR);
    #else
       // Set receiving time-out value
       if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(timeval)))


### PR DESCRIPTION
Previously we set the minimum recv timeout to 1ms on Windows, but there is an undocumented minimum receive timeout of 500ms, according to some sources online[1](https://social.msdn.microsoft.com/Forums/en-US/76620f6d-22b1-4872-aaf0-833204f3f867/minimum-timeout-value-for-sorcvtimeo?forum=windowsgeneraldevelopmentissues) a result, some packets were lost for srt, but were still received by wireshark. This commit sets the socket to non-blocking via ioctl, which causes all packets to be correctly received.