### PR TITLE
ReadMe.md: Deleted invalid SRT slack channel link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ SRT is applied to contribution and distribution endpoints as part of a video str
 
 As audio/video packets are streamed from a source to a destination device, SRT detects and adapts to the real-time network conditions between the two endpoints. SRT helps compensate for jitter and bandwidth fluctuations due to congestion over noisy networks, such as the Internet. Its error recovery mechanism minimizes the packet loss typical of Internet connections. And SRT supports AES encryption for end-to-end security, keeping your streams safe from prying eyes.
 
-[Join the conversation](https://join.slack.com/t/srtalliance/shared_invite/enQtMjY5MzY4MjQ0Njc4LTJjYWYzMmYzN2RjYWI4MWMxZDdiYTE4OTZlMDE4YWQyOGJhNTgwYjIzOTdiODY5OGE4YTQ4ZGZjN2Y0OTI5ZTA) in the #development channel on [Slack](https://srtalliance.slack.com).
-
 # Guides
 * [Why SRT Was Created](docs/why-srt-was-created.md)
 * [Using the `stransmit` App](docs/stransmit.md)


### PR DESCRIPTION
The SRT slack channel is currently for SRT alliance members only. So this link is invalid.
Fixes #543 
