### PR TITLE
[apps] Fixed srt-file-transit (issue #645)

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -180,7 +180,7 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
         return 2;
     }
 
-    cfg.chunk_size    = stoul(Option<OutString>(params, "1316", o_chunk));
+    cfg.chunk_size    = stoul(Option<OutString>(params, "1456", o_chunk));
     cfg.skip_flushing = Option<OutBool>(params, false, o_no_flush);
     cfg.bw_report     = stoi(Option<OutString>(params, "0", o_bwreport));
     cfg.stats_report  = stoi(Option<OutString>(params, "0", o_statsrep));
@@ -584,16 +584,15 @@ bool DoDownload(UriParser& us, string directory, string filename,
         if (connected)
         {
             vector<char> buf(cfg.chunk_size);
-            int n;
 
-            if(!ofile.is_open())
+            if (!ofile.is_open())
             {
                 const char * fn = id.empty() ? filename.c_str() : id.c_str();
                 directory.append("/");
                 directory.append(fn);
                 ofile.open(directory.c_str(), ios::out | ios::trunc | ios::binary);
 
-                if(!ofile.is_open())
+                if (!ofile.is_open())
                 {
                     cerr << "Error opening file [" << directory << "]" << endl;
                     goto exit;
@@ -601,7 +600,7 @@ bool DoDownload(UriParser& us, string directory, string filename,
                 cerr << "Writing output to [" << directory << "]" << endl;
             }
 
-            n = src->Read(cfg.chunk_size, buf, out_stats);
+            int n = src->Read(cfg.chunk_size, buf, out_stats);
             if (n == SRT_ERROR)
             {
                 cerr << "Download: SRT error: " << srt_getlasterror_str() << endl;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -720,7 +720,9 @@ int main(int argc, char** argv)
                             if (srt_getlasterror(NULL) == SRT_EASYNCRCV)
                                 break;
 
-                            throw std::runtime_error(string("error: recvmsg: ") + string(srt_getlasterror_str()));
+                            throw std::runtime_error(
+                                string("error: recvmsg: ") + string(srt_getlasterror_str())
+                            );
                         }
 
                         if (res == 0 || pdata->empty())

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -712,10 +712,22 @@ int main(int argc, char** argv)
                     {
                         std::shared_ptr<bytevector> pdata(
                             new bytevector(cfg.chunk_size));
-                        if (!src->Read(cfg.chunk_size, *pdata, out_stats) || (*pdata).empty())
+
+                        const int res = src->Read(cfg.chunk_size, *pdata, out_stats);
+
+                        if (res == SRT_ERROR && src->uri.type() == UriParser::SRT)
+                        {
+                            if (srt_getlasterror(NULL) == SRT_EASYNCRCV)
+                                break;
+
+                            throw std::runtime_error(string("error: recvmsg: ") + string(srt_getlasterror_str()));
+                        }
+
+                        if (res == 0 || pdata->empty())
                         {
                             break;
                         }
+
                         dataqueue.push_back(pdata);
                         receivedBytes += (*pdata).size();
                     }

--- a/apps/srt-multiplex.cpp
+++ b/apps/srt-multiplex.cpp
@@ -105,8 +105,8 @@ struct MediumPair
 
         if (!initial_portion.empty())
         {
-            tar->Write(initial_portion);
-            if ( tar->Broken() )
+            tar->Write(initial_portion.data(), initial_portion.size());
+            if (tar->Broken())
             {
                 applog.Note() << "OUTPUT BROKEN for loop: " << name;
                 return;
@@ -121,7 +121,9 @@ struct MediumPair
                 ostringstream sout;
                 alarm(1);
                 bytevector data;
-                src->Read(chunk, data);
+                const int read_res = src->Read(chunk, data);
+
+
                 alarm(0);
                 if (alarm_state)
                 {
@@ -138,8 +140,8 @@ struct MediumPair
                     applog.Note() << sout.str();
                     break;
                 }
-                tar->Write(data);
-                if ( tar->Broken() )
+                tar->Write(data.data(), data.size());
+                if (tar->Broken())
                 {
                     sout << " OUTPUT broken";
                     applog.Note() << sout.str();

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -42,7 +42,7 @@ public:
 class Source: public Location
 {
 public:
-    virtual bool Read(size_t chunk, bytevector& data, std::ostream &out_stats = std::cout) = 0;
+    virtual int  Read(size_t chunk, bytevector& data, std::ostream &out_stats = std::cout) = 0;
     virtual bool IsOpen() = 0;
     virtual bool End() = 0;
     static std::unique_ptr<Source> Create(const std::string& url);
@@ -65,8 +65,7 @@ public:
 class Target: public Location
 {
 public:
-    virtual int Write(const char* data, size_t size, std::ostream &out_stats = std::cout) = 0;
-    virtual bool Write(const bytevector& portion) = 0;
+    virtual int  Write(const char* data, size_t size, std::ostream &out_stats = std::cout) = 0;
     virtual bool IsOpen() = 0;
     virtual bool Broken() = 0;
     virtual void Close() {}

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -821,7 +821,7 @@ public:
 
         bool st = cin.read(data.data(), chunk).good();
         chunk = cin.gcount();
-        if (chunk == 0 && !st)
+        if (chunk == 0 || !st)
         {
             data.clear();
             return 0;
@@ -829,8 +829,6 @@ public:
 
         if (chunk < data.size())
             data.resize(chunk);
-        if (data.empty())
-            return 0;
 
         return (int) chunk;
     }

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -631,23 +631,14 @@ int SrtSource::Read(size_t chunk, bytevector& data, ostream &out_stats)
         data.resize(chunk);
 
     const int stat = srt_recvmsg(m_sock, data.data(), (int) chunk);
-    if (stat == SRT_ERROR)
+    if (stat <= 0)
     {
-        // EAGAIN for SRT READING
-        if (srt_getlasterror(NULL) == SRT_EASYNCRCV)
-        {
-            data.clear();
-        }
-        return stat;
-    }
-
-    if (stat == 0)
-    {
+        data.clear();
         return stat;
     }
 
     chunk = size_t(stat);
-    if ( chunk < data.size() )
+    if (chunk < data.size())
         data.resize(chunk);
 
     const bool need_bw_report = transmit_bw_report && (counter % transmit_bw_report) == transmit_bw_report - 1;

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -94,7 +94,7 @@ public:
         // Do nothing - create just to prepare for use
     }
 
-    bool Read(size_t chunk, bytevector& data, ostream& out_stats = cout) override;
+    int Read(size_t chunk, bytevector& data, ostream& out_stats = cout) override;
 
     /*
        In this form this isn't needed.
@@ -135,7 +135,6 @@ public:
 
     int ConfigurePre(SRTSOCKET sock) override;
     int Write(const char* data, size_t size, ostream &out_stats = cout) override;
-    bool Write(const bytevector& data) override;
     bool IsOpen() override { return IsUsable(); }
     bool Broken() override { return IsBroken(); }
     void Close() override { return SrtCommon::Close(); }


### PR DESCRIPTION
Fixed `srt-file-transmit` issue, introduced by #598.
`Source::Read(…)` now returns int and does not throw exceptions.

Fixes #645