### PR TITLE
[build] Fixed CMAKE_BUILD_TYPE=Debug processing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,10 @@ endif()
 # Set CMAKE_BUILD_TYPE properly, now that you know
 # that ENABLE_DEBUG is set as it should.
 
-if (ENABLE_DEBUG EQUAL 1)
-	set (CMAKE_BUILD_TYPE "Debug")
-elseif (ENABLE_DEBUG EQUAL 2)
+if (ENABLE_DEBUG EQUAL 2)
 	set (CMAKE_BUILD_TYPE "RelWithDebInfo")
+elseif (ENABLE_DEBUG) # 1, ON, YES, TRUE, Y, or any other non-zero number
+	set (CMAKE_BUILD_TYPE "Debug")
 else()
 	set (CMAKE_BUILD_TYPE "Release")
 endif()


### PR DESCRIPTION
When `CMAKE_BUILD_TYPE=Debug` is specified, the `ENABLE_DEBUG` will be set to `ON` (line 48).
Leading to `set (CMAKE_BUILD_TYPE "Release")` because `ON != 1`:
```
if (ENABLE_DEBUG EQUAL 1)
	set (CMAKE_BUILD_TYPE "Debug")
elseif (ENABLE_DEBUG EQUAL 2)
	set (CMAKE_BUILD_TYPE "RelWithDebInfo")
else()
	set (CMAKE_BUILD_TYPE "Release")
endif()
```

After the fix the condition is:
```
if (ENABLE_DEBUG EQUAL 2)
	set (CMAKE_BUILD_TYPE "RelWithDebInfo")
elseif (ENABLE_DEBUG) # 1, ON, YES, TRUE, Y, or any other non-zero number
	set (CMAKE_BUILD_TYPE "Debug")
else()
	set (CMAKE_BUILD_TYPE "Release")
endif()
```