### PR TITLE
Deleted unimplemented function CRcvBuffer::isReadyToPlay(...)

### DIFF
--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -317,7 +317,6 @@ public:
        return m_iLastAckPos != m_iStartPos;
    }
    CPacket* getRcvReadyPacket();
-   bool isReadyToPlay(const CPacket* p, uint64_t& tsbpdtime);
 
       ///    Set TimeStamp-Based Packet Delivery Rx Mode
       ///    @param [in] timebase localtime base (uSec) of packet time stamps including buffering delay

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -91,9 +91,9 @@ TEST(Core, ConnectionTimeout) {
         // Check the actual timeout
         const chrono::steady_clock::time_point chrono_ts_end = chrono::steady_clock::now();
         const auto delta_ms = chrono::duration_cast<chrono::milliseconds>(chrono_ts_end - chrono_ts_start).count();
-        // Confidence interval border : +/-30 ms
-        EXPECT_LT(delta_ms, connection_timeout_ms + 30);
-        EXPECT_GT(delta_ms, connection_timeout_ms - 30);
+        // Confidence interval border : +/-50 ms
+        EXPECT_LE(delta_ms, connection_timeout_ms + 50);
+        EXPECT_GE(delta_ms, connection_timeout_ms - 50);
         cerr << "Timeout was: " << delta_ms << "\n";
 
         EXPECT_EQ(rlen, 1);

--- a/test/test_strict_encription.cpp
+++ b/test/test_strict_encription.cpp
@@ -16,6 +16,13 @@
 #include "srt.h"
 
 
+#ifdef __GNUC__
+#  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+#else
+#  define UNUSED(x) UNUSED_ ## x
+#endif
+
+
 enum PEER_TYPE
 {
     PEER_CALLER   = 0,
@@ -428,8 +435,9 @@ private:
 };
 
 
+
 template<>
-int TestStrictEncryption::WaitOnEpoll<TestResultBlocking>(const TestResultBlocking &expect)
+int TestStrictEncryption::WaitOnEpoll<TestResultBlocking>(const TestResultBlocking & UNUSED(expect))
 {
     return SRT_SUCCESS;
 }


### PR DESCRIPTION
- Deleted unimplemented CRcvBuffer::isReadyToPlay(...)
- ConnectionTimeout test. Epoll wait confidence interval increased to +/-50 ms