### PR TITLE
Added statistics mutex to sync read/write

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -36,7 +36,6 @@
 using namespace std;
 
 bool transmit_total_stats = false;
-bool clear_stats = false;
 unsigned long transmit_bw_report = 0;
 unsigned long transmit_stats_report = 0;
 unsigned long transmit_chunk_size = SRT_LIVE_DEF_PLSIZE;
@@ -618,8 +617,7 @@ bool SrtSource::Read(size_t chunk, bytevector& data)
     if (need_bw_report || need_stats_report)
     {
         CBytePerfMon perf;
-        srt_bstats(m_sock, &perf, clear_stats);
-        clear_stats = false;
+        srt_bstats(m_sock, &perf, need_stats_report && !transmit_total_stats);
         if (need_bw_report)
         {
             PrintSrtBandwidth(perf.mbpsBandwidth);
@@ -627,7 +625,6 @@ bool SrtSource::Read(size_t chunk, bytevector& data)
         if (need_stats_report)
         {
             PrintSrtStats(m_sock, perf);
-            clear_stats = !transmit_total_stats;
         }
     }
 
@@ -670,8 +667,7 @@ bool SrtTarget::Write(const bytevector& data)
     if (need_bw_report || need_stats_report)
     {
         CBytePerfMon perf;
-        srt_bstats(m_sock, &perf, clear_stats);
-        clear_stats = false;
+        srt_bstats(m_sock, &perf, need_stats_report && !transmit_total_stats);
         if (need_bw_report)
         {
             PrintSrtBandwidth(perf.mbpsBandwidth);
@@ -679,7 +675,6 @@ bool SrtTarget::Write(const bytevector& data)
         if (need_stats_report)
         {
             PrintSrtStats(m_sock, perf);
-            clear_stats = !transmit_total_stats;
         }
     }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6736,7 +6736,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
           // acknowledge the sending buffer (remove data that predate 'ack')
           m_pSndBuffer->ackData(offset);
 
-          int64_t currtime = currtime_tk/m_ullCPUFrequency;
+          const int64_t currtime = CTimer::getTime();
           // record total time used for sending
           CGuard::enterCS(m_StatsLock);
           m_stats.sndDuration += currtime - m_stats.sndDurationCounter;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5904,11 +5904,6 @@ void CUDT::bstats(CBytePerfMon* perf, bool clear, bool instantaneous)
    if (m_bBroken || m_bClosing)
       throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-   /* 
-   * RecvLock to protect consistency (pkts vs. bytes vs. timespan) of Recv buffer stats.
-   * Send buffer stats protected in send buffer class
-   */
-   CGuard recvguard(m_RecvLock);
    CGuard statsguard(m_StatsLock);
 
    uint64_t currtime = CTimer::getTime();

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1167,40 +1167,40 @@ void CUDT::clearData()
 
    // trace information
    CGuard::enterCS(m_StatsLock);
-   m_stats.m_StartTime = CTimer::getTime();
-   m_stats.m_llSentTotal = m_stats.m_llRecvTotal = m_stats.m_iSndLossTotal = m_stats.m_iRcvLossTotal = m_stats.m_iRetransTotal = m_stats.m_iSentACKTotal = m_stats.m_iRecvACKTotal = m_stats.m_iSentNAKTotal = m_stats.m_iRecvNAKTotal = 0;
-   m_stats.m_LastSampleTime = CTimer::getTime();
-   m_stats.m_llTraceSent = m_stats.m_llTraceRecv = m_stats.m_iTraceSndLoss = m_stats.m_iTraceRcvLoss = m_stats.m_iTraceRetrans = m_stats.m_iSentACK = m_stats.m_iRecvACK = m_stats.m_iSentNAK = m_stats.m_iRecvNAK = 0;
-   m_stats.m_iTraceRcvRetrans = 0;
-   m_stats.m_iTraceReorderDistance = 0;
-   m_stats.m_fTraceBelatedTime = 0.0;
-   m_stats.m_iTraceRcvBelated          = 0;
+   m_stats.startTime = CTimer::getTime();
+   m_stats.sentTotal = m_stats.recvTotal = m_stats.sndLossTotal = m_stats.rcvLossTotal = m_stats.retransTotal = m_stats.sentACKTotal = m_stats.recvACKTotal = m_stats.sentNAKTotal = m_stats.recvNAKTotal = 0;
+   m_stats.lastSampleTime = CTimer::getTime();
+   m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans = m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
+   m_stats.traceRcvRetrans = 0;
+   m_stats.traceReorderDistance = 0;
+   m_stats.traceBelatedTime = 0.0;
+   m_stats.traceRcvBelated          = 0;
 
-   m_stats.m_iSndDropTotal             = 0;
-   m_stats.m_iTraceSndDrop             = 0;
-   m_stats.m_iRcvDropTotal             = 0;
-   m_stats.m_iTraceRcvDrop             = 0;
+   m_stats.sndDropTotal             = 0;
+   m_stats.traceSndDrop             = 0;
+   m_stats.rcvDropTotal             = 0;
+   m_stats.traceRcvDrop             = 0;
 
-   m_stats.m_iRcvUndecryptTotal        = 0;
-   m_stats.m_iTraceRcvUndecrypt        = 0;
+   m_stats.m_rcvUndecryptTotal        = 0;
+   m_stats.traceRcvUndecrypt        = 0;
 
-   m_stats.m_ullBytesSentTotal         = 0;
-   m_stats.m_ullBytesRecvTotal         = 0;
-   m_stats.m_ullBytesRetransTotal      = 0;
-   m_stats.m_ullTraceBytesSent         = 0;
-   m_stats.m_ullTraceBytesRecv         = 0;
-   m_stats.m_ullTraceBytesRetrans      = 0;
+   m_stats.bytesSentTotal         = 0;
+   m_stats.bytesRecvTotal         = 0;
+   m_stats.bytesRetransTotal      = 0;
+   m_stats.traceBytesSent         = 0;
+   m_stats.traceBytesRecv         = 0;
+   m_stats.traceBytesRetrans      = 0;
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-   m_stats.m_ullTraceRcvBytesLoss      = 0;
+   m_stats.traceRcvBytesLoss      = 0;
 #endif
-   m_stats.m_ullSndBytesDropTotal      = 0;
-   m_stats.m_ullRcvBytesDropTotal      = 0;
-   m_stats.m_ullTraceSndBytesDrop      = 0;
-   m_stats.m_ullTraceRcvBytesDrop      = 0;
-   m_stats.m_ullRcvBytesUndecryptTotal = 0;
-   m_stats.m_ullTraceRcvBytesUndecrypt = 0;
+   m_stats.sndBytesDropTotal      = 0;
+   m_stats.rcvBytesDropTotal      = 0;
+   m_stats.traceSndBytesDrop      = 0;
+   m_stats.traceRcvBytesDrop      = 0;
+   m_stats.m_rcvBytesUndecryptTotal = 0;
+   m_stats.traceRcvBytesUndecrypt = 0;
 
-   m_stats.m_llSndDuration = m_stats.m_llSndDurationTotal = 0;
+   m_stats.sndDuration = m_stats.m_sndDurationTotal = 0;
    CGuard::leaveCS(m_StatsLock);
 
 
@@ -2816,7 +2816,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
 
     CGuard::enterCS(m_StatsLock);
     uint64_t now = CTimer::getTime();
-    reqpkt.m_iTimeStamp = int32_t(now - m_stats.m_StartTime);
+    reqpkt.m_iTimeStamp = int32_t(now - m_stats.startTime);
     CGuard::leaveCS(m_StatsLock);
 
     HLOGC(mglog.Debug, log << CONID() << "CUDT::startConnect: REQ-TIME set HIGH (" << now << "). SENDING HS: " << m_ConnReq.show());
@@ -2888,7 +2888,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
 #endif
 
             m_llLastReqTime = now;
-            reqpkt.m_iTimeStamp = int32_t(now - m_stats.m_StartTime);
+            reqpkt.m_iTimeStamp = int32_t(now - m_stats.startTime);
             CGuard::leaveCS(m_StatsLock);
             m_pSndQueue->sendto(serv_addr, reqpkt);
         }
@@ -3079,7 +3079,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const
     request.allocate(m_iMaxSRTPayloadSize);
     CGuard::enterCS(m_StatsLock);
     uint64_t now = CTimer::getTime();
-    request.m_iTimeStamp = int(now - m_stats.m_StartTime);
+    request.m_iTimeStamp = int(now - m_stats.startTime);
     CGuard::leaveCS(m_StatsLock);
 
     HLOGC(mglog.Debug, log << "processAsyncConnectRequest: REQ-TIME: HIGH (" << now << "). Should prevent too quick responses.");
@@ -3470,11 +3470,11 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
         // AGREEMENT is missed, it may have kinda initial tearing.
 
         CGuard::enterCS(m_StatsLock);
-        uint64_t now = CTimer::getTime();
-        HLOGC(mglog.Debug, log << "processRendezvous: rsp=AGREEMENT, reporting ACCEPT and sending just this one, REQ-TIME HIGH (" << now << ").");
+        const uint64_t now = CTimer::getTime();
         m_llLastReqTime = now;
-        rpkt.m_iTimeStamp = int32_t(now - m_stats.m_StartTime);
+        rpkt.m_iTimeStamp = int32_t(now - m_stats.startTime);
         CGuard::leaveCS(m_StatsLock);
+        HLOGC(mglog.Debug, log << "processRendezvous: rsp=AGREEMENT, reporting ACCEPT and sending just this one, REQ-TIME HIGH (" << now << ").");
 
         m_pSndQueue->sendto(serv_addr, rpkt);
 
@@ -4245,13 +4245,13 @@ void* CUDT::tsbpd(void* param)
                 */
 
                 /* Update drop/skip stats */
-                 CGuard::enterCS(self->m_StatsLock);
-                self->m_stats.m_iRcvDropTotal += seqlen;
-                self->m_stats.m_iTraceRcvDrop += seqlen;
+                CGuard::enterCS(self->m_StatsLock);
+                self->m_stats.rcvDropTotal += seqlen;
+                self->m_stats.traceRcvDrop += seqlen;
                 /* Estimate dropped/skipped bytes from average payload */
                 int avgpayloadsz = self->m_pRcvBuffer->getRcvAvgPayloadSize();
-                self->m_stats.m_ullRcvBytesDropTotal += seqlen * avgpayloadsz;
-                self->m_stats.m_ullTraceRcvBytesDrop += seqlen * avgpayloadsz;
+                self->m_stats.rcvBytesDropTotal += seqlen * avgpayloadsz;
+                self->m_stats.traceRcvBytesDrop += seqlen * avgpayloadsz;
                 CGuard::leaveCS(self->m_StatsLock);
 
                 self->unlose(self->m_iRcvLastSkipAck, CSeqNo::decseq(skiptoseqno)); //remove(from,to-inclusive)
@@ -4707,7 +4707,7 @@ void CUDT::addressAndSend(CPacket& pkt)
 {
     pkt.m_iID = m_PeerID;
     CGuard::enterCS(m_StatsLock);
-    pkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+    pkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
     CGuard::leaveCS(m_StatsLock);
 
     m_pSndQueue->sendto(m_pPeerAddr, pkt);
@@ -5098,10 +5098,10 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
         if (dpkts > 0)
         {
             CGuard::enterCS(m_StatsLock);
-            m_stats.m_iTraceSndDrop        += dpkts;
-            m_stats.m_iSndDropTotal        += dpkts;
-            m_stats.m_ullTraceSndBytesDrop += dbytes;
-            m_stats.m_ullSndBytesDropTotal += dbytes;
+            m_stats.traceSndDrop        += dpkts;
+            m_stats.sndDropTotal        += dpkts;
+            m_stats.traceSndBytesDrop += dbytes;
+            m_stats.sndBytesDropTotal += dbytes;
             CGuard::leaveCS(m_StatsLock);
 
 #if ENABLE_HEAVY_LOGGING
@@ -5320,7 +5320,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     if (m_pSndBuffer->getCurrBufSize() == 0)
     {
         CGuard::enterCS(m_StatsLock);
-        m_stats.m_llSndDurationCounter = CTimer::getTime();
+        m_stats.sndDurationCounter = CTimer::getTime();
         CGuard::leaveCS(m_StatsLock);
     }
 
@@ -5670,7 +5670,7 @@ int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
         if (m_pSndBuffer->getCurrBufSize() == 0)
         {
             CGuard::enterCS(m_StatsLock);
-            m_stats.m_llSndDurationCounter = CTimer::getTime();
+            m_stats.sndDurationCounter = CTimer::getTime();
             CGuard::leaveCS(m_StatsLock);
         }
 
@@ -5820,38 +5820,38 @@ void CUDT::sample(CPerfMon* perf, bool clear)
 
    CGuard statsLock(m_StatsLock);
    uint64_t currtime = CTimer::getTime();
-   perf->msTimeStamp = (currtime - m_stats.m_StartTime) / 1000;
+   perf->msTimeStamp = (currtime - m_stats.startTime) / 1000;
 
-   perf->pktSent = m_stats.m_llTraceSent;
-   perf->pktRecv = m_stats.m_llTraceRecv;
-   perf->pktSndLoss = m_stats.m_iTraceSndLoss;
-   perf->pktRcvLoss = m_stats.m_iTraceRcvLoss;
-   perf->pktRetrans = m_stats.m_iTraceRetrans;
-   perf->pktRcvRetrans = m_stats.m_iTraceRcvRetrans;
-   perf->pktSentACK = m_stats.m_iSentACK;
-   perf->pktRecvACK = m_stats.m_iRecvACK;
-   perf->pktSentNAK = m_stats.m_iSentNAK;
-   perf->pktRecvNAK = m_stats.m_iRecvNAK;
-   perf->usSndDuration = m_stats.m_llSndDuration;
-   perf->pktReorderDistance = m_stats.m_iTraceReorderDistance;
-   perf->pktRcvAvgBelatedTime = m_stats.m_fTraceBelatedTime;
-   perf->pktRcvBelated = m_stats.m_iTraceRcvBelated;
+   perf->pktSent = m_stats.traceSent;
+   perf->pktRecv = m_stats.traceRecv;
+   perf->pktSndLoss = m_stats.traceSndLoss;
+   perf->pktRcvLoss = m_stats.traceRcvLoss;
+   perf->pktRetrans = m_stats.traceRetrans;
+   perf->pktRcvRetrans = m_stats.traceRcvRetrans;
+   perf->pktSentACK = m_stats.sentACK;
+   perf->pktRecvACK = m_stats.recvACK;
+   perf->pktSentNAK = m_stats.sentNAK;
+   perf->pktRecvNAK = m_stats.recvNAK;
+   perf->usSndDuration = m_stats.sndDuration;
+   perf->pktReorderDistance = m_stats.traceReorderDistance;
+   perf->pktRcvAvgBelatedTime = m_stats.traceBelatedTime;
+   perf->pktRcvBelated = m_stats.traceRcvBelated;
 
-   perf->pktSentTotal = m_stats.m_llSentTotal;
-   perf->pktRecvTotal = m_stats.m_llRecvTotal;
-   perf->pktSndLossTotal = m_stats.m_iSndLossTotal;
-   perf->pktRcvLossTotal = m_stats.m_iRcvLossTotal;
-   perf->pktRetransTotal = m_stats.m_iRetransTotal;
-   perf->pktSentACKTotal = m_stats.m_iSentACKTotal;
-   perf->pktRecvACKTotal = m_stats.m_iRecvACKTotal;
-   perf->pktSentNAKTotal = m_stats.m_iSentNAKTotal;
-   perf->pktRecvNAKTotal = m_stats.m_iRecvNAKTotal;
-   perf->usSndDurationTotal = m_stats.m_llSndDurationTotal;
+   perf->pktSentTotal = m_stats.sentTotal;
+   perf->pktRecvTotal = m_stats.recvTotal;
+   perf->pktSndLossTotal = m_stats.sndLossTotal;
+   perf->pktRcvLossTotal = m_stats.rcvLossTotal;
+   perf->pktRetransTotal = m_stats.retransTotal;
+   perf->pktSentACKTotal = m_stats.sentACKTotal;
+   perf->pktRecvACKTotal = m_stats.recvACKTotal;
+   perf->pktSentNAKTotal = m_stats.sentNAKTotal;
+   perf->pktRecvNAKTotal = m_stats.recvNAKTotal;
+   perf->usSndDurationTotal = m_stats.m_sndDurationTotal;
 
-   double interval = double(currtime - m_stats.m_LastSampleTime);
+   double interval = double(currtime - m_stats.lastSampleTime);
 
-   perf->mbpsSendRate = double(m_stats.m_llTraceSent) * m_iMaxSRTPayloadSize * 8.0 / interval;
-   perf->mbpsRecvRate = double(m_stats.m_llTraceRecv) * m_iMaxSRTPayloadSize * 8.0 / interval;
+   perf->mbpsSendRate = double(m_stats.traceSent) * m_iMaxSRTPayloadSize * 8.0 / interval;
+   perf->mbpsRecvRate = double(m_stats.traceRecv) * m_iMaxSRTPayloadSize * 8.0 / interval;
 
    perf->usPktSndPeriod = m_ullInterval_tk / double(m_ullCPUFrequency);
    perf->pktFlowWindow = m_iFlowWindowSize;
@@ -5877,23 +5877,23 @@ void CUDT::sample(CPerfMon* perf, bool clear)
 
    if (clear)
    {
-      m_stats.m_iTraceSndDrop        = 0;
-      m_stats.m_iTraceRcvDrop        = 0;
-      m_stats.m_ullTraceSndBytesDrop = 0;
-      m_stats.m_ullTraceRcvBytesDrop = 0;
-      m_stats.m_iTraceRcvUndecrypt        = 0;
-      m_stats.m_ullTraceRcvBytesUndecrypt = 0;
+      m_stats.traceSndDrop        = 0;
+      m_stats.traceRcvDrop        = 0;
+      m_stats.traceSndBytesDrop = 0;
+      m_stats.traceRcvBytesDrop = 0;
+      m_stats.traceRcvUndecrypt        = 0;
+      m_stats.traceRcvBytesUndecrypt = 0;
       //new>
-      m_stats.m_ullTraceBytesSent = m_stats.m_ullTraceBytesRecv = m_stats.m_ullTraceBytesRetrans = 0;
+      m_stats.traceBytesSent = m_stats.traceBytesRecv = m_stats.traceBytesRetrans = 0;
       //<
-      m_stats.m_llTraceSent = m_stats.m_llTraceRecv = m_stats.m_iTraceSndLoss = m_stats.m_iTraceRcvLoss = m_stats.m_iTraceRetrans = m_stats.m_iSentACK = m_stats.m_iRecvACK = m_stats.m_iSentNAK = m_stats.m_iRecvNAK = 0;
-      m_stats.m_llSndDuration = 0;
-      m_stats.m_iTraceRcvRetrans = 0;
-      m_stats.m_iTraceRcvBelated = 0;
+      m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans = m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
+      m_stats.sndDuration = 0;
+      m_stats.traceRcvRetrans = 0;
+      m_stats.traceRcvBelated = 0;
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-      m_stats.m_ullTraceRcvBytesLoss = 0;
+      m_stats.traceRcvBytesLoss = 0;
 #endif
-      m_stats.m_LastSampleTime = currtime;
+      m_stats.lastSampleTime = currtime;
    }
 }
 
@@ -5912,67 +5912,67 @@ void CUDT::bstats(CBytePerfMon* perf, bool clear, bool instantaneous)
    CGuard statsguard(m_StatsLock);
 
    uint64_t currtime = CTimer::getTime();
-   perf->msTimeStamp = (currtime - m_stats.m_StartTime) / 1000;
+   perf->msTimeStamp = (currtime - m_stats.startTime) / 1000;
 
-   perf->pktSent = m_stats.m_llTraceSent;
-   perf->pktRecv = m_stats.m_llTraceRecv;
-   perf->pktSndLoss = m_stats.m_iTraceSndLoss;
-   perf->pktRcvLoss = m_stats.m_iTraceRcvLoss;
-   perf->pktRetrans = m_stats.m_iTraceRetrans;
-   perf->pktRcvRetrans = m_stats.m_iTraceRcvRetrans;
-   perf->pktSentACK = m_stats.m_iSentACK;
-   perf->pktRecvACK = m_stats.m_iRecvACK;
-   perf->pktSentNAK = m_stats.m_iSentNAK;
-   perf->pktRecvNAK = m_stats.m_iRecvNAK;
-   perf->usSndDuration = m_stats.m_llSndDuration;
-   perf->pktReorderDistance = m_stats.m_iTraceReorderDistance;
-   perf->pktRcvAvgBelatedTime = m_stats.m_fTraceBelatedTime;
-   perf->pktRcvBelated = m_stats.m_iTraceRcvBelated;
+   perf->pktSent = m_stats.traceSent;
+   perf->pktRecv = m_stats.traceRecv;
+   perf->pktSndLoss = m_stats.traceSndLoss;
+   perf->pktRcvLoss = m_stats.traceRcvLoss;
+   perf->pktRetrans = m_stats.traceRetrans;
+   perf->pktRcvRetrans = m_stats.traceRcvRetrans;
+   perf->pktSentACK = m_stats.sentACK;
+   perf->pktRecvACK = m_stats.recvACK;
+   perf->pktSentNAK = m_stats.sentNAK;
+   perf->pktRecvNAK = m_stats.recvNAK;
+   perf->usSndDuration = m_stats.sndDuration;
+   perf->pktReorderDistance = m_stats.traceReorderDistance;
+   perf->pktRcvAvgBelatedTime = m_stats.traceBelatedTime;
+   perf->pktRcvBelated = m_stats.traceRcvBelated;
    //>new
    /* perf byte counters include all headers (SRT+UDP+IP) */
    const int pktHdrSize = CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE;
-   perf->byteSent = m_stats.m_ullTraceBytesSent + (m_stats.m_llTraceSent * pktHdrSize);
-   perf->byteRecv = m_stats.m_ullTraceBytesRecv + (m_stats.m_llTraceRecv * pktHdrSize);
-   perf->byteRetrans = m_stats.m_ullTraceBytesRetrans + (m_stats.m_iTraceRetrans * pktHdrSize);
+   perf->byteSent = m_stats.traceBytesSent + (m_stats.traceSent * pktHdrSize);
+   perf->byteRecv = m_stats.traceBytesRecv + (m_stats.traceRecv * pktHdrSize);
+   perf->byteRetrans = m_stats.traceBytesRetrans + (m_stats.traceRetrans * pktHdrSize);
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-   perf->byteRcvLoss = m_stats.m_ullTraceRcvBytesLoss + (m_stats.m_iTraceRcvLoss * pktHdrSize);
+   perf->byteRcvLoss = m_stats.traceRcvBytesLoss + (m_stats.traceRcvLoss * pktHdrSize);
 #endif
 
-   perf->pktSndDrop = m_stats.m_iTraceSndDrop;
-   perf->pktRcvDrop = m_stats.m_iTraceRcvDrop + m_stats.m_iTraceRcvUndecrypt;
-   perf->byteSndDrop = m_stats.m_ullTraceSndBytesDrop + (m_stats.m_iTraceSndDrop * pktHdrSize);
-   perf->byteRcvDrop = m_stats.m_ullTraceRcvBytesDrop + (m_stats.m_iTraceRcvDrop * pktHdrSize) + m_stats.m_ullTraceRcvBytesUndecrypt;
-   perf->pktRcvUndecrypt = m_stats.m_iTraceRcvUndecrypt;
-   perf->byteRcvUndecrypt = m_stats.m_ullTraceRcvBytesUndecrypt;
+   perf->pktSndDrop = m_stats.traceSndDrop;
+   perf->pktRcvDrop = m_stats.traceRcvDrop + m_stats.traceRcvUndecrypt;
+   perf->byteSndDrop = m_stats.traceSndBytesDrop + (m_stats.traceSndDrop * pktHdrSize);
+   perf->byteRcvDrop = m_stats.traceRcvBytesDrop + (m_stats.traceRcvDrop * pktHdrSize) + m_stats.traceRcvBytesUndecrypt;
+   perf->pktRcvUndecrypt = m_stats.traceRcvUndecrypt;
+   perf->byteRcvUndecrypt = m_stats.traceRcvBytesUndecrypt;
 
    //<
 
-   perf->pktSentTotal = m_stats.m_llSentTotal;
-   perf->pktRecvTotal = m_stats.m_llRecvTotal;
-   perf->pktSndLossTotal = m_stats.m_iSndLossTotal;
-   perf->pktRcvLossTotal = m_stats.m_iRcvLossTotal;
-   perf->pktRetransTotal = m_stats.m_iRetransTotal;
-   perf->pktSentACKTotal = m_stats.m_iSentACKTotal;
-   perf->pktRecvACKTotal = m_stats.m_iRecvACKTotal;
-   perf->pktSentNAKTotal = m_stats.m_iSentNAKTotal;
-   perf->pktRecvNAKTotal = m_stats.m_iRecvNAKTotal;
-   perf->usSndDurationTotal = m_stats.m_llSndDurationTotal;
+   perf->pktSentTotal = m_stats.sentTotal;
+   perf->pktRecvTotal = m_stats.recvTotal;
+   perf->pktSndLossTotal = m_stats.sndLossTotal;
+   perf->pktRcvLossTotal = m_stats.rcvLossTotal;
+   perf->pktRetransTotal = m_stats.retransTotal;
+   perf->pktSentACKTotal = m_stats.sentACKTotal;
+   perf->pktRecvACKTotal = m_stats.recvACKTotal;
+   perf->pktSentNAKTotal = m_stats.sentNAKTotal;
+   perf->pktRecvNAKTotal = m_stats.recvNAKTotal;
+   perf->usSndDurationTotal = m_stats.m_sndDurationTotal;
    //>new
-   perf->byteSentTotal = m_stats.m_ullBytesSentTotal + (m_stats.m_llSentTotal * pktHdrSize);
-   perf->byteRecvTotal = m_stats.m_ullBytesRecvTotal + (m_stats.m_llRecvTotal * pktHdrSize);
-   perf->byteRetransTotal = m_stats.m_ullBytesRetransTotal + (m_stats.m_iRetransTotal * pktHdrSize);
+   perf->byteSentTotal = m_stats.bytesSentTotal + (m_stats.sentTotal * pktHdrSize);
+   perf->byteRecvTotal = m_stats.bytesRecvTotal + (m_stats.recvTotal * pktHdrSize);
+   perf->byteRetransTotal = m_stats.bytesRetransTotal + (m_stats.retransTotal * pktHdrSize);
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-   perf->byteRcvLossTotal = m_stats.m_ullRcvBytesLossTotal + (m_stats.m_iRcvLossTotal * pktHdrSize);
+   perf->byteRcvLossTotal = m_stats.rcvBytesLossTotal + (m_stats.rcvLossTotal * pktHdrSize);
 #endif
-   perf->pktSndDropTotal = m_stats.m_iSndDropTotal;
-   perf->pktRcvDropTotal = m_stats.m_iRcvDropTotal + m_stats.m_iRcvUndecryptTotal;
-   perf->byteSndDropTotal = m_stats.m_ullSndBytesDropTotal + (m_stats.m_iSndDropTotal * pktHdrSize);
-   perf->byteRcvDropTotal = m_stats.m_ullRcvBytesDropTotal + (m_stats.m_iRcvDropTotal * pktHdrSize) + m_stats.m_ullRcvBytesUndecryptTotal;
-   perf->pktRcvUndecryptTotal = m_stats.m_iRcvUndecryptTotal;
-   perf->byteRcvUndecryptTotal = m_stats.m_ullRcvBytesUndecryptTotal;
+   perf->pktSndDropTotal = m_stats.sndDropTotal;
+   perf->pktRcvDropTotal = m_stats.rcvDropTotal + m_stats.m_rcvUndecryptTotal;
+   perf->byteSndDropTotal = m_stats.sndBytesDropTotal + (m_stats.sndDropTotal * pktHdrSize);
+   perf->byteRcvDropTotal = m_stats.rcvBytesDropTotal + (m_stats.rcvDropTotal * pktHdrSize) + m_stats.m_rcvBytesUndecryptTotal;
+   perf->pktRcvUndecryptTotal = m_stats.m_rcvUndecryptTotal;
+   perf->byteRcvUndecryptTotal = m_stats.m_rcvBytesUndecryptTotal;
    //<
 
-   double interval = double(currtime - m_stats.m_LastSampleTime);
+   double interval = double(currtime - m_stats.lastSampleTime);
 
    //>mod
    perf->mbpsSendRate = double(perf->byteSent) * 8.0 / interval;
@@ -6076,23 +6076,23 @@ void CUDT::bstats(CBytePerfMon* perf, bool clear, bool instantaneous)
 
    if (clear)
    {
-      m_stats.m_iTraceSndDrop        = 0;
-      m_stats.m_iTraceRcvDrop        = 0;
-      m_stats.m_ullTraceSndBytesDrop = 0;
-      m_stats.m_ullTraceRcvBytesDrop = 0;
-      m_stats.m_iTraceRcvUndecrypt        = 0;
-      m_stats.m_ullTraceRcvBytesUndecrypt = 0;
+      m_stats.traceSndDrop        = 0;
+      m_stats.traceRcvDrop        = 0;
+      m_stats.traceSndBytesDrop = 0;
+      m_stats.traceRcvBytesDrop = 0;
+      m_stats.traceRcvUndecrypt        = 0;
+      m_stats.traceRcvBytesUndecrypt = 0;
       //new>
-      m_stats.m_ullTraceBytesSent = m_stats.m_ullTraceBytesRecv = m_stats.m_ullTraceBytesRetrans = 0;
+      m_stats.traceBytesSent = m_stats.traceBytesRecv = m_stats.traceBytesRetrans = 0;
       //<
-      m_stats.m_llTraceSent = m_stats.m_llTraceRecv = m_stats.m_iTraceSndLoss = m_stats.m_iTraceRcvLoss = m_stats.m_iTraceRetrans = m_stats.m_iSentACK = m_stats.m_iRecvACK = m_stats.m_iSentNAK = m_stats.m_iRecvNAK = 0;
-      m_stats.m_llSndDuration = 0;
-      m_stats.m_iTraceRcvRetrans = 0;
-      m_stats.m_iTraceRcvBelated = 0;
+      m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans = m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
+      m_stats.sndDuration = 0;
+      m_stats.traceRcvRetrans = 0;
+      m_stats.traceRcvBelated = 0;
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-      m_stats.m_ullTraceRcvBytesLoss = 0;
+      m_stats.traceRcvBytesLoss = 0;
 #endif
-      m_stats.m_LastSampleTime = currtime;
+      m_stats.lastSampleTime = currtime;
    }
 }
 
@@ -6187,7 +6187,7 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
                 m_Smoother->updateBandwidth(0, withOverhead(inputbw)); //Bytes/sec
 
             CGuard::enterCS(m_StatsLock);
-            if ((m_stats.m_llSentTotal > SND_INPUTRATE_MAX_PACKETS) && (period < SND_INPUTRATE_RUNNING_US))
+            if ((m_stats.sentTotal > SND_INPUTRATE_MAX_PACKETS) && (period < SND_INPUTRATE_RUNNING_US))
                 m_pSndBuffer->setInputRateSmpPeriod(SND_INPUTRATE_RUNNING_US); //1 sec period after fast start
             CGuard::leaveCS(m_StatsLock);
         }
@@ -6323,7 +6323,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
    CTimer::rdtsc(currtime_tk);
 
    CGuard::enterCS(m_StatsLock);
-   ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+   ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
    CGuard::leaveCS(m_StatsLock);
 
    int nbsent = 0;
@@ -6494,7 +6494,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
 
          ctrlpkt.m_iID = m_PeerID;
          CGuard::enterCS(m_StatsLock);
-         ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+         ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
          CGuard::leaveCS(m_StatsLock);
          nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
          DebugAck("sendCtrl: " + CONID(), local_prevack, ack);
@@ -6502,8 +6502,8 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
          m_ACKWindow.store(m_iAckSeqNo, m_iRcvLastAck);
 
          CGuard::enterCS(m_StatsLock);
-         ++ m_stats.m_iSentACK;
-         ++ m_stats.m_iSentACKTotal;
+         ++ m_stats.sentACK;
+         ++ m_stats.sentACKTotal;
          CGuard::leaveCS(m_StatsLock);
       }
       CGuard::leaveCS(m_AckLock);
@@ -6531,8 +6531,8 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
               nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
               CGuard::enterCS(m_StatsLock);
-              ++ m_stats.m_iSentNAK;
-              ++ m_stats.m_iSentNAKTotal;
+              ++ m_stats.sentNAK;
+              ++ m_stats.sentNAKTotal;
               CGuard::leaveCS(m_StatsLock);
           }
           // Call with no arguments - get loss list from internal data.
@@ -6552,8 +6552,8 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
                   nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
                   CGuard::enterCS(m_StatsLock);
-                  ++ m_stats.m_iSentNAK;
-                  ++ m_stats.m_iSentNAKTotal;
+                  ++ m_stats.sentNAK;
+                  ++ m_stats.sentNAKTotal;
                   CGuard::leaveCS(m_StatsLock);
               }
 
@@ -6739,9 +6739,9 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
           int64_t currtime = currtime_tk/m_ullCPUFrequency;
           // record total time used for sending
           CGuard::enterCS(m_StatsLock);
-          m_stats.m_llSndDuration += currtime - m_stats.m_llSndDurationCounter;
-          m_stats.m_llSndDurationTotal += currtime - m_stats.m_llSndDurationCounter;
-          m_stats.m_llSndDurationCounter = currtime;
+          m_stats.sndDuration += currtime - m_stats.sndDurationCounter;
+          m_stats.m_sndDurationTotal += currtime - m_stats.sndDurationCounter;
+          m_stats.sndDurationCounter = currtime;
           CGuard::leaveCS(m_StatsLock);
 
           HLOGC(mglog.Debug, log << CONID() << "ACK covers: " << m_iSndLastDataAck << " - " << ack
@@ -6890,8 +6890,8 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
       updateCC(TEV_ACK, ack);
 
       CGuard::enterCS(m_StatsLock);
-      ++ m_stats.m_iRecvACK;
-      ++ m_stats.m_iRecvACKTotal;
+      ++ m_stats.recvACK;
+      ++ m_stats.recvACKTotal;
       CGuard::leaveCS(m_StatsLock);
 
       break;
@@ -6985,8 +6985,8 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
             }
 
             CGuard::enterCS(m_StatsLock);
-            m_stats.m_iTraceSndLoss += num;
-            m_stats.m_iSndLossTotal += num;
+            m_stats.traceSndLoss += num;
+            m_stats.sndLossTotal += num;
             CGuard::leaveCS(m_StatsLock);
 
          }
@@ -7005,8 +7005,8 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
             int num = m_pSndLossList->insert(losslist[i], losslist[i]);
 
             CGuard::enterCS(m_StatsLock);
-            m_stats.m_iTraceSndLoss += num;
-            m_stats.m_iSndLossTotal += num;
+            m_stats.traceSndLoss += num;
+            m_stats.sndLossTotal += num;
             CGuard::leaveCS(m_StatsLock);
          }
       }
@@ -7025,8 +7025,8 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
       m_pSndQueue->m_pSndUList->update(this, CSndUList::DO_RESCHEDULE);
 
       CGuard::enterCS(m_StatsLock);
-      ++ m_stats.m_iRecvNAK;
-      ++ m_stats.m_iRecvNAKTotal;
+      ++ m_stats.recvNAK;
+      ++ m_stats.recvNAKTotal;
       CGuard::leaveCS(m_StatsLock);
 
       break;
@@ -7139,7 +7139,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
              CGuard::enterCS(m_StatsLock);
              uint64_t currtime_tk;
              CTimer::rdtsc(currtime_tk);
-             response.m_iTimeStamp = int(currtime_tk/m_ullCPUFrequency - m_stats.m_StartTime);
+             response.m_iTimeStamp = int(currtime_tk/m_ullCPUFrequency - m_stats.startTime);
              CGuard::leaveCS(m_StatsLock);
              int nbsent = m_pSndQueue->sendto(m_pPeerAddr, response);
              if (nbsent)
@@ -7391,10 +7391,10 @@ int CUDT::packData(CPacket& packet, uint64_t& ts_tk)
          return 0;
 
       CGuard::enterCS(m_StatsLock);
-      ++ m_stats.m_iTraceRetrans;
-      ++ m_stats.m_iRetransTotal;
-      m_stats.m_ullTraceBytesRetrans += payload;
-      m_stats.m_ullBytesRetransTotal += payload;
+      ++ m_stats.traceRetrans;
+      ++ m_stats.retransTotal;
+      m_stats.traceBytesRetrans += payload;
+      m_stats.bytesRetransTotal += payload;
       CGuard::leaveCS(m_StatsLock);
 
       // Kinda confusion here. Despite the contextual interpretation of packet.m_iMsgNo around
@@ -7464,14 +7464,14 @@ int CUDT::packData(CPacket& packet, uint64_t& ts_tk)
        * XXX Isn't it then better to not decrease it by m_StartTime? As long as it
        * doesn't screw up the start time on the other side.
        */
-      if (origintime >= m_stats.m_StartTime)
-         packet.m_iTimeStamp = int(origintime - m_stats.m_StartTime);
+      if (origintime >= m_stats.startTime)
+         packet.m_iTimeStamp = int(origintime - m_stats.startTime);
       else
-         packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+         packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
    }
    else
    {
-       packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+       packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
    }
    CGuard::leaveCS(m_StatsLock);
 
@@ -7519,10 +7519,10 @@ int CUDT::packData(CPacket& packet, uint64_t& ts_tk)
    //m_pSndTimeWindow->onPktSent(packet.m_iTimeStamp);
 
    CGuard::enterCS(m_StatsLock);
-   m_stats.m_ullTraceBytesSent += payload;
-   m_stats.m_ullBytesSentTotal += payload;
-   ++ m_stats.m_llTraceSent;
-   ++ m_stats.m_llSentTotal;
+   m_stats.traceBytesSent += payload;
+   m_stats.bytesSentTotal += payload;
+   ++ m_stats.traceSent;
+   ++ m_stats.sentTotal;
    CGuard::leaveCS(m_StatsLock);
 
    if (probe)
@@ -7616,7 +7616,7 @@ int CUDT::processData(CUnit* unit)
    if ( pktrexmitflag == 1 ) // rexmitted
    {
        CGuard::enterCS(m_StatsLock);
-       m_stats.m_iTraceRcvRetrans++;
+       m_stats.traceRcvRetrans++;
        CGuard::leaveCS(m_StatsLock);
 
 #if ENABLE_HEAVY_LOGGING
@@ -7663,10 +7663,10 @@ int CUDT::processData(CUnit* unit)
       m_RcvTimeWindow.probe2Arrival(pktsz);
 
    CGuard::enterCS(m_StatsLock);
-   m_stats.m_ullTraceBytesRecv += pktsz;
-   m_stats.m_ullBytesRecvTotal += pktsz;
-   ++ m_stats.m_llTraceRecv;
-   ++ m_stats.m_llRecvTotal;
+   m_stats.traceBytesRecv += pktsz;
+   m_stats.bytesRecvTotal += pktsz;
+   ++ m_stats.traceRecv;
+   ++ m_stats.recvTotal;
    CGuard::leaveCS(m_StatsLock);
 
    {
@@ -7686,12 +7686,12 @@ int CUDT::processData(CUnit* unit)
           CGuard::enterCS(m_StatsLock);
           exc_type = "BELATED";
           excessive = true;
-          m_stats.m_iTraceRcvBelated++;
+          m_stats.traceRcvBelated++;
           uint64_t tsbpdtime = m_pRcvBuffer->getPktTsbPdTime(packet.getMsgTimeStamp());
           uint64_t bltime = CountIIR(
-                  uint64_t(m_stats.m_fTraceBelatedTime)*1000,
+                  uint64_t(m_stats.traceBelatedTime)*1000,
                   CTimer::getTime() - tsbpdtime, 0.2);
-          m_stats.m_fTraceBelatedTime = double(bltime)/1000.0;
+          m_stats.traceBelatedTime = double(bltime)/1000.0;
           CGuard::leaveCS(m_StatsLock);
       }
       else
@@ -7769,10 +7769,10 @@ int CUDT::processData(CUnit* unit)
                * It will be acknowledged
                */
               CGuard::enterCS(m_StatsLock);
-              m_stats.m_iTraceRcvUndecrypt += 1;
-              m_stats.m_ullTraceRcvBytesUndecrypt += pktsz;
-              m_stats.m_iRcvUndecryptTotal += 1;
-              m_stats.m_ullRcvBytesUndecryptTotal += pktsz;
+              m_stats.traceRcvUndecrypt += 1;
+              m_stats.traceRcvBytesUndecrypt += pktsz;
+              m_stats.m_rcvUndecryptTotal += 1;
+              m_stats.m_rcvBytesUndecryptTotal += pktsz;
               CGuard::leaveCS(m_StatsLock);
           }
       }
@@ -7846,11 +7846,11 @@ int CUDT::processData(CUnit* unit)
 
            CGuard::enterCS(m_StatsLock);
            int loss = CSeqNo::seqlen(m_iRcvCurrSeqNo, packet.m_iSeqNo) - 2;
-           m_stats.m_iTraceRcvLoss += loss;
-           m_stats.m_iRcvLossTotal += loss;
+           m_stats.traceRcvLoss += loss;
+           m_stats.rcvLossTotal += loss;
            uint64_t lossbytes = loss * m_pRcvBuffer->getRcvAvgPayloadSize();
-           m_stats.m_ullTraceRcvBytesLoss += lossbytes;
-           m_stats.m_ullRcvBytesLossTotal += lossbytes;
+           m_stats.traceRcvBytesLoss += lossbytes;
+           m_stats.rcvBytesLossTotal += lossbytes;
            CGuard::leaveCS(m_StatsLock);
        }
 
@@ -7965,7 +7965,7 @@ int CUDT::processData(CUnit* unit)
            {
                m_iReorderTolerance--;
                CGuard::enterCS(m_StatsLock);
-               m_stats.m_iTraceReorderDistance--;
+               m_stats.traceReorderDistance--;
                CGuard::leaveCS(m_StatsLock);
                HLOGF(mglog.Debug,  "ORDERED DELIVERY of 50 packets in a row - decreasing tolerance to %d", m_iReorderTolerance);
            }
@@ -8015,7 +8015,7 @@ void CUDT::unlose(const CPacket& packet)
 
             int seqdiff = abs(CSeqNo::seqcmp(m_iRcvCurrSeqNo, packet.m_iSeqNo));
             CGuard::enterCS(m_StatsLock);
-            m_stats.m_iTraceReorderDistance = max(seqdiff, m_stats.m_iTraceReorderDistance);
+            m_stats.traceReorderDistance = max(seqdiff, m_stats.traceReorderDistance);
             CGuard::leaveCS(m_StatsLock);
             if ( seqdiff > m_iReorderTolerance )
             {
@@ -8123,7 +8123,7 @@ breakbreak: ;
                 {
                     m_iReorderTolerance--;
                     CGuard::enterCS(m_StatsLock);
-                    m_stats.m_iTraceReorderDistance--;
+                    m_stats.traceReorderDistance--;
                     CGuard::leaveCS(m_StatsLock);
                     HLOGF(mglog.Debug, "... reached %d times - decreasing tolerance to %d", m_iConsecEarlyDelivery, m_iReorderTolerance);
                 }
@@ -8196,7 +8196,7 @@ int32_t CUDT::bake(const sockaddr* addr, int32_t current_cookie, int correction)
                 clienthost, sizeof(clienthost), clientport, sizeof(clientport),
                 NI_NUMERICHOST|NI_NUMERICSERV);
         CGuard::enterCS(m_StatsLock);
-        int64_t timestamp = ((CTimer::getTime() - m_stats.m_StartTime) / 60000000) + distractor - correction; // secret changes every one minute
+        int64_t timestamp = ((CTimer::getTime() - m_stats.startTime) / 60000000) + distractor - correction; // secret changes every one minute
         CGuard::leaveCS(m_StatsLock);
         stringstream cookiestr;
         cookiestr << clienthost << ":" << clientport << ":" << timestamp;
@@ -8337,7 +8337,7 @@ int CUDT::processConnectRequest(const sockaddr* addr, CPacket& packet)
       size_t size = packet.getLength();
       hs.store_to(packet.m_pcData, Ref(size));
       CGuard::enterCS(m_StatsLock);
-      packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+      packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
       CGuard::leaveCS(m_StatsLock);
       m_pSndQueue->sendto(addr, packet);
       return URQ_INDUCTION;
@@ -8410,7 +8410,7 @@ int CUDT::processConnectRequest(const sockaddr* addr, CPacket& packet)
        hs.store_to(packet.m_pcData, Ref(size));
        packet.m_iID = id;
        CGuard::enterCS(m_StatsLock);
-       packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+       packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
        CGuard::leaveCS(m_StatsLock);
        m_pSndQueue->sendto(addr, packet);
    }
@@ -8460,7 +8460,7 @@ int CUDT::processConnectRequest(const sockaddr* addr, CPacket& packet)
            hs.store_to(packet.m_pcData, Ref(size));
            packet.m_iID = id;
            CGuard::enterCS(m_StatsLock);
-           packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.m_StartTime);
+           packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
            CGuard::leaveCS(m_StatsLock);
            m_pSndQueue->sendto(addr, packet);
        }
@@ -8639,8 +8639,8 @@ void CUDT::checkTimers()
                     int num = m_pSndLossList->insert(m_iSndLastAck, csn);
                     if (num > 0) {
                         CGuard::enterCS(m_StatsLock);
-                        m_stats.m_iTraceSndLoss += 1; // num;
-                        m_stats.m_iSndLossTotal += 1; // num;
+                        m_stats.traceSndLoss += 1; // num;
+                        m_stats.sndLossTotal += 1; // num;
                         CGuard::leaveCS(m_StatsLock);
 
                         HLOGC(mglog.Debug, log << CONID() << "ENFORCED LATEREXMIT by ACK-TMOUT (scheduling): " << CSeqNo::incseq(m_iSndLastAck) << "-" << csn
@@ -8711,8 +8711,8 @@ void CUDT::checkTimers()
 
                 if (num > 0) {
                     CGuard::enterCS(m_StatsLock);
-                    m_stats.m_iTraceSndLoss += 1; // num;
-                    m_stats.m_iSndLossTotal += 1; // num;
+                    m_stats.traceSndLoss += 1; // num;
+                    m_stats.sndLossTotal += 1; // num;
                     CGuard::leaveCS(m_StatsLock);
                 }
             }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -732,7 +732,7 @@ private: // Trace
         uint64_t m_ullRcvBytesDropTotal;
         int m_iRcvUndecryptTotal;
         uint64_t m_ullRcvBytesUndecryptTotal;
-        int64_t m_llSndDurationTotal;		// total real time for sending
+        int64_t m_llSndDurationTotal;                // total real time for sending
 
         uint64_t m_LastSampleTime;                   // last performance sample time
         int64_t m_llTraceSent;                       // number of packets sent in the last trace interval

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -615,8 +615,8 @@ private: // Sending related data
     CSndLossList* m_pSndLossList;                // Sender loss list
     CPktTimeWindow<16, 16> m_SndTimeWindow;            // Packet sending time window
 
-    volatile uint64_t m_ullInterval_tk;             // Inter-packet time, in CPU clock cycles
-    uint64_t m_ullTimeDiff_tk;                      // aggregate difference in inter-packet time
+    volatile uint64_t m_ullInterval_tk;          // Inter-packet time, in CPU clock cycles
+    uint64_t m_ullTimeDiff_tk;                   // aggregate difference in inter-packet time
 
     volatile int m_iFlowWindowSize;              // Flow control window size
     volatile double m_dCongestionWindow;         // congestion window size
@@ -629,30 +629,30 @@ private: // Sending related data
     int32_t m_iSndLastAck2;                      // Last ACK2 sent back
     uint64_t m_ullSndLastAck2Time;               // The time when last ACK2 was sent back
     int32_t m_iISN;                              // Initial Sequence Number
-    bool m_bPeerTsbPd;                            // Peer accept TimeStamp-Based Rx mode
-    bool m_bPeerTLPktDrop;                        // Enable sender late packet dropping
-    bool m_bPeerNakReport;                    // Sender's peer (receiver) issues Periodic NAK Reports
-    bool m_bPeerRexmitFlag;                   // Receiver supports rexmit flag in payload packets
+    bool m_bPeerTsbPd;                           // Peer accept TimeStamp-Based Rx mode
+    bool m_bPeerTLPktDrop;                       // Enable sender late packet dropping
+    bool m_bPeerNakReport;                       // Sender's peer (receiver) issues Periodic NAK Reports
+    bool m_bPeerRexmitFlag;                      // Receiver supports rexmit flag in payload packets
     int32_t m_iReXmitCount;                      // Re-Transmit Count since last ACK
 
 private: // Receiving related data
-    CRcvBuffer* m_pRcvBuffer;               //< Receiver buffer
-    CRcvLossList* m_pRcvLossList;           //< Receiver loss list
-    std::deque<CRcvFreshLoss> m_FreshLoss;  //< Lost sequence already added to m_pRcvLossList, but not yet sent UMSG_LOSSREPORT for.
-    int m_iReorderTolerance;                //< Current value of dynamic reorder tolerance
-    int m_iMaxReorderTolerance;             //< Maximum allowed value for dynamic reorder tolerance
-    int m_iConsecEarlyDelivery;             //< Increases with every OOO packet that came <TTL-2 time, resets with every increased reorder tolerance
-    int m_iConsecOrderedDelivery;           //< Increases with every packet coming in order or retransmitted, resets with every out-of-order packet
+    CRcvBuffer* m_pRcvBuffer;                    //< Receiver buffer
+    CRcvLossList* m_pRcvLossList;                //< Receiver loss list
+    std::deque<CRcvFreshLoss> m_FreshLoss;       //< Lost sequence already added to m_pRcvLossList, but not yet sent UMSG_LOSSREPORT for.
+    int m_iReorderTolerance;                     //< Current value of dynamic reorder tolerance
+    int m_iMaxReorderTolerance;                  //< Maximum allowed value for dynamic reorder tolerance
+    int m_iConsecEarlyDelivery;                  //< Increases with every OOO packet that came <TTL-2 time, resets with every increased reorder tolerance
+    int m_iConsecOrderedDelivery;                //< Increases with every packet coming in order or retransmitted, resets with every out-of-order packet
 
-    CACKWindow<1024> m_ACKWindow;             //< ACK history window
-    CPktTimeWindow<16, 64> m_RcvTimeWindow;   //< Packet arrival time window
+    CACKWindow<1024> m_ACKWindow;                //< ACK history window
+    CPktTimeWindow<16, 64> m_RcvTimeWindow;      //< Packet arrival time window
 
     int32_t m_iRcvLastAck;                       //< Last sent ACK
 #ifdef ENABLE_LOGGING
     int32_t m_iDebugPrevLastAck;
 #endif
     int32_t m_iRcvLastSkipAck;                   // Last dropped sequence ACK
-    uint64_t m_ullLastAckTime_tk;                   // Timestamp of last ACK
+    uint64_t m_ullLastAckTime_tk;                // Timestamp of last ACK
     int32_t m_iRcvLastAckAck;                    // Last sent ACK that has been acknowledged
     int32_t m_iAckSeqNo;                         // Last ACK sequence number
     int32_t m_iRcvCurrSeqNo;                     // Largest received sequence number
@@ -666,7 +666,7 @@ private: // Receiving related data
     uint32_t m_lMinimumPeerSrtVersion;
     uint32_t m_lPeerSrtVersion;
 
-    bool m_bTsbPd;                            // Peer sends TimeStamp-Based Packet Delivery Packets 
+    bool m_bTsbPd;                               // Peer sends TimeStamp-Based Packet Delivery Packets 
     pthread_t m_RcvTsbPdThread;                  // Rcv TsbPD Thread handle
     pthread_cond_t m_RcvTsbPdCond;
     bool m_bTsbPdAckWakeup;                      // Signal TsbPd thread on Ack sent
@@ -712,54 +712,54 @@ private: // Trace
 
     struct CoreStats
     {
-        uint64_t m_StartTime;                        // timestamp when the UDT entity is started
-        int64_t m_llSentTotal;                       // total number of sent data packets, including retransmissions
-        int64_t m_llRecvTotal;                       // total number of received packets
-        int m_iSndLossTotal;                         // total number of lost packets (sender side)
-        int m_iRcvLossTotal;                         // total number of lost packets (receiver side)
-        int m_iRetransTotal;                         // total number of retransmitted packets
-        int m_iSentACKTotal;                         // total number of sent ACK packets
-        int m_iRecvACKTotal;                         // total number of received ACK packets
-        int m_iSentNAKTotal;                         // total number of sent NAK packets
-        int m_iRecvNAKTotal;                         // total number of received NAK packets
-        int m_iSndDropTotal;
-        int m_iRcvDropTotal;
-        uint64_t m_ullBytesSentTotal;                // total number of bytes sent,  including retransmissions
-        uint64_t m_ullBytesRecvTotal;                // total number of received bytes
-        uint64_t m_ullRcvBytesLossTotal;             // total number of loss bytes (estimate)
-        uint64_t m_ullBytesRetransTotal;             // total number of retransmitted bytes
-        uint64_t m_ullSndBytesDropTotal;
-        uint64_t m_ullRcvBytesDropTotal;
-        int m_iRcvUndecryptTotal;
-        uint64_t m_ullRcvBytesUndecryptTotal;
-        int64_t m_llSndDurationTotal;                // total real time for sending
+        uint64_t startTime;                 // timestamp when the UDT entity is started
+        int64_t sentTotal;                  // total number of sent data packets, including retransmissions
+        int64_t recvTotal;                  // total number of received packets
+        int sndLossTotal;                   // total number of lost packets (sender side)
+        int rcvLossTotal;                   // total number of lost packets (receiver side)
+        int retransTotal;                   // total number of retransmitted packets
+        int sentACKTotal;                   // total number of sent ACK packets
+        int recvACKTotal;                   // total number of received ACK packets
+        int sentNAKTotal;                   // total number of sent NAK packets
+        int recvNAKTotal;                   // total number of received NAK packets
+        int sndDropTotal;
+        int rcvDropTotal;
+        uint64_t bytesSentTotal;            // total number of bytes sent,  including retransmissions
+        uint64_t bytesRecvTotal;            // total number of received bytes
+        uint64_t rcvBytesLossTotal;         // total number of loss bytes (estimate)
+        uint64_t bytesRetransTotal;         // total number of retransmitted bytes
+        uint64_t sndBytesDropTotal;
+        uint64_t rcvBytesDropTotal;
+        int m_rcvUndecryptTotal;
+        uint64_t m_rcvBytesUndecryptTotal;
+        int64_t m_sndDurationTotal;         // total real time for sending
 
-        uint64_t m_LastSampleTime;                   // last performance sample time
-        int64_t m_llTraceSent;                       // number of packets sent in the last trace interval
-        int64_t m_llTraceRecv;                       // number of packets received in the last trace interval
-        int m_iTraceSndLoss;                         // number of lost packets in the last trace interval (sender side)
-        int m_iTraceRcvLoss;                         // number of lost packets in the last trace interval (receiver side)
-        int m_iTraceRetrans;                         // number of retransmitted packets in the last trace interval
-        int m_iSentACK;                              // number of ACKs sent in the last trace interval
-        int m_iRecvACK;                              // number of ACKs received in the last trace interval
-        int m_iSentNAK;                              // number of NAKs sent in the last trace interval
-        int m_iRecvNAK;                              // number of NAKs received in the last trace interval
-        int m_iTraceSndDrop;
-        int m_iTraceRcvDrop;
-        int m_iTraceRcvRetrans;
-        int m_iTraceReorderDistance;
-        double m_fTraceBelatedTime;
-        int64_t m_iTraceRcvBelated;
-        uint64_t m_ullTraceBytesSent;                // number of bytes sent in the last trace interval
-        uint64_t m_ullTraceBytesRecv;                // number of bytes sent in the last trace interval
-        uint64_t m_ullTraceRcvBytesLoss;             // number of bytes bytes lost in the last trace interval (estimate)
-        uint64_t m_ullTraceBytesRetrans;             // number of bytes retransmitted in the last trace interval
-        uint64_t m_ullTraceSndBytesDrop;
-        uint64_t m_ullTraceRcvBytesDrop;
-        int m_iTraceRcvUndecrypt;
-        uint64_t m_ullTraceRcvBytesUndecrypt;
-        int64_t m_llSndDuration;			// real time for sending
-        int64_t m_llSndDurationCounter;		// timers to record the sending duration
+        uint64_t lastSampleTime;            // last performance sample time
+        int64_t traceSent;                  // number of packets sent in the last trace interval
+        int64_t traceRecv;                  // number of packets received in the last trace interval
+        int traceSndLoss;                   // number of lost packets in the last trace interval (sender side)
+        int traceRcvLoss;                   // number of lost packets in the last trace interval (receiver side)
+        int traceRetrans;                   // number of retransmitted packets in the last trace interval
+        int sentACK;                        // number of ACKs sent in the last trace interval
+        int recvACK;                        // number of ACKs received in the last trace interval
+        int sentNAK;                        // number of NAKs sent in the last trace interval
+        int recvNAK;                        // number of NAKs received in the last trace interval
+        int traceSndDrop;
+        int traceRcvDrop;
+        int traceRcvRetrans;
+        int traceReorderDistance;
+        double traceBelatedTime;
+        int64_t traceRcvBelated;
+        uint64_t traceBytesSent;            // number of bytes sent in the last trace interval
+        uint64_t traceBytesRecv;            // number of bytes sent in the last trace interval
+        uint64_t traceRcvBytesLoss;         // number of bytes bytes lost in the last trace interval (estimate)
+        uint64_t traceBytesRetrans;         // number of bytes retransmitted in the last trace interval
+        uint64_t traceSndBytesDrop;
+        uint64_t traceRcvBytesDrop;
+        int traceRcvUndecrypt;
+        uint64_t traceRcvBytesUndecrypt;
+        int64_t sndDuration;                // real time for sending
+        int64_t sndDurationCounter;         // timers to record the sending duration
     } m_stats;
 
 public:
@@ -772,10 +772,10 @@ public:
 
 private: // Timers
     uint64_t m_ullCPUFrequency;               // CPU clock frequency, used for Timer, ticks per microsecond
-    uint64_t m_ullNextACKTime_tk;			  // Next ACK time, in CPU clock cycles, same below
-    uint64_t m_ullNextNAKTime_tk;			  // Next NAK time
+    uint64_t m_ullNextACKTime_tk;             // Next ACK time, in CPU clock cycles, same below
+    uint64_t m_ullNextNAKTime_tk;             // Next NAK time
 
-    volatile uint64_t m_ullSYNInt_tk;		  // SYN interval
+    volatile uint64_t m_ullSYNInt_tk;         // SYN interval
     volatile uint64_t m_ullACKInt_tk;         // ACK interval
     volatile uint64_t m_ullNAKInt_tk;         // NAK interval
     volatile uint64_t m_ullLastRspTime_tk;    // time stamp of last response from the peer
@@ -784,10 +784,10 @@ private: // Timers
     uint64_t m_ullMinNakInt_tk;               // NAK timeout lower bound; too small value can cause unnecessary retransmission
     uint64_t m_ullMinExpInt_tk;               // timeout lower bound threshold: too small timeout can cause problem
 
-    int m_iPktCount;				// packet counter for ACK
-    int m_iLightACKCount;			// light ACK counter
+    int m_iPktCount;                          // packet counter for ACK
+    int m_iLightACKCount;                     // light ACK counter
 
-    uint64_t m_ullTargetTime_tk;			// scheduled time of next packet sending
+    uint64_t m_ullTargetTime_tk;              // scheduled time of next packet sending
 
     void checkTimers();
 
@@ -798,12 +798,12 @@ public: // For the use of CCryptoControl
 
 
 private: // for UDP multiplexer
-    CSndQueue* m_pSndQueue;			// packet sending queue
-    CRcvQueue* m_pRcvQueue;			// packet receiving queue
-    sockaddr* m_pPeerAddr;			// peer address
-    uint32_t m_piSelfIP[4];			// local UDP IP address
-    CSNode* m_pSNode;				// node information for UDT list used in snd queue
-    CRNode* m_pRNode;                            // node information for UDT list used in rcv queue
+    CSndQueue* m_pSndQueue;         // packet sending queue
+    CRcvQueue* m_pRcvQueue;         // packet receiving queue
+    sockaddr* m_pPeerAddr;          // peer address
+    uint32_t m_piSelfIP[4];         // local UDP IP address
+    CSNode* m_pSNode;               // node information for UDT list used in snd queue
+    CRNode* m_pRNode;               // node information for UDT list used in rcv queue
 
 public: // For smoother
     const CSndQueue* sndQueue() { return m_pSndQueue; }


### PR DESCRIPTION
Statistics, which is obtained through `srt_bstats()`, has no thread lock. The implication was that `srt_bstats()` locks the receiving thread, thereby achieving the sustainability of the data. But the sending stream is not blocked during a call to `srt_bstats()`. Therefore, in some situations, statistics for sent packets, bytes, etc. may not be reset. A reset occurs in `srt_bstats()`, if at this time another thread increases the value of the variables, then a reset will not succeed.
- [core] Added core statistics access mutex 
- [apps] Fixed stats clearing condition
- [core] Renamed internal stats variables