### PR TITLE
Improving sending queue sleepto() accuracy

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -214,7 +214,11 @@ void CTimer::sleepto(uint64_t nexttime)
        __nop ();
 #endif
 #else
-       const uint64_t wait_us = 10000;  // 10 ms
+       const uint64_t wait_us = (m_ullSchedTime - t) / CTimer::getCPUFrequency();
+       // The while loop ensures that (t < m_ullSchedTime).
+       // Division by frequency ьшпре loos prevision.
+       if (wait_us == 0)
+           break;
 
        timeval now;
        gettimeofday(&now, 0);


### PR DESCRIPTION
The sleeping time for the SRT sending queue is 10 ms, and it is discrete.
That means, if a thread wants to sleep for 5 ms, it will sleep for 10 ms.
If a thread wants to sleep for 15 ms, it will sleep for 10 ms, and then again for another 10 ms, that will make a total sleep time of 20 ms.
This behavior is incorrect and unnecessary.

Fixes #673.

## TODO
**Accuracy of the new sleepto()**
- [X] Windows 10 test `sleepto` function accuracy
- [X] Linux test `sleepto` function accuracy
- [x] MacOS test `sleepto` function accuracy
- [ ] Other platforms (iOS, Android, etc.)

**Accuracy on Windows**
- [x] Check accuracy of [`CreateWaitableTimer`](https://stackoverflow.com/questions/13397571/precise-thread-sleep-needed-max-1ms-error)
- [ ] Check whether increasing thread/process priority increasing the timing accuracy.

**Live mode sending accuracy**
- [ ] Windows 10 sender accuracy measurements (based on pcapng)
- [x] Linux sender accuracy measurements (based on pcapng)
- [ ] MacOS sender accuracy measurements (based on pcapng)

**File mode sending accuracy**
- [ ] Sending 

## Do we need a maximum sleeping time of 10 ms?
In pseudocode, the `sleepto` function works like this:
```
CTimer::sleepto(nexttime) {
    m_ullSchedTime = nexttime;
    rdtsc(now);
    while (now < m_ullSchedTime) {
        condTimedWaitUS(&m_TickCond, &m_TickLock, (m_ullSchedTime- now));
        rdtsc(now);
    }
}
```

`CTimer::sleepto(nexttime)` waits on a CV `m_TickCond`. 

### `CTimer::tick()` function
The function `CTimer::tick()` signals this CV, and it will break the wait to force time checking. The `tick()` function is called from the receiving thread in `CRcvQueue::worker_RetrieveUnit()` before every operation of reading data from the socket. This is probably wrong, but requires further review.

### `CTimer::interrupt()` function
In case the thread has to be forced break, there is another function `CTimer::interrupt()`, that changes the `m_ullSchedTime` to he current time and calls `tick()` to break any waits.

### Conclusion
This means that maximum waiting time of 10 ms is not necessary.

## Do we need a minimum allowed sleeping time?

As shown in #637, the `sleepto()` function has certain inaccuracy.

**A final matrix to be placed here.**

`CTimer::sleepto()` accuracy (proposed implementation) in CV-based waiting mode. Each column shows the actual sleeping time in microseconds for each platform. Measured using unit test `CTimer.SleeptoAccuracy`.

| Time, μs | Win 10 | CentOS 7 | MacBook Pro | iOS | Android |
|---------:|-------:|---------:|------------:|----:|--------:|
|        1 |     64 |       49 |           1 |     |         |
|        5 |    209 |       58 |          10 |     |         |
|       10 |    354 |       62 |          17 |     |         |
|       50 |   1181 |       99 |          68 |     |         |
|      100 |   1536 |      150 |         140 |     |         |
|      250 |   1559 |      315 |         389 |     |         |
|      500 |   1469 |      582 |         738 |     |         |
|     1000 |   1593 |     1080 |        1346 |     |         |
|     5000 |   5506 |     5110 |        6118 |     |         |
|    10000 |  10717 |    10112 |       11963 |     |         |