### PR TITLE
Fix ios build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,16 @@ matrix:
             - ./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64
             - make
             - cd ..
-            - export OPENSSL_ROOT_DIR="$PWD/openssl"
-            - export CMAKE_SYSTEM_NAME="Windows"
-            - export CC="x86_64-w64-mingw32-gcc"
-            - export CXX="x86_64-w64-mingw32-g++"
           env: BUILD_TYPE=Release
 script:
-    - if [ "$TRAVIS_OS_NAME" == "linux" ]; then cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_UNITTESTS="ON" -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" -DCMAKE_SYSTEM_NAME="$CMAKE_SYSTEM_NAME"; fi
-    - if [ "$TRAVIS_OS_NAME" == "osx" ];   then cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_UNITTESTS="ON" -DCMAKE_PREFIX_PATH=/usr/local/opt/openssl; fi
+    - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
+        export CC="x86_64-w64-mingw32-gcc";
+        export CXX="x86_64-w64-mingw32-g++";
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_UNITTESTS="ON" -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
+      elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_UNITTESTS="ON";
+      elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_UNITTESTS="ON" -DCMAKE_PREFIX_PATH=/usr/local/opt/openssl;
+      fi
     - make
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then ctest --extra-verbose; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ option(USE_GNUTLS "Should use gnutls instead of openssl" OFF)
 option(ENABLE_CXX_DEPS "Extra library dependencies in srt.pc for the CXX libraries useful with C language" ON)
 option(USE_STATIC_LIBSTDCXX "Should use static rather than shared libstdc++" OFF)
 option(ENABLE_INET_PTON "Set to OFF to prevent usage of inet_pton when building against modern SDKs while still requiring compatibility with older Windows versions, such as Windows XP, Windows Server 2003 etc." ON)
+option(USE_OPENSSL_PC "Use pkg-config to find OpenSSL libraries" ON)
 
 set(TARGET_srt "srt" CACHE STRING "The name for the haisrt library")
 
@@ -186,13 +187,10 @@ if ( USE_GNUTLS )
 else()
 		message(STATUS "SSL Dependency: using OpenSSL (default)")
 
-		# if OPENSSL_ROOT_DIR or USE_OPENSSL_PC are set, we assume
-		# that the user wants to use find_package(OpenSSL) method to
-		# find OpenSSL package. Otherwise default to pkg-config.
-		if (NOT IOS)
-			if (NOT OPENSSL_ROOT_DIR OR USE_OPENSSL_PC)
-				pkg_check_modules(SSL "openssl libcrypto")
-			endif()
+		# Try using pkg-config method first if enabled,
+		# fall back to find_package method otherwise
+		if (USE_OPENSSL_PC)
+			pkg_check_modules(SSL "openssl libcrypto")
 		endif()
 		if (SSL_FOUND)
 			set (SSL_REQUIRED_MODULES "openssl libcrypto")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,10 @@ else()
 		# if OPENSSL_ROOT_DIR or USE_OPENSSL_PC are set, we assume
 		# that the user wants to use find_package(OpenSSL) method to
 		# find OpenSSL package. Otherwise default to pkg-config.
-		if (NOT OPENSSL_ROOT_DIR OR USE_OPENSSL_PC)
-			pkg_check_modules(SSL "openssl libcrypto")
+		if (NOT IOS)
+			if (NOT OPENSSL_ROOT_DIR OR USE_OPENSSL_PC)
+				pkg_check_modules(SSL "openssl libcrypto")
+			endif()
 		endif()
 		if (SSL_FOUND)
 			set (SSL_REQUIRED_MODULES "openssl libcrypto")

--- a/docs/build_iOS.md
+++ b/docs/build_iOS.md
@@ -21,7 +21,7 @@ Results (both libraries and headers) will be placed in bin/&lt;SDK_VERSION&gt;-&
 Now you can build SRT providing path to OpenSSL library and toolchain file for iOS
 
 ```
-./configure --cmake-prefix-path=$IOS_OPENSSL --cmake-toolchain-file=scripts/iOS.cmake
+./configure --cmake-prefix-path=$IOS_OPENSSL --use-openssl-pc=OFF --cmake-toolchain-file=scripts/iOS.cmake
 make
 ```
 


### PR DESCRIPTION
#475 broke the ios build. pkg-config should be disabled explicitly, because it returns host openssl libraries instead of ios ones.

I would like to set USE_OPENSSL_PC to False inside scripts/iOS.cmake, not in root CMakeLists.txt, but this will force me to set OPENSSL_ROOT_DIR also to some non empty value to override "NOT OPENSSL_ROOT_DIR" condition.

@rndi please advice how can we disable pkg-config better then direct "NOT IOS" condition