### PR TITLE
Fixed epoll connection issue.

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -429,9 +429,7 @@ int main( int argc, char** argv )
                     }
                     else if (tar && tar->GetSRTSocket() != s)
                     {
-                        cerr << "Unexpected socket poll: " << s;
-                        doabort = true;
-                        break;
+                        continue;
                     }
 
                     const char * dirstring = (issource)? "source" : "target";


### PR DESCRIPTION
After PR #597. Sender-listener. `tar->GetSRTSocket()` returns bind socket at the start, but then the accepted socket when connection happens. While the bind socket is still in the srtrwfds list of polled sockets.