### PR TITLE
[tests] Fixed strict encryption check for accept in non-blocking mode

### DIFF
--- a/test/test_strict_encription.cpp
+++ b/test/test_strict_encription.cpp
@@ -351,7 +351,7 @@ public:
         const int epoll_res = WaitOnEpoll(expect);
 
         auto accepting_thread = std::thread([&] {
-            if (epoll_res != SRT_SUCCESS)
+            if (epoll_res == SRT_ERROR)
                 return;
             // In a blocking mode we expect a socket returned from srt_accept() if the srt_connect succeeded.
             // In a non-blocking mode we expect a socket returned from srt_accept() if the srt_connect succeeded,


### PR DESCRIPTION
Wrong condition was making the check of the accepted socket to be skipped in the non-blocking mode.