### PR TITLE
Notify epoll the data is available to be read

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6379,6 +6379,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
              }
              // acknowledge any waiting epolls to read
              s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_IN, true);
+             CTimer::triggerEvent();
          }
          CGuard::enterCS(m_AckLock);
       }


### PR DESCRIPTION
`CTimer::triggerEvent()` should be called after `m_EPoll.update_events(...)` to notify epoll about the change of state. Otherwise it will continue waiting until the periodic trigger event.