### PR TITLE
Lazy initialization of CTimer::s_ullCPUFrequency

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -533,7 +533,7 @@ SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
     // protects the m_Sockets structure
     CGuard cg(m_ControlLock);
 
-    map<SRTSOCKET, CUDTSocket*>::iterator i = m_Sockets.find(u);
+    map<SRTSOCKET, CUDTSocket*>::const_iterator i = m_Sockets.find(u);
 
     if (i == m_Sockets.end())
     {
@@ -542,7 +542,7 @@ SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
 
         return SRTS_NONEXIST;
     }
-    CUDTSocket* s = i->second;
+    const CUDTSocket* s = i->second;
 
     if (s->m_pUDT->m_bBroken)
         return SRTS_BROKEN;

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -73,7 +73,7 @@ public:
    CUDTSocket();
    ~CUDTSocket();
 
-   SRT_SOCKSTATUS m_Status;                       //< current socket state
+   SRT_SOCKSTATUS m_Status;                  //< current socket state
 
    uint64_t m_TimeStamp;                     //< time when the socket is closed
 

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -162,7 +162,7 @@ void CChannel::open(const sockaddr* addr)
       if (0 != ::getaddrinfo(NULL, "0", &hints, &res))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 
-      if (0 != ::bind(m_iSocket, res->ai_addr, (int) res->ai_addrlen))
+      if (0 != ::bind(m_iSocket, res->ai_addr, (socklen_t) res->ai_addrlen))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
       memcpy(&m_BindAddr, res->ai_addr, res->ai_addrlen);
       m_BindAddr.len = (socklen_t) res->ai_addrlen;
@@ -390,7 +390,7 @@ int CChannel::sendto(const sockaddr* addr, CPacket& packet) const
    // convert control information into network order
    // XXX USE HtoNLA!
    if (packet.isControl())
-      for (ptrdiff_t i = 0, n = (ptrdiff_t) packet.getLength() / 4; i < n; ++i)
+      for (ptrdiff_t i = 0, n = packet.getLength() / 4; i < n; ++i)
          *((uint32_t *)packet.m_pcData + i) = htonl(*((uint32_t *)packet.m_pcData + i));
 
    // convert packet header into network order

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -81,7 +81,7 @@ modified by
 #include <srt_compat.h> // SysStrError
 
 bool CTimer::m_bUseMicroSecond = false;
-uint64_t CTimer::s_ullCPUFrequency = CTimer::readCPUFrequency();
+uint64_t CTimer::s_ullCPUFrequency = 0;
 
 pthread_mutex_t CTimer::m_EventLock = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t CTimer::m_EventCond = PTHREAD_COND_INITIALIZER;
@@ -130,7 +130,7 @@ void CTimer::rdtsc(uint64_t &x)
       BOOL ret = QueryPerformanceCounter((LARGE_INTEGER *)&x);
       //SetThreadAffinityMask(hCurThread, dwOldMask);
       if (!ret)
-         x = getTime() * s_ullCPUFrequency;
+         x = getTime() * getCPUFrequency();
    #elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
       x = mach_absolute_time();
    #else
@@ -176,6 +176,10 @@ uint64_t CTimer::readCPUFrequency()
 
 uint64_t CTimer::getCPUFrequency()
 {
+   if (s_ullCPUFrequency)
+       return s_ullCPUFrequency;
+
+   s_ullCPUFrequency = CTimer::readCPUFrequency();
    return s_ullCPUFrequency;
 }
 
@@ -252,7 +256,7 @@ uint64_t CTimer::getTime()
 #if defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
     uint64_t x;
     rdtsc(x);
-    return x / s_ullCPUFrequency;
+    return x / getCPUFrequency();
     //Specific fix may be necessary if rdtsc is not available either.
 #else
     timeval t;


### PR DESCRIPTION
Changing `CTimer::s_ullCPUFrequency` from dynamic initialization to lazy initialization works the following way.
1. Static zero-initialization of `CTimer::s_ullCPUFrequency`.
2. Initialization with the actual value on request.

`CTimer::s_ullCPUFrequency` will have a zero value before any other dynamic initialization happens (like with the `CUDTUnited()`).

Fixes #507 in `common.cpp`. Some minor code cleanup in other files, with respect to the discussion in PR #510.
