### PR TITLE
[core] make Loggers static

### DIFF
--- a/apps/srt-multiplex.cpp
+++ b/apps/srt-multiplex.cpp
@@ -48,7 +48,7 @@ using namespace std;
 const size_t DEFAULT_CHUNK = 1316;
 
 const logging::LogFA SRT_LOGFA_APP = 10;
-logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-mplex");
+static logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-mplex");
 
 volatile bool siplex_int_state = false;
 void OnINT_SetIntState(int)

--- a/haicrypt/haicrypt_log.cpp
+++ b/haicrypt/haicrypt_log.cpp
@@ -18,7 +18,7 @@
 extern logging::LogConfig srt_logger_config;
 
 // LOGFA symbol defined in srt.h
-logging::Logger hclog(SRT_LOGFA_HAICRYPT, srt_logger_config, "SRT.k");
+static logging::Logger hclog(SRT_LOGFA_HAICRYPT, srt_logger_config, "SRT.k");
 
 extern "C" {
 

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -78,6 +78,7 @@ modified by
 #include "packet.h"
 #include "api.h" // SockaddrToString - possibly move it to somewhere else
 #include "logging.h"
+#include "static_loggers.h"
 #include "utilities.h"
 
 #ifdef _WIN32
@@ -92,8 +93,6 @@ modified by
 
 using namespace std;
 
-
-extern logging::Logger mglog;
 
 CChannel::CChannel():
 m_iIPversion(AF_INET),
@@ -171,7 +170,7 @@ void CChannel::open(const sockaddr* addr)
       ::freeaddrinfo(res);
    }
 
-   HLOGC(mglog.Debug, log << "CHANNEL: Bound to local address: " << SockaddrToString(&m_BindAddr));
+   HLOGC(mglob().Debug, log << "CHANNEL: Bound to local address: " << SockaddrToString(&m_BindAddr));
 
    setUDPSockOpt();
 }
@@ -383,7 +382,7 @@ int CChannel::sendto(const sockaddr* addr, CPacket& packet) const
             spec << " [REXMIT]";
     }
 
-    HLOGC(mglog.Debug, log << "CChannel::sendto: SENDING NOW DST=" << SockaddrToString(addr)
+    HLOGC(mglob().Debug, log << "CChannel::sendto: SENDING NOW DST=" << SockaddrToString(addr)
         << " target=%" << packet.m_iID
         << spec.str());
 #endif
@@ -512,7 +511,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
         }
         else
         {
-            HLOGC(mglog.Debug, log << CONID() << "(sys)recvmsg: " << SysStrError(err) << " [" << err << "]");
+            HLOGC(mglob().Debug, log << CONID() << "(sys)recvmsg: " << SysStrError(err) << " [" << err << "]");
             status = RST_ERROR;
         }
 
@@ -571,7 +570,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
         const int err = NET_ERROR;
         if (std::find(fatals, fatals_end, err) != fatals_end)
         {
-            HLOGC(mglog.Debug, log << CONID() << "(sys)WSARecvFrom: " << SysStrError(err) << " [" << err << "]");
+            HLOGC(mglob().Debug, log << CONID() << "(sys)WSARecvFrom: " << SysStrError(err) << " [" << err << "]");
             status = RST_ERROR;
         }
         else
@@ -592,7 +591,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
     if (size_t(recv_size) < CPacket::HDR_SIZE)
     {
         status = RST_AGAIN;
-        HLOGC(mglog.Debug, log << CONID() << "POSSIBLE ATTACK: received too short packet with " << recv_size << " bytes");
+        HLOGC(mglob().Debug, log << CONID() << "POSSIBLE ATTACK: received too short packet with " << recv_size << " bytes");
         goto Return_error;
     }
 
@@ -615,7 +614,7 @@ EReadStatus CChannel::recvfrom(sockaddr* addr, CPacket& packet) const
     // packet was received, so the packet will be then retransmitted.
     if ( msg_flags != 0 )
     {
-        HLOGC(mglog.Debug, log << CONID() << "NET ERROR: packet size=" << recv_size
+        HLOGC(mglob().Debug, log << CONID() << "NET ERROR: packet size=" << recv_size
             << " msg_flags=0x" << hex << msg_flags << ", possibly MSG_TRUNC (0x" << hex << int(MSG_TRUNC) << ")");
         status = RST_AGAIN;
         goto Return_error;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -70,16 +70,7 @@ modified by
 #include "handshake.h"
 #include "smoother.h"
 #include "utilities.h"
-
 #include <haicrypt.h>
-
-extern logging::Logger
-    glog,
-    blog,
-    mglog,
-    dlog,
-    tslog,
-    rxlog;
 
 
 // XXX Utility function - to be moved to utilities.h?

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -24,6 +24,7 @@ written by
 #include "packet.h"
 #include "utilities.h"
 #include "logging.h"
+#include "static_loggers.h"
 
 #include <haicrypt.h>
 #include <hcrypt_msg.h>
@@ -32,7 +33,6 @@ written by
 
 std::string KmStateStr(SRT_KM_STATE state);
 
-extern logging::Logger mglog;
 
 #endif
 
@@ -156,11 +156,11 @@ public:
         if (runtime)
         {
             m_SndKmMsg[ki].iPeerRetry--;
-            HLOGC(mglog.Debug, log << "getKmMsg_markSent: key[" << ki << "]: len=" << m_SndKmMsg[ki].MsgLen << " retry=" << m_SndKmMsg[ki].iPeerRetry);
+            HLOGC(mglob().Debug, log << "getKmMsg_markSent: key[" << ki << "]: len=" << m_SndKmMsg[ki].MsgLen << " retry=" << m_SndKmMsg[ki].iPeerRetry);
         }
         else
         {
-            HLOGC(mglog.Debug, log << "getKmMsg_markSent: key[" << ki << "]: len=" << m_SndKmMsg[ki].MsgLen << " STILL IN USE.");
+            HLOGC(mglob().Debug, log << "getKmMsg_markSent: key[" << ki << "]: len=" << m_SndKmMsg[ki].MsgLen << " STILL IN USE.");
         }
     }
 

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -53,15 +53,15 @@ written by
 
 // LOGC uses an iostream-like syntax, using the special 'log' symbol.
 // This symbol isn't visible outside the log macro parameters.
-// Usage: LOGC(mglog.Debug, log << param1 << param2 << param3);
+// Usage: LOGC(mglob().Debug, log << param1 << param2 << param3);
 #define LOGC(logdes, args) if (logdes.CheckEnabled()) { logging::LogDispatcher::Proxy log(logdes); log.setloc(__FILE__, __LINE__, __FUNCTION__); args; }
 
 // LOGF uses printf-like style formatting.
-// Usage: LOGF(mglog.Debug, "%s: %d", param1.c_str(), int(param2));
+// Usage: LOGF(mglob().Debug, "%s: %d", param1.c_str(), int(param2));
 #define LOGF(logdes, ...) if (logdes.CheckEnabled()) logdes().setloc(__FILE__, __LINE__, __FUNCTION__).form(__VA_ARGS__)
 
 // LOGP is C++11 only OR with only one string argument.
-// Usage: LOGP(mglog.Debug, param1, param2, param3);
+// Usage: LOGP(mglob().Debug, param1, param2, param3);
 #define LOGP(logdes, ...) if (logdes.CheckEnabled()) logdes.printloc(__FILE__, __LINE__, __FUNCTION__,##__VA_ARGS__)
 
 #if ENABLE_HEAVY_LOGGING

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -163,8 +163,8 @@ modified by
 #include <cstring>
 #include "packet.h"
 #include "logging.h"
+#include "static_loggers.h"
 
-extern logging::Logger mglog;
 
 // Set up the aliases in the constructure
 CPacket::CPacket():
@@ -404,7 +404,7 @@ EncryptionStatus CPacket::encrypt(HaiCrypt_Handle hcrypto)
 {
     if ( !hcrypto )
     {
-        LOGC(mglog.Error, log << "IPE: NULL crypto passed to CPacket::encrypt!");
+        LOGC(mglob().Error, log << "IPE: NULL crypto passed to CPacket::encrypt!");
         return ENCS_FAILED;
     }
 
@@ -424,13 +424,13 @@ EncryptionStatus CPacket::decrypt(HaiCrypt_Handle hcrypto)
 {
    if (getMsgCryptoFlags() == EK_NOENC)
    {
-       //HLOGC(mglog.Debug, log << "CPacket::decrypt: packet not encrypted");
+       //HLOGC(mglob().Debug, log << "CPacket::decrypt: packet not encrypted");
        return ENCS_CLEAR; // not encrypted, no need do decrypt, no flags to be modified
    }
 
    if (!hcrypto)
    {
-        LOGC(mglog.Error, log << "IPE: NULL crypto passed to CPacket::decrypt!");
+        LOGC(mglob().Error, log << "IPE: NULL crypto passed to CPacket::decrypt!");
         return ENCS_FAILED; // "invalid argument" (leave encryption flags untouched)
    }
 

--- a/srtcore/static_loggers.h
+++ b/srtcore/static_loggers.h
@@ -1,0 +1,25 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2018 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+
+#ifndef STATIC_LOGGERS_H_INCLUDED
+#define STATIC_LOGGERS_H_INCLUDED
+
+#include "logging.h"
+
+logging::Logger& glob();
+logging::Logger& blog();
+logging::Logger& mglob();
+logging::Logger& dlog();
+logging::Logger& tslog();
+logging::Logger& rxlog();
+
+
+#endif

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -444,7 +444,6 @@ int main( int argc, char** argv )
         alarm(remain - final_delay);
     }
 
-    extern logging::Logger glog;
     try
     {
         for (;;)


### PR DESCRIPTION
static variables are initialized before main() is invoked.
This early initialization fixes the crash in OBS, which was
related somehow to global Logger variable initialization