### PR TITLE
Fixed status change order for connection state.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -547,7 +547,7 @@ SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
     if (s->m_pUDT->m_bBroken)
         return SRTS_BROKEN;
 
-    // Connecting timed out
+    // Connecting timed out (TTL in CRendezvousQueue::updateConnStatus())
     if ((s->m_Status == SRTS_CONNECTING) && !s->m_pUDT->m_bConnecting)
         return SRTS_BROKEN;
 
@@ -831,7 +831,6 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
    // So we need to update the status before connect() is called,
    // otherwise the status may be overwritten with wrong value
    // (CONNECTED vs. CONNECTING).
-   s->m_Status = SRTS_CONNECTING;
 
    /* 
    * In blocking mode, connect can block for up to 30 seconds for
@@ -850,6 +849,8 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
       s->m_Status = SRTS_OPENED;
       throw e;
    }
+
+   s->m_Status = SRTS_CONNECTING;
 
    // record peer address
    delete s->m_pPeerAddr;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3737,10 +3737,6 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
 
     setupCC();
 
-    // And, I am connected too.
-    m_bConnecting = false;
-    m_bConnected = true;
-
     // register this socket for receiving data packets
     m_pRNode->m_bOnList = true;
     m_pRcvQueue->setNewEntry(this);
@@ -3759,6 +3755,10 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
 
     // acknowledge the management module.
     s_UDTUnited.connect_complete(m_SocketID);
+
+    // And, I am connected too.
+    m_bConnecting = false;
+    m_bConnected = true;
 
     // acknowledde any waiting epolls to write
     s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_OUT, true);


### PR DESCRIPTION
Fixes #508.
### Restrictions for status changing
The following restrictions have to be followed.

1.  `s->m_pUDT->m_bConnecting = true` must happen before `s->m_Status = SRTS_CONNECTING`.
2. `s->m_Status = SRTS_CONNECTED` must happen before `s->m_pUDT->m_bConnecting = false`.

### The issues being fixed:
1️⃣ `CUDTUnited::connect()` sets `s->m_Status = SRTS_CONNECTING;`, then calls `s->m_pUDT->startConnect(name, forced_isn);`, that sets `m_bConnecting = true;`. This violates the above restriction no. 1.

2️⃣  The `CUDT::postConnect` behavior, which sets `s->m_pUDT->m_bConnecting` to `false` several steps before the `CUDTSocket::m_Status` is changed to `SRTS_CONNECTED` in `s_UDTUnited.connect_complete(m_SocketID);` described in the previous comment, violates the restriction no. 2.
