### PR TITLE
Formatting srt.h. Extern keyword deleted (default).

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -48,16 +48,16 @@ written by
          typedef __int64 uint64_t;
       #endif
 
-	#ifdef SRT_DYNAMIC
-      #ifdef SRT_EXPORTS
-         #define SRT_API __declspec(dllexport)
+      #ifdef SRT_DYNAMIC
+         #ifdef SRT_EXPORTS
+            #define SRT_API __declspec(dllexport)
+         #else
+            #define SRT_API __declspec(dllimport)
+         #endif
       #else
-         #define SRT_API __declspec(dllimport)
+         #define SRT_API
       #endif
-	#else
-		#define SRT_API
-	#endif
-   #else
+   #else // __MINGW__
       #define SRT_API
    #endif
 #else
@@ -110,76 +110,76 @@ typedef SYSSOCKET UDPSOCKET;
 
 // Values returned by srt_getsockstate()
 typedef enum SRT_SOCKSTATUS {
-	SRTS_INIT = 1,
-	SRTS_OPENED,
-	SRTS_LISTENING,
-	SRTS_CONNECTING,
-	SRTS_CONNECTED,
-	SRTS_BROKEN,
-	SRTS_CLOSING,
-	SRTS_CLOSED,
-	SRTS_NONEXIST
+   SRTS_INIT = 1,
+   SRTS_OPENED,
+   SRTS_LISTENING,
+   SRTS_CONNECTING,
+   SRTS_CONNECTED,
+   SRTS_BROKEN,
+   SRTS_CLOSING,
+   SRTS_CLOSED,
+   SRTS_NONEXIST
 } SRT_SOCKSTATUS;
 
 // This is a duplicate enum. Must be kept in sync with the original UDT enum for
 // backward compatibility until all compat is destroyed.
 typedef enum SRT_SOCKOPT {
 
-	SRTO_MSS = 0,             // the Maximum Transfer Unit
-	SRTO_SNDSYN = 1,          // if sending is blocking
-	SRTO_RCVSYN = 2,          // if receiving is blocking
-	SRTO_ISN = 3,             // Initial Sequence Number (valid only after srt_connect or srt_accept-ed sockets)
-	SRTO_FC = 4,              // Flight flag size (window size)
-	SRTO_SNDBUF = 5,          // maximum buffer in sending queue
-	SRTO_RCVBUF = 6,          // UDT receiving buffer size
-	SRTO_LINGER = 7,          // waiting for unsent data when closing
-	SRTO_UDP_SNDBUF = 8,      // UDP sending buffer size
-	SRTO_UDP_RCVBUF = 9,      // UDP receiving buffer size
-    // XXX Here space free for 2 options
-    // after deprecated ones are removed
-	SRTO_RENDEZVOUS = 12,      // rendezvous connection mode
-	SRTO_SNDTIMEO = 13,        // send() timeout
-	SRTO_RCVTIMEO = 14,        // recv() timeout
-	SRTO_REUSEADDR = 15,       // reuse an existing port or create a new one
-	SRTO_MAXBW = 16,           // maximum bandwidth (bytes per second) that the connection can use
-	SRTO_STATE = 17,           // current socket state, see UDTSTATUS, read only
-	SRTO_EVENT = 18,           // current available events associated with the socket
-	SRTO_SNDDATA = 19,         // size of data in the sending buffer
-	SRTO_RCVDATA = 20,         // size of data available for recv
-	SRTO_SENDER = 21,     // Sender mode (independent of conn mode), for encryption, tsbpd handshake.
-	SRTO_TSBPDMODE = 22,  // Enable/Disable TsbPd. Enable -> Tx set origin timestamp, Rx deliver packet at origin time + delay
-    SRTO_LATENCY = 23,    // DEPRECATED. SET: to both SRTO_RCVLATENCY and SRTO_PEERLATENCY. GET: same as SRTO_RCVLATENCY.
-	SRTO_TSBPDDELAY = 23, // ALIAS: SRTO_LATENCY
-	SRTO_INPUTBW = 24,    // Estimated input stream rate.
-	SRTO_OHEADBW,         // MaxBW ceiling based on % over input stream rate. Applies when UDT_MAXBW=0 (auto).
-	SRTO_PASSPHRASE = 26, // Crypto PBKDF2 Passphrase size[0,10..64] 0:disable crypto
-	SRTO_PBKEYLEN,        // Crypto key len in bytes {16,24,32} Default: 16 (128-bit)
-	SRTO_KMSTATE,         // Key Material exchange status (UDT_SRTKmState)
-	SRTO_IPTTL = 29,      // IP Time To Live (passthru for system sockopt IPPROTO_IP/IP_TTL)
-	SRTO_IPTOS,           // IP Type of Service (passthru for system sockopt IPPROTO_IP/IP_TOS)
-	SRTO_TLPKTDROP = 31,  // Enable receiver pkt drop
-	SRTO_SNDDROPDELAY = 32, // Extra delay towards latency for sender TLPKTDROP decision (-1 to off)
-	SRTO_NAKREPORT = 33,  // Enable receiver to send periodic NAK reports
-	SRTO_VERSION = 34,    // Local SRT Version
-	SRTO_PEERVERSION,     // Peer SRT Version (from SRT Handshake)
-	SRTO_CONNTIMEO = 36,   // Connect timeout in msec. Ccaller default: 3000, rendezvous (x 10)
-    // deprecated: SRTO_TWOWAYDATA, SRTO_SNDPBKEYLEN, SRTO_RCVPBKEYLEN (@c below)
-    _DEPRECATED_SRTO_SNDPBKEYLEN = 38, // (needed to use inside the code without generating -Wswitch)
-    //
-    SRTO_SNDKMSTATE = 40,  // (GET) the current state of the encryption at the peer side
-    SRTO_RCVKMSTATE,      // (GET) the current state of the encryption at the agent side
-    SRTO_LOSSMAXTTL,      // Maximum possible packet reorder tolerance (number of packets to receive after loss to send lossreport)
-    SRTO_RCVLATENCY,      // TsbPd receiver delay (mSec) to absorb burst of missed packet retransmission
-    SRTO_PEERLATENCY,     // Minimum value of the TsbPd receiver delay (mSec) for the opposite side (peer)
-    SRTO_MINVERSION,      // Minimum SRT version needed for the peer (peers with less version will get connection reject)
-    SRTO_STREAMID,        // A string set to a socket and passed to the listener's accepted socket
-    SRTO_SMOOTHER,        // Smoother selection (congestion control algorithm)
-    SRTO_MESSAGEAPI,      // In File mode, use message API (portions of data with boundaries)
-    SRTO_PAYLOADSIZE,     // Maximum payload size sent in one UDP packet (0 if unlimited)
-    SRTO_TRANSTYPE,       // Transmission type (set of options required for given transmission type)
-    SRTO_KMREFRESHRATE,   // After sending how many packets the encryption key should be flipped to the new key
-    SRTO_KMPREANNOUNCE,   // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
-    SRTO_STRICTENC,       // Connection to be rejected or quickly broken when one side encryption set or bad password
+   SRTO_MSS = 0,             // the Maximum Transfer Unit
+   SRTO_SNDSYN = 1,          // if sending is blocking
+   SRTO_RCVSYN = 2,          // if receiving is blocking
+   SRTO_ISN = 3,             // Initial Sequence Number (valid only after srt_connect or srt_accept-ed sockets)
+   SRTO_FC = 4,              // Flight flag size (window size)
+   SRTO_SNDBUF = 5,          // maximum buffer in sending queue
+   SRTO_RCVBUF = 6,          // UDT receiving buffer size
+   SRTO_LINGER = 7,          // waiting for unsent data when closing
+   SRTO_UDP_SNDBUF = 8,      // UDP sending buffer size
+   SRTO_UDP_RCVBUF = 9,      // UDP receiving buffer size
+   // XXX Free space for 2 options
+   // after deprecated ones are removed
+   SRTO_RENDEZVOUS = 12,     // rendezvous connection mode
+   SRTO_SNDTIMEO = 13,       // send() timeout
+   SRTO_RCVTIMEO = 14,       // recv() timeout
+   SRTO_REUSEADDR = 15,      // reuse an existing port or create a new one
+   SRTO_MAXBW = 16,          // maximum bandwidth (bytes per second) that the connection can use
+   SRTO_STATE = 17,          // current socket state, see UDTSTATUS, read only
+   SRTO_EVENT = 18,          // current available events associated with the socket
+   SRTO_SNDDATA = 19,        // size of data in the sending buffer
+   SRTO_RCVDATA = 20,        // size of data available for recv
+   SRTO_SENDER = 21,         // Sender mode (independent of conn mode), for encryption, tsbpd handshake.
+   SRTO_TSBPDMODE = 22,      // Enable/Disable TsbPd. Enable -> Tx set origin timestamp, Rx deliver packet at origin time + delay
+   SRTO_LATENCY = 23,        // DEPRECATED. SET: to both SRTO_RCVLATENCY and SRTO_PEERLATENCY. GET: same as SRTO_RCVLATENCY.
+   SRTO_TSBPDDELAY = 23,     // ALIAS: SRTO_LATENCY
+   SRTO_INPUTBW = 24,        // Estimated input stream rate.
+   SRTO_OHEADBW,             // MaxBW ceiling based on % over input stream rate. Applies when UDT_MAXBW=0 (auto).
+   SRTO_PASSPHRASE = 26,     // Crypto PBKDF2 Passphrase size[0,10..64] 0:disable crypto
+   SRTO_PBKEYLEN,            // Crypto key len in bytes {16,24,32} Default: 16 (128-bit)
+   SRTO_KMSTATE,             // Key Material exchange status (UDT_SRTKmState)
+   SRTO_IPTTL = 29,          // IP Time To Live (passthru for system sockopt IPPROTO_IP/IP_TTL)
+   SRTO_IPTOS,               // IP Type of Service (passthru for system sockopt IPPROTO_IP/IP_TOS)
+   SRTO_TLPKTDROP = 31,      // Enable receiver pkt drop
+   SRTO_SNDDROPDELAY = 32,   // Extra delay towards latency for sender TLPKTDROP decision (-1 to off)
+   SRTO_NAKREPORT = 33,      // Enable receiver to send periodic NAK reports
+   SRTO_VERSION = 34,        // Local SRT Version
+   SRTO_PEERVERSION,         // Peer SRT Version (from SRT Handshake)
+   SRTO_CONNTIMEO = 36,      // Connect timeout in msec. Ccaller default: 3000, rendezvous (x 10)
+   // deprecated: SRTO_TWOWAYDATA, SRTO_SNDPBKEYLEN, SRTO_RCVPBKEYLEN (@c below)
+   _DEPRECATED_SRTO_SNDPBKEYLEN = 38, // (needed to use inside the code without generating -Wswitch)
+   //
+   SRTO_SNDKMSTATE = 40,     // (GET) the current state of the encryption at the peer side
+   SRTO_RCVKMSTATE,          // (GET) the current state of the encryption at the agent side
+   SRTO_LOSSMAXTTL,          // Maximum possible packet reorder tolerance (number of packets to receive after loss to send lossreport)
+   SRTO_RCVLATENCY,          // TsbPd receiver delay (mSec) to absorb burst of missed packet retransmission
+   SRTO_PEERLATENCY,         // Minimum value of the TsbPd receiver delay (mSec) for the opposite side (peer)
+   SRTO_MINVERSION,          // Minimum SRT version needed for the peer (peers with less version will get connection reject)
+   SRTO_STREAMID,            // A string set to a socket and passed to the listener's accepted socket
+   SRTO_SMOOTHER,            // Smoother selection (congestion control algorithm)
+   SRTO_MESSAGEAPI,          // In File mode, use message API (portions of data with boundaries)
+   SRTO_PAYLOADSIZE,         // Maximum payload size sent in one UDP packet (0 if unlimited)
+   SRTO_TRANSTYPE,           // Transmission type (set of options required for given transmission type)
+   SRTO_KMREFRESHRATE,       // After sending how many packets the encryption key should be flipped to the new key
+   SRTO_KMPREANNOUNCE,       // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
+   SRTO_STRICTENC,           // Connection to be rejected or quickly broken when one side encryption set or bad password
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:
@@ -242,21 +242,21 @@ static const int SRT_LIVE_DEF_LATENCY_MS = 120;
 struct CBytePerfMon
 {
    // global measurements
-   int64_t msTimeStamp;                 // time since the UDT entity is started, in milliseconds
-   int64_t pktSentTotal;                // total number of sent data packets, including retransmissions
-   int64_t pktRecvTotal;                // total number of received packets
-   int pktSndLossTotal;                 // total number of lost packets (sender side)
-   int pktRcvLossTotal;                 // total number of lost packets (receiver side)
-   int pktRetransTotal;                 // total number of retransmitted packets
-   int pktSentACKTotal;                 // total number of sent ACK packets
-   int pktRecvACKTotal;                 // total number of received ACK packets
-   int pktSentNAKTotal;                 // total number of sent NAK packets
-   int pktRecvNAKTotal;                 // total number of received NAK packets
-   int64_t usSndDurationTotal;		// total time duration when UDT is sending data (idle time exclusive)
+   int64_t  msTimeStamp;                // time since the UDT entity is started, in milliseconds
+   int64_t  pktSentTotal;               // total number of sent data packets, including retransmissions
+   int64_t  pktRecvTotal;               // total number of received packets
+   int      pktSndLossTotal;            // total number of lost packets (sender side)
+   int      pktRcvLossTotal;            // total number of lost packets (receiver side)
+   int      pktRetransTotal;            // total number of retransmitted packets
+   int      pktSentACKTotal;            // total number of sent ACK packets
+   int      pktRecvACKTotal;            // total number of received ACK packets
+   int      pktSentNAKTotal;            // total number of sent NAK packets
+   int      pktRecvNAKTotal;            // total number of received NAK packets
+   int64_t  usSndDurationTotal;         // total time duration when UDT is sending data (idle time exclusive)
    //>new
-   int pktSndDropTotal;                 // number of too-late-to-send dropped packets
-   int pktRcvDropTotal;                 // number of too-late-to play missing packets
-   int pktRcvUndecryptTotal;            // number of undecrypted packets
+   int      pktSndDropTotal;            // number of too-late-to-send dropped packets
+   int      pktRcvDropTotal;            // number of too-late-to play missing packets
+   int      pktRcvUndecryptTotal;       // number of undecrypted packets
    uint64_t byteSentTotal;              // total number of sent data bytes, including retransmissions
    uint64_t byteRecvTotal;              // total number of received bytes
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
@@ -269,26 +269,26 @@ struct CBytePerfMon
    //<
 
    // local measurements
-   int64_t pktSent;                     // number of sent data packets, including retransmissions
-   int64_t pktRecv;                     // number of received packets
-   int pktSndLoss;                      // number of lost packets (sender side)
-   int pktRcvLoss;                      // number of lost packets (receiver side)
-   int pktRetrans;                      // number of retransmitted packets
-   int pktRcvRetrans;                   // number of retransmitted packets received
-   int pktSentACK;                      // number of sent ACK packets
-   int pktRecvACK;                      // number of received ACK packets
-   int pktSentNAK;                      // number of sent NAK packets
-   int pktRecvNAK;                      // number of received NAK packets
-   double mbpsSendRate;                 // sending rate in Mb/s
-   double mbpsRecvRate;                 // receiving rate in Mb/s
-   int64_t usSndDuration;		// busy sending time (i.e., idle time exclusive)
-   int pktReorderDistance;              // size of order discrepancy in received sequences
-   double pktRcvAvgBelatedTime;             // average time of packet delay for belated packets (packets with sequence past the ACK)
-   int64_t pktRcvBelated;              // number of received AND IGNORED packets due to having come too late
+   int64_t  pktSent;                    // number of sent data packets, including retransmissions
+   int64_t  pktRecv;                    // number of received packets
+   int      pktSndLoss;                 // number of lost packets (sender side)
+   int      pktRcvLoss;                 // number of lost packets (receiver side)
+   int      pktRetrans;                 // number of retransmitted packets
+   int      pktRcvRetrans;              // number of retransmitted packets received
+   int      pktSentACK;                 // number of sent ACK packets
+   int      pktRecvACK;                 // number of received ACK packets
+   int      pktSentNAK;                 // number of sent NAK packets
+   int      pktRecvNAK;                 // number of received NAK packets
+   double   mbpsSendRate;               // sending rate in Mb/s
+   double   mbpsRecvRate;               // receiving rate in Mb/s
+   int64_t  usSndDuration;              // busy sending time (i.e., idle time exclusive)
+   int      pktReorderDistance;         // size of order discrepancy in received sequences
+   double   pktRcvAvgBelatedTime;       // average time of packet delay for belated packets (packets with sequence past the ACK)
+   int64_t  pktRcvBelated;              // number of received AND IGNORED packets due to having come too late
    //>new
-   int pktSndDrop;                      // number of too-late-to-send dropped packets
-   int pktRcvDrop;                      // number of too-late-to play missing packets
-   int pktRcvUndecrypt;                 // number of undecrypted packets
+   int      pktSndDrop;                 // number of too-late-to-send dropped packets
+   int      pktRcvDrop;                 // number of too-late-to play missing packets
+   int      pktRcvUndecrypt;            // number of undecrypted packets
    uint64_t byteSent;                   // number of sent data bytes, including retransmissions
    uint64_t byteRecv;                   // number of received bytes
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
@@ -301,27 +301,27 @@ struct CBytePerfMon
    //<
 
    // instant measurements
-   double usPktSndPeriod;               // packet sending period, in microseconds
-   int pktFlowWindow;                   // flow window size, in number of packets
-   int pktCongestionWindow;             // congestion window size, in number of packets
-   int pktFlightSize;                   // number of packets on flight
-   double msRTT;                        // RTT, in milliseconds
-   double mbpsBandwidth;                // estimated bandwidth, in Mb/s
-   int byteAvailSndBuf;                 // available UDT sender buffer size
-   int byteAvailRcvBuf;                 // available UDT receiver buffer size
+   double   usPktSndPeriod;             // packet sending period, in microseconds
+   int      pktFlowWindow;              // flow window size, in number of packets
+   int      pktCongestionWindow;        // congestion window size, in number of packets
+   int      pktFlightSize;              // number of packets on flight
+   double   msRTT;                      // RTT, in milliseconds
+   double   mbpsBandwidth;              // estimated bandwidth, in Mb/s
+   int      byteAvailSndBuf;            // available UDT sender buffer size
+   int      byteAvailRcvBuf;            // available UDT receiver buffer size
    //>new
-   double  mbpsMaxBW;                   // Transmit Bandwidth ceiling (Mbps)
-   int     byteMSS;                     // MTU
+   double   mbpsMaxBW;                  // Transmit Bandwidth ceiling (Mbps)
+   int      byteMSS;                    // MTU
 
-   int     pktSndBuf;                   // UnACKed packets in UDT sender
-   int     byteSndBuf;                  // UnACKed bytes in UDT sender
-   int     msSndBuf;                    // UnACKed timespan (msec) of UDT sender
-   int     msSndTsbPdDelay;             // Timestamp-based Packet Delivery Delay
+   int      pktSndBuf;                  // UnACKed packets in UDT sender
+   int      byteSndBuf;                 // UnACKed bytes in UDT sender
+   int      msSndBuf;                   // UnACKed timespan (msec) of UDT sender
+   int      msSndTsbPdDelay;            // Timestamp-based Packet Delivery Delay
 
-   int     pktRcvBuf;                   // Undelivered packets in UDT receiver
-   int     byteRcvBuf;                  // Undelivered bytes of UDT receiver
-   int     msRcvBuf;                    // Undelivered timespan (msec) of UDT receiver
-   int     msRcvTsbPdDelay;             // Timestamp-based Packet Delivery Delay
+   int      pktRcvBuf;                  // Undelivered packets in UDT receiver
+   int      byteRcvBuf;                 // Undelivered bytes of UDT receiver
+   int      msRcvBuf;                   // Undelivered timespan (msec) of UDT receiver
+   int      msRcvTsbPdDelay;            // Timestamp-based Packet Delivery Delay
    //<
 };
 
@@ -332,113 +332,113 @@ struct CBytePerfMon
 // in all throw CUDTException expressions.
 enum CodeMajor
 {
-    MJ_UNKNOWN = -1,
-    MJ_SUCCESS = 0,
-    MJ_SETUP = 1,
-    MJ_CONNECTION = 2,
-    MJ_SYSTEMRES = 3,
-    MJ_FILESYSTEM = 4,
-    MJ_NOTSUP = 5,
-    MJ_AGAIN = 6,
-    MJ_PEERERROR = 7
+    MJ_UNKNOWN    = -1,
+    MJ_SUCCESS    =  0,
+    MJ_SETUP      =  1,
+    MJ_CONNECTION =  2,
+    MJ_SYSTEMRES  =  3,
+    MJ_FILESYSTEM =  4,
+    MJ_NOTSUP     =  5,
+    MJ_AGAIN      =  6,
+    MJ_PEERERROR  =  7
 };
 
 enum CodeMinor
 {
     // These are "minor" error codes from various "major" categories
     // MJ_SETUP
-    MN_NONE = 0,
-    MN_TIMEOUT = 1,
-    MN_REJECTED = 2,
-    MN_NORES = 3,
-    MN_SECURITY = 4,
+    MN_NONE            =  0,
+    MN_TIMEOUT         =  1,
+    MN_REJECTED        =  2,
+    MN_NORES           =  3,
+    MN_SECURITY        =  4,
     // MJ_CONNECTION
-    MN_CONNLOST = 1,
-    MN_NOCONN = 2,
+    MN_CONNLOST        =  1,
+    MN_NOCONN          =  2,
     // MJ_SYSTEMRES
-    MN_THREAD = 1,
-    MN_MEMORY = 2,
+    MN_THREAD          =  1,
+    MN_MEMORY          =  2,
     // MJ_FILESYSTEM
-    MN_SEEKGFAIL = 1,
-    MN_READFAIL = 2,
-    MN_SEEKPFAIL = 3,
-    MN_WRITEFAIL = 4,
+    MN_SEEKGFAIL       =  1,
+    MN_READFAIL        =  2,
+    MN_SEEKPFAIL       =  3,
+    MN_WRITEFAIL       =  4,
     // MJ_NOTSUP
-    MN_ISBOUND = 1,
-    MN_ISCONNECTED = 2,
-    MN_INVAL = 3,
-    MN_SIDINVAL = 4,
-    MN_ISUNBOUND = 5,
-    MN_NOLISTEN = 6,
-    MN_ISRENDEZVOUS = 7,
-    MN_ISRENDUNBOUND = 8,
-    MN_INVALMSGAPI = 9,
-    MN_INVALBUFFERAPI = 10,
-    MN_BUSY = 11,
-    MN_XSIZE = 12,
-    MN_EIDINVAL = 13,
+    MN_ISBOUND         =  1,
+    MN_ISCONNECTED     =  2,
+    MN_INVAL           =  3,
+    MN_SIDINVAL        =  4,
+    MN_ISUNBOUND       =  5,
+    MN_NOLISTEN        =  6,
+    MN_ISRENDEZVOUS    =  7,
+    MN_ISRENDUNBOUND   =  8,
+    MN_INVALMSGAPI     =  9,
+    MN_INVALBUFFERAPI  = 10,
+    MN_BUSY            = 11,
+    MN_XSIZE           = 12,
+    MN_EIDINVAL        = 13,
     // MJ_AGAIN
-    MN_WRAVAIL = 1,
-    MN_RDAVAIL = 2,
-    MN_XMTIMEOUT = 3,
-    MN_CONGESTION = 4
+    MN_WRAVAIL         =  1,
+    MN_RDAVAIL         =  2,
+    MN_XMTIMEOUT       =  3,
+    MN_CONGESTION      =  4
 };
 
 static const enum CodeMinor MN_ISSTREAM SRT_ATR_DEPRECATED = (enum CodeMinor)(9);
 static const enum CodeMinor MN_ISDGRAM SRT_ATR_DEPRECATED = (enum CodeMinor)(10);
 
 // Stupid, but effective. This will be #undefined, so don't worry.
-#define MJ(major) (1000*MJ_##major)
-#define MN(major, minor) (1000*MJ_##major + MN_##minor)
+#define MJ(major) (1000 * MJ_##major)
+#define MN(major, minor) (1000 * MJ_##major + MN_##minor)
 
 // Some better way to define it, and better for C language.
 typedef enum SRT_ERRNO
 {
-    SRT_EUNKNOWN = -1,
-    SRT_SUCCESS = MJ_SUCCESS,
+    SRT_EUNKNOWN        = -1,
+    SRT_SUCCESS         = MJ_SUCCESS,
 
-    SRT_ECONNSETUP = MJ(SETUP),
-    SRT_ENOSERVER  = MN(SETUP, TIMEOUT),
-    SRT_ECONNREJ   = MN(SETUP, REJECTED),
-    SRT_ESOCKFAIL  = MN(SETUP, NORES),
-    SRT_ESECFAIL   = MN(SETUP, SECURITY),
+    SRT_ECONNSETUP      = MJ(SETUP),
+    SRT_ENOSERVER       = MN(SETUP, TIMEOUT),
+    SRT_ECONNREJ        = MN(SETUP, REJECTED),
+    SRT_ESOCKFAIL       = MN(SETUP, NORES),
+    SRT_ESECFAIL        = MN(SETUP, SECURITY),
 
-    SRT_ECONNFAIL =  MJ(CONNECTION),
-    SRT_ECONNLOST =  MN(CONNECTION, CONNLOST),
-    SRT_ENOCONN =    MN(CONNECTION, NOCONN),
+    SRT_ECONNFAIL       = MJ(CONNECTION),
+    SRT_ECONNLOST       = MN(CONNECTION, CONNLOST),
+    SRT_ENOCONN         = MN(CONNECTION, NOCONN),
 
-    SRT_ERESOURCE =  MJ(SYSTEMRES),
-    SRT_ETHREAD =    MN(SYSTEMRES, THREAD),
-    SRT_ENOBUF =     MN(SYSTEMRES, MEMORY),
+    SRT_ERESOURCE       = MJ(SYSTEMRES),
+    SRT_ETHREAD         = MN(SYSTEMRES, THREAD),
+    SRT_ENOBUF          = MN(SYSTEMRES, MEMORY),
 
-    SRT_EFILE =      MJ(FILESYSTEM),
-    SRT_EINVRDOFF =  MN(FILESYSTEM, SEEKGFAIL),
-    SRT_ERDPERM =    MN(FILESYSTEM, READFAIL),
-    SRT_EINVWROFF =  MN(FILESYSTEM, SEEKPFAIL),
-    SRT_EWRPERM =    MN(FILESYSTEM, WRITEFAIL),
+    SRT_EFILE           = MJ(FILESYSTEM),
+    SRT_EINVRDOFF       = MN(FILESYSTEM, SEEKGFAIL),
+    SRT_ERDPERM         = MN(FILESYSTEM, READFAIL),
+    SRT_EINVWROFF       = MN(FILESYSTEM, SEEKPFAIL),
+    SRT_EWRPERM         = MN(FILESYSTEM, WRITEFAIL),
 
-    SRT_EINVOP =       MJ(NOTSUP),
-    SRT_EBOUNDSOCK =   MN(NOTSUP, ISBOUND),
-    SRT_ECONNSOCK =    MN(NOTSUP, ISCONNECTED),
-    SRT_EINVPARAM =    MN(NOTSUP, INVAL),
-    SRT_EINVSOCK =     MN(NOTSUP, SIDINVAL),
-    SRT_EUNBOUNDSOCK = MN(NOTSUP, ISUNBOUND),
-    SRT_ENOLISTEN =    MN(NOTSUP, NOLISTEN),
-    SRT_ERDVNOSERV =   MN(NOTSUP, ISRENDEZVOUS),
-    SRT_ERDVUNBOUND =  MN(NOTSUP, ISRENDUNBOUND),
-    SRT_EINVALMSGAPI =   MN(NOTSUP, INVALMSGAPI),
+    SRT_EINVOP          = MJ(NOTSUP),
+    SRT_EBOUNDSOCK      = MN(NOTSUP, ISBOUND),
+    SRT_ECONNSOCK       = MN(NOTSUP, ISCONNECTED),
+    SRT_EINVPARAM       = MN(NOTSUP, INVAL),
+    SRT_EINVSOCK        = MN(NOTSUP, SIDINVAL),
+    SRT_EUNBOUNDSOCK    = MN(NOTSUP, ISUNBOUND),
+    SRT_ENOLISTEN       = MN(NOTSUP, NOLISTEN),
+    SRT_ERDVNOSERV      = MN(NOTSUP, ISRENDEZVOUS),
+    SRT_ERDVUNBOUND     = MN(NOTSUP, ISRENDUNBOUND),
+    SRT_EINVALMSGAPI    = MN(NOTSUP, INVALMSGAPI),
     SRT_EINVALBUFFERAPI = MN(NOTSUP, INVALBUFFERAPI),
-    SRT_EDUPLISTEN =   MN(NOTSUP, BUSY),
-    SRT_ELARGEMSG =    MN(NOTSUP, XSIZE),
-    SRT_EINVPOLLID =   MN(NOTSUP, EIDINVAL),
+    SRT_EDUPLISTEN      = MN(NOTSUP, BUSY),
+    SRT_ELARGEMSG       = MN(NOTSUP, XSIZE),
+    SRT_EINVPOLLID      = MN(NOTSUP, EIDINVAL),
 
-    SRT_EASYNCFAIL = MJ(AGAIN),
-    SRT_EASYNCSND =  MN(AGAIN, WRAVAIL),
-    SRT_EASYNCRCV =  MN(AGAIN, RDAVAIL),
-    SRT_ETIMEOUT =   MN(AGAIN, XMTIMEOUT),
-    SRT_ECONGEST =   MN(AGAIN, CONGESTION),
+    SRT_EASYNCFAIL      = MJ(AGAIN),
+    SRT_EASYNCSND       = MN(AGAIN, WRAVAIL),
+    SRT_EASYNCRCV       = MN(AGAIN, RDAVAIL),
+    SRT_ETIMEOUT        = MN(AGAIN, XMTIMEOUT),
+    SRT_ECONGEST        = MN(AGAIN, CONGESTION),
 
-    SRT_EPEERERR = MJ(PEERERROR)
+    SRT_EPEERERR        = MJ(PEERERROR)
 } SRT_ERRNO;
 
 static const SRT_ERRNO SRT_EISSTREAM SRT_ATR_DEPRECATED = (SRT_ERRNO) MN(NOTSUP, INVALMSGAPI);
@@ -457,13 +457,13 @@ static const SRT_ERRNO SRT_EISDGRAM  SRT_ATR_DEPRECATED = (SRT_ERRNO) MN(NOTSUP,
 // Note that 0 is "general".
 
 // Made by #define so that it's available also for C API.
-#define SRT_LOGFA_GENERAL 0
-#define SRT_LOGFA_BSTATS 1
-#define SRT_LOGFA_CONTROL 2
-#define SRT_LOGFA_DATA 3
-#define SRT_LOGFA_TSBPD 4
-#define SRT_LOGFA_REXMIT 5
-#define SRT_LOGFA_HAICRYPT 6
+#define SRT_LOGFA_GENERAL   0
+#define SRT_LOGFA_BSTATS    1
+#define SRT_LOGFA_CONTROL   2
+#define SRT_LOGFA_DATA      3
+#define SRT_LOGFA_TSBPD     4
+#define SRT_LOGFA_REXMIT    5
+#define SRT_LOGFA_HAICRYPT  6
 
 // To make a typical int32_t size, although still use std::bitset.
 // C API will carry it over.
@@ -480,12 +480,12 @@ enum SRT_KM_STATE
 
 enum SRT_EPOLL_OPT
 {
-   SRT_EPOLL_OPT_NONE = 0, // fallback
+   SRT_EPOLL_OPT_NONE = 0x0, // fallback
    // this values are defined same as linux epoll.h
    // so that if system values are used by mistake, they should have the same effect
-   SRT_EPOLL_IN = 0x1,
-   SRT_EPOLL_OUT = 0x4,
-   SRT_EPOLL_ERR = 0x8
+   SRT_EPOLL_IN       = 0x1,
+   SRT_EPOLL_OUT      = 0x4,
+   SRT_EPOLL_ERR      = 0x8
 };
 
 #ifdef __cplusplus
@@ -514,27 +514,30 @@ static const SRTSOCKET SRT_INVALID_SOCK = -1;
 static const int SRT_ERROR = -1;
 
 // library initialization
-SRT_API extern int srt_startup(void);
-SRT_API extern int srt_cleanup(void);
+SRT_API       int srt_startup(void);
+SRT_API       int srt_cleanup(void);
 
-// socket operations
-SRT_API extern SRTSOCKET srt_socket(int af, int type, int protocol);
-SRT_API extern SRTSOCKET srt_create_socket();
-SRT_API extern int srt_bind(SRTSOCKET u, const struct sockaddr* name, int namelen);
-SRT_API extern int srt_bind_peerof(SRTSOCKET u, UDPSOCKET udpsock);
-SRT_API extern int srt_listen(SRTSOCKET u, int backlog);
-SRT_API extern SRTSOCKET srt_accept(SRTSOCKET u, struct sockaddr* addr, int* addrlen);
-SRT_API extern int srt_connect(SRTSOCKET u, const struct sockaddr* name, int namelen);
-SRT_API extern int srt_connect_debug(SRTSOCKET u, const struct sockaddr* name, int namelen, int forced_isn);
-SRT_API extern int srt_rendezvous(SRTSOCKET u, const struct sockaddr* local_name, int local_namelen,
-        const struct sockaddr* remote_name, int remote_namelen);
-SRT_API extern int srt_close(SRTSOCKET u);
-SRT_API extern int srt_getpeername(SRTSOCKET u, struct sockaddr* name, int* namelen);
-SRT_API extern int srt_getsockname(SRTSOCKET u, struct sockaddr* name, int* namelen);
-SRT_API extern int srt_getsockopt(SRTSOCKET u, int level /*ignored*/, SRT_SOCKOPT optname, void* optval, int* optlen);
-SRT_API extern int srt_setsockopt(SRTSOCKET u, int level /*ignored*/, SRT_SOCKOPT optname, const void* optval, int optlen);
-SRT_API extern int srt_getsockflag(SRTSOCKET u, SRT_SOCKOPT opt, void* optval, int* optlen);
-SRT_API extern int srt_setsockflag(SRTSOCKET u, SRT_SOCKOPT opt, const void* optval, int optlen);
+//
+// Socket operations
+//
+SRT_API SRTSOCKET srt_socket       (int af, int type, int protocol);
+SRT_API SRTSOCKET srt_create_socket();
+SRT_API       int srt_bind         (SRTSOCKET u, const struct sockaddr* name, int namelen);
+SRT_API       int srt_bind_peerof  (SRTSOCKET u, UDPSOCKET udpsock);
+SRT_API       int srt_listen       (SRTSOCKET u, int backlog);
+SRT_API SRTSOCKET srt_accept       (SRTSOCKET u, struct sockaddr* addr, int* addrlen);
+SRT_API       int srt_connect      (SRTSOCKET u, const struct sockaddr* name, int namelen);
+SRT_API       int srt_connect_debug(SRTSOCKET u, const struct sockaddr* name, int namelen, int forced_isn);
+SRT_API       int srt_rendezvous   (SRTSOCKET u, const struct sockaddr* local_name, int local_namelen,
+                                    const struct sockaddr* remote_name, int remote_namelen);
+SRT_API       int srt_close        (SRTSOCKET u);
+SRT_API       int srt_getpeername  (SRTSOCKET u, struct sockaddr* name, int* namelen);
+SRT_API       int srt_getsockname  (SRTSOCKET u, struct sockaddr* name, int* namelen);
+SRT_API       int srt_getsockopt   (SRTSOCKET u, int level /*ignored*/, SRT_SOCKOPT optname, void* optval, int* optlen);
+SRT_API       int srt_setsockopt   (SRTSOCKET u, int level /*ignored*/, SRT_SOCKOPT optname, const void* optval, int optlen);
+SRT_API       int srt_getsockflag  (SRTSOCKET u, SRT_SOCKOPT opt, void* optval, int* optlen);
+SRT_API       int srt_setsockflag  (SRTSOCKET u, SRT_SOCKOPT opt, const void* optval, int optlen);
+
 
 // XXX Note that the srctime functionality doesn't work yet and needs fixing.
 typedef struct SRT_MsgCtrl_
@@ -542,7 +545,7 @@ typedef struct SRT_MsgCtrl_
    int flags;            // Left for future
    int msgttl;           // TTL for a message, default -1 (delivered always)
    int inorder;          // Whether a message is allowed to supersede partially lost one. Unused in stream and live mode.
-   int boundary;         //0:mid pkt, 1(01b):end of frame, 2(11b):complete frame, 3(10b): start of frame
+   int boundary;         // 0:mid pkt, 1(01b):end of frame, 2(11b):complete frame, 3(10b): start of frame
    uint64_t srctime;     // source timestamp (usec), 0: use internal time     
    int32_t pktseq;       // sequence number of the first packet in received message (unused for sending)
    int32_t msgno;        // message number (output value for both sending and receiving)
@@ -550,7 +553,7 @@ typedef struct SRT_MsgCtrl_
 
 // You are free to use either of these two methods to set SRT_MSGCTRL object
 // to default values: either call srt_msgctrl_init(&obj) or obj = srt_msgctrl_default.
-SRT_API extern void srt_msgctrl_init(SRT_MSGCTRL* mctrl);
+SRT_API void srt_msgctrl_init(SRT_MSGCTRL* mctrl);
 SRT_API extern const SRT_MSGCTRL srt_msgctrl_default;
 
 // The send/receive functions.
@@ -572,17 +575,21 @@ SRT_API extern const SRT_MSGCTRL srt_msgctrl_default;
 // compat applications that pass useless 0 there are fixed, this will be
 // removed.
 
-// Sending
-SRT_API extern int srt_send(SRTSOCKET u, const char* buf, int len);
-SRT_API extern int srt_sendmsg(SRTSOCKET u, const char* buf, int len, int ttl/* = -1*/, int inorder/* = false*/);
-SRT_API extern int srt_sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL *mctrl);
+//
+// Sending functions
+//
+SRT_API int srt_send    (SRTSOCKET u, const char* buf, int len);
+SRT_API int srt_sendmsg (SRTSOCKET u, const char* buf, int len, int ttl/* = -1*/, int inorder/* = false*/);
+SRT_API int srt_sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL *mctrl);
 
-// Receiving
-SRT_API extern int srt_recv(SRTSOCKET u, char* buf, int len);
+//
+// Receiving functions
+//
+SRT_API int srt_recv    (SRTSOCKET u, char* buf, int len);
 
 // srt_recvmsg is actually an alias to srt_recv, it stays under the old name for compat reasons.
-SRT_API extern int srt_recvmsg(SRTSOCKET u, char* buf, int len);
-SRT_API extern int srt_recvmsg2(SRTSOCKET u, char *buf, int len, SRT_MSGCTRL *mctrl);
+SRT_API int srt_recvmsg (SRTSOCKET u, char* buf, int len);
+SRT_API int srt_recvmsg2(SRTSOCKET u, char *buf, int len, SRT_MSGCTRL *mctrl);
 
 
 // Special send/receive functions for files only.
@@ -593,34 +600,33 @@ SRT_API int64_t srt_recvfile(SRTSOCKET u, const char* path, int64_t* offset, int
 
 
 // last error detection
-SRT_API extern const char* srt_getlasterror_str(void);
-SRT_API extern int srt_getlasterror(int* errno_loc);
-SRT_API extern const char* srt_strerror(int code, int errnoval);
-SRT_API extern void srt_clearlasterror(void);
+SRT_API const char* srt_getlasterror_str(void);
+SRT_API        int  srt_getlasterror(int* errno_loc);
+SRT_API const char* srt_strerror(int code, int errnoval);
+SRT_API       void  srt_clearlasterror(void);
 
 // performance track
 // srt_perfmon is deprecated - use srt_bistats, which provides the same stats plus more.
-SRT_API extern int srt_perfmon(SRTSOCKET u, SRT_TRACEINFO * perf, int clear) SRT_ATR_DEPRECATED;
+SRT_API int srt_perfmon(SRTSOCKET u, SRT_TRACEINFO * perf, int clear) SRT_ATR_DEPRECATED;
 // perfmon with Byte counters for better bitrate estimation.
-SRT_API extern int srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear);
+SRT_API int srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear);
 // permon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
-SRT_API extern int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int instantaneous);
+SRT_API int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int instantaneous);
 
 // Socket Status (for problem tracking)
-SRT_API extern SRT_SOCKSTATUS srt_getsockstate(SRTSOCKET u);
+SRT_API SRT_SOCKSTATUS srt_getsockstate(SRTSOCKET u);
 
-SRT_API extern int srt_epoll_create(void);
-SRT_API extern int srt_epoll_add_usock(int eid, SRTSOCKET u, const int* events);
-SRT_API extern int srt_epoll_add_ssock(int eid, SYSSOCKET s, const int* events);
-SRT_API extern int srt_epoll_remove_usock(int eid, SRTSOCKET u);
-SRT_API extern int srt_epoll_remove_ssock(int eid, SYSSOCKET s);
-SRT_API extern int srt_epoll_update_usock(int eid, SRTSOCKET u, const int* events);
-SRT_API extern int srt_epoll_update_ssock(int eid, SYSSOCKET s, const int* events);
-///SRT_API extern int srt_epoll_wait(int eid, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, int64_t msTimeOut,
-///                       std::set<SYSSOCKET>* lrfds = NULL, std::set<SYSSOCKET>* wrfds = NULL);
-SRT_API extern int srt_epoll_wait(int eid, SRTSOCKET* readfds, int* rnum, SRTSOCKET* writefds, int* wnum, int64_t msTimeOut,
-                        SYSSOCKET* lrfds, int* lrnum, SYSSOCKET* lwfds, int* lwnum);
-SRT_API extern int srt_epoll_release(int eid);
+SRT_API int srt_epoll_create(void);
+SRT_API int srt_epoll_add_usock(int eid, SRTSOCKET u, const int* events);
+SRT_API int srt_epoll_add_ssock(int eid, SYSSOCKET s, const int* events);
+SRT_API int srt_epoll_remove_usock(int eid, SRTSOCKET u);
+SRT_API int srt_epoll_remove_ssock(int eid, SYSSOCKET s);
+SRT_API int srt_epoll_update_usock(int eid, SRTSOCKET u, const int* events);
+SRT_API int srt_epoll_update_ssock(int eid, SYSSOCKET s, const int* events);
+
+SRT_API int srt_epoll_wait(int eid, SRTSOCKET* readfds, int* rnum, SRTSOCKET* writefds, int* wnum, int64_t msTimeOut,
+                           SYSSOCKET* lrfds, int* lrnum, SYSSOCKET* lwfds, int* lwnum);
+SRT_API int srt_epoll_release(int eid);
 
 // Logging control
 

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -54,7 +54,7 @@ int srt_bind_peerof(SRTSOCKET u, UDPSOCKET udpsock) { return CUDT::bind(u, udpso
 int srt_listen(SRTSOCKET u, int backlog) { return CUDT::listen(u, backlog); }
 SRTSOCKET srt_accept(SRTSOCKET u, struct sockaddr * addr, int * addrlen) { return CUDT::accept(u, addr, addrlen); }
 int srt_connect(SRTSOCKET u, const struct sockaddr * name, int namelen) { return CUDT::connect(u, name, namelen, 0); }
-int srt_connect_debug(SRTSOCKET u, const struct sockaddr * name, int namelen, int32_t forced_isn) { return CUDT::connect(u, name, namelen, forced_isn); }
+int srt_connect_debug(SRTSOCKET u, const struct sockaddr * name, int namelen, int forced_isn) { return CUDT::connect(u, name, namelen, forced_isn); }
 
 int srt_rendezvous(SRTSOCKET u, const struct sockaddr* local_name, int local_namelen,
         const struct sockaddr* remote_name, int remote_namelen)


### PR DESCRIPTION
- Replaced TABs with 3 spaces (like the rest of the header file).
- Functions are `extern` by default - deleted extern keywords.
- `srt_connect_debug(...)` function had slightly different prototype in srt.h, than its implementation in `srt_c_api.c`.