### PR TITLE
Silencing the queues before closing the UDP socket

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1619,8 +1619,8 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
       // The queues must be silenced before closing the channel
       // because this will cause error to be returned in any operation
       // being currently done in the queues, if any.
-      mx.m_pSndQueue->silence();
-      mx.m_pRcvQueue->silence();
+      mx.m_pSndQueue->setClosing();
+      mx.m_pRcvQueue->setClosing();
       mx.m_pChannel->close();
       delete mx.m_pSndQueue;
       delete mx.m_pRcvQueue;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1604,19 +1604,28 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
       return;
    }
 
-   m->second.m_iRefCount --;
+   CMultiplexer& mx = m->second;
+
+   mx.m_iRefCount --;
    // HLOGF(mglog.Debug, "unrefing underlying socket for %u: %u\n",
-   //    u, m->second.m_iRefCount);
-   if (0 == m->second.m_iRefCount)
+   //    u, mx.m_iRefCount);
+   if (0 == mx.m_iRefCount)
    {
        HLOGC(mglog.Debug, log << "MUXER id=" << mid << " lost last socket %"
            << u << " - deleting muxer bound to port "
-           << m->second.m_pChannel->bindAddressAny().hport());
-      m->second.m_pChannel->close();
-      delete m->second.m_pSndQueue;
-      delete m->second.m_pRcvQueue;
-      delete m->second.m_pTimer;
-      delete m->second.m_pChannel;
+           << mx.m_pChannel->bindAddressAny().hport());
+      // The channel has no access to the queues and
+      // it looks like the multiplexer is the master of all of them.
+      // The queues must be silenced before closing the channel
+      // because this will cause error to be returned in any operation
+      // being currently done in the queues, if any.
+      mx.m_pSndQueue->silence();
+      mx.m_pRcvQueue->silence();
+      mx.m_pChannel->close();
+      delete mx.m_pSndQueue;
+      delete mx.m_pRcvQueue;
+      delete mx.m_pTimer;
+      delete mx.m_pChannel;
       m_mMultiplexer.erase(m);
    }
 }

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -385,7 +385,7 @@ public:
    int ioctlQuery(int type) const { return m_pChannel->ioctlQuery(type); }
    int sockoptQuery(int level, int type) const { return m_pChannel->sockoptQuery(level, type); }
 
-   void silence()
+   void setClosing()
    {
        m_bClosing = true;
    }
@@ -458,7 +458,7 @@ public:
 
    int recvfrom(int32_t id, ref_t<CPacket> packet);
 
-   void silence()
+   void setClosing()
    {
        m_bClosing = true;
    }

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -385,6 +385,11 @@ public:
    int ioctlQuery(int type) const { return m_pChannel->ioctlQuery(type); }
    int sockoptQuery(int level, int type) const { return m_pChannel->sockoptQuery(level, type); }
 
+   void silence()
+   {
+       m_bClosing = true;
+   }
+
 private:
    static void* worker(void* param);
    pthread_t m_WorkerThread;
@@ -452,6 +457,11 @@ public:
       /// @return Data size of the packet
 
    int recvfrom(int32_t id, ref_t<CPacket> packet);
+
+   void silence()
+   {
+       m_bClosing = true;
+   }
 
 private:
    static void* worker(void* param);


### PR DESCRIPTION
Fixes #652.

The problem was that the socket was closed while the queues might be using it, so the system operation on the socket simply returned an error, and the queues reported it as a fatal error, unaware that this is because they are going to be closed in a while.

The fix sets both queues m_bClosing flag before closing the socket so that they treat this error as expected.