### PR TITLE
Replaced ENABLE_LOGGING with ENABLE_HEAVY_LOGGING

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -366,7 +366,7 @@ void CChannel::getPeerAddr(sockaddr* addr) const
 
 int CChannel::sendto(const sockaddr* addr, CPacket& packet) const
 {
-#if ENABLE_LOGGING
+#if ENABLE_HEAVY_LOGGING
     std::ostringstream spec;
 
     if (packet.isControl())


### PR DESCRIPTION
Just a small fix. HLOGP is actually called. If ENABLE_HEAVY_LOGGING is not defined, then those calculations, that follow, are not used.