### PR TITLE
Replaced pthread_mutex_t and pthread_cond_t usage by C++-11 constructions

### DIFF
--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -134,15 +134,15 @@ private:
    void increase();
 
 private:
-   pthread_mutex_t m_BufLock;           // used to synchronize buffer operation
+   std::mutex m_BufLock;                // used to synchronize buffer operation
 
    struct Block
    {
       char* m_pcData;                   // pointer to the data block
       int m_iLength;                    // length of the block
 
-      int32_t m_iMsgNoBitset;                 // message number
-      uint64_t m_ullOriginTime_us;            // original request time
+      int32_t m_iMsgNoBitset;           // message number
+      uint64_t m_ullOriginTime_us;      // original request time
       uint64_t m_ullSourceTime_us;
       int m_iTTL;                       // time to live (milliseconds)
 
@@ -329,7 +329,7 @@ public:
       /// @param [in] timestamp packet time stamp
       /// @param [ref] lock Mutex that should be locked for the operation
 
-   void addRcvTsbPdDriftSample(uint32_t timestamp, pthread_mutex_t& lock);
+   void addRcvTsbPdDriftSample(uint32_t timestamp, std::mutex& lock);
 
 #ifdef SRT_DEBUG_TSBPD_DRIFT
    void printDriftHistogram(int64_t iDrift);
@@ -394,16 +394,16 @@ private:
 private:
    CUnit** m_pUnit;                     // pointer to the protocol buffer
    int m_iSize;                         // size of the protocol buffer
-   CUnitQueue* m_pUnitQueue;		// the shared unit queue
+   CUnitQueue* m_pUnitQueue;	    	// the shared unit queue
 
    int m_iStartPos;                     // the head position for I/O (inclusive)
    int m_iLastAckPos;                   // the last ACKed position (exclusive)
-					// EMPTY: m_iStartPos = m_iLastAckPos   FULL: m_iStartPos = m_iLastAckPos + 1
-   int m_iMaxPos;			// the furthest data position
+                                        // EMPTY: m_iStartPos = m_iLastAckPos   FULL: m_iStartPos = m_iLastAckPos + 1
+   int m_iMaxPos;		            	// the furthest data position
 
-   int m_iNotch;			// the starting read point of the first unit
+   int m_iNotch;		             	// the starting read point of the first unit
 
-   pthread_mutex_t m_BytesCountLock;    // used to protect counters operations
+   std::mutex m_BytesCountLock;         // used to protect counters operations
    int m_iBytesCount;                   // Number of payload bytes in the buffer
    int m_iAckedPktsCount;               // Number of acknowledged pkts in the buffer
    int m_iAckedBytesCount;              // Number of acknowledged payload bytes in the buffer

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -42,6 +42,7 @@ written by
 #define __UDT_CACHE_H__
 
 #include <list>
+#include <mutex>
 #include <vector>
 
 #include "common.h"
@@ -82,13 +83,11 @@ public:
    m_iCurrSize(0)
    {
       m_vHashPtr.resize(m_iHashSize);
-      CGuard::createMutex(m_Lock);
    }
 
    ~CCache()
    {
       clear();
-      CGuard::releaseMutex(m_Lock);
    }
 
 public:
@@ -98,7 +97,7 @@ public:
 
    int lookup(T* data)
    {
-      CGuard cacheguard(m_Lock);
+      std::lock_guard<std::mutex> cacheguard(m_Lock);
 
       int key = data->getKey();
       if (key < 0)
@@ -126,7 +125,7 @@ public:
 
    int update(T* data)
    {
-      CGuard cacheguard(m_Lock);
+      std::lock_guard<std::mutex> cacheguard(m_Lock);
 
       int key = data->getKey();
       if (key < 0)
@@ -223,7 +222,7 @@ private:
    int m_iHashSize;
    int m_iCurrSize;
 
-   pthread_mutex_t m_Lock;
+   std::mutex m_Lock;
 
 private:
    CCache(const CCache&);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -666,29 +666,28 @@ private: // Receiving related data
     uint32_t m_lMinimumPeerSrtVersion;
     uint32_t m_lPeerSrtVersion;
 
-    bool m_bTsbPd;                            // Peer sends TimeStamp-Based Packet Delivery Packets 
+    bool m_bTsbPd;                               // Peer sends TimeStamp-Based Packet Delivery Packets
     pthread_t m_RcvTsbPdThread;                  // Rcv TsbPD Thread handle
-    pthread_cond_t m_RcvTsbPdCond;
+    std::condition_variable m_RcvTsbPdCond;
     bool m_bTsbPdAckWakeup;                      // Signal TsbPd thread on Ack sent
 
 private: // synchronization: mutexes and conditions
-    pthread_mutex_t m_ConnectionLock;            // used to synchronize connection operation
+    std::mutex      m_ConnectionLock;            // used to synchronize connection operation
 
-    pthread_cond_t m_SendBlockCond;              // used to block "send" call
-    pthread_mutex_t m_SendBlockLock;             // lock associated to m_SendBlockCond
+    std::condition_variable m_SendBlockCond;     // used to block "send" call
+    std::mutex m_SendBlockLock;                  // lock associated to m_SendBlockCond
 
-    pthread_mutex_t m_AckLock;                   // used to protected sender's loss list when processing ACK
+    std::mutex m_AckLock;                        // used to protected sender's loss list when processing ACK
 
-    pthread_cond_t m_RecvDataCond;               // used to block "recv" when there is no data
-    pthread_mutex_t m_RecvDataLock;              // lock associated to m_RecvDataCond
+    std::condition_variable m_RecvDataCond;      // used to block "recv" when there is no data
+    std::mutex m_RecvDataLock;                   // lock associated to m_RecvDataCond
 
-    pthread_mutex_t m_SendLock;                  // used to synchronize "send" call
-    pthread_mutex_t m_RecvLock;                  // used to synchronize "recv" call
+    std::mutex m_SendLock;                       // used to synchronize "send" call
+    std::mutex m_RecvLock;                       // used to synchronize "recv" call
 
-    pthread_mutex_t m_RcvLossLock;               // Protects the receiver loss list (access: CRcvQueue::worker, CUDT::tsbpd)
+    std::mutex m_RcvLossLock;                    // Protects the receiver loss list (access: CRcvQueue::worker, CUDT::tsbpd)
 
     void initSynch();
-    void destroySynch();
     void releaseSynch();
 
 private: // Common connection Congestion Control setup

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -55,6 +55,7 @@ modified by
 
 
 #include <map>
+#include <mutex>
 #include <set>
 #include "udt.h"
 
@@ -165,10 +166,9 @@ public: // for CUDT to acknowledge IO status
 
 private:
    int m_iIDSeed;                            // seed to generate a new ID
-   pthread_mutex_t m_SeedLock;
 
    std::map<int, CEPollDesc> m_mPolls;       // all epolls
-   pthread_mutex_t m_EPollLock;
+   std::mutex m_EPollLock;
 };
 
 

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -58,8 +58,7 @@ m_caSeq(),
 m_iHead(-1),
 m_iLength(0),
 m_iSize(size),
-m_iLastInsertPos(-1),
-m_ListLock()
+m_iLastInsertPos(-1)
 {
     m_caSeq = new Seq[size];
 
@@ -69,20 +68,16 @@ m_ListLock()
       m_caSeq[i].data1 = -1;
       m_caSeq[i].data2 = -1;
    }
-
-   // sender list needs mutex protection
-   pthread_mutex_init(&m_ListLock, 0);
 }
 
 CSndLossList::~CSndLossList()
 {
     delete [] m_caSeq;
-    pthread_mutex_destroy(&m_ListLock);
 }
 
 int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> listguard(m_ListLock);
 
    if (0 == m_iLength)
    {
@@ -254,7 +249,7 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 
 void CSndLossList::remove(int32_t seqno)
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> listguard(m_ListLock);
 
    if (0 == m_iLength)
       return;
@@ -366,7 +361,7 @@ void CSndLossList::remove(int32_t seqno)
 
 int CSndLossList::getLossLength()
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> listguard(m_ListLock);
 
    return m_iLength;
 }
@@ -376,7 +371,7 @@ int32_t CSndLossList::getLostSeq()
    if (0 == m_iLength)
      return -1;
 
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> listguard(m_ListLock);
 
    if (0 == m_iLength)
      return -1;

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -54,6 +54,8 @@ modified by
 #define __UDT_LIST_H__
 
 
+#include<mutex>
+
 #include "udt.h"
 #include "common.h"
 
@@ -99,7 +101,7 @@ private:
    int m_iSize;                         // size of the static array
    int m_iLastInsertPos;                // position of last insert node
 
-   pthread_mutex_t m_ListLock;          // used to synchronize list operation
+   std::mutex m_ListLock;               // used to synchronize list operation
 
 private:
    CSndLossList(const CSndLossList&);

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -240,24 +240,20 @@ CSndUList::CSndUList():
     m_pHeap(NULL),
     m_iArrayLength(4096),
     m_iLastEntry(-1),
-    m_ListLock(),
-    m_pWindowLock(NULL),
     m_pWindowCond(NULL),
     m_pTimer(NULL)
 {
     m_pHeap = new CSNode*[m_iArrayLength];
-    pthread_mutex_init(&m_ListLock, NULL);
 }
 
 CSndUList::~CSndUList()
 {
     delete [] m_pHeap;
-    pthread_mutex_destroy(&m_ListLock);
 }
 
 void CSndUList::insert(int64_t ts, const CUDT* u)
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> guard(m_ListLock);
 
    // increase the heap array size if necessary
    if (m_iLastEntry == m_iArrayLength - 1)
@@ -284,7 +280,7 @@ void CSndUList::insert(int64_t ts, const CUDT* u)
 
 void CSndUList::update(const CUDT* u, EReschedule reschedule)
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> guard(m_ListLock);
 
    CSNode* n = u->m_pSNode;
 
@@ -308,7 +304,7 @@ void CSndUList::update(const CUDT* u, EReschedule reschedule)
 
 int CSndUList::pop(sockaddr*& addr, CPacket& pkt)
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> guard(m_ListLock);
 
    if (-1 == m_iLastEntry)
       return -1;
@@ -340,14 +336,14 @@ int CSndUList::pop(sockaddr*& addr, CPacket& pkt)
 
 void CSndUList::remove(const CUDT* u)
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> guard(m_ListLock);
 
    remove_(u);
 }
 
 uint64_t CSndUList::getNextProcTime()
 {
-   CGuard listguard(m_ListLock);
+   std::lock_guard<std::mutex> guard(m_ListLock);
 
    if (-1 == m_iLastEntry)
       return 0;
@@ -393,9 +389,8 @@ void CSndUList::insert_(int64_t ts, const CUDT* u)
    // first entry, activate the sending queue
    if (0 == m_iLastEntry)
    {
-       pthread_mutex_lock(m_pWindowLock);
-       pthread_cond_signal(m_pWindowCond);
-       pthread_mutex_unlock(m_pWindowLock);
+       std::lock_guard<std::mutex> guard(*m_pWindowLock);
+       m_pWindowCond->notify_one();
    }
 }
 
@@ -446,13 +441,8 @@ m_WorkerThread(),
 m_pSndUList(NULL),
 m_pChannel(NULL),
 m_pTimer(NULL),
-m_WindowLock(),
-m_WindowCond(),
-m_bClosing(false),
-m_ExitCond()
+m_bClosing(false)
 {
-    pthread_cond_init(&m_WindowCond, NULL);
-    pthread_mutex_init(&m_WindowLock, NULL);
 }
 
 CSndQueue::~CSndQueue()
@@ -464,13 +454,12 @@ CSndQueue::~CSndQueue()
         m_pTimer->interrupt();
    }
 
-   pthread_mutex_lock(&m_WindowLock);
-   pthread_cond_signal(&m_WindowCond);
-   pthread_mutex_unlock(&m_WindowLock);
+   {// mutex scope
+       std::lock_guard<std::mutex> guard(m_WindowLock);
+       m_WindowCond.notify_one();
+   }
    if (!pthread_equal(m_WorkerThread, pthread_t()))
        pthread_join(m_WorkerThread, NULL);
-   pthread_cond_destroy(&m_WindowCond);
-   pthread_mutex_destroy(&m_WindowLock);
 
    delete m_pSndUList;
 }
@@ -588,16 +577,15 @@ void* CSndQueue::worker(void* param)
 
             // wait here if there is no sockets with data to be sent
             THREAD_PAUSED();
-            pthread_mutex_lock(&self->m_WindowLock);
+            std::unique_lock<std::mutex> unique_lock(self->m_WindowLock);
             if (!self->m_bClosing && (self->m_pSndUList->m_iLastEntry < 0)) {
-                pthread_cond_wait(&self->m_WindowCond, &self->m_WindowLock);
+                self->m_WindowCond.wait(unique_lock);
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
                 self->m_WorkerStats.lCondWait++;
 #endif         /* SRT_DEBUG_SNDQ_HIGHRATE */
             }
             THREAD_RESUMED();
-            pthread_mutex_unlock(&self->m_WindowLock);
         }
     }
 
@@ -793,16 +781,12 @@ void CHash::remove(int32_t id)
 
 //
 CRendezvousQueue::CRendezvousQueue():
-m_lRendezvousID(),
-m_RIDVectorLock()
+m_lRendezvousID()
 {
-    pthread_mutex_init(&m_RIDVectorLock, NULL);
 }
 
 CRendezvousQueue::~CRendezvousQueue()
 {
-   pthread_mutex_destroy(&m_RIDVectorLock);
-
    for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++ i)
    {
       if (AF_INET == i->m_iIPversion)
@@ -816,7 +800,7 @@ CRendezvousQueue::~CRendezvousQueue()
 
 void CRendezvousQueue::insert(const SRTSOCKET& id, CUDT* u, int ipv, const sockaddr* addr, uint64_t ttl)
 {
-   CGuard vg(m_RIDVectorLock);
+   std::lock_guard<std::mutex> guard(m_RIDVectorLock);
 
    CRL r;
    r.m_iID = id;
@@ -831,7 +815,7 @@ void CRendezvousQueue::insert(const SRTSOCKET& id, CUDT* u, int ipv, const socka
 
 void CRendezvousQueue::remove(const SRTSOCKET& id, bool should_lock)
 {
-   CGuard vg(m_RIDVectorLock, should_lock);
+   auto guard = (should_lock ? std::unique_lock<std::mutex>(m_RIDVectorLock) : std::unique_lock<std::mutex>());
 
    for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++ i)
    {
@@ -851,7 +835,7 @@ void CRendezvousQueue::remove(const SRTSOCKET& id, bool should_lock)
 
 CUDT* CRendezvousQueue::retrieve(const sockaddr* addr, ref_t<SRTSOCKET> r_id)
 {
-   CGuard vg(m_RIDVectorLock);
+   std::lock_guard<std::mutex> guard(m_RIDVectorLock);
    SRTSOCKET& id = *r_id;
 
    // TODO: optimize search
@@ -869,7 +853,7 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr* addr, ref_t<SRTSOCKET> r_id)
 
 void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket& response)
 {
-    CGuard vg(m_RIDVectorLock);
+    std::lock_guard<std::mutex> guard(m_RIDVectorLock);
 
     if (m_lRendezvousID.empty())
         return;
@@ -1008,20 +992,11 @@ CRcvQueue::CRcvQueue():
     m_pTimer(NULL),
     m_iPayloadSize(),
     m_bClosing(false),
-    m_ExitCond(),
-    m_LSLock(),
     m_pListener(NULL),
     m_pRendezvousQueue(NULL),
     m_vNewEntry(),
-    m_IDLock(),
-    m_mBuffer(),
-    m_PassLock(),
-    m_PassCond()
+    m_mBuffer()
 {
-    pthread_mutex_init(&m_PassLock, NULL);
-    pthread_cond_init(&m_PassCond, NULL);
-    pthread_mutex_init(&m_LSLock, NULL);
-    pthread_mutex_init(&m_IDLock, NULL);
 }
 
 CRcvQueue::~CRcvQueue()
@@ -1029,10 +1004,6 @@ CRcvQueue::~CRcvQueue()
     m_bClosing = true;
 	if (!pthread_equal(m_WorkerThread, pthread_t()))
         pthread_join(m_WorkerThread, NULL);
-    pthread_mutex_destroy(&m_PassLock);
-    pthread_cond_destroy(&m_PassCond);
-    pthread_mutex_destroy(&m_LSLock);
-    pthread_mutex_destroy(&m_IDLock);
 
     delete m_pRcvUList;
     delete m_pHash;
@@ -1281,7 +1252,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     int listener_ret = 0;
     bool have_listener = false;
     {
-        CGuard cg(m_LSLock);
+        std::lock_guard<std::mutex> guard(m_LSLock);
         if (m_pListener)
         {
             LOGC(mglog.Note, log << "PASSING request from: " << SockaddrToString(addr) << " to agent:" << m_pListener->socketID());
@@ -1488,14 +1459,14 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
 
 int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
 {
-   CGuard bufferlock(m_PassLock);
+   std::unique_lock<std::mutex> bufferlock(m_PassLock);
    CPacket& packet = *r_packet;
 
    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 
    if (i == m_mBuffer.end())
    {
-      CTimer::condTimedWaitUS(&m_PassCond, &m_PassLock, 1000000);
+      m_PassCond.wait_for(bufferlock, std::chrono::microseconds(1000000));
 
       i = m_mBuffer.find(id);
       if (i == m_mBuffer.end())
@@ -1540,7 +1511,7 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
 
 int CRcvQueue::setListener(CUDT* u)
 {
-   CGuard lslock(m_LSLock);
+   std::lock_guard<std::mutex> guard(m_LSLock);
 
    if (NULL != m_pListener)
       return -1;
@@ -1551,7 +1522,7 @@ int CRcvQueue::setListener(CUDT* u)
 
 void CRcvQueue::removeListener(const CUDT* u)
 {
-   CGuard lslock(m_LSLock);
+   std::lock_guard<std::mutex> guard(m_LSLock);
 
    if (u == m_pListener)
       m_pListener = NULL;
@@ -1568,7 +1539,7 @@ void CRcvQueue::removeConnector(const SRTSOCKET& id, bool should_lock)
     HLOGC(mglog.Debug, log << "removeConnector: removing %" << id);
     m_pRendezvousQueue->remove(id, should_lock);
 
-    CGuard bufferlock(m_PassLock);
+    std::lock_guard<std::mutex> bufferlock(m_PassLock);
 
     map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
     if (i != m_mBuffer.end())
@@ -1587,7 +1558,7 @@ void CRcvQueue::removeConnector(const SRTSOCKET& id, bool should_lock)
 void CRcvQueue::setNewEntry(CUDT* u)
 {
    HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
-   CGuard listguard(m_IDLock);
+   std::lock_guard<std::mutex> guard(m_IDLock);
    m_vNewEntry.push_back(u);
 }
 
@@ -1598,7 +1569,7 @@ bool CRcvQueue::ifNewEntry()
 
 CUDT* CRcvQueue::getNewEntry()
 {
-   CGuard listguard(m_IDLock);
+   std::lock_guard<std::mutex> guard(m_IDLock);
 
    if (m_vNewEntry.empty())
       return NULL;
@@ -1611,14 +1582,14 @@ CUDT* CRcvQueue::getNewEntry()
 
 void CRcvQueue::storePkt(int32_t id, CPacket* pkt)
 {
-   CGuard bufferlock(m_PassLock);
+   std::lock_guard<std::mutex> bufferlock(m_PassLock);
 
    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 
    if (i == m_mBuffer.end())
    {
       m_mBuffer[id].push(pkt);
-      pthread_cond_signal(&m_PassCond);
+      m_PassCond.notify_one();
    }
    else
    {

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -59,8 +59,10 @@ modified by
 #include "packet.h"
 #include "netinet_any.h"
 #include "utilities.h"
+#include <condition_variable>
 #include <list>
 #include <map>
+#include <mutex>
 #include <queue>
 #include <vector>
 
@@ -193,10 +195,10 @@ private:
    int m_iArrayLength;			// physical length of the array
    int m_iLastEntry;			// position of last entry on the heap array
 
-   pthread_mutex_t m_ListLock;
+   std::mutex m_ListLock;
 
-   pthread_mutex_t* m_pWindowLock;
-   pthread_cond_t* m_pWindowCond;
+   std::mutex* m_pWindowLock;
+   std::condition_variable* m_pWindowCond;
 
    CTimer* m_pTimer;
 
@@ -325,7 +327,7 @@ private:
    };
    std::list<CRL> m_lRendezvousID;      // The sockets currently in rendezvous mode
 
-   pthread_mutex_t m_RIDVectorLock;
+   std::mutex m_RIDVectorLock;
 };
 
 class CSndQueue
@@ -384,11 +386,10 @@ private:
    CChannel* m_pChannel;                // The UDP channel for data sending
    CTimer* m_pTimer;			// Timing facility
 
-   pthread_mutex_t m_WindowLock;
-   pthread_cond_t m_WindowCond;
+   std::mutex m_WindowLock;
+   std::condition_variable m_WindowCond;
 
    volatile bool m_bClosing;		// closing the worker
-   pthread_cond_t m_ExitCond;
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)//>>debug high freq worker
    uint64_t m_ullDbgPeriod;
@@ -462,7 +463,6 @@ private:
    int m_iPayloadSize;                  // packet payload size
 
    volatile bool m_bClosing;            // closing the worker
-   pthread_cond_t m_ExitCond;
 
 private:
    int setListener(CUDT* u);
@@ -478,16 +478,16 @@ private:
    void storePkt(int32_t id, CPacket* pkt);
 
 private:
-   pthread_mutex_t m_LSLock;
+   std::mutex m_LSLock;
    CUDT* m_pListener;                                   // pointer to the (unique, if any) listening UDT entity
    CRendezvousQueue* m_pRendezvousQueue;                // The list of sockets in rendezvous mode
 
    std::vector<CUDT*> m_vNewEntry;                      // newly added entries, to be inserted
-   pthread_mutex_t m_IDLock;
+   std::mutex m_IDLock;
 
    std::map<int32_t, std::queue<CPacket*> > m_mBuffer;	// temporary buffer for rendezvous connection request
-   pthread_mutex_t m_PassLock;
-   pthread_cond_t m_PassCond;
+   std::mutex m_PassLock;
+   std::condition_variable m_PassCond;
 
 private:
    CRcvQueue(const CRcvQueue&);


### PR DESCRIPTION
This patch prepares the removal of pthread usages/dependencies.
Advantages:
- simpler overall setup (esp. on Windows this eases the setup of a compile/dev. environment)
- benefit from C++-11 cross-platform implementation and abstractions (could also solve problems with pthread which were described in the source code)
- more compact source code

If you accept this part, we can help to also replace the usage of pthread_t and other pthread parts.
This work is funded by CineMassive displays.