### PR TITLE
Add SRTO_IPV6ONLY option

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -508,9 +508,9 @@ int main( int argc, char** argv )
                                 // force re-connection
                                 srt_epoll_remove_usock(pollid, s);
                                 if (issource)
-                                    src.release();
+                                    src.reset();
                                 else
-                                    tar.release();
+                                    tar.reset();
                             }
                         }
                         break;

--- a/docs/API.md
+++ b/docs/API.md
@@ -471,6 +471,16 @@ regular development.*
 - *Sender: user configurable, default: 64*
 ---
 
+| OptName           | Since | Binding | Type  | Units | Default            | Range |
+| ----------------- | ----- | ------- | ----- | ----- | ------------------ | ------|
+| `SRTO_IPV6ONLY`   | 1.4.0 | pre     | `int` | n/a   | (platform default) | -1..1 |
+
+- **[GET or SET]** - Set system socket flag IPV6ONLY. When set to 0 a listening
+socket binding an IPv6 address accepts also IPv4 clients (their addresses will be 
+formatted as IPv4-mapped IPv6 addresses). By default (-1) this option is not set 
+and the platform default value is used.
+---
+
 | OptName               | Since | Binding | Type      | Units  | Default  | Range  |
 | --------------------- | ----- | ------- | --------- | ------ | -------- | ------ |
 | `SRTO_KMSTATE`        | 1.0.2 | n/a     | `int32_t` |        | n/a      | n/a    |

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1654,6 +1654,7 @@ void CUDTUnited::updateMux(
             &&  (i->second.m_iIpTTL == s->m_pUDT->m_iIpTTL)
             && (i->second.m_iIpToS == s->m_pUDT->m_iIpToS)
 #endif
+            && (i->second.m_iIpV6Only == s->m_pUDT->m_iIpV6Only)
             &&  i->second.m_bReusable)
          {
             if (i->second.m_iPort == port)
@@ -1680,6 +1681,7 @@ void CUDTUnited::updateMux(
    m.m_iIpToS = s->m_pUDT->m_iIpToS;
 #endif
    m.m_iRefCount = 1;
+   m.m_iIpV6Only = s->m_pUDT->m_iIpV6Only;
    m.m_bReusable = s->m_pUDT->m_bReuseAddr;
    m.m_iID = s->m_SocketID;
 
@@ -1690,7 +1692,8 @@ void CUDTUnited::updateMux(
 #endif
    m.m_pChannel->setSndBufSize(s->m_pUDT->m_iUDPSndBufSize);
    m.m_pChannel->setRcvBufSize(s->m_pUDT->m_iUDPRcvBufSize);
-   m.m_pChannel->setIpV6Only(s->m_pUDT->m_bIpV6Only);
+   if (s->m_pUDT->m_iIpV6Only != -1)
+      m.m_pChannel->setIpV6Only(s->m_pUDT->m_iIpV6Only);
 
    try
    {

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1691,6 +1691,7 @@ void CUDTUnited::updateMux(
 #endif
    m.m_pChannel->setSndBufSize(s->m_pUDT->m_iUDPSndBufSize);
    m.m_pChannel->setRcvBufSize(s->m_pUDT->m_iUDPRcvBufSize);
+   m.m_pChannel->setIpV6Only(s->m_pUDT->m_bIpV6Only);
 
    try
    {

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -140,8 +140,8 @@ void CChannel::open(const sockaddr* addr)
    #endif
       throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
 
-   if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)(&m_bIpV6Only), sizeof(m_bIpV6Only)))
-      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+   if (m_iIPversion == AF_INET6) // (not an error if it fails)
+      ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)(&m_bIpV6Only), sizeof(m_bIpV6Only));
 
    if (NULL != addr)
    {

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -292,7 +292,7 @@ void CChannel::setRcvBufSize(int size)
    m_iRcvBufSize = size;
 }
 
-void CChannel::setIpV6Only(bool ipV6Only) 
+void CChannel::setIpV6Only(int ipV6Only) 
 {
    m_iIpV6Only = ipV6Only;
 }

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -104,7 +104,8 @@ m_iIpTTL(-1),   /* IPv4 TTL or IPv6 HOPs [1..255] (-1:undefined) */
 m_iIpToS(-1),   /* IPv4 Type of Service or IPv6 Traffic Class [0x00..0xff] (-1:undefined) */
 #endif
 m_iSndBufSize(65536),
-m_iRcvBufSize(65536)
+m_iRcvBufSize(65536),
+m_bIpV6Only(1)
 {
 }
 
@@ -117,6 +118,7 @@ m_iIpToS(-1),
 #endif
 m_iSndBufSize(65536),
 m_iRcvBufSize(65536),
+m_bIpV6Only(1),
 m_BindAddr(version)
 {
    m_iSockAddrSize = (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6);
@@ -137,6 +139,9 @@ void CChannel::open(const sockaddr* addr)
       if (m_iSocket < 0)
    #endif
       throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
+
+   if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)(&m_bIpV6Only), sizeof(m_bIpV6Only)))
+      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 
    if (NULL != addr)
    {
@@ -196,7 +201,7 @@ void CChannel::setUDPSockOpt()
       if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*)&m_iRcvBufSize, sizeof(int))) ||
           (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*)&m_iSndBufSize, sizeof(int))))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-   #endif
+   #endif	  
 
 #ifdef SRT_ENABLE_IPOPTS
       if (-1 != m_iIpTTL)
@@ -285,6 +290,11 @@ void CChannel::setSndBufSize(int size)
 void CChannel::setRcvBufSize(int size)
 {
    m_iRcvBufSize = size;
+}
+
+void CChannel::setIpV6Only(bool ipV6Only) 
+{
+   m_bIpV6Only = ipV6Only;
 }
 
 #ifdef SRT_ENABLE_IPOPTS

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -103,7 +103,7 @@ m_iIpToS(-1),   /* IPv4 Type of Service or IPv6 Traffic Class [0x00..0xff] (-1:u
 #endif
 m_iSndBufSize(65536),
 m_iRcvBufSize(65536),
-m_bIpV6Only(false)
+m_iIpV6Only(-1)
 {
 }
 
@@ -116,7 +116,7 @@ m_iIpToS(-1),
 #endif
 m_iSndBufSize(65536),
 m_iRcvBufSize(65536),
-m_bIpV6Only(false),
+m_iIpV6Only(-1),
 m_BindAddr(version)
 {
    m_iSockAddrSize = (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6);
@@ -138,8 +138,8 @@ void CChannel::open(const sockaddr* addr)
    #endif
       throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
 
-   if (m_iIPversion == AF_INET6) // (not an error if it fails)
-      ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)(&m_bIpV6Only), sizeof(m_bIpV6Only));
+   if ((m_iIpV6Only != -1) && (m_iIPversion == AF_INET6)) // (not an error if it fails)
+      ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)(&m_iIpV6Only), sizeof(m_iIpV6Only));
 
    if (NULL != addr)
    {
@@ -294,7 +294,7 @@ void CChannel::setRcvBufSize(int size)
 
 void CChannel::setIpV6Only(bool ipV6Only) 
 {
-   m_bIpV6Only = ipV6Only;
+   m_iIpV6Only = ipV6Only;
 }
 
 #ifdef SRT_ENABLE_IPOPTS

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -366,7 +366,7 @@ void CChannel::getPeerAddr(sockaddr* addr) const
 
 int CChannel::sendto(const sockaddr* addr, CPacket& packet) const
 {
-#if ENABLE_LOGGING
+#if ENABLE_HEAVY_LOGGING
     std::ostringstream spec;
 
     if (packet.isControl())

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -103,7 +103,7 @@ m_iIpToS(-1),   /* IPv4 Type of Service or IPv6 Traffic Class [0x00..0xff] (-1:u
 #endif
 m_iSndBufSize(65536),
 m_iRcvBufSize(65536),
-m_bIpV6Only(1)
+m_bIpV6Only(false)
 {
 }
 
@@ -116,7 +116,7 @@ m_iIpToS(-1),
 #endif
 m_iSndBufSize(65536),
 m_iRcvBufSize(65536),
-m_bIpV6Only(1),
+m_bIpV6Only(false),
 m_BindAddr(version)
 {
    m_iSockAddrSize = (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6);
@@ -199,7 +199,7 @@ void CChannel::setUDPSockOpt()
       if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*)&m_iRcvBufSize, sizeof(int))) ||
           (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*)&m_iSndBufSize, sizeof(int))))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-   #endif	  
+   #endif
 
 #ifdef SRT_ENABLE_IPOPTS
       if (-1 != m_iIpTTL)

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -109,7 +109,7 @@ public:
    /// Set the IPV6ONLY option.
    /// @param [in] IPV6ONLY value.
 
-   void setIpV6Only(bool ipV6Only);
+   void setIpV6Only(int ipV6Only);
 
       /// Query the socket address that the channel is using.
       /// @param [out] addr pointer to store the returned socket address.

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -179,7 +179,7 @@ private:
 #endif
    int m_iSndBufSize;                   // UDP sending buffer size
    int m_iRcvBufSize;                   // UDP receiving buffer size
-   bool m_bIpV6Only;                    // IPV6_V6ONLY option
+   int m_iIpV6Only;                     // IPV6_V6ONLY option (-1 if not set)
    sockaddr_any m_BindAddr;
 };
 

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -106,8 +106,8 @@ public:
 
    void setRcvBufSize(int size);
 
-   /// Set the IPV6ONLY option.
-   /// @param [in] IPV6ONLY value.
+      /// Set the IPV6ONLY option.
+      /// @param [in] IPV6ONLY value.
 
    void setIpV6Only(int ipV6Only);
 

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -106,6 +106,11 @@ public:
 
    void setRcvBufSize(int size);
 
+   /// Set the IPV6ONLY option.
+   /// @param [in] IPV6ONLY value.
+
+   void setIpV6Only(bool ipV6Only);
+
       /// Query the socket address that the channel is using.
       /// @param [out] addr pointer to store the returned socket address.
 
@@ -174,6 +179,7 @@ private:
 #endif
    int m_iSndBufSize;                   // UDP sending buffer size
    int m_iRcvBufSize;                   // UDP receiving buffer size
+   bool m_bIpV6Only;                    // IPV6_V6ONLY option
    sockaddr_any m_BindAddr;
 };
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1127,7 +1127,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void* optval, int& optlen)
 
    case SRTO_IPV6ONLY:
       optlen = sizeof(int);
-	  *(int*)optval = m_iIpV6Only;
+      *(int*)optval = m_iIpV6Only;
       break;
 
    default:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -264,7 +264,7 @@ CUDT::CUDT()
    m_bTLPktDrop = true;         //Too-late Packet Drop
    m_bMessageAPI = true;
    m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
-   m_bIpV6Only = true;
+   m_iIpV6Only = -1;
    //Runtime
    m_bRcvNakReport = true;      //Receiver's Periodic NAK Reports
    m_llInputBW = 0;             // Application provided input bandwidth (internal input rate sampling == 0)
@@ -327,7 +327,7 @@ CUDT::CUDT(const CUDT& ancestor)
    m_zOPT_ExpPayloadSize = ancestor.m_zOPT_ExpPayloadSize;
    m_bTLPktDrop = ancestor.m_bTLPktDrop;
    m_bMessageAPI = ancestor.m_bMessageAPI;
-   m_bIpV6Only = ancestor.m_bIpV6Only;
+   m_iIpV6Only = ancestor.m_iIpV6Only;
    //Runtime
    m_bRcvNakReport = ancestor.m_bRcvNakReport;
 
@@ -850,7 +850,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
       if (m_bConnected)
          throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
       
-      m_bIpV6Only = bool_int_value(optval, optlen);
+      m_iIpV6Only = *(int*)optval;
       break;
 
     default:
@@ -1126,8 +1126,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void* optval, int& optlen)
       break;
 
    case SRTO_IPV6ONLY:
-      optlen = sizeof(int32_t);
-      *(int32_t*)optval = m_bIpV6Only;
+      optlen = sizeof(int);
+	  *(int*)optval = m_iIpV6Only;
       break;
 
    default:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -249,6 +249,7 @@ CUDT::CUDT()
    m_bTLPktDrop = true;         //Too-late Packet Drop
    m_bMessageAPI = true;
    m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
+   m_bIpV6Only = true;
    //Runtime
    m_bRcvNakReport = true;      //Receiver's Periodic NAK Reports
    m_llInputBW = 0;             // Application provided input bandwidth (internal input rate sampling == 0)
@@ -311,6 +312,7 @@ CUDT::CUDT(const CUDT& ancestor)
    m_zOPT_ExpPayloadSize = ancestor.m_zOPT_ExpPayloadSize;
    m_bTLPktDrop = ancestor.m_bTLPktDrop;
    m_bMessageAPI = ancestor.m_bMessageAPI;
+   m_bIpV6Only = ancestor.m_bIpV6Only;
    //Runtime
    m_bRcvNakReport = ancestor.m_bRcvNakReport;
 
@@ -829,6 +831,13 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         m_bOPT_StrictEncryption = bool_int_value(optval, optlen);
         break;
 
+   case SRTO_IPV6ONLY:
+	   if (m_bConnected)
+		   throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+
+	   m_bIpV6Only = bool_int_value(optval, optlen);
+	   break;
+
     default:
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
     }
@@ -1100,6 +1109,11 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void* optval, int& optlen)
       optlen = sizeof (int32_t); // also with TSBPDMODE and SENDER
       *(int32_t*)optval = m_bOPT_StrictEncryption;
       break;
+
+   case SRTO_IPV6ONLY:
+	   optlen = sizeof(int32_t);
+	   *(int32_t*)optval = m_bIpV6Only;
+	   break;
 
    default:
       throw CUDTException(MJ_NOTSUP, MN_NONE, 0);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -847,11 +847,11 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
    case SRTO_IPV6ONLY:
-	   if (m_bConnected)
-		   throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-
-	   m_bIpV6Only = bool_int_value(optval, optlen);
-	   break;
+      if (m_bConnected)
+         throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+      
+      m_bIpV6Only = bool_int_value(optval, optlen);
+      break;
 
     default:
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -1126,9 +1126,9 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void* optval, int& optlen)
       break;
 
    case SRTO_IPV6ONLY:
-	   optlen = sizeof(int32_t);
-	   *(int32_t*)optval = m_bIpV6Only;
-	   break;
+      optlen = sizeof(int32_t);
+      *(int32_t*)optval = m_bIpV6Only;
+      break;
 
    default:
       throw CUDTException(MJ_NOTSUP, MN_NONE, 0);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -573,7 +573,7 @@ private: // Identification
     int64_t m_llInputBW;                         // Input stream rate (bytes/sec)
     int m_iOverheadBW;                           // Percent above input stream rate (applies if m_llMaxBW == 0)
     bool m_bRcvNakReport;                        // Enable Receiver Periodic NAK Reports
-    bool m_bIpV6Only;                            // IPV6_V6ONLY option
+    int m_iIpV6Only;                             // IPV6_V6ONLY option (-1 if not set)
 private:
     UniquePtr<CCryptoControl> m_pCryptoControl;                            // congestion control SRT class (small data extension)
     CCache<CInfoBlock>* m_pCache;                // network information cache

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -568,6 +568,8 @@ private: // Identification
     int64_t m_llInputBW;                         // Input stream rate (bytes/sec)
     int m_iOverheadBW;                           // Percent above input stream rate (applies if m_llMaxBW == 0)
     bool m_bRcvNakReport;                        // Enable Receiver Periodic NAK Reports
+
+	bool m_bIpV6Only;                // IPV6_V6ONLY option
 private:
     UniquePtr<CCryptoControl> m_pCryptoControl;                            // congestion control SRT class (small data extension)
     CCache<CInfoBlock>* m_pCache;                // network information cache

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -573,8 +573,7 @@ private: // Identification
     int64_t m_llInputBW;                         // Input stream rate (bytes/sec)
     int m_iOverheadBW;                           // Percent above input stream rate (applies if m_llMaxBW == 0)
     bool m_bRcvNakReport;                        // Enable Receiver Periodic NAK Reports
-
-	bool m_bIpV6Only;                // IPV6_V6ONLY option
+    bool m_bIpV6Only;                            // IPV6_V6ONLY option
 private:
     UniquePtr<CCryptoControl> m_pCryptoControl;                            // congestion control SRT class (small data extension)
     CCache<CInfoBlock>* m_pCache;                // network information cache

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -520,6 +520,7 @@ struct CMultiplexer
 #endif
    int m_iMSS;			// Maximum Segment Size
    int m_iRefCount;		// number of UDT instances that are associated with this multiplexer
+   int m_iIpV6Only;     // IPV6_V6ONLY option
    bool m_bReusable;		// if this one can be shared with others
 
    int m_iID;			// multiplexer ID

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -507,23 +507,23 @@ private:
 
 struct CMultiplexer
 {
-   CSndQueue* m_pSndQueue;	// The sending queue
-   CRcvQueue* m_pRcvQueue;	// The receiving queue
-   CChannel* m_pChannel;	// The UDP channel for sending and receiving
-   CTimer* m_pTimer;		// The timer
+   CSndQueue* m_pSndQueue;  // The sending queue
+   CRcvQueue* m_pRcvQueue;  // The receiving queue
+   CChannel* m_pChannel;    // The UDP channel for sending and receiving
+   CTimer* m_pTimer;        // The timer
 
-   int m_iPort;			// The UDP port number of this multiplexer
-   int m_iIPversion;		// IP version
+   int m_iPort;         // The UDP port number of this multiplexer
+   int m_iIPversion;    // IP version
 #ifdef SRT_ENABLE_IPOPTS
    int m_iIpTTL;
    int m_iIpToS;
 #endif
-   int m_iMSS;			// Maximum Segment Size
-   int m_iRefCount;		// number of UDT instances that are associated with this multiplexer
+   int m_iMSS;          // Maximum Segment Size
+   int m_iRefCount;     // number of UDT instances that are associated with this multiplexer
    int m_iIpV6Only;     // IPV6_V6ONLY option
-   bool m_bReusable;		// if this one can be shared with others
+   bool m_bReusable;    // if this one can be shared with others
 
-   int m_iID;			// multiplexer ID
+   int m_iID;           // multiplexer ID
 };
 
 #endif

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -180,6 +180,7 @@ typedef enum SRT_SOCKOPT {
     SRTO_KMREFRESHRATE,   // After sending how many packets the encryption key should be flipped to the new key
     SRTO_KMPREANNOUNCE,   // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
     SRTO_STRICTENC,       // Connection to be rejected or quickly broken when one side encryption set or bad password
+	SRTO_IPV6ONLY,        // ipv6 only mode
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -501,7 +501,7 @@ inline bool operator&(int flags, SRT_EPOLL_OPT eflg)
     // Using an enum prevents treating int automatically as enum,
     // requires explicit enum to be passed here, and minimizes the
     // risk that the right side value will contain multiple flags.
-    return flags & int(eflg);
+    return (flags & int(eflg)) > 0;
 }
 #endif
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -180,7 +180,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_KMREFRESHRATE,       // After sending how many packets the encryption key should be flipped to the new key
    SRTO_KMPREANNOUNCE,       // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
    SRTO_STRICTENC,           // Connection to be rejected or quickly broken when one side encryption set or bad password
-   SRTO_IPV6ONLY,             // IPV6_V6ONLY mode
+   SRTO_IPV6ONLY,            // IPV6_V6ONLY mode
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:
@@ -502,7 +502,7 @@ inline bool operator&(int flags, SRT_EPOLL_OPT eflg)
     // Using an enum prevents treating int automatically as enum,
     // requires explicit enum to be passed here, and minimizes the
     // risk that the right side value will contain multiple flags.
-    return (flags & int(eflg)) > 0;
+    return (flags & int(eflg)) != 0;
 }
 #endif
 


### PR DESCRIPTION
Add SRTO_IPV6ONLY to SRT_SOCKOPT for setting the IPV6_V6ONLY sockoption before the ::bind call
Also delete a "performance warning" in Visual Studio (srt.h)