### PR TITLE
Set binary mode for stdin and stdout on Windows

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -20,6 +20,9 @@
 #include <srt.h>
 #if !defined(_WIN32)
 #include <sys/ioctl.h>
+#else
+#include <fcntl.h> 
+#include <io.h>
 #endif
 
 #include "netinet_any.h"
@@ -766,6 +769,11 @@ public:
 
     ConsoleSource()
     {
+#ifdef _WIN32
+        // The default stdin mode on windows is text.
+        // We have to set it to the binary mode
+        _setmode(_fileno(stdin), _O_BINARY);
+#endif
     }
 
     bool Read(size_t chunk, bytevector& data) override
@@ -800,6 +808,11 @@ public:
 
     ConsoleTarget()
     {
+#ifdef _WIN32
+        // The default stdout mode on windows is text.
+        // We have to set it to the binary mode
+        _setmode(_fileno(stdout), _O_BINARY);
+#endif
     }
 
     bool Write(const bytevector& data) override


### PR DESCRIPTION
The default stdout mode on Windows is TEXT. This way the output file has extra carriage return–line feed (CR-LF) bytes, that make a TS stream file unreadable, when created with **file://con**.
`srt-live-transmit srt://:4200?mode=listener file://con > received.ts`
The solution is to set the binary mode to the stdout and stdin.