### PR TITLE
Fix OSX Builds SDK pre 10.8.

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -219,7 +219,9 @@ void CChannel::setUDPSockOpt()
          }
          else //Assuming AF_INET6
          {
+#ifdef IPV6_TCLASS
             if(0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (const char*)&m_iIpToS, sizeof(m_iIpToS)))
+#endif
                throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
          }
       }
@@ -309,7 +311,9 @@ int CChannel::getIpToS() const
    }
    else
    {
+#ifdef IPV6_TCLASS
       ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (char *)&m_iIpToS, &size);
+#endif
    }
    return m_iIpToS;
 }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7856,15 +7856,7 @@ int CUDT::processData(CUnit* unit)
    }
    if ( !lossdata.empty() )
    {
-       sendCtrl(UMSG_LOSSREPORT, NULL,
-#if (__cplusplus >= 201103L)
-           // ::std::vector<>.data() is c++11.
-           lossdata.data(),
-#else
-           // This is portable.
-           &lossdata[0],
-#endif
-           lossdata.size());
+       sendCtrl(UMSG_LOSSREPORT, NULL, &lossdata[0], lossdata.size());
    }
 
    // This is not a regular fixed size packet...

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7855,7 +7855,17 @@ int CUDT::processData(CUnit* unit)
 
    }
    if ( !lossdata.empty() )
-       sendCtrl(UMSG_LOSSREPORT, NULL, lossdata.data(), lossdata.size());
+   {
+       sendCtrl(UMSG_LOSSREPORT, NULL,
+#if (__cplusplus >= 201103L)
+           // ::std::vector<>.data() is c++11.
+           lossdata.data(),
+#else
+           // This is portable.
+           &lossdata[0],
+#endif
+           lossdata.size());
+   }
 
    // This is not a regular fixed size packet...
    // an irregular sized packet usually indicates the end of a message, so send an ACK immediately


### PR DESCRIPTION
This fixes OSX Builds for SDK pre 10.8 which does not support C++11 and some IPV6 features. Tested with my application using OpenSRT on iBookG4 on OSX-10.5 and PowerBook on OSX-10.7. Works with and without encryption.