### PR TITLE
Fixed crash found with non-blocking linger in srt-live-transmit

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -137,6 +137,8 @@ int main( int argc, char** argv )
 {
     // This is mainly required on Windows to initialize the network system,
     // for a case when the instance would use UDP. SRT does it on its own, independently.
+    srt_startup();
+
     if ( !SysInitializeNetwork() )
         throw std::runtime_error("Can't initialize network!");
 
@@ -146,6 +148,7 @@ int main( int argc, char** argv )
     {
         ~NetworkCleanup()
         {
+            srt_cleanup();
             SysCleanupNetwork();
         }
     } cleanupobj;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -950,10 +950,10 @@ int CUDTUnited::close(const SRTSOCKET u)
        // it became invalid
        map<SRTSOCKET, CUDTSocket*>::iterator i = m_Sockets.find(u);
        if ((i == m_Sockets.end()) || (i->second->m_Status == SRTS_CLOSED))
-	   {
-		   HLOGC(mglog.Debug, log << "@" << u << "U::close: NOT AN ACTIVE SOCKET, returning.");
-		   return 0;
-	   }
+       {
+           HLOGC(mglog.Debug, log << "@" << u << "U::close: NOT AN ACTIVE SOCKET, returning.");
+           return 0;
+       }
        s = i->second;
 
        s->m_Status = SRTS_CLOSED;
@@ -965,8 +965,8 @@ int CUDTUnited::close(const SRTSOCKET u)
        s->m_TimeStamp = CTimer::getTime();
 
        m_Sockets.erase(s->m_SocketID);
-	   m_ClosedSockets[s->m_SocketID] = s;
-	   HLOGC(mglog.Debug, log << "@" << u << "U::close: Socket MOVED TO CLOSED for collecting later.");
+       m_ClosedSockets[s->m_SocketID] = s;
+       HLOGC(mglog.Debug, log << "@" << u << "U::close: Socket MOVED TO CLOSED for collecting later.");
 
        CTimer::triggerEvent();
    }
@@ -1833,7 +1833,7 @@ void* CUDTUnited::garbageCollect(void* p)
        timeout.tv_sec = now.tv_sec + 1;
        timeout.tv_nsec = now.tv_usec * 1000;
 
-	   HLOGC(mglog.Debug, log << "GC: sleep until " << FormatTime(uint64_t(now.tv_usec) + 1000000*(timeout.tv_sec)));
+       HLOGC(mglog.Debug, log << "GC: sleep until " << FormatTime(uint64_t(now.tv_usec) + 1000000*(timeout.tv_sec)));
        pthread_cond_timedwait(
                &self->m_GCStopCond, &self->m_GCStopLock, &timeout);
    }

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -820,7 +820,7 @@ std::string ConnectStatusStr(EConnectStatus cst)
 
 std::string TransmissionEventStr(ETransmissionEvent ev)
 {
-    static const std::string vals [] =
+    static const char* const vals [] =
     {
         "init",
         "ack",

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -307,7 +307,7 @@ CUDT::CUDT(const CUDT& ancestor)
 #endif
    m_iSndTimeOut = ancestor.m_iSndTimeOut;
    m_iRcvTimeOut = ancestor.m_iRcvTimeOut;
-   m_bReuseAddr = true;	// this must be true, because all accepted sockets shared the same port with the listener
+   m_bReuseAddr = true; // this must be true, because all accepted sockets share the same port with the listener
    m_llMaxBW = ancestor.m_llMaxBW;
 #ifdef SRT_ENABLE_IPOPTS
    m_iIpTTL = ancestor.m_iIpTTL;
@@ -4725,8 +4725,8 @@ bool CUDT::close()
             if (m_ullLingerExpiration == 0)
                m_ullLingerExpiration = entertime + m_Linger.l_linger * uint64_t(1000000);
 
-			HLOGC(mglog.Debug, log << "CUDT::close: linger-nonblocking, setting expire time T="
-					<< FormatTime(m_ullLingerExpiration));
+            HLOGC(mglog.Debug, log << "CUDT::close: linger-nonblocking, setting expire time T="
+                    << FormatTime(m_ullLingerExpiration));
 
             return false;
          }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -369,7 +369,7 @@ private:
 
     /// Close the opened UDT entity.
 
-    void close();
+    bool close();
 
     /// Request UDT to send out a data block "data" with size of "len".
     /// @param data [in] The address of the application data to be sent.

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -480,10 +480,10 @@ std::string CPacket::MessageFlagStr()
 
     stringstream out;
 
-    static const string boundary [] = { "PB_SUBSEQUENT", "PB_LAST", "PB_FIRST", "PB_SOLO" };
-    static const string order [] = { "ORD_RELAXED", "ORD_REQUIRED" };
-    static const string crypto [] = { "EK_NOENC", "EK_EVEN", "EK_ODD", "EK*ERROR" };
-    static const string rexmit [] = { "SN_ORIGINAL", "SN_REXMIT" };
+    static const char* const boundary [] = { "PB_SUBSEQUENT", "PB_LAST", "PB_FIRST", "PB_SOLO" };
+    static const char* const order [] = { "ORD_RELAXED", "ORD_REQUIRED" };
+    static const char* const crypto [] = { "EK_NOENC", "EK_EVEN", "EK_ODD", "EK*ERROR" };
+    static const char* const rexmit [] = { "SN_ORIGINAL", "SN_REXMIT" };
 
     out << boundary[int(getMsgBoundary())] << " ";
     out << order[int(getMsgOrderFlag())] << " ";

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -340,6 +340,21 @@ int CSndUList::pop(sockaddr*& addr, CPacket& pkt)
    CUDT* u = m_pHeap[0]->m_pUDT;
    remove_(u);
 
+#define UST(field) ( (u->m_b##field) ? "+" : "-" ) << #field << " "
+
+   HLOGC(mglog.Debug, log << "SND:pop: requesting packet from @" << u->socketID()
+		   << " STATUS: "
+		   << UST(Listening)
+		   << UST(Connecting)
+		   << UST(Connected)
+		   << UST(Closing)
+		   << UST(Shutdown)
+		   << UST(Broken)
+		   << UST(PeerHealth)
+		   << UST(Opened)
+		);
+#undef UST
+
    if (!u->m_bConnected || u->m_bBroken)
       return -1;
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -343,16 +343,16 @@ int CSndUList::pop(sockaddr*& addr, CPacket& pkt)
 #define UST(field) ( (u->m_b##field) ? "+" : "-" ) << #field << " "
 
    HLOGC(mglog.Debug, log << "SND:pop: requesting packet from @" << u->socketID()
-		   << " STATUS: "
-		   << UST(Listening)
-		   << UST(Connecting)
-		   << UST(Connected)
-		   << UST(Closing)
-		   << UST(Shutdown)
-		   << UST(Broken)
-		   << UST(PeerHealth)
-		   << UST(Opened)
-		);
+           << " STATUS: "
+           << UST(Listening)
+           << UST(Connecting)
+           << UST(Connected)
+           << UST(Closing)
+           << UST(Shutdown)
+           << UST(Broken)
+           << UST(PeerHealth)
+           << UST(Opened)
+        );
 #undef UST
 
    if (!u->m_bConnected || u->m_bBroken)


### PR DESCRIPTION
The crash observed during closing the program with non-blocking and working linger was due to collision of the global object destruction.

This fix provides fair call of srt_cleanup() at the end, as it should be, and some smaller fixes to avoid possible collisions around global variables in the future.