### PR TITLE
[apps] Handle invalid options values properly.

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -60,47 +60,49 @@ struct SocketOption
     static int setso(int socket, int protocol, int symbol, const void* data, size_t size);
 
     template<Type T>
-    void extract(std::string value, OptionValue& val) const;
+    bool extract(std::string value, OptionValue& val) const;
 };
 
-template<> inline
-int SocketOption::setso<SocketOption::SRT>(int socket, int /*ignored*/, int sym, const void* data, size_t size)
+template<>
+inline int SocketOption::setso<SocketOption::SRT>(int socket, int /*ignored*/, int sym, const void* data, size_t size)
 {
     return srt_setsockopt(socket, 0, SRT_SOCKOPT(sym), data, size);
 }
 
-template<> inline
-int SocketOption::setso<SocketOption::SYSTEM>(int socket, int proto, int sym, const void* data, size_t size)
+template<>
+inline int SocketOption::setso<SocketOption::SYSTEM>(int socket, int proto, int sym, const void* data, size_t size)
 {
     return ::setsockopt(socket, proto, sym, (const char *)data, size);
 }
 
-template<> inline
-void SocketOption::extract<SocketOption::STRING>(std::string value, OptionValue& o) const
+template<>
+inline bool SocketOption::extract<SocketOption::STRING>(std::string value, OptionValue& o) const
 {
     o.s = value;
     o.value = o.s.data();
     o.size = o.s.size();
+    return true;
 }
 
 template<>
-inline void SocketOption::extract<SocketOption::INT>(std::string value, OptionValue& o) const
+inline bool SocketOption::extract<SocketOption::INT>(std::string value, OptionValue& o) const
 {
     try
     {
         o.i = stoi(value, 0, 0);
         o.value = &o.i;
         o.size = sizeof o.i;
-        return;
+        return true;
     }
     catch (...) // stoi throws
     {
-        return; // do not change o
+        return false; // do not change o
     }
+    return false;
 }
 
 template<>
-inline void SocketOption::extract<SocketOption::INT64>(std::string value, OptionValue& o) const
+inline bool SocketOption::extract<SocketOption::INT64>(std::string value, OptionValue& o) const
 {
     try
     {
@@ -108,16 +110,17 @@ inline void SocketOption::extract<SocketOption::INT64>(std::string value, Option
         o.l = vall; // int64_t resolves to either 'long long', or 'long' being 64-bit integer
         o.value = &o.l;
         o.size = sizeof o.l;
-        return ;
+        return true;
     }
     catch (...) // stoll throws
     {
-        return ;
+        return false;
     }
+    return false;
 }
 
 template<>
-inline void SocketOption::extract<SocketOption::BOOL>(std::string value, OptionValue& o) const
+inline bool SocketOption::extract<SocketOption::BOOL>(std::string value, OptionValue& o) const
 {
     bool val;
     if ( false_names.count(value) )
@@ -125,15 +128,16 @@ inline void SocketOption::extract<SocketOption::BOOL>(std::string value, OptionV
     else if ( true_names.count(value) )
         val = true;
     else
-        return;
+        return false;
 
     o.b = val;
     o.value = &o.b;
     o.size = sizeof o.b;
+    return true;
 }
 
 template<>
-inline void SocketOption::extract<SocketOption::ENUM>(std::string value, OptionValue& o) const
+inline bool SocketOption::extract<SocketOption::ENUM>(std::string value, OptionValue& o) const
 {
     if (valmap)
     {
@@ -144,7 +148,7 @@ inline void SocketOption::extract<SocketOption::ENUM>(std::string value, OptionV
             o.i = p->second;
             o.value = &o.i;
             o.size = sizeof o.i;
-            return;
+            return true;
         }
     }
 
@@ -154,20 +158,22 @@ inline void SocketOption::extract<SocketOption::ENUM>(std::string value, OptionV
         o.i = stoi(value, 0, 0);
         o.value = &o.i;
         o.size = sizeof o.i;
-        return;
+        return true;
     }
     catch (...) // stoi throws
     {
-        return; // do not change o
+        return false; // do not change o
     }
+    return false;
 }
 
 template <SocketOption::Domain D, SocketOption::Type T>
 inline bool SocketOption::applyt(int socket, std::string value) const
 {
     OptionValue o; // common meet point
-    extract<T>(value, o);
-    int result = setso<D>(socket, protocol, symbol, o.value, o.size);
+    int result = -1;
+    if (extract<T>(value, o))
+        result = setso<D>(socket, protocol, symbol, o.value, o.size);
     return result != -1;
 }
 

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -282,7 +282,7 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
         Error(UDT::getlasterror(), "srt_bind");
     }
 
-    Verb() << " listen...\n";
+    Verb() << " listen...";
 
     stat = srt_listen(m_bindsock, backlog);
     if ( stat == SRT_ERROR )
@@ -326,7 +326,7 @@ bool SrtCommon::AcceptNewClient()
     srt_close(m_bindsock);
     m_bindsock = SRT_INVALID_SOCK;
 
-    Verb() << " connected.\n";
+    Verb() << " connected.";
 
     // ConfigurePre is done on bindsock, so any possible Pre flags
     // are DERIVED by sock. ConfigurePost is done exclusively on sock.
@@ -343,7 +343,7 @@ void SrtCommon::Init(string host, int port, map<string,string> par, bool dir_out
     InitParameters(host, par);
 
     Verb() << "Opening SRT " << (dir_output ? "target" : "source") << " " << m_mode
-        << " on " << host << ":" << port << "\n";
+        << " on " << host << ":" << port;
 
     if ( m_mode == "caller" )
         OpenClient(host, port);
@@ -480,7 +480,7 @@ void SrtCommon::ConnectClient(string host, int port)
     sockaddr_in sa = CreateAddrInet(host, port);
     sockaddr* psa = (sockaddr*)&sa;
 
-    Verb() << "Connecting to " << host << ":" << port << "\n";
+    Verb() << "Connecting to " << host << ":" << port;
 
     int stat = srt_connect(m_sock, psa, sizeof sa);
     if ( stat == SRT_ERROR )
@@ -498,7 +498,7 @@ void SrtCommon::Error(UDT::ERRORINFO& udtError, string src)
 {
     int udtResult = udtError.getErrorCode();
     string message = udtError.getErrorMessage();
-    Verb() << "\nERROR #" << udtResult << ": " << message << "\n";
+    Verb() << "\nERROR #" << udtResult << ": " << message;
 
     udtError.clear();
     throw TransmissionError("error: " + src + ": " + message);
@@ -520,7 +520,7 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
     sockaddr_in localsa = CreateAddrInet(adapter, port);
     sockaddr* plsa = (sockaddr*)&localsa;
 
-    Verb() << "Binding a server on " << adapter << ":" << port << "\n";
+    Verb() << "Binding a server on " << adapter << ":" << port;
 
     stat = srt_bind(m_sock, plsa, sizeof localsa);
     if ( stat == SRT_ERROR )
@@ -531,7 +531,7 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
 
     sockaddr_in sa = CreateAddrInet(host, port);
     sockaddr* psa = (sockaddr*)&sa;
-    Verb() << "Connecting to " << host << ":" << port << "\n";
+    Verb() << "Connecting to " << host << ":" << port;
 
     stat = srt_connect(m_sock, psa, sizeof sa);
     if ( stat == SRT_ERROR )
@@ -547,7 +547,7 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
 
 void SrtCommon::Close()
 {
-    Verb() << "SrtCommon: DESTROYING CONNECTION, closing sockets (rt%" << m_sock << " ls%" << m_bindsock << ")...\n";
+    Verb() << "SrtCommon: DESTROYING CONNECTION, closing sockets (rt%" << m_sock << " ls%" << m_bindsock << ")...";
 
     if ( m_sock != SRT_INVALID_SOCK )
     {
@@ -561,7 +561,7 @@ void SrtCommon::Close()
         m_bindsock = SRT_INVALID_SOCK ;
     }
 
-    Verb() << "SrtCommon: ... done.\n";
+    Verb() << "SrtCommon: ... done.";
 }
 
 SrtCommon::~SrtCommon()
@@ -989,10 +989,10 @@ protected:
             int ttl = stoi(attr.at("ttl"));
             int res = setsockopt(m_sock, IPPROTO_IP, IP_TTL, (const char*)&ttl, sizeof ttl);
             if (res == -1)
-                Verb() << "WARNING: failed to set 'ttl' (IP_TTL) to " << ttl << "\n";
+                Verb() << "WARNING: failed to set 'ttl' (IP_TTL) to " << ttl;
             res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&ttl, sizeof ttl);
             if (res == -1)
-                Verb() << "WARNING: failed to set 'ttl' (IP_MULTICAST_TTL) to " << ttl << "\n";
+                Verb() << "WARNING: failed to set 'ttl' (IP_MULTICAST_TTL) to " << ttl;
 
             attr.erase("ttl");
         }
@@ -1007,7 +1007,7 @@ protected:
                 string value = m_options.at(o.name);
                 bool ok = o.apply<SocketOption::SYSTEM>(m_sock, value);
                 if ( !ok )
-                    Verb() << "WARNING: failed to set '" << o.name << "' to " << value << "\n";
+                    Verb() << "WARNING: failed to set '" << o.name << "' to " << value;
             }
         }
     }


### PR DESCRIPTION
`extract()` can fail, but `apply()` will still try to apply the option, causing a program to crash.