### PR TITLE
Send UMSG_SHUTDOWN when caller closes the connection

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2913,6 +2913,9 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
                 break;
             }
 
+            if (cst == CONN_REJECT)
+                sendCtrl(UMSG_SHUTDOWN);
+
             if ( cst != CONN_CONTINUE )
                 break; // --> OUTSIDE-LOOP
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -977,6 +977,7 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
                 if (!i->m_pUDT->processAsyncConnectRequest(rst, cst, response, i->m_pPeerAddr))
                 {
                     LOGC(mglog.Error, log << "RendezvousQueue: processAsyncConnectRequest FAILED. Setting TTL as EXPIRED.");
+                    i->m_pUDT->sendCtrl(UMSG_SHUTDOWN);
                     i->m_ullTTL = 0; // Make it expire right now, will be picked up at the next iteration
 #if ENABLE_HEAVY_LOGGING
                     ++debug_nfail;
@@ -1088,7 +1089,7 @@ void* CRcvQueue::worker(void* param)
        EReadStatus rst = self->worker_RetrieveUnit(Ref(id), Ref(unit), &sa);
        if (rst == RST_OK)
        {
-           if ( id < 0 )
+           if (id < 0)
            {
                // User error on peer. May log something, but generally can only ignore it.
                // XXX Think maybe about sending some "connection rejection response".


### PR DESCRIPTION
Send UMSG_SHUTDOWN when caller closes the connection after reject on HS conclusion.

Without this fix the listener thinks the connection is established, and starts sending packets (in sender mode). The sending stops after the connection timeout event.
Sending UMSG_SHUTDOWN by the caller helps the lister to knows the connection was closed by the caller, and to stop the data transmission earlier.