### PR TITLE
[apps] Added linger URI socket option

### DIFF
--- a/apps/socketoptions.cpp
+++ b/apps/socketoptions.cpp
@@ -66,6 +66,15 @@ SocketOption::Mode SrtConfigurePre(SRTSOCKET socket, string host, map<string, st
         fails.push_back("mode");
     }
 
+    if (options.count("linger"))
+    {
+        linger lin;
+        lin.l_linger = stoi(options["linger"]);
+        lin.l_onoff  = lin.l_linger > 0 ? 1 : 0;
+        srt_setsockopt(socket, SocketOption::PRE, SRTO_LINGER, &lin, sizeof(linger));
+    }
+
+
     bool all_clear = true;
     for (auto o: srt_options)
     {

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -209,6 +209,8 @@ const SocketOption srt_options [] {
     { "fc", 0, SRTO_FC, SocketOption::PRE, SocketOption::INT, nullptr},
     { "sndbuf", 0, SRTO_SNDBUF, SocketOption::PRE, SocketOption::INT, nullptr},
     { "rcvbuf", 0, SRTO_RCVBUF, SocketOption::PRE, SocketOption::INT, nullptr},
+    // linger option is handled outside of the common loop, therefore commented out.
+    //{ "linger", 0, SRTO_LINGER, SocketOption::PRE, SocketOption::INT, nullptr},
     { "ipttl", 0, SRTO_IPTTL, SocketOption::PRE, SocketOption::INT, nullptr},
     { "iptos", 0, SRTO_IPTOS, SocketOption::PRE, SocketOption::INT, nullptr},
     { "inputbw", 0, SRTO_INPUTBW, SocketOption::POST, SocketOption::INT64, nullptr},


### PR DESCRIPTION
In `socketoptions.hpp` the `linger` option is commented, because this list is for general loop over the options. And we can't do a general loop, because linger is a struct, not an integer, therefore requires special handling. But still added to the structure to show to the user that this option will be handled.