### PR TITLE
fix CSNode array overflow issue

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -319,9 +319,13 @@ void CSndUList::update(const CUDT* u, EReschedule reschedule)
       }
 
       remove_(u);
+      insert_(1, u);
+      return;
    }
 
-   insert_(1, u);
+   listguard.forceUnlock();
+
+   insert(1, u);
 }
 
 int CSndUList::pop(sockaddr*& addr, CPacket& pkt)


### PR DESCRIPTION
If a node has not been insert into CSNode array before, when update() is called, we need to call insert() to check whether the CSNode array is full or not.