### PR TITLE
[apps] Fixing space char handling in ProcessOptions

### DIFF
--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -282,12 +282,12 @@ inline options_t ProcessOptions(char* const* argv, int argc, std::vector<OptionS
                     }
                     else if (s.type == OptionScheme::ARG_ONE)
                     {
-                        params[current_key].push_back(value);
+                        if (!value.empty())
+                            params[current_key].push_back(value);
                     }
                     type = s.type;
                     goto Found;
                 }
-
             }
             // Not found: set ARG_NONE.
             // cout << "*D KEY '" << current_key << "' assumed type NONE\n";


### PR DESCRIPTION
When space character is used as a separator, empty `""` value is added to the list of values.