### PR TITLE
Incorrect wording in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # Introduction
 
-Secure Reliable Transport (SRT) is a proprietary transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.
+Secure Reliable Transport (SRT) is an open source transport technology that optimizes streaming performance across unpredictable networks, such as the Internet.
 
 |    |    |
 | --- | --- |


### PR DESCRIPTION
Everywhere I look the technology is described as open source. I think this is a mistake in the README.