### PR TITLE
Set IPv4 TOS and TTL for accepted IPv4 socket of IPv4mapped-IPv6

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -213,6 +213,9 @@ void CChannel::setUDPSockOpt()
          {
             if(0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char*)&m_iIpTTL, sizeof(m_iIpTTL)))
                throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+            //For IPv4mapped-IPv6 accepted connection also set the IPV4 socket.
+            if(0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*)&m_iIpTTL, sizeof(m_iIpTTL)))
+               throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
          }
       }   
       if (-1 != m_iIpToS)
@@ -227,6 +230,9 @@ void CChannel::setUDPSockOpt()
 #ifdef IPV6_TCLASS
             if(0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (const char*)&m_iIpToS, sizeof(m_iIpToS)))
 #endif
+               throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+            //For IPv4mapped-IPv6 accepted connection also set the IPV4 socket.
+            if(0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*)&m_iIpToS, sizeof(m_iIpToS)))
                throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
          }
       }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6671,7 +6671,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
       int32_t* ackdata = (int32_t*)ctrlpkt.m_pcData;
 
       // process a lite ACK
-      if (ctrlpkt.getLength() == SEND_LITE_ACK)
+      if (ctrlpkt.getLength() == (size_t)SEND_LITE_ACK)
       {
          ack = *ackdata;
          if (CSeqNo::seqcmp(ack, m_iSndLastAck) >= 0)
@@ -7622,7 +7622,9 @@ int CUDT::processData(CUnit* unit)
    }
 
    int pktrexmitflag = m_bPeerRexmitFlag ? (int)packet.getRexmitFlag() : 2;
+#if ENABLE_HEAVY_LOGGING
    static const char* const rexmitstat [] = {"ORIGINAL", "REXMITTED", "RXS-UNKNOWN"};
+#endif
    string rexmit_reason;
 
 


### PR DESCRIPTION
Set IPv4 TOS and TTL when setting IPv6 TCLASS and HOPS to set accepted IPv4 socket of IPv4mapped-IPv6 addresses. Also fixed some compiler warnings.
An IPv4 accepted socket of an IPv6 listening socket (IPV6_V6ONLY=0) will not have TTL and TOS set  if only the IPv6 socket is set. This fix has been tested with the v1.3.1 code, this commit seems to enable IPV6_V6ONLY by default. (incoming IPv4 call never connect to the IPv6 listener).