### PR TITLE
Fix static linking error for apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -688,6 +688,9 @@ macro(srt_make_application name)
 	set_target_properties(${name} PROPERTIES COMPILE_FLAGS "${CFLAGS_CXX_STANDARD} ${EXTRA_stransmit}" ${FORCE_RPATH})
 
 	target_link_libraries(${name} ${srt_link_library})
+	if (srt_libspec_static AND CMAKE_DL_LIBS)
+		target_link_libraries(${name} ${CMAKE_DL_LIBS})
+	endif()
 endmacro()
 
 macro(srt_add_application name sources)


### PR DESCRIPTION
Fix such an error:
```
PKG_CONFIG_PATH="/tmp/ffmpeg-static/lib/pkgconfig" ./configure --prefix="/tmp/ffmpeg-static/target" --disable-shared
NOTE: --disable-shared changed into --enable-shared=0
Running: cmake . -DCMAKE_INSTALL_PREFIX=/tmp/ffmpeg-static/target -DENABLE_SHARED=0
[...]
make
[...]
[ 95%] Linking CXX executable srt-live-transmit
/tmp/ffmpeg-static/target/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_globallookup':
dso_dlfcn.c:(.text+0x11): undefined reference to `dlopen'
dso_dlfcn.c:(.text+0x24): undefined reference to `dlsym'
dso_dlfcn.c:(.text+0x2f): undefined reference to `dlclose'
/tmp/ffmpeg-static/target/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_bind_func':
dso_dlfcn.c:(.text+0x344): undefined reference to `dlsym'
dso_dlfcn.c:(.text+0x402): undefined reference to `dlerror'
/tmp/ffmpeg-static/target/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_bind_var':
dso_dlfcn.c:(.text+0x47b): undefined reference to `dlsym'
dso_dlfcn.c:(.text+0x538): undefined reference to `dlerror'
/tmp/ffmpeg-static/target/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_load':
dso_dlfcn.c:(.text+0x5a8): undefined reference to `dlopen'
dso_dlfcn.c:(.text+0x60d): undefined reference to `dlclose'
dso_dlfcn.c:(.text+0x645): undefined reference to `dlerror'
/tmp/ffmpeg-static/target/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_pathbyaddr':
dso_dlfcn.c:(.text+0x6d1): undefined reference to `dladdr'
dso_dlfcn.c:(.text+0x731): undefined reference to `dlerror'
/tmp/ffmpeg-static/target/lib/libcrypto.a(dso_dlfcn.o): In function `dlfcn_unload':
dso_dlfcn.c:(.text+0x792): undefined reference to `dlclose'
collect2: error: ld returned 1 exit status
CMakeFiles/srt-live-transmit.dir/build.make:105: recipe for target 'srt-live-transmit' failed
make[2]: *** [srt-live-transmit] Error 1
CMakeFiles/Makefile2:217: recipe for target 'CMakeFiles/srt-live-transmit.dir/all' failed
make[1]: *** [CMakeFiles/srt-live-transmit.dir/all] Error 2
```

I pondered appending `${CMAKE_DL_LIBS}` to `srt_link_library` instead of this.