### PR TITLE
Fixed StreamID and Smoother name swapping for big endian machines

### DIFF
--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -134,7 +134,6 @@ written by
 #elif defined(__WINDOWS__)
 
 #	include <winsock2.h>
-#	include <sys/param.h>
 
 #	if BYTE_ORDER == LITTLE_ENDIAN
 

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -76,6 +76,144 @@ written by
 
 // -------------- UTILITIES ------------------------
 
+// --- ENDIAN ---
+// Copied from: https://gist.github.com/panzi/6856583
+// License: Public Domain.
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#	define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+#	include <endian.h>
+
+#elif defined(__APPLE__)
+
+#	include <libkern/OSByteOrder.h>
+
+#	define htobe16(x) OSSwapHostToBigInt16(x)
+#	define htole16(x) OSSwapHostToLittleInt16(x)
+#	define be16toh(x) OSSwapBigToHostInt16(x)
+#	define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#	define htobe32(x) OSSwapHostToBigInt32(x)
+#	define htole32(x) OSSwapHostToLittleInt32(x)
+#	define be32toh(x) OSSwapBigToHostInt32(x)
+#	define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#	define htobe64(x) OSSwapHostToBigInt64(x)
+#	define htole64(x) OSSwapHostToLittleInt64(x)
+#	define be64toh(x) OSSwapBigToHostInt64(x)
+#	define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#	include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+#	include <sys/endian.h>
+
+#	define be16toh(x) betoh16(x)
+#	define le16toh(x) letoh16(x)
+
+#	define be32toh(x) betoh32(x)
+#	define le32toh(x) letoh32(x)
+
+#	define be64toh(x) betoh64(x)
+#	define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+#	include <winsock2.h>
+#	include <sys/param.h>
+
+#	if BYTE_ORDER == LITTLE_ENDIAN
+
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
+
+#	elif BYTE_ORDER == BIG_ENDIAN
+
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#	error Endian: platform not supported
+
+#endif
+
+// Hardware <--> Network (big endian) convention
+inline void HtoNLA(uint32_t* dst, const uint32_t* src, size_t size)
+{
+    for (size_t i = 0; i < size; ++ i)
+        dst[i] = htonl(src[i]);
+}
+
+inline void NtoHLA(uint32_t* dst, const uint32_t* src, size_t size)
+{
+    for (size_t i = 0; i < size; ++ i)
+        dst[i] = ntohl(src[i]);
+}
+
+// Hardware <--> Intel (little endian) convention
+inline void HtoILA(uint32_t* dst, const uint32_t* src, size_t size)
+{
+    for (size_t i = 0; i < size; ++ i)
+        dst[i] = htole32(src[i]);
+}
+
+inline void ItoHLA(uint32_t* dst, const uint32_t* src, size_t size)
+{
+    for (size_t i = 0; i < size; ++ i)
+        dst[i] = le32toh(src[i]);
+}
+
 // Bit numbering utility.
 //
 // This is something that allows you to turn 32-bit integers into bit fields.
@@ -231,18 +369,6 @@ struct DynamicStruct
 inline bool IsSet(int32_t bitset, int32_t flagset)
 {
     return (bitset & flagset) == flagset;
-}
-
-inline void HtoNLA(uint32_t* dst, const uint32_t* src, size_t size)
-{
-    for (size_t i = 0; i < size; ++ i)
-        dst[i] = htonl(src[i]);
-}
-
-inline void NtoHLA(uint32_t* dst, const uint32_t* src, size_t size)
-{
-    for (size_t i = 0; i < size; ++ i)
-        dst[i] = ntohl(src[i]);
 }
 
 // Homecooked version of ref_t. It's a copy of std::reference_wrapper


### PR DESCRIPTION
Fixes #634.

The protocol definitions stays as before (that is, characters in StreamID and Smoother are fourwise inverted). There's a fix made especially for big endian machines, which turns them to the "little endian convention" for the sake of transport.