### PR TITLE
[core] Fixed packet retransmission

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -454,7 +454,7 @@ private:
     /// @param perf [in, out] pointer to a CPerfMon structure to record the performance data.
     /// @param clear [in] flag to decide if the local performance trace should be cleared. 
     /// @param instantaneous [in] flag to request instantaneous data 
-    /// instead of moving averages. 
+    /// instead of moving averages.
     void bstats(CBytePerfMon* perf, bool clear = true, bool instantaneous = false);
 
     /// Mark sequence contained in the given packet as not lost. This
@@ -702,6 +702,15 @@ private: // Common connection Congestion Control setup
 private: // Generation and processing of packets
     void sendCtrl(UDTMessageType pkttype, void* lparam = NULL, void* rparam = NULL, int size = 0);
     void processCtrl(CPacket& ctrlpkt);
+
+    /// Pack a packet from a list of lost packets.
+    ///
+    /// @param packet [in, out] a packet structure to fill
+    /// @param origintime [in, out] origin timestamp of the packet
+    ///
+    /// @return payload size on success, <=0 on failure
+    int packLostData(CPacket& packet, uint64_t& origintime);
+
     int packData(CPacket& packet, uint64_t& ts);
     int processData(CUnit* unit);
     void processClose();


### PR DESCRIPTION
When trying to re-transmit a packet from the `m_pSndLossList` (a packet considered or reported lost), but later on was yet acknowledged, the sending function `packData()` returns and does not reschedule the sending queue for next operation. Instead it goes into waiting for some event that is expected to change the sending buffer state (e.g. ACK).

Instead the processing in `packData()` should go further through the list of reported lost packets or end up sending a new packet from the buffer.

This PR adds the `CUDT::packLostData()` function that iterates through packets in the loss list and tries to construct an SRT packet. On success the payload size is returned. If it fails to construct a retransmission packet, then 0 is returned, it the parent function `packData()` tries to prepare a new packet for sending.