### PR TITLE
Remove legacy references to stransmit

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -11,7 +11,7 @@
 // NOTE: This application uses C++11.
 
 // This program uses quite a simple architecture, which is mainly related to
-// the way how it's invoked: stransmit <source> <target> (plus options).
+// the way how it's invoked: srt-live-transmit <source> <target> (plus options).
 //
 // The media for <source> and <target> are filled by abstract classes
 // named Source and Target respectively. Most important virtuals to

--- a/docs/live-streaming.md
+++ b/docs/live-streaming.md
@@ -125,7 +125,7 @@ into single network units with appropriate time intervals between them. This can
 be done by an application with explicit knowledge of the type of stream and how to 
 transform it into time-divided single network transport units.
 
-The `stransmit` application, or any other application that uses SRT for
+The `srt-live-transmit` application, or any other application that uses SRT for
 reading, should always read data in 1316-byte segments (network transport units) and
 feed each such unit into the call to an appropriate `srt_send*` function. The
 important part of this process is that these 1316-byte units appear at precise times 

--- a/examples/suflip.cpp
+++ b/examples/suflip.cpp
@@ -9,7 +9,7 @@
  */
 
 // This is a simplified version of srt-live-transmit, which does not use C++11,
-// however its functionality is limited to SRT to UDT only.
+// however its functionality is limited to SRT to UDP only.
 
 #include <iostream>
 #include <string>

--- a/examples/suflip.cpp
+++ b/examples/suflip.cpp
@@ -8,7 +8,7 @@
  * 
  */
 
-// This is a simplified version of stransmit, which does not use C++11,
+// This is a simplified version of srt-live-transmit, which does not use C++11,
 // however its functionality is limited to SRT to UDT only.
 
 #include <iostream>

--- a/scripts/srt-ffplay
+++ b/scripts/srt-ffplay
@@ -27,5 +27,5 @@ if [[ -z $SRCLOC ]]; then
 	exit 1
 fi
 
-$DIRNAME/stransmit "$1" file://con/ | ffplay -
+$DIRNAME/srt-live-transmit "$1" file://con/ | ffplay -
 

--- a/srt-ffplay
+++ b/srt-ffplay
@@ -1,0 +1,1 @@
+scripts/srt-ffplay

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -11,7 +11,7 @@
 // NOTE: This application uses C++11.
 
 // This program uses quite a simple architecture, which is mainly related to
-// the way how it's invoked: stransmit <source> <target> (plus options).
+// the way how it's invoked: srt-test-live <source> <target> (plus options).
 //
 // The media for <source> and <target> are filled by abstract classes
 // named Source and Target respectively. Most important virtuals to


### PR DESCRIPTION
Seems like at some point `stransmit` got renamed to `srt-live-transmit`. I noticed this when trying to use the `srt-ffplay` script. This PR renames the few remaining references to `stransmit`. Hopefully this is helpful.