### PR TITLE
srt-live-transmit: add option to cancel timeout

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -178,7 +178,7 @@ int main( int argc, char** argv )
         cerr << "Usage: " << argv[0] << " [options] <input-uri> <output-uri>\n";
 #ifndef _WIN32
         cerr << "\t-t:<timeout=0> - exit timer in seconds\n";
-        cerr << "\t-tm - timeout mode (0 - since app start - default; 1 - like 0, but cancel on connect; 2 - since connect - TBD)\n";
+        cerr << "\t-tm:<mode=0> - timeout mode (0 - since app start; 1 - like 0, but cancel on connect)\n";
 #endif
         cerr << "\t-c:<chunk=1316> - max size of data read in one step\n";
         cerr << "\t-b:<bandwidth> - set SRT bandwidth\n";

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -176,8 +176,10 @@ int main( int argc, char** argv )
     if ( params.size() != 2 )
     {
         cerr << "Usage: " << argv[0] << " [options] <input-uri> <output-uri>\n";
+#ifndef _WIN32
         cerr << "\t-t:<timeout=0> - exit timer in seconds\n";
-        cerr << "\t-taoc - abort timeout on connect (default no)\n";
+        cerr << "\t-tm - timeout mode (0 - since app start - default; 1 - like 0, but cancel on connect; 2 - since connect - TBD)\n";
+#endif
         cerr << "\t-c:<chunk=1316> - max size of data read in one step\n";
         cerr << "\t-b:<bandwidth> - set SRT bandwidth\n";
         cerr << "\t-r:<report-frequency=0> - bandwidth report frequency\n";
@@ -191,7 +193,7 @@ int main( int argc, char** argv )
     }
 
     int timeout = stoi(Option("0", "t", "to", "timeout"), 0, 0);
-    bool timeout_abrt_conn = Option("no", "taoc", "timeout-abort-on-connect") != "no";
+    int timeout_mode = stoi(Option("0", "tm", "timeout-mode"), 0, 0);
     unsigned long chunk = stoul(Option("0", "c", "chunk"), 0, 0);
     if ( chunk == 0 )
     {
@@ -472,7 +474,7 @@ int main( int argc, char** argv )
                                         << endl;
                                 }
 #ifndef _WIN32
-                                if (timeout_abrt_conn && timeout > 0)
+                                if (timeout_mode == 1 && timeout > 0)
                                 {
                                     if (!quiet)
 				        cerr << "TIMEOUT: cancel\n";

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -477,7 +477,7 @@ int main( int argc, char** argv )
                                 if (timeout_mode == 1 && timeout > 0)
                                 {
                                     if (!quiet)
-				        cerr << "TIMEOUT: cancel\n";
+                                        cerr << "TIMEOUT: cancel\n";
                                     alarm(0);
                                 }
 #endif

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -177,6 +177,7 @@ int main( int argc, char** argv )
     {
         cerr << "Usage: " << argv[0] << " [options] <input-uri> <output-uri>\n";
         cerr << "\t-t:<timeout=0> - exit timer in seconds\n";
+        cerr << "\t-taoc - abort timeout on connect (default no)\n";
         cerr << "\t-c:<chunk=1316> - max size of data read in one step\n";
         cerr << "\t-b:<bandwidth> - set SRT bandwidth\n";
         cerr << "\t-r:<report-frequency=0> - bandwidth report frequency\n";
@@ -190,6 +191,7 @@ int main( int argc, char** argv )
     }
 
     int timeout = stoi(Option("0", "t", "to", "timeout"), 0, 0);
+    bool timeout_abrt_conn = Option("no", "taoc", "timeout-abort-on-connect") != "no";
     unsigned long chunk = stoul(Option("0", "c", "chunk"), 0, 0);
     if ( chunk == 0 )
     {
@@ -469,6 +471,14 @@ int main( int argc, char** argv )
                                         <<  " connection"
                                         << endl;
                                 }
+#ifndef _WIN32
+                                if (timeout_abrt_conn && timeout > 0)
+                                {
+                                    if (!quiet)
+				        cerr << "TIMEOUT: cancel\n";
+                                    alarm(0);
+                                }
+#endif
                                 if (issource)
                                     srcConnected = true;
                                 else


### PR DESCRIPTION
Add an option (`-taoc`, `-timeout-abort-on-connect`) to cancel the timeout (as set with `-t`) after a client is accepted. This allows for `srt-live-transmit` to run in listener mode and wait for a limited amount of time (timeout) for a client to connect.

Due to the paired tx/rx operation of `srt-live-transmit` and the fact that a sender process may not accept multiple clients, should one want to operate such a server they would need to devise a way to spawn sender processes as necessary. In such a case sender processes spawned in listener mode wait for the client to connect; it then becomes important to enforce a timeout so the sender process does not wait forever. You already have the `timeout` option for `srt-live-transmit`, but that works as an unconditional exit timer. This patch introduces a second option, which changes the behavior of `timeout`: once a client is accepted the pending `alarm(2)` is canceled.

This is probably an abuse of the `timeout` option, but it seems to be the only way to achieve a listener timeout. The `timeout` (`SRTO_RCVTIMEO`, `SRTO_SNDTIMEO`) and `conntimeo` parameters do not seem to have any effect at the particular stage.