### PR TITLE
Fixed TTL status handling by getStatus() funcion

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -547,8 +547,11 @@ SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
     if (s->m_pUDT->m_bBroken)
         return SRTS_BROKEN;
 
-    // Connecting timed out
-    if ((s->m_Status == SRTS_CONNECTING) && !s->m_pUDT->m_bConnecting)
+    // TTL in CRendezvousQueue::updateConnStatus() will set m_bConnecting to false.
+    // Although m_Status is still SRTS_CONNECTING, the connection is in fact to be closed due to TTL expiry.
+    // In this case m_bConnected is also false. Both checks are required to avoid hitting
+    // a regular state transition from CONNECTING to CONNECTED.
+    if ((s->m_Status == SRTS_CONNECTING) && !s->m_pUDT->m_bConnecting && !s->m_pUDT->m_bConnected)
         return SRTS_BROKEN;
 
     return s->m_Status;


### PR DESCRIPTION
Fixes #508. Closes #527.

### The issues being fixed:
The `CUDT::postConnect` behavior, which sets `s->m_pUDT->m_bConnecting` to `false` several steps before the `CUDTSocket::m_Status` is changed to `SRTS_CONNECTED` in `s_UDTUnited.connect_complete(m_SocketID);`.
This makes the `getStatus()` function to wrongfully return `SRTS_BROKEN` due to the following check.
```if ((s->m_Status == SRTS_CONNECTING) && !s->m_pUDT->m_bConnecting)```
The check is to handle the case of connection timeout. When a socket's TTL is expired, `CRendezvousQueue::updateConnStatus()` sets `m_pUDT->m_bConnecting = false;` (connection timeout). But the status of CUDTSocket remains SRTS_CONNECTING until the connection is closed.

Adding additional check for `m_bConnected` improves the handling of this state.
