### PR TITLE
Android build scripts for NDK r19

### DIFF
--- a/docs/Android/Compiling.md
+++ b/docs/Android/Compiling.md
@@ -1,13 +1,14 @@
 # Establishing a Build Environment
 ## Installing the Android NDK
-The Android NDK is required to build native modules for Android.  
-Download the appropriate NDK archive from the following site: [Download the Android NDK](https://developer.android.com/ndk/downloads/index.html)  
+The Android NDK is required to build native modules for Android.
+Download the NDK r19 or newer archive from the following site:
+[Download the Android NDK on developer.android.com](https://developer.android.com/ndk/downloads/index.html)
 To install the Android NDK, simply expand the archive in the folder where you want to install it.
-## Creating the Toolchain
-Run ```mktoolchains``` script to prepare standalone toolchains for all supported architectures. Refer to [NDK docs](https://developer.android.com/ndk/guides/standalone_toolchain.html) for details.
-## Working with Clang and libc++
-GNU compilers and gnustl will be removed from NDK starting Q3 2018, so we will use clang and libc++.
 ## OpenSSL
 Google removed openssl from Android 7+. You must build openssl libs by yourself.
+# Configure the NDK path
+Edit the ```mkall``` script to configure NDK path. Set the ```NDK``` to the directory where the NDK is installed.
 # Build SRT for Android
-Run ```/bin/bash mkall```. Libraries will be installed to ```./target-architecture/lib```.
+Run ```/bin/bash mkall > build.log``` script. Libraries will be installed to ```./target-architecture/lib```.
+# Export SRT libraries
+Run ```/bin/bash packjni``` to generate ```jniLibs``` archive for Android Studio.

--- a/docs/Android/mkall
+++ b/docs/Android/mkall
@@ -1,23 +1,41 @@
 #!/bin/bash
 
-openssl_ver=1.0.2n
-srt_branch=dev
+NDK=/opt/android-ndk-r19
 
+openssl_ver=1.0.2q
+srt_version=1.3.1
+#srt_branch=dev
+
+# Determine the path of the executing script
 BASE_DIR=$(readlink -f $0 | xargs dirname)
 
 wget -N https://www.openssl.org/source/openssl-$openssl_ver.tar.gz
 
 if [ ! -d $BASE_DIR/srt ]; then
  git clone https://github.com/Haivision/srt srt
- git -C $BASE_DIR/srt checkout -b $srt_branch origin/$srt_branch
+# git -C $BASE_DIR/srt checkout v${srt_version}
+# git -C $BASE_DIR/srt checkout -b $srt_branch origin/$srt_branch
 fi
 
+# Clang, binutils, the sysroot, and other toolchain pieces are all installed to $NDK/toolchains/llvm/prebuilt/<host-tag>
+toolchain=$NDK/toolchains/llvm/prebuilt/linux-x86_64
+
+# Cross-compiler tool prefix
 declare -A target_hosts
 target_hosts=(
  [arm]=arm-linux-androideabi
  [arm64]=aarch64-linux-android
  [x86]=i686-linux-android
  [x86_64]=x86_64-linux-android
+)
+
+# Cross-compiler prefix for -clang and -clang++ has api version
+declare -A target_api
+target_api=(
+ [arm]=armv7a-linux-androideabi16
+ [arm64]=aarch64-linux-android21
+ [x86]=i686-linux-android16
+ [x86_64]=x86_64-linux-android21
 )
 
 declare -A sysroots
@@ -31,8 +49,8 @@ sysroots=(
 for arch in arm arm64 x86 x86_64; do
  rm -rf $BASE_DIR/openssl-$openssl_ver
  tar xf $BASE_DIR/openssl-$openssl_ver.tar.gz
- $BASE_DIR/mkssl -t $BASE_DIR/android-toolchain-$arch -h ${target_hosts[$arch]} -s $BASE_DIR/openssl-$openssl_ver -i ${sysroots[$arch]}
+ $BASE_DIR/mkssl -t $toolchain -h ${target_hosts[$arch]} -a ${target_api[$arch]} -s $BASE_DIR/openssl-$openssl_ver -i ${sysroots[$arch]}
 
  git -C $BASE_DIR/srt clean -fd
- $BASE_DIR/mksrt -t $BASE_DIR/android-toolchain-$arch -h ${target_hosts[$arch]} -s $BASE_DIR/srt -i ${sysroots[$arch]}
+ $BASE_DIR/mksrt -t $toolchain -h ${target_hosts[$arch]} -a ${target_api[$arch]} -s $BASE_DIR/srt -i ${sysroots[$arch]}
 done

--- a/docs/Android/mksrt
+++ b/docs/Android/mksrt
@@ -2,6 +2,6 @@
 
 source prepare_build
 
-./configure --CMAKE_PREFIX_PATH=$install_dir --CMAKE_INSTALL_PREFIX=$install_dir
+./configure --use-openssl-pc=OFF --CMAKE_PREFIX_PATH=$install_dir --CMAKE_INSTALL_PREFIX=$install_dir
 make
 make install

--- a/docs/Android/mkssl
+++ b/docs/Android/mkssl
@@ -2,7 +2,7 @@
 
 source prepare_build
 
-./Configure android --openssldir=$install_dir
+./Configure android --openssldir=$install_dir -fPIC
 # OpenSSL (1.0.2) adds -mandroid to the compile flags. This flag is not recognized by clang.
 sed -i 's/-mandroid//g' Makefile
 make

--- a/docs/Android/mktoolchains
+++ b/docs/Android/mktoolchains
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-BASE_DIR=$(readlink -f $0 | xargs dirname)
-
-export PATH=$PATH:/opt/android-ndk-r16b/build/tools
-
-for arch in arm arm64 x86 x86_64; do
- make_standalone_toolchain.py -v --arch $arch --api 21 --stl=libc++ --install-dir=$BASE_DIR/android-toolchain-$arch
-done

--- a/docs/Android/packjni
+++ b/docs/Android/packjni
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+BASE_DIR=$(readlink -f $0 | xargs dirname)
+
+declare -A sysroots
+sysroots=(
+ [arm]=$BASE_DIR/armeabi-v7a
+ [arm64]=$BASE_DIR/arm64-v8a
+ [x86]=$BASE_DIR/x86
+ [x86_64]=$BASE_DIR/x86_64
+)
+
+srt_version=1.3.1
+jni_dir=$BASE_DIR/jniLibs
+
+declare -A jnilibs
+jnilibs=(
+ [arm]=$jni_dir/armeabi-v7a
+ [arm64]=$jni_dir/arm64-v8a
+ [x86]=$jni_dir/x86
+ [x86_64]=$jni_dir/x86_64
+)
+
+jni_dir=$BASE_DIR/jniLibs
+
+# Android < 6.0 has an issue with loading versioned libraries
+# The issue is because of library so-name libsrt.so.1
+
+for arch in arm arm64 x86 x86_64; do
+ mkdir -p ${jnilibs[$arch]}
+ cp ${sysroots[$arch]}/lib/libsrt.so.${srt_version} ${jnilibs[$arch]}/libsrt.so
+ /usr/local/bin/patchelf --set-soname libsrt.so ${jnilibs[$arch]}/libsrt.so
+ objdump -p ${jnilibs[$arch]}/libsrt.so | grep libsrt.so 
+done
+
+zip -r libsrt_$(date +%Y-%m-%d).zip jniLibs

--- a/docs/Android/prepare_build
+++ b/docs/Android/prepare_build
@@ -1,26 +1,29 @@
 #!/bin/bash
 
-while getopts t:h:s:i: option
+while getopts t:h:a:s:i: option
 do
  case "${option}"
  in
  t) toolchain_dir=${OPTARG};;
  h) target_host=${OPTARG};;
+ a) target_host_api=${OPTARG};;
  s) src_dir=${OPTARG};;
  i) install_dir=$OPTARG;;
  esac
 done
 
-# Add the standalone toolchain to the search path.
+# Add toolchain to the search path.
 export PATH=$PATH:$toolchain_dir/bin
 
 # Tell configure what tools to use.
 export AR=$target_host-ar
-export AS=$target_host-clang
-export CC=$target_host-clang
-export CXX=$target_host-clang++
+export AS=$target_host-as
 export LD=$target_host-ld
 export STRIP=$target_host-strip
+
+# Tell configure which android api to use.
+export CC=$target_host_api-clang
+export CXX=$target_host_api-clang++
 
 # Tell configure what flags Android requires.
 export CFLAGS="-fPIE -fPIC"


### PR DESCRIPTION
Update for Android NDK, Revision r19 (January 2019). Standalone toolchains are now unnecessary.