### PR TITLE
Update logging.h for flushing log stream

### DIFF
--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -452,7 +452,7 @@ inline void LogDispatcher::SendLogLine(const char* file, int line, const std::st
     else if ( src_config->log_stream )
     {
         (*src_config->log_stream) << msg;
-	(*src_config->log_stream).flush();
+        (*src_config->log_stream).flush();
     }
     src_config->unlock();
 }


### PR DESCRIPTION
Logging stream is accumulating logs and not getting flushed . So, flushing log stream so that if we can see logs even if we have only one log line while debugging.