### PR TITLE
cmake: use system googletest if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,18 +797,28 @@ endif()
 
 if (ENABLE_UNITTESTS)
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-	include(googletest)
-	fetch_googletest(
-		${PROJECT_SOURCE_DIR}/scripts
-		${PROJECT_BINARY_DIR}/googletest
+
+	find_package(GTest 1.8)
+	if (NOT GTEST_FOUND)
+		message(STATUS "GTEST not found! Fetching from git.")
+		include(googletest)
+		fetch_googletest(
+			${PROJECT_SOURCE_DIR}/scripts
+			${PROJECT_BINARY_DIR}/googletest
+		)
+		set(GTEST_BOTH_LIBRARIES "gtest_main" CACHE STRING "Add gtest_main target")
+	endif()
+
+	MafReadDir(test filelist.maf
+		SOURCES SOURCES_unittests
 	)
 
-	srt_add_program(test_srt test/test_buffer.cpp test/test_connection_timeout.cpp test/test_strict_encription.cpp)
+	srt_add_program(test_srt ${SOURCES_unittests})
 	srt_make_application(test_srt)
 
 	target_link_libraries(
 		test_srt
-		gtest_main
+		${GTEST_BOTH_LIBRARIES}
 		${srt_link_library}
 		${PTHREAD_LIBRARY}
 		)

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -1,0 +1,6 @@
+
+
+SOURCES
+test_buffer.cpp
+test_connection_timeout.cpp
+test_strict_encription.cpp


### PR DESCRIPTION
Calling `find_package()` to find system google tests. If not found, then fetch from GitHub.
One note is that the `find_package` seems not to properly check the version of google tests. It just shows the message about the version required.
Fixes #500

Minor things:

- Added `MafReadDir` to list the source files for unit tests