### PR TITLE
[apps] Receive the connection event on the client (caller) socket

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -395,7 +395,7 @@ int main( int argc, char** argv )
 
             int srtrfdslen = 2;
             int srtwfdslen = 2;
-            SRTSOCKET srtrwfds[4] = {};
+            SRTSOCKET srtrwfds[4] = {SRT_INVALID_SOCK, SRT_INVALID_SOCK , SRT_INVALID_SOCK , SRT_INVALID_SOCK };
             int sysrfdslen = 2;
             SYSSOCKET sysrfds[2];
             if (srt_epoll_wait(pollid,
@@ -412,10 +412,10 @@ int main( int argc, char** argv )
                 }
 
                 bool doabort = false;
-                for (int i = 0; i < sizeof(srtrwfds) / sizeof(SRTSOCKET); i++)
+                for (size_t i = 0; i < sizeof(srtrwfds) / sizeof(SRTSOCKET); i++)
                 {
                     SRTSOCKET s = srtrwfds[i];
-                    if (s == NULL)
+                    if (s == SRT_INVALID_SOCK)
                         continue;
 
                     bool issource = false;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -371,7 +371,7 @@ int main( int argc, char** argv )
                 }
 
                 // IN because we care for state transitions only
-                // ON - to ckeck the connection state changes
+                // ON - to check the connection state changes
                 int events = SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR;
                 switch(tar->uri.type())
                 {
@@ -419,11 +419,11 @@ int main( int argc, char** argv )
                         continue;
 
                     bool issource = false;
-                    if (src->GetSRTSocket() == s)
+                    if (src && src->GetSRTSocket() == s)
                     {
                         issource = true;
                     }
-                    else if (tar->GetSRTSocket() != s)
+                    else if (tar && tar->GetSRTSocket() != s)
                     {
                         cerr << "Unexpected socket poll: " << s;
                         doabort = true;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -371,7 +371,7 @@ int main( int argc, char** argv )
                 }
 
                 // IN because we care for state transitions only
-                // ON - to check the connection state changes
+                // OUT - to check the connection state changes
                 int events = SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR;
                 switch(tar->uri.type())
                 {
@@ -535,6 +535,18 @@ int main( int argc, char** argv )
                                 if (!quiet)
                                     cerr << "SRT target connected" << endl;
                                 tarConnected = true;
+                                if (tar->uri.type() == UriParser::SRT)
+                                {
+                                    const int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+                                    // Disable OUT event polling when connected
+                                    if (srt_epoll_update_usock(pollid,
+                                        tar->GetSRTSocket(), &events))
+                                    {
+                                        cerr << "Failed to add SRT destination to poll, "
+                                            << tar->GetSRTSocket() << endl;
+                                        return 1;
+                                    }
+                                }
                             }
                         }
 


### PR DESCRIPTION
The fix makes it possible to receive the connection event on the client (caller) socket. The following conditions have to be met:

- The epoll should have `SRT_EPOLL_OUT` flag set.
- When you call `srt_epoll_wait(...)`, the `writefds` argument has to be passed.

Fixes #410 