### PR TITLE
Putting global objects with short names under a namespace

### DIFF
--- a/apps/logsupport.cpp
+++ b/apps/logsupport.cpp
@@ -44,9 +44,9 @@ map<string, int> srt_level_names
 
 
 
-logging::LogLevel::type SrtParseLogLevel(string level)
+srt_logging::LogLevel::type SrtParseLogLevel(string level)
 {
-    using namespace logging;
+    using namespace srt_logging;
 
     if ( level.empty() )
         return LogLevel::fatal;
@@ -74,9 +74,9 @@ logging::LogLevel::type SrtParseLogLevel(string level)
     return LogLevel::type(i->second);
 }
 
-set<logging::LogFA> SrtParseLogFA(string fa)
+set<srt_logging::LogFA> SrtParseLogFA(string fa)
 {
-    using namespace logging;
+    using namespace srt_logging;
 
     set<LogFA> fas;
 

--- a/apps/logsupport.hpp
+++ b/apps/logsupport.hpp
@@ -14,8 +14,8 @@
 #include "../srtcore/srt.h"
 #include "../srtcore/logging_api.h"
 
-logging::LogLevel::type SrtParseLogLevel(std::string level);
-std::set<logging::LogFA> SrtParseLogFA(std::string fa);
+srt_logging::LogLevel::type SrtParseLogLevel(std::string level);
+std::set<srt_logging::LogFA> SrtParseLogFA(std::string fa);
 
 SRT_API extern std::map<std::string, int> srt_level_names;
 

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -45,7 +45,7 @@ written by
 bool Upload(UriParser& srt, UriParser& file);
 bool Download(UriParser& srt, UriParser& file);
 
-const logging::LogFA SRT_LOGFA_APP = 10;
+const srt_logging::LogFA SRT_LOGFA_APP = 10;
 
 static size_t g_buffer_size = 1456;
 static bool g_skip_flushing = false;
@@ -95,7 +95,7 @@ int main( int argc, char** argv )
     }
 
     string loglevel = Option<OutString>(params, "error", o_loglevel);
-    logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
+    srt_logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
     UDT::setloglevel(lev);
     UDT::addlogfa(SRT_LOGFA_APP);
 

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -235,8 +235,8 @@ int main( int argc, char** argv )
     std::ofstream logfile_stream; // leave unused if not set
 
     srt_setloglevel(SrtParseLogLevel(loglevel));
-    set<logging::LogFA> fas = SrtParseLogFA(logfa);
-    for (set<logging::LogFA>::iterator i = fas.begin(); i != fas.end(); ++i)
+    set<srt_logging::LogFA> fas = SrtParseLogFA(logfa);
+    for (set<srt_logging::LogFA>::iterator i = fas.begin(); i != fas.end(); ++i)
         srt_addlogfa(*i);
 
     char NAME[] = "SRTLIB";

--- a/apps/srt-multiplex.cpp
+++ b/apps/srt-multiplex.cpp
@@ -47,8 +47,8 @@ using namespace std;
 // So far, this function must be used and up to this length of payload.
 const size_t DEFAULT_CHUNK = 1316;
 
-const logging::LogFA SRT_LOGFA_APP = 10;
-logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-mplex");
+const srt_logging::LogFA SRT_LOGFA_APP = 10;
+srt_logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-mplex");
 
 volatile bool siplex_int_state = false;
 void OnINT_SetIntState(int)
@@ -545,7 +545,7 @@ int main( int argc, char** argv )
     }
 
     string loglevel = Option<OutString>(params, "error", "ll", "loglevel");
-    logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
+    srt_logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
     UDT::setloglevel(lev);
     UDT::addlogfa(SRT_LOGFA_APP);
 

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -68,7 +68,7 @@ modified by
 #endif
 
 using namespace std;
-using namespace logging;
+using namespace srt_logging;
 extern LogConfig srt_logger_config;
 
 
@@ -3077,25 +3077,25 @@ SRT_SOCKSTATUS getsockstate(SRTSOCKET u)
    return CUDT::getsockstate(u);
 }
 
-void setloglevel(logging::LogLevel::type ll)
+void setloglevel(LogLevel::type ll)
 {
     CGuard gg(srt_logger_config.mutex);
     srt_logger_config.max_level = ll;
 }
 
-void addlogfa(logging::LogFA fa)
+void addlogfa(LogFA fa)
 {
     CGuard gg(srt_logger_config.mutex);
     srt_logger_config.enabled_fa.set(fa, true);
 }
 
-void dellogfa(logging::LogFA fa)
+void dellogfa(LogFA fa)
 {
     CGuard gg(srt_logger_config.mutex);
     srt_logger_config.enabled_fa.set(fa, false);
 }
 
-void resetlogfa(set<logging::LogFA> fas)
+void resetlogfa(set<LogFA> fas)
 {
     CGuard gg(srt_logger_config.mutex);
     for (int i = 0; i <= SRT_LOGFA_LASTNONE; ++i)

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -68,10 +68,9 @@ modified by
 #endif
 
 using namespace std;
+using namespace logging;
+extern LogConfig srt_logger_config;
 
-extern logging::LogConfig srt_logger_config;
-
-extern logging::Logger mglog;
 
 CUDTSocket::CUDTSocket():
 m_Status(SRTS_INIT),

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -58,7 +58,7 @@ modified by
 #include "logging.h"
 
 using namespace std;
-using namespace logging;
+using namespace srt_logging;
 
 CSndBuffer::CSndBuffer(int size, int mss):
 m_BufLock(),
@@ -1628,7 +1628,7 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
                 int64_t nowdiff = prev_now ? (nowtime - prev_now) : 0;
                 uint64_t srctimediff = prev_srctime ? (srctime - prev_srctime) : 0;
 
-                HLOGC(dlog.Debug, log << CONID() << "readMsg: DELIVERED seq=" << seq << " T=" << logging::FormatTime(srctime) << " in " << (timediff/1000.0) << "ms - "
+                HLOGC(dlog.Debug, log << CONID() << "readMsg: DELIVERED seq=" << seq << " T=" << FormatTime(srctime) << " in " << (timediff/1000.0) << "ms - "
                     "TIME-PREVIOUS: PKT: " << (srctimediff/1000.0) << " LOCAL: " << (nowdiff/1000.0));
 
                 prev_now = nowtime;

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -58,8 +58,7 @@ modified by
 #include "logging.h"
 
 using namespace std;
-
-extern logging::Logger mglog, dlog, tslog;
+using namespace logging;
 
 CSndBuffer::CSndBuffer(int size, int mss):
 m_BufLock(),

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -91,7 +91,7 @@ modified by
 #endif
 
 using namespace std;
-using namespace logging;
+using namespace srt_logging;
 
 CChannel::CChannel():
 m_iIPversion(AF_INET),

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -91,9 +91,7 @@ modified by
 #endif
 
 using namespace std;
-
-
-extern logging::Logger mglog;
+using namespace logging;
 
 CChannel::CChannel():
 m_iIPversion(AF_INET),

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -839,7 +839,10 @@ std::string TransmissionEventStr(ETransmissionEvent ev)
     return vals[ev];
 }
 
-std::string logging::FormatTime(uint64_t time)
+namespace srt_logging
+{
+
+std::string FormatTime(uint64_t time)
 {
     using namespace std;
 
@@ -862,7 +865,7 @@ std::string logging::FormatTime(uint64_t time)
 // Some logging imps
 #if ENABLE_LOGGING
 
-logging::LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabled(that.CheckEnabled())
+LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabled(that.CheckEnabled())
 {
 	if (that_enabled)
 	{
@@ -874,12 +877,12 @@ logging::LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabl
 	}
 }
 
-logging::LogDispatcher::Proxy logging::LogDispatcher::operator()()
+LogDispatcher::Proxy LogDispatcher::operator()()
 {
 	return Proxy(*this);
 }
 
-void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
+void LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
 {
     using namespace std;
 
@@ -925,7 +928,7 @@ void logging::LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
     }
 }
 
-std::string logging::LogDispatcher::Proxy::ExtractName(std::string pretty_function)
+std::string LogDispatcher::Proxy::ExtractName(std::string pretty_function)
 {
     if ( pretty_function == "" )
         return "";
@@ -987,4 +990,7 @@ std::string logging::LogDispatcher::Proxy::ExtractName(std::string pretty_functi
 
     return pretty_function.substr(pos+2);
 }
+
+} // (end namespace srt_logging)
+
 #endif

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -80,13 +80,16 @@ modified by
 
 using namespace std;
 
+namespace logging
+{
+
 struct AllFaOn
 {
     logging::LogConfig::fa_bitset_t allfa;
 
     AllFaOn()
     {
-        allfa.set(SRT_LOGFA_BSTATS, true);
+//        allfa.set(SRT_LOGFA_BSTATS, true);
         allfa.set(SRT_LOGFA_CONTROL, true);
         allfa.set(SRT_LOGFA_DATA, true);
         allfa.set(SRT_LOGFA_TSBPD, true);
@@ -97,14 +100,26 @@ struct AllFaOn
     }
 } logger_fa_all;
 
-SRT_API logging::LogConfig srt_logger_config (logger_fa_all.allfa);
+}
 
-logging::Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
-logging::Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
-logging::Logger mglog(SRT_LOGFA_CONTROL, srt_logger_config, "SRT.c");
-logging::Logger dlog(SRT_LOGFA_DATA, srt_logger_config, "SRT.d");
-logging::Logger tslog(SRT_LOGFA_TSBPD, srt_logger_config, "SRT.t");
-logging::Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
+// We need it outside the namespace to preserve the global name.
+// It's a part of "hidden API" (used by applications)
+SRT_API logging::LogConfig srt_logger_config (logging::logger_fa_all.allfa);
+
+namespace logging
+{
+
+Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
+// Unused. If not found useful, maybe reuse for another FA.
+//Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
+Logger mglog(SRT_LOGFA_CONTROL, srt_logger_config, "SRT.c");
+Logger dlog(SRT_LOGFA_DATA, srt_logger_config, "SRT.d");
+Logger tslog(SRT_LOGFA_TSBPD, srt_logger_config, "SRT.t");
+Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
+
+}
+
+using namespace logging;
 
 CUDTUnited CUDT::s_UDTUnited;
 
@@ -4231,7 +4246,7 @@ void* CUDT::tsbpd(void* param)
                      timediff = int64_t(tsbpdtime) - int64_t(CTimer::getTime());
 #if ENABLE_HEAVY_LOGGING
                 HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: DROPSEQ: up to seq=" << CSeqNo::decseq(skiptoseqno)
-                    << " (" << seqlen << " packets) playable at " << logging::FormatTime(tsbpdtime) << " delayed "
+                    << " (" << seqlen << " packets) playable at " << FormatTime(tsbpdtime) << " delayed "
                     << (timediff/1000) << "." << (timediff%1000) << " ms");
 #endif
                 LOGC(dlog.Debug, log << "RCV-DROPPED packet delay=" << (timediff/1000) << "ms");
@@ -4284,7 +4299,7 @@ void* CUDT::tsbpd(void* param)
           self->m_bTsbPdAckWakeup = false;
           THREAD_PAUSED();
           HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: FUTURE PACKET seq=" << current_pkt_seq
-              << " T=" << logging::FormatTime(tsbpdtime) << " - waiting " << (timediff/1000.0) << "ms");
+              << " T=" << FormatTime(tsbpdtime) << " - waiting " << (timediff/1000.0) << "ms");
           CTimer::condTimedWaitUS(&self->m_RcvTsbPdCond, &self->m_RecvLock, timediff);
           THREAD_RESUMED();
       }
@@ -8387,7 +8402,7 @@ void CUDT::checkTimers()
 
     // This is a very heavy log, unblock only for temporary debugging!
 #if 0
-    HLOGC(mglog.Debug, log << CONID() << "checkTimers: nextacktime=" << logging::FormatTime(m_ullNextACKTime_tk)
+    HLOGC(mglog.Debug, log << CONID() << "checkTimers: nextacktime=" << FormatTime(m_ullNextACKTime_tk)
         << " AckInterval=" << m_iACKInterval
         << " pkt-count=" << m_iPktCount << " liteack-count=" << m_iLightACKCount);
 #endif

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -80,12 +80,12 @@ modified by
 
 using namespace std;
 
-namespace logging
+namespace srt_logging
 {
 
 struct AllFaOn
 {
-    logging::LogConfig::fa_bitset_t allfa;
+    LogConfig::fa_bitset_t allfa;
 
     AllFaOn()
     {
@@ -104,9 +104,9 @@ struct AllFaOn
 
 // We need it outside the namespace to preserve the global name.
 // It's a part of "hidden API" (used by applications)
-SRT_API logging::LogConfig srt_logger_config (logging::logger_fa_all.allfa);
+SRT_API srt_logging::LogConfig srt_logger_config (srt_logging::logger_fa_all.allfa);
 
-namespace logging
+namespace srt_logging
 {
 
 Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
@@ -119,7 +119,7 @@ Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
 
 }
 
-using namespace logging;
+using namespace srt_logging;
 
 CUDTUnited CUDT::s_UDTUnited;
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -73,13 +73,18 @@ modified by
 
 #include <haicrypt.h>
 
-extern logging::Logger
+namespace logging
+{
+
+extern Logger
     glog,
-    blog,
+//    blog,
     mglog,
     dlog,
     tslog,
     rxlog;
+
+}
 
 
 // XXX Utility function - to be moved to utilities.h?

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -73,7 +73,7 @@ modified by
 
 #include <haicrypt.h>
 
-namespace logging
+namespace srt_logging
 {
 
 extern Logger

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -25,7 +25,7 @@ written by
 #include "logging.h"
 #include "core.h"
 
-extern logging::Logger mglog, dlog;
+using namespace logging;
 
 #define SRT_MAX_KMRETRY     10
  

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -25,7 +25,7 @@ written by
 #include "logging.h"
 #include "core.h"
 
-using namespace logging;
+using namespace srt_logging;
 
 #define SRT_MAX_KMRETRY     10
  

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -32,7 +32,7 @@ written by
 
 std::string KmStateStr(SRT_KM_STATE state);
 
-namespace logging
+namespace srt_logging
 {
 extern Logger mglog;
 }
@@ -155,7 +155,7 @@ public:
     ///                during transmission (otherwise it's during the handshake)
     void getKmMsg_markSent(size_t ki, bool runtime)
     {
-        using logging::mglog;
+        using srt_logging::mglog;
 
         m_SndKmLastTime = CTimer::getTime();
         if (runtime)

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -32,7 +32,10 @@ written by
 
 std::string KmStateStr(SRT_KM_STATE state);
 
-extern logging::Logger mglog;
+namespace logging
+{
+extern Logger mglog;
+}
 
 #endif
 
@@ -152,6 +155,8 @@ public:
     ///                during transmission (otherwise it's during the handshake)
     void getKmMsg_markSent(size_t ki, bool runtime)
     {
+        using logging::mglog;
+
         m_SndKmLastTime = CTimer::getTime();
         if (runtime)
         {

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -150,7 +150,7 @@ public:
     {
         // XXX stpcpy desired, but not enough portable
         // Composing the exact prefix is not critical, so simply
-        // cut the prefix, if the lenght is exceeded
+        // cut the prefix, if the length is exceeded
 
         // See Logger::Logger; we know this has normally 2 characters,
         // except !!FATAL!!, which has 9. Still less than 32.
@@ -158,7 +158,7 @@ public:
 
         // If the size of the FA name together with severity exceeds the size,
         // just skip the former.
-        if (logger_pfx && strlen(prefix) + strlen(logger_pfx) < MAX_PREFIX_SIZE)
+        if (logger_pfx && strlen(prefix) + strlen(logger_pfx) + 1 < MAX_PREFIX_SIZE)
         {
             strcat(prefix, ":");
             strcat(prefix, logger_pfx);

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -133,7 +133,8 @@ struct SRT_API LogDispatcher
 private:
     int fa;
     LogLevel::type level;
-    std::string prefix;
+    static const size_t MAX_PREFIX_SIZE = 32;
+    char prefix[MAX_PREFIX_SIZE+1];
     LogConfig* src_config;
     pthread_mutex_t mutex;
 
@@ -141,13 +142,27 @@ private:
 
 public:
 
-    LogDispatcher(int functional_area, LogLevel::type log_level, const std::string& pfx, LogConfig& config):
+    LogDispatcher(int functional_area, LogLevel::type log_level, const char* your_pfx,
+            const char* logger_pfx /*[[nullable]]*/, LogConfig& config):
         fa(functional_area),
         level(log_level),
-        prefix(pfx),
-        //enabled(false),
         src_config(&config)
     {
+        // XXX stpcpy desired, but not enough portable
+        // Composing the exact prefix is not critical, so simply
+        // cut the prefix, if the lenght is exceeded
+
+        // See Logger::Logger; we know this has normally 2 characters,
+        // except !!FATAL!!, which has 9. Still less than 32.
+        strcpy(prefix, your_pfx);
+
+        // If the size of the FA name together with severity exceeds the size,
+        // just skip the former.
+        if (logger_pfx && strlen(prefix) + strlen(logger_pfx) < MAX_PREFIX_SIZE)
+        {
+            strcat(prefix, ":");
+            strcat(prefix, logger_pfx);
+        }
         pthread_mutex_init(&mutex, 0);
     }
 
@@ -346,7 +361,6 @@ struct LogDispatcher::Proxy
 
 class Logger
 {
-    std::string m_prefix;
     int m_fa;
     LogConfig& m_config;
 
@@ -358,15 +372,14 @@ public:
     LogDispatcher Error;
     LogDispatcher Fatal;
 
-    Logger(int functional_area, LogConfig& config, std::string globprefix = std::string()):
-        m_prefix( globprefix == "" ? globprefix : ": " + globprefix),
+    Logger(int functional_area, LogConfig& config, const char* logger_pfx = NULL):
         m_fa(functional_area),
         m_config(config),
-        Debug ( m_fa, LogLevel::debug, " D" + m_prefix, m_config ),
-        Note  ( m_fa, LogLevel::note,  ".N" + m_prefix, m_config ),
-        Warn  ( m_fa, LogLevel::warning, "!W" + m_prefix, m_config ),
-        Error ( m_fa, LogLevel::error, "*E" + m_prefix, m_config ),
-        Fatal ( m_fa, LogLevel::fatal, "!!FATAL!!" + m_prefix, m_config )
+        Debug ( m_fa, LogLevel::debug, " D", logger_pfx, m_config ),
+        Note  ( m_fa, LogLevel::note,  ".N", logger_pfx, m_config ),
+        Warn  ( m_fa, LogLevel::warning, "!W", logger_pfx, m_config ),
+        Error ( m_fa, LogLevel::error, "*E", logger_pfx, m_config ),
+        Fatal ( m_fa, LogLevel::fatal, "!!FATAL!!", logger_pfx, m_config )
     {
     }
 

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -54,7 +54,7 @@ written by
 // LOGC uses an iostream-like syntax, using the special 'log' symbol.
 // This symbol isn't visible outside the log macro parameters.
 // Usage: LOGC(mglog.Debug, log << param1 << param2 << param3);
-#define LOGC(logdes, args) if (logdes.CheckEnabled()) { logging::LogDispatcher::Proxy log(logdes); log.setloc(__FILE__, __LINE__, __FUNCTION__); args; }
+#define LOGC(logdes, args) if (logdes.CheckEnabled()) { srt_logging::LogDispatcher::Proxy log(logdes); log.setloc(__FILE__, __LINE__, __FUNCTION__); args; }
 
 // LOGF uses printf-like style formatting.
 // Usage: LOGF(mglog.Debug, "%s: %d", param1.c_str(), int(param2));
@@ -90,7 +90,7 @@ written by
 
 #endif
 
-namespace logging
+namespace srt_logging
 {
 
 struct LogConfig

--- a/srtcore/logging_api.h
+++ b/srtcore/logging_api.h
@@ -50,7 +50,7 @@ written by
 typedef void SRT_LOG_HANDLER_FN(void* opaque, int level, const char* file, int line, const char* area, const char* message);
 
 #ifdef __cplusplus
-namespace logging
+namespace srt_logging
 {
 
 

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -164,11 +164,11 @@ modified by
 #include "packet.h"
 #include "logging.h"
 
-namespace logging
+namespace srt_logging
 {
     extern Logger mglog;
 }
-using namespace logging;
+using namespace srt_logging;
 
 // Set up the aliases in the constructure
 CPacket::CPacket():

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -164,7 +164,11 @@ modified by
 #include "packet.h"
 #include "logging.h"
 
-extern logging::Logger mglog;
+namespace logging
+{
+    extern Logger mglog;
+}
+using namespace logging;
 
 // Set up the aliases in the constructure
 CPacket::CPacket():

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -64,6 +64,7 @@ modified by
 #include "queue.h"
 
 using namespace std;
+using namespace logging;
 
 CUnitQueue::CUnitQueue():
 m_pQEntry(NULL),

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -64,7 +64,7 @@ modified by
 #include "queue.h"
 
 using namespace std;
-using namespace logging;
+using namespace srt_logging;
 
 CUnitQueue::CUnitQueue():
 m_pQEntry(NULL),

--- a/srtcore/smoother.cpp
+++ b/srtcore/smoother.cpp
@@ -34,6 +34,7 @@
 #include "logging.h"
 
 using namespace std;
+using namespace logging;
 
 SmootherBase::SmootherBase(CUDT* parent)
 {

--- a/srtcore/smoother.cpp
+++ b/srtcore/smoother.cpp
@@ -34,7 +34,7 @@
 #include "logging.h"
 
 using namespace std;
-using namespace logging;
+using namespace srt_logging;
 
 SmootherBase::SmootherBase(CUDT* parent)
 {

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -284,17 +284,17 @@ int srt_epoll_release(int eid) { return CUDT::epoll_release(eid); }
 
 void srt_setloglevel(int ll)
 {
-    UDT::setloglevel(logging::LogLevel::type(ll));
+    UDT::setloglevel(srt_logging::LogLevel::type(ll));
 }
 
 void srt_addlogfa(int fa)
 {
-    UDT::addlogfa(logging::LogFA(fa));
+    UDT::addlogfa(srt_logging::LogFA(fa));
 }
 
 void srt_dellogfa(int fa)
 {
-    UDT::dellogfa(logging::LogFA(fa));
+    UDT::dellogfa(srt_logging::LogFA(fa));
 }
 
 void srt_resetlogfa(const int* fara, size_t fara_size)

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -387,10 +387,10 @@ UDT_API int bstats(UDTSOCKET u, TRACEBSTATS* perf, bool clear = true);
 UDT_API SRT_SOCKSTATUS getsockstate(UDTSOCKET u);
 
 // This is a C++ SRT API extension. This is not a part of legacy UDT API.
-UDT_API void setloglevel(logging::LogLevel::type ll);
-UDT_API void addlogfa(logging::LogFA fa);
-UDT_API void dellogfa(logging::LogFA fa);
-UDT_API void resetlogfa(std::set<logging::LogFA> fas);
+UDT_API void setloglevel(srt_logging::LogLevel::type ll);
+UDT_API void addlogfa(srt_logging::LogFA fa);
+UDT_API void dellogfa(srt_logging::LogFA fa);
+UDT_API void resetlogfa(std::set<srt_logging::LogFA> fas);
 UDT_API void resetlogfa(const int* fara, size_t fara_size);
 UDT_API void setlogstream(std::ostream& stream);
 UDT_API void setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler);
@@ -406,8 +406,8 @@ UDT_API std::string getstreamid(UDTSOCKET u);
 // are free to create their own logger configuration objects for their
 // own logger FA objects, or create their own. The object of this type
 // is required to initialize the logger FA object.
-namespace logging { struct LogConfig; }
-UDT_API extern logging::LogConfig srt_logger_config;
+namespace srt_logging { struct LogConfig; }
+UDT_API extern srt_logging::LogConfig srt_logger_config;
 
 
 #endif /* __cplusplus */

--- a/testing/srt-test-file.cpp
+++ b/testing/srt-test-file.cpp
@@ -43,7 +43,7 @@ written by
 bool Upload(UriParser& srt, UriParser& file);
 bool Download(UriParser& srt, UriParser& file);
 
-const logging::LogFA SRT_LOGFA_APP = 10;
+const srt_logging::LogFA SRT_LOGFA_APP = 10;
 
 static size_t g_buffer_size = 1456;
 static bool g_skip_flushing = false;
@@ -83,7 +83,7 @@ int main( int argc, char** argv )
     }
 
     string loglevel = Option<OutString>(params, "error", o_loglevel);
-    logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
+    srt_logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
     UDT::setloglevel(lev);
     UDT::addlogfa(SRT_LOGFA_APP);
 

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -196,6 +196,11 @@ struct BandwidthGuard
 
 extern "C" void TestLogHandler(void* opaque, int level, const char* file, int line, const char* area, const char* message);
 
+namespace srt_logging
+{
+    extern Logger glog;
+}
+
 int main( int argc, char** argv )
 {
     // This is mainly required on Windows to initialize the network system,
@@ -315,8 +320,8 @@ int main( int argc, char** argv )
     std::ofstream logfile_stream; // leave unused if not set
 
     srt_setloglevel(SrtParseLogLevel(loglevel));
-    set<logging::LogFA> fas = SrtParseLogFA(logfa);
-    for (set<logging::LogFA>::iterator i = fas.begin(); i != fas.end(); ++i)
+    set<srt_logging::LogFA> fas = SrtParseLogFA(logfa);
+    for (set<srt_logging::LogFA>::iterator i = fas.begin(); i != fas.end(); ++i)
         srt_addlogfa(*i);
 
     char NAME[] = "SRTLIB";
@@ -444,7 +449,6 @@ int main( int argc, char** argv )
         alarm(remain - final_delay);
     }
 
-    extern logging::Logger glog;
     try
     {
         for (;;)

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -41,7 +41,7 @@ written by
 bool Upload(UriParser& srt, UriParser& file);
 bool Download(UriParser& srt, UriParser& file);
 
-const logging::LogFA SRT_LOGFA_APP = 10;
+const srt_logging::LogFA SRT_LOGFA_APP = 10;
 
 using namespace std;
 
@@ -327,7 +327,7 @@ int main( int argc, char** argv )
     }
 
     string loglevel = Option<OutString>(params, "error", o_loglevel);
-    logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
+    srt_logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
     UDT::setloglevel(lev);
     UDT::addlogfa(SRT_LOGFA_APP);
 


### PR DESCRIPTION
This fix provides the following changes:

1. All log-related global objects are put into `logging` namespace. This should keep away any name conflicts with other libraries. This exactly case was believed to cause problems when added to ffmpeg linked to OBS Studio.
2. The `blog` logger is commented out (it was the one caught with suspected name conflict). This isn't in use, but it was commented out just so that the existing FA can be reused for something else in future.
3. The use of `std::string` was removed from the initialization of the global objects. Although it wasn't causing problems with building OBS Studio, as it was initially suspected, keeping the solution using only C standard library keeps it safe against any future problems concerning the order of initialization.