### PR TITLE
Add option for configuring connection response timeout

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -229,7 +229,8 @@ const SocketOption srt_options [] {
     { "payloadsize", 0, SRTO_PAYLOADSIZE, SocketOption::PRE, SocketOption::INT, nullptr},
     { "kmrefreshrate", 0, SRTO_KMREFRESHRATE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "kmpreannounce", 0, SRTO_KMPREANNOUNCE, SocketOption::PRE, SocketOption::INT, nullptr },
-    { "strictenc", 0, SRTO_STRICTENC, SocketOption::PRE, SocketOption::BOOL, nullptr }
+    { "strictenc", 0, SRTO_STRICTENC, SocketOption::PRE, SocketOption::BOOL, nullptr },
+    { "rsptimeo", 0, SRTO_RSPTIMEO, SocketOption::PRE, SocketOption::INT, nullptr }
 };
 }
 

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -230,7 +230,7 @@ const SocketOption srt_options [] {
     { "kmrefreshrate", 0, SRTO_KMREFRESHRATE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "kmpreannounce", 0, SRTO_KMPREANNOUNCE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "strictenc", 0, SRTO_STRICTENC, SocketOption::PRE, SocketOption::BOOL, nullptr },
-    { "rsptimeo", 0, SRTO_RSPTIMEO, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "peeridletimeo", 0, SRTO_PEERIDLETIMEO, SocketOption::PRE, SocketOption::INT, nullptr }
 };
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -678,6 +678,15 @@ different in 1.2.0 (HSv4) and 1.3.0 (HSv5):
 
 | OptName               | Since | Binding | Type      | Units  | Default  | Range         |
 | --------------------- | ----- | ------- | --------- | ------ | -------- | ------------- |
+| `SRTO_PEERIDLETIMEO`  | 1.3.3 | pre     | `int32_t` | msec   | 5000     | positive only |
+
+- The maximum time in `[ms]` to wait until any packet is received from peer since
+the last such packet reception. If this time is passed, connection is considered
+broken on timeout.
+---
+
+| OptName               | Since | Binding | Type      | Units  | Default  | Range         |
+| --------------------- | ----- | ------- | --------- | ------ | -------- | ------------- |
 | `SRTO_PEERLATENCY`    | 1.3.0 | pre     | `int32_t` | msec   | 0        | positive only |
 
 - The latency value (as described in `SRTO_RCVLATENCY`) that is set by the sender 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -261,6 +261,7 @@ CUDT::CUDT()
    m_bOPT_TLPktDrop = true;
    m_iOPT_SndDropDelay = 0;
    m_bOPT_StrictEncryption = true;
+   m_iOPT_ResponseTimeout = COMM_RESPONSE_TIMEOUT_US;
    m_bTLPktDrop = true;         //Too-late Packet Drop
    m_bMessageAPI = true;
    m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
@@ -324,6 +325,7 @@ CUDT::CUDT(const CUDT& ancestor)
    m_bOPT_TLPktDrop = ancestor.m_bOPT_TLPktDrop;
    m_iOPT_SndDropDelay = ancestor.m_iOPT_SndDropDelay;
    m_bOPT_StrictEncryption = ancestor.m_bOPT_StrictEncryption;
+   m_iOPT_ResponseTimeout = ancestor.m_iOPT_ResponseTimeout;
    m_zOPT_ExpPayloadSize = ancestor.m_zOPT_ExpPayloadSize;
    m_bTLPktDrop = ancestor.m_bTLPktDrop;
    m_bMessageAPI = ancestor.m_bMessageAPI;
@@ -861,6 +863,13 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         m_bOPT_StrictEncryption = bool_int_value(optval, optlen);
         break;
 
+   case SRTO_RSPTIMEO:
+
+        if (m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        m_iOPT_ResponseTimeout = *(int*)optval;
+        break;
+
    case SRTO_IPV6ONLY:
       if (m_bConnected)
          throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
@@ -1143,6 +1152,11 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void* optval, int& optlen)
    case SRTO_IPV6ONLY:
       optlen = sizeof(int);
       *(int*)optval = m_iIpV6Only;
+      break;
+
+   case SRTO_RSPTIMEO:
+      *(int*)optval = m_iOPT_ResponseTimeout;
+      optlen = sizeof(int);
       break;
 
    default:
@@ -8643,7 +8657,7 @@ void CUDT::checkTimers()
         // Haven't received any information from the peer, is it dead?!
         // timeout: at least 16 expirations and must be greater than 5 seconds
         if ((m_iEXPCount > COMM_RESPONSE_MAX_EXP)
-                && (currtime_tk - m_ullLastRspTime_tk > COMM_RESPONSE_TIMEOUT_US * m_ullCPUFrequency))
+                && (currtime_tk - m_ullLastRspTime_tk > m_iOPT_ResponseTimeout * m_ullCPUFrequency))
         {
             //
             // Connection is broken.
@@ -8669,7 +8683,7 @@ void CUDT::checkTimers()
         }
 
         HLOGC(mglog.Debug, log << "EXP TIMER: count=" << m_iEXPCount << "/" << (+COMM_RESPONSE_MAX_EXP)
-            << " elapsed=" << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "/" << (+COMM_RESPONSE_TIMEOUT_US) << "us");
+            << " elapsed=" << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "/" << (+m_iOPT_ResponseTimeout) << "us");
 
         /* 
          * This part is only used with FileCC. This retransmits

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -261,7 +261,7 @@ CUDT::CUDT()
    m_bOPT_TLPktDrop = true;
    m_iOPT_SndDropDelay = 0;
    m_bOPT_StrictEncryption = true;
-   m_iOPT_ResponseTimeout = COMM_RESPONSE_TIMEOUT_US;
+   m_iOPT_ResponseTimeout = COMM_RESPONSE_TIMEOUT_MS;
    m_bTLPktDrop = true;         //Too-late Packet Drop
    m_bMessageAPI = true;
    m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
@@ -8654,10 +8654,12 @@ void CUDT::checkTimers()
 
     if (currtime_tk > next_exp_time_tk)
     {
+        // ms -> us
+        const int RESPONSE_TIMEOUT = m_iOPT_ResponseTimeout*1000;
         // Haven't received any information from the peer, is it dead?!
         // timeout: at least 16 expirations and must be greater than 5 seconds
         if ((m_iEXPCount > COMM_RESPONSE_MAX_EXP)
-                && (currtime_tk - m_ullLastRspTime_tk > m_iOPT_ResponseTimeout * m_ullCPUFrequency))
+                && (currtime_tk - m_ullLastRspTime_tk > RESPONSE_TIMEOUT * m_ullCPUFrequency))
         {
             //
             // Connection is broken.
@@ -8683,7 +8685,7 @@ void CUDT::checkTimers()
         }
 
         HLOGC(mglog.Debug, log << "EXP TIMER: count=" << m_iEXPCount << "/" << (+COMM_RESPONSE_MAX_EXP)
-            << " elapsed=" << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "/" << (+m_iOPT_ResponseTimeout) << "us");
+            << " elapsed=" << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "/" << (+RESPONSE_TIMEOUT) << "us");
 
         /* 
          * This part is only used with FileCC. This retransmits

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -225,7 +225,7 @@ public: // internal API
     // Note: use notation with X*1000*1000* ... instead of million zeros in a row.
     // In C++17 there is a possible notation of 5'000'000 for convenience, but that's
     // something only for a far future.
-    static const int COMM_RESPONSE_TIMEOUT_US = 5*1000*1000; // 5 seconds
+    static const int COMM_RESPONSE_TIMEOUT_MS = 5*1000; // 5 seconds
     static const int COMM_RESPONSE_MAX_EXP = 16;
     static const int SRT_TLPKTDROP_MINTHRESHOLD_MS = 1000;
     static const uint64_t COMM_KEEPALIVE_PERIOD_US = 1*1000*1000;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -566,6 +566,7 @@ private: // Identification
     int m_iOPT_SndDropDelay;         // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
     bool m_bOPT_StrictEncryption;    // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
     std::string m_sStreamName;
+    int m_iOPT_ResponseTimeout;      // Timeout for hearing anything from the peer.
 
     int m_iTsbPdDelay_ms;                           // Rx delay to absorb burst in milliseconds
     int m_iPeerTsbPdDelay_ms;                       // Tx delay that the peer uses to absorb burst in milliseconds

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -566,7 +566,7 @@ private: // Identification
     int m_iOPT_SndDropDelay;         // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
     bool m_bOPT_StrictEncryption;    // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
     std::string m_sStreamName;
-    int m_iOPT_ResponseTimeout;      // Timeout for hearing anything from the peer.
+    int m_iOPT_PeerIdleTimeout;      // Timeout for hearing anything from the peer.
 
     int m_iTsbPdDelay_ms;                           // Rx delay to absorb burst in milliseconds
     int m_iPeerTsbPdDelay_ms;                       // Tx delay that the peer uses to absorb burst in milliseconds

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -181,7 +181,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_KMPREANNOUNCE,       // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
    SRTO_STRICTENC,           // Connection to be rejected or quickly broken when one side encryption set or bad password
    SRTO_IPV6ONLY,            // IPV6_V6ONLY mode
-   SRTO_RSPTIMEO,            // Response timeout (max time of silence heard from peer) in [ms]
+   SRTO_PEERIDLETIMEO,       // Peer-idle timeout (max time of silence heard from peer) in [ms]
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -181,6 +181,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_KMPREANNOUNCE,       // How many packets before key flip the new key is annnounced and after key flip the old one decommissioned
    SRTO_STRICTENC,           // Connection to be rejected or quickly broken when one side encryption set or bad password
    SRTO_IPV6ONLY,            // IPV6_V6ONLY mode
+   SRTO_RSPTIMEO,            // Response timeout (max time of silence heard from peer) in [ms]
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:


### PR DESCRIPTION
New option: `SRTO_RSPTIMEO` allows to configure "response time", that is, the longest tolerable time during which agent receives no packets from peer. Upon passing of this time the connection is considered broken.