### PR TITLE
Synchronize pthread_join on TspPd

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6324,11 +6324,15 @@ void CUDT::releaseSynch()
     pthread_mutex_lock(&m_RecvLock);
     pthread_cond_signal(&m_RcvTsbPdCond);
     pthread_mutex_unlock(&m_RecvLock);
+
+    pthread_mutex_lock(&m_RecvDataLock);
     if (!pthread_equal(m_RcvTsbPdThread, pthread_t())) 
     {
         pthread_join(m_RcvTsbPdThread, NULL);
         m_RcvTsbPdThread = pthread_t();
     }
+    pthread_mutex_unlock(&m_RecvDataLock);
+
     pthread_mutex_lock(&m_RecvLock);
     pthread_mutex_unlock(&m_RecvLock);
 }


### PR DESCRIPTION
SRT is a great piece of software and we've had a really good time working with it. However, occasionally it was freezing for us and we decided to dig a little bit.

When closing an SRT socket with `srt_close`,`CUDT::releaseSynch()` is eventually called, and it calls pthread_join for the TspPd thread. If the connection happens to be broken/dead, `CUDT::releaseSynch()` may also be called from a different thread (from `CUDT::checkTimers()`).

Now, according to pthread_join's manpage: _If multiple threads simultaneously try to join with the same thread, the results are undefined_.

What we've experienced in practice is that one of the threads calling `pthread_join` is released after the thread completes, but the other is blocked forever. After this happens, usually other SRT's threads get deadlocked too (either on mutexes, or on some condition variables).

The proposed change simply wraps the call to pthread_join in a mutex. In our tests this remedies the problem, and accoring to pthreads' docs: _If that thread has already terminated, then pthread_join() returns immediately_.

If this isn't the best approach, I'll be happy to rework it into something more suitable.