### PR TITLE
Fix BSD Builds. Builds and the SRT library on FreeBSD-11, TrueOS-12, …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 # options
 option(CYGWIN_USE_POSIX "Should the POSIX API be used for cygwin. Ignored if the system isn't cygwin." OFF)
 option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" ON)
-option(DISABLE_SUPPORT "Should the Support Applications be Disabled?" OFF)
+option(DISABLE_SUPPORT_APPLICATIONS "Should the Support Applications be Disabled?" OFF)
 option(ENABLE_PROFILE "Should instrument the code for profiling. Ignored for non-GNU compiler." $ENV{HAI_BUILD_PROFILE})
 option(ENABLE_LOGGING "Should logging be enabled" ON)
 option(ENABLE_HEAVY_LOGGING "Should heavy debug logging be enabled" ${ENABLE_HEAVY_LOGGING_DEFAULT})
@@ -700,11 +700,11 @@ endmacro()
 ##    See https://man.openbsd.org/multicast
 if (BSD
    AND ${CMAKE_SYSTEM_NAME} MATCHES "^[oO][pP][eE][nN][bB][sS][dD]$")
-   set(DISABLE_SUPPORT ON)
+   set(DISABLE_SUPPORT_APPLICATIONS ON)
 endif()
 
 if ( ENABLE_CXX11
-   AND NOT DISABLE_SUPPORT )
+   AND NOT DISABLE_SUPPORT_APPLICATIONS )
 
 	# Make a virtual library of all shared app files
 	MafReadDir(apps support.maf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include(CheckFunctionExists)
 # Platform shortcuts
 set_if(DARWIN      ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 set_if(LINUX       ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+set_if(BSD         ${CMAKE_SYSTEM_NAME} MATCHES "[bB][sS][dD]$")
 set_if(MICROSOFT   WIN32 AND (NOT MINGW AND NOT CYGWIN))
 set_if(SYMLINKABLE LINUX OR DARWIN OR CYGWIN)
 
@@ -77,6 +78,7 @@ endif()
 # options
 option(CYGWIN_USE_POSIX "Should the POSIX API be used for cygwin. Ignored if the system isn't cygwin." OFF)
 option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" ON)
+option(DISABLE_SUPPORT "Should the Support Applications be Disabled?" OFF)
 option(ENABLE_PROFILE "Should instrument the code for profiling. Ignored for non-GNU compiler." $ENV{HAI_BUILD_PROFILE})
 option(ENABLE_LOGGING "Should logging be enabled" ON)
 option(ENABLE_HEAVY_LOGGING "Should heavy debug logging be enabled" ${ENABLE_HEAVY_LOGGING_DEFAULT})
@@ -306,6 +308,9 @@ if(WIN32)
 elseif(DARWIN)
 	message(STATUS "DETECTED SYSTEM: DARWIN;  OSX=1")
 	add_definitions(-DOSX=1)
+elseif(BSD)
+	message(STATUS "DETECTED SYSTEM: BSD;  BSD=1")
+	add_definitions(-DBSD=1)
 elseif(LINUX)
 	add_definitions(-DLINUX=1)
 	message(STATUS "DETECTED SYSTEM: LINUX;  LINUX=1" )
@@ -690,7 +695,16 @@ macro(srt_add_application name sources)
 	install(TARGETS ${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endmacro()
 
-if ( ENABLE_CXX11 )
+## FIXME: transmitmedia.cpp does not build on OpenBSD as some of the Multicast
+##    socket operations used there are non-portable.
+##    See https://man.openbsd.org/multicast
+if (BSD
+   AND ${CMAKE_SYSTEM_NAME} MATCHES "^[oO][pP][eE][nN][bB][sS][dD]$")
+   set(DISABLE_SUPPORT ON)
+endif()
+
+if ( ENABLE_CXX11
+   AND NOT DISABLE_SUPPORT )
 
 	# Make a virtual library of all shared app files
 	MafReadDir(apps support.maf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,12 @@ include(FindThreads)
 include(CheckFunctionExists)
 
 # Platform shortcuts
+string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSNAME_LC)
 set_if(DARWIN      ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 set_if(LINUX       ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-set_if(BSD         ${CMAKE_SYSTEM_NAME} MATCHES "[bB][sS][dD]$")
+set_if(BSD         ${SYSNAME_LC} MATCHES "bsd$")
 set_if(MICROSOFT   WIN32 AND (NOT MINGW AND NOT CYGWIN))
-set_if(SYMLINKABLE LINUX OR DARWIN OR CYGWIN)
+set_if(SYMLINKABLE LINUX OR DARWIN OR BSD OR CYGWIN)
 
 # Not sure what to do in case of compiling by MSVC.
 # This will make installdir in C:\Program Files\SRT then
@@ -698,7 +699,7 @@ endmacro()
 ## FIXME: transmitmedia.cpp does not build on OpenBSD
 ##    Issue: https://github.com/Haivision/srt/issues/590
 if (BSD
-   AND ${CMAKE_SYSTEM_NAME} MATCHES "^[oO][pP][eE][nN][bB][sS][dD]$")
+   AND ${SYSNAME_LC} MATCHES "^openbsd$")
    set(ENABLE_APPS OFF)
 endif()
 ## The applications currently require c++11.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 # options
 option(CYGWIN_USE_POSIX "Should the POSIX API be used for cygwin. Ignored if the system isn't cygwin." OFF)
 option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" ON)
-option(DISABLE_SUPPORT_APPLICATIONS "Should the Support Applications be Disabled?" OFF)
+option(ENABLE_APPS "Should the Support Applications be Built?" ON)
 option(ENABLE_PROFILE "Should instrument the code for profiling. Ignored for non-GNU compiler." $ENV{HAI_BUILD_PROFILE})
 option(ENABLE_LOGGING "Should logging be enabled" ON)
 option(ENABLE_HEAVY_LOGGING "Should heavy debug logging be enabled" ${ENABLE_HEAVY_LOGGING_DEFAULT})
@@ -700,11 +700,14 @@ endmacro()
 ##    See https://man.openbsd.org/multicast
 if (BSD
    AND ${CMAKE_SYSTEM_NAME} MATCHES "^[oO][pP][eE][nN][bB][sS][dD]$")
-   set(DISABLE_SUPPORT_APPLICATIONS ON)
+   set(ENABLE_APPS OFF)
+endif()
+## The applications currently require c++11.
+if (NOT ENABLE_CXX11)
+   set(ENABLE_APPS OFF)
 endif()
 
-if ( ENABLE_CXX11
-   AND NOT DISABLE_SUPPORT_APPLICATIONS )
+if (ENABLE_APPS)
 
 	# Make a virtual library of all shared app files
 	MafReadDir(apps support.maf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -695,9 +695,8 @@ macro(srt_add_application name sources)
 	install(TARGETS ${name} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endmacro()
 
-## FIXME: transmitmedia.cpp does not build on OpenBSD as some of the Multicast
-##    socket operations used there are non-portable.
-##    See https://man.openbsd.org/multicast
+## FIXME: transmitmedia.cpp does not build on OpenBSD
+##    Issue: https://github.com/Haivision/srt/issues/590
 if (BSD
    AND ${CMAKE_SYSTEM_NAME} MATCHES "^[oO][pP][eE][nN][bB][sS][dD]$")
    set(ENABLE_APPS OFF)

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -57,7 +57,7 @@ modified by
 #if __APPLE__
    #include "TargetConditionals.h"
 #endif
-#if defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+#if defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
    #include <sys/types.h>
    #include <sys/event.h>
    #include <sys/time.h>
@@ -103,7 +103,7 @@ ENOMEM: There was insufficient memory to create the kernel object.
        */
    if (localid < 0)
       throw CUDTException(MJ_SETUP, MN_NONE, errno);
-   #elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+   #elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
    localid = kqueue();
    if (localid < 0)
       throw CUDTException(MJ_SETUP, MN_NONE, errno);
@@ -170,7 +170,7 @@ int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
    ev.data.fd = s;
    if (::epoll_ctl(p->second.m_iLocalID, EPOLL_CTL_ADD, s, &ev) < 0)
       throw CUDTException();
-#elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+#elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
    struct kevent ke[2];
    int num = 0;
 
@@ -246,7 +246,7 @@ int CEPoll::remove_ssock(const int eid, const SYSSOCKET& s)
    epoll_event ev;  // ev is ignored, for compatibility with old Linux kernel only.
    if (::epoll_ctl(p->second.m_iLocalID, EPOLL_CTL_DEL, s, &ev) < 0)
       throw CUDTException();
-#elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+#elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
    struct kevent ke;
 
    //
@@ -332,7 +332,7 @@ int CEPoll::update_ssock(const int eid, const SYSSOCKET& s, const int* events)
    ev.data.fd = s;
    if (::epoll_ctl(p->second.m_iLocalID, EPOLL_CTL_MOD, s, &ev) < 0)
       throw CUDTException();
-#elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+#elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
    struct kevent ke[2];
    int num = 0;
 
@@ -438,7 +438,7 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
                ++ total;
             }
          }
-         #elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+         #elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
          #if (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
          // 
          // for iOS setting a timeout of 1ms for kevent and not doing CTimer::waitForEvent(); in the code below
@@ -538,7 +538,7 @@ int CEPoll::release(const int eid)
    #ifdef LINUX
    // release local/system epoll descriptor
    ::close(i->second.m_iLocalID);
-   #elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+   #elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
    ::close(i->second.m_iLocalID);
    #endif
 

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -213,7 +213,7 @@ int srt_epoll_add_ssock(int eid, SYSSOCKET s, const int * events)
 	} else {
         flag = SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR;
     }
-#elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+#elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
     if (events) {
         flag = *events;
 	} else {
@@ -253,7 +253,7 @@ int srt_epoll_update_ssock(int eid, SYSSOCKET s, const int * events)
 	} else {
         flag = SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR;
     }
-#elif defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
+#elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
     if (events) {
         flag = *events;
 	} else {

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -22,7 +22,8 @@ written by
 #include <stdio.h>
 #include <errno.h>
 #if !defined(_WIN32) \
-   && !defined(__MACH__)
+   && !defined(__MACH__) \
+   && !(defined(__unix__) && defined(BSD))
 #include <features.h>
 #endif
 

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -21,9 +21,7 @@ written by
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
-#if !defined(_WIN32) \
-   && !defined(__MACH__) \
-   && !(defined(__unix__) && defined(BSD))
+#if defined(__unix__) && !defined(BSD)
 #include <features.h>
 #endif
 


### PR DESCRIPTION
Fix BSD Builds. Builds and the SRT library on FreeBSD-11, TrueOS-12, and OpenBSD-6.4 and my tests are working. NOTE: the support applications currently do not build on OpenBSD, but do on FreeBSD. I have not done a lot of testing. All testing was with my application and the library sending/receiving TS over SRT. With and without encryption was tested. This commit also adds the ability to disable the SUPPORT applications in the top level of the build. Added a CMAKE variable DISABLE_SUPPORT which is OFF by default. I have not tested DragonFlyBSD or NetBSD.