### PR TITLE
Fix build with MinGW v6.0.0

### DIFF
--- a/common/win/wintime.h
+++ b/common/win/wintime.h
@@ -3,6 +3,11 @@
 
 #include <winsock2.h>
 #include <windows.h>
+// HACK: This include is a workaround for a bug in the MinGW headers
+// where pthread.h, which defines _POSIX_THREAD_SAFE_FUNCTIONS,
+// has to be included before time.h so that time.h defines
+// localtime_r correctly
+#include <pthread.h>
 #include <time.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
Including pthread.h is a workaround for a bug in the MinGW headers,
where pthread.h (which defines _POSIX_THREAD_SAFE_FUNCTIONS)
has to be included before time.h so that time.h defines
localtime_r correctly, wich depends in _POSIX_THREAD_SAFE_FUNCTIONS
being defined previously.

Compilation error:
[...]srt_compat.h:78:9: error: 'localtime_r' was not declared in this scope