### PR TITLE
[tests] Improved epoll connection break test

### DIFF
--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -342,7 +342,11 @@ TEST(CEPoll, NotifyConnectionBreak)
     // Wait for the caller to close connection
     // There should be no wait, as epoll should wait untill connection is closed.
     EXPECT_EQ(close_res.get(), SRT_SUCCESS);
-    EXPECT_EQ(srt_getsockstate(sock), SRTS_BROKEN);
+    const SRT_SOCKSTATUS state = srt_getsockstate(sock);
+    const bool state_valid = state == SRTS_BROKEN || state == SRTS_CLOSING || state == SRTS_CLOSED;
+    EXPECT_TRUE(state_valid);
+    if (!state_valid)
+        cerr << "socket state: " << state << endl;
 
     EXPECT_EQ(srt_cleanup(), 0);
 }


### PR DESCRIPTION
Transition of a socket state after it is closed by peer is the following: `BROKEN` -> `CLOSING` -> `CLOSED` -> `NONEXIST`. And finally a socket is removed from the list and becomes `NONEXIST`. Status of the socket depends on the time, when it is requested. We can assume, that current test can have `BROKEN`, `CLOSING` or `CLOSED` socket state, because the state is expected to be asked almost immidiatelly after a peer has closed the connection.
