### PR TITLE
CRYSPR/4SRT: CRYpto Service PRovider for SRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,10 +235,10 @@ if (ENABLE_ENCRYPTION)
 			set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
 			message(STATUS "SSL via find_package(OpenSSL): -I ${SSL_INCLUDE_DIRS} -l;${SSL_LIBRARIES}")
 		endif()
-    add_definitions(
+		add_definitions(
 			-DUSE_OPENSSL
-      )
-      endif()
+			)
+	endif()
 
 	add_definitions(-DSRT_ENABLE_ENCRYPTION)
 	message(STATUS "ENCRYPTION: ENABLED, using: ${SSL_REQUIRED_MODULES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,11 +235,10 @@ if (ENABLE_ENCRYPTION)
 			set (SSL_LIBRARIES ${OPENSSL_LIBRARIES})
 			message(STATUS "SSL via find_package(OpenSSL): -I ${SSL_INCLUDE_DIRS} -l;${SSL_LIBRARIES}")
 		endif()
-		add_definitions(
-			-DHAICRYPT_USE_OPENSSL_EVP=1
-			-DHAICRYPT_USE_OPENSSL_AES
-		)
-	endif()
+    add_definitions(
+			-DUSE_OPENSSL
+      )
+      endif()
 
 	add_definitions(-DSRT_ENABLE_ENCRYPTION)
 	message(STATUS "ENCRYPTION: ENABLED, using: ${SSL_REQUIRED_MODULES}")

--- a/haicrypt/cryspr-gnutls.c
+++ b/haicrypt/cryspr-gnutls.c
@@ -1,0 +1,178 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+
+   2019-06-27 (jdube)
+        GnuTLS/Nettle CRYSPR/4SRT (CRYypto Service PRovider for SRT)
+*****************************************************************************/
+
+#include "hcrypt.h"
+
+#include <string.h>
+
+typedef struct tag_crysprGnuTLS_AES_cb {
+        CRYSPR_cb       ccb;        /* CRYSPR control block */
+        /* Add other cryptolib specific data here */
+} crysprGnuTLS_cb;
+
+
+int crysprGnuTLS_Prng(unsigned char *rn, int len)
+{
+    return(gnutls_rnd(GNUTLS_RND_KEY,(rn),(len)) < 0 ? -1 : 0);
+}
+
+int crysprGnuTLS_AES_SetKey(
+    bool bEncrypt,              /* true:encrypt key, false:decrypt key*/
+    const unsigned char *kstr,  /* key string */
+    size_t kstr_len,            /* kstr length in  bytes (16, 24, or 32 bytes (for AES128,AES192, or AES256) */
+    CRYSPR_AESCTX *aes_key)     /* Cryptolib Specific AES key context */
+{
+    if (bEncrypt) {        /* Encrypt key */
+        if (!(kstr_len == 16 || kstr_len == 24 || kstr_len == 32)) {
+            HCRYPT_LOG(LOG_ERR, "%s", "AES_set_encrypt_key(kek) bad length\n");
+          return -1;
+        }
+        aes_set_encrypt_key (aes_key, kstr_len, kstr);
+    } else {               /* Decrypt key */
+        if (!(kstr_len == 16 || kstr_len == 24 || kstr_len == 32)) {
+            HCRYPT_LOG(LOG_ERR, "%s", "AES_set_decrypt_key(kek) bad length\n");
+          return -1;
+        }
+        aes_set_decrypt_key (aes_key, kstr_len, kstr);
+    }
+    return(0);
+}
+
+int crysprGnuTLS_AES_EcbCipher( /* AES Electronic Codebook cipher*/
+    bool bEncrypt,              /* true:encrypt, false:decrypt */
+    CRYSPR_AESCTX *aes_key,     /* CryptoLib AES context */
+    const unsigned char *indata,/* src (clear text)*/
+    size_t inlen,               /* length */
+    unsigned char *out_txt,     /* dst (cipher text) */
+    size_t *outlen)             /* dst len */
+{
+    int nblk = inlen/CRYSPR_AESBLKSZ;
+    int nmore = inlen%CRYSPR_AESBLKSZ;
+    int i;
+
+    if (bEncrypt) {
+        /* Encrypt packet payload, block by block, in output buffer */
+        for (i=0; i<nblk; i++){
+            aes_encrypt(aes_key, CRYSPR_AESBLKSZ, &out_txt[(i*CRYSPR_AESBLKSZ)], &indata[(i*CRYSPR_AESBLKSZ)]);
+        }
+        /* Encrypt last incomplete block */
+        if (0 < nmore) {
+            unsigned char intxt[CRYSPR_AESBLKSZ];
+
+            memcpy(intxt, &indata[(nblk*CRYSPR_AESBLKSZ)], nmore);
+            memset(intxt+nmore, 0, CRYSPR_AESBLKSZ-nmore);
+            aes_encrypt(aes_key, CRYSPR_AESBLKSZ, &out_txt[(nblk*CRYSPR_AESBLKSZ)], intxt);
+            nblk++;
+        }
+        if (outlen != NULL) *outlen = nblk*CRYSPR_AESBLKSZ;
+    } else { /* Decrypt */
+        for (i=0; i<nblk; i++){
+            aes_decrypt(aes_key, CRYSPR_AESBLKSZ, &out_txt[(i*CRYSPR_AESBLKSZ)], &indata[(i*CRYSPR_AESBLKSZ)]);
+        }
+        /* Encrypt last incomplete block */
+        if (0 < nmore) {
+            //shall not happens in decrypt
+        }
+        if (outlen != NULL) *outlen = nblk*CRYSPR_AESBLKSZ;
+    }
+    return 0;
+}
+
+int crysprGnuTLS_AES_CtrCipher( /* AES-CTR128 Encryption */
+    bool bEncrypt,              /* true:encrypt, false:decrypt */
+    CRYSPR_AESCTX *aes_key,     /* CryptoLib AES context */
+    unsigned char *iv,          /* iv */
+    const unsigned char *indata,/* src */
+    size_t inlen,               /* src length */
+    unsigned char *out_txt)     /* dest buffer[inlen] */
+{
+    (void)bEncrypt;             /* CTR mode encrypt for both encryption and decryption */
+
+    ctr_crypt (aes_key,         /* ctx */
+               (nettle_cipher_func*)aes_encrypt, /* nettle_cipher_func */
+               CRYSPR_AESBLKSZ,  /* cipher blocksize */
+               iv,              /* iv */
+               inlen,           /* length */
+               out_txt,         /* dest */
+               indata);         /* src */
+    return 0;
+}
+
+#ifdef CRYSPR_HAS_PBKDF2
+/*
+* Password-based Key Derivation Function
+*/
+int crysprGnuTLS_KmPbkdf2(
+    CRYSPR_cb *cryspr_cb,
+    char *passwd,           /* passphrase */
+    size_t passwd_len,      /* passphrase len */
+    unsigned char *salt,    /* salt */
+    size_t salt_len,        /* salt_len */
+    int itr,                /* iterations */
+    size_t key_len,         /* key_len */
+    unsigned char *out)     /* derived key buffer[key_len]*/
+{
+    (void)cryspr_cb;
+
+    pbkdf2_hmac_sha1(passwd_len,(const uint8_t *)passwd,itr,salt_len,salt,key_len,out);
+    return(0);
+}
+#endif /* CRYSPR_HAS_PBKDF2 */
+
+static CRYSPR_methods crysprGnuTLS_methods;
+
+CRYSPR_methods *crysprGnuTLS(void)
+{
+    if(NULL == crysprGnuTLS_methods.open) {
+        crysprInit(&crysprGnuTLS_methods); /* Set default methods */
+
+        /* CryptoLib Primitive API */
+        crysprGnuTLS_methods.prng           = crysprGnuTLS_Prng;
+        crysprGnuTLS_methods.aes_set_key    = crysprGnuTLS_AES_SetKey;
+    #if CRYSPR_HAS_AESCTR
+        crysprGnuTLS_methods.aes_ctr_cipher = crysprGnuTLS_AES_CtrCipher;
+    #endif
+    #if !(CRYSPR_HAS_AESCTR && CRYSPR_HAS_AESKWRAP)
+        /* AES-ECB only required if cryspr has no AES-CTR or no AES KeyWrap */
+        crysprGnuTLS_methods.aes_ecb_cipher = crysprGnuTLS_AES_EcbCipher;
+    #endif
+    #if !CRYSPR_HAS_PBKDF2
+        crysprGnuTLS_methods.sha1_msg_digest= crysprGnuTLS_SHA1_MsgDigest; //Onl required if using generic KmPbkdf2
+    #endif
+
+    //--Crypto Session (Top API)
+    //  crysprGnuTLS_methods.open     =
+    //  crysprGnuTLS_methods.close    =
+    //--Keying material (km) encryption
+#if CRYSPR_HAS_PBKDF2
+    	crysprGnuTLS_methods.km_pbkdf2  = crysprGnuTLS_KmPbkdf2;
+#endif
+    //	crysprGnuTLS_methods.km_setkey  =
+    //  crysprGnuTLS_methods.km_wrap    =
+    //  crysprGnuTLS_methods.km_unwrap  =
+    //--Media stream (ms) encryption
+    //  crysprGnuTLS_methods.ms_setkey  =
+    //	crysprGnuTLS_methods.ms_encrypt =
+    //	crysprGnuTLS_methods.ms_decrypt =
+    }
+    return(&crysprGnuTLS_methods);
+}
+
+
+

--- a/haicrypt/cryspr-gnutls.h
+++ b/haicrypt/cryspr-gnutls.h
@@ -1,0 +1,60 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+
+   2019-06-27 (jdube)
+        GnuTLS/Nettle CRYSPR/4SRT (CRYypto Service PRovider for SRT)
+
+*****************************************************************************/
+
+#ifndef CRYSPR_GNUTLS_H
+#define CRYSPR_GNUTLS_H
+
+#include <gnutls/crypto.h>  //gnutls_rnd()
+
+#include <nettle/aes.h>     //has AES cipher
+#include <nettle/ctr.h>     //has CTR cipher mode
+#include <nettle/pbkdf2.h>  //has Password-based Key Derivation Function 2
+//#include <nettle/sha1.h>  //No need for sha1 since we have pbkdf2
+
+
+/* Define CRYSPR_HAS_AESCTR to 1 if this CRYSPR has AESCTR cipher mode
+   if not set it 0 to use enable CTR cipher mode implementation using ECB cipher mode
+   and provide the aes_ecb_cipher method.
+*/
+#define CRYSPR_HAS_AESCTR 1
+
+/* Define CRYSPR_HAS_AESKWRAP to 1 if this CRYSPR has AES Key Wrap
+   if not set to 0 to enable default/fallback crysprFallback_AES_WrapKey/crysprFallback_AES_UnwrapKey methods
+   and provide the aes_ecb_cipher method  .
+*/
+#define CRYSPR_HAS_AESKWRAP 0
+
+/* Define CRYSPR_HAS_PBKDF2 to 1 if this CRYSPR has SHA1-HMAC Password-based Key Derivaion Function 2
+   if not set to 0 to enable not-yet-implemented/fallback crysprFallback.km_pbkdf2 method
+   and provide the sha1_msg_digest method.
+*/
+#define CRYSPR_HAS_PBKDF2 1
+
+/*
+#define CRYSPR_AESCTX to the CRYSPR specifix AES key context object.
+This type reserves room in the CRYPSPR control block for Haicrypt KEK and SEK
+It is set from hte keystring through CRYSPR_methods.aes_set_key and passed
+to CRYSPR_methods.aes_XXX.
+*/
+typedef struct aes_ctx CRYSPR_AESCTX;   /* CRYpto Service PRovider AES key context */
+
+struct tag_CRYSPR_methods *crysprGnuTLS(void);
+
+#endif /* CRYSPR_GNUTLS_H */
+

--- a/haicrypt/cryspr-openssl.c
+++ b/haicrypt/cryspr-openssl.c
@@ -1,0 +1,215 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+
+   2019-06-26 (jdube)
+        OpenSSL CRYSPR/4SRT (CRYypto Service PRovider for SRT).
+*****************************************************************************/
+
+#include "hcrypt.h"
+
+#include <string.h>
+
+
+typedef struct tag_crysprOpenSSL_AES_cb {
+        CRYSPR_cb       ccb;
+        /* Add cryptolib specific data here */
+} crysprOpenSSL_cb;
+
+
+int crysprOpenSSL_Prng(unsigned char *rn, int len)
+{
+    return(RAND_bytes(rn, len) <= 0 ? -1 : 0);
+}
+
+int crysprOpenSSL_AES_SetKey(
+    bool bEncrypt,              /* true Enxcrypt key, false: decrypt */
+    const unsigned char *kstr,  /* key sttring*/
+    size_t kstr_len,            /* kstr len in  bytes (16, 24, or 32 bytes (for AES128,AES192, or AES256) */
+    CRYSPR_AESCTX *aes_key)     /* CRYpto Service PRovider AES Key context */
+{
+    if (bEncrypt) {        /* Encrypt key */
+        if (AES_set_encrypt_key(kstr, kstr_len * 8, aes_key)) {
+            HCRYPT_LOG(LOG_ERR, "%s", "AES_set_encrypt_key(kek) failed\n");
+            return(-1);
+        }
+    } else {               /* Decrypt key */
+        if (AES_set_decrypt_key(kstr, kstr_len * 8, aes_key)) {
+            HCRYPT_LOG(LOG_ERR, "%s", "AES_set_decrypt_key(kek) failed\n");
+            return(-1);
+        }
+    }
+    return(0);
+}
+
+#if !(CRYSPR_HAS_AESCTR && CRYSPR_HAS_AESKWRAP)
+
+int crysprOpenSSL_AES_EcbCipher(
+    bool bEncrypt,              /* true:encrypt, false:decrypt */
+    CRYSPR_AESCTX *aes_key,     /* CRYpto Service PRovider AES Key context */
+    const unsigned char *indata,/* src (clear text)*/
+    size_t inlen,               /* length */
+    unsigned char *out_txt,     /* dst (cipher text) */
+    size_t *outlen)             /* dst len */
+{
+    int nblk = inlen/CRYSPR_AESBLKSZ;
+    int nmore = inlen%CRYSPR_AESBLKSZ;
+    int i;
+
+    if (bEncrypt) {
+        /* Encrypt packet payload, block by block, in output buffer */
+        for (i=0; i<nblk; i++){
+            AES_ecb_encrypt(&indata[(i*CRYSPR_AESBLKSZ)],
+                &out_txt[(i*CRYSPR_AESBLKSZ)], aes_key, AES_ENCRYPT);
+        }
+        /* Encrypt last incomplete block */
+        if (0 < nmore) {
+            unsigned char intxt[CRYSPR_AESBLKSZ];
+
+            memcpy(intxt, &indata[(nblk*CRYSPR_AESBLKSZ)], nmore);
+            memset(intxt+nmore, 0, CRYSPR_AESBLKSZ-nmore);
+            AES_ecb_encrypt(intxt, &out_txt[(nblk*CRYSPR_AESBLKSZ)], aes_key, AES_ENCRYPT);
+            nblk++;
+        }
+        if (outlen != NULL) *outlen = nblk*CRYSPR_AESBLKSZ;
+    } else { /* Decrypt */
+        for (i=0; i<nblk; i++){
+            AES_ecb_encrypt(&indata[(i*CRYSPR_AESBLKSZ)],
+                &out_txt[(i*CRYSPR_AESBLKSZ)], aes_key, AES_DECRYPT);
+        }
+        /* Encrypt last incomplete block */
+        if (0 < nmore) {
+            //shall not happens in decrypt
+        }
+        if (outlen != NULL) *outlen = nblk*CRYSPR_AESBLKSZ;
+    }
+    return 0;
+}
+#endif /* !(CRYSPR_HAS_AESCTR && CRYSPR_HAS_AESKWRAP) */
+
+int crysprOpenSSL_AES_CtrCipher(
+    bool bEncrypt,              /* true:encrypt, false:decrypt */
+    CRYSPR_AESCTX *aes_key,     /* CRYpto Service PRovider AES Key context */
+    unsigned char *iv,          /* iv */
+    const unsigned char *indata,/* src */
+    size_t inlen,               /* length */
+    unsigned char *out_txt)     /* dest */
+{
+    unsigned char ctr[CRYSPR_AESBLKSZ];
+    unsigned blk_ofs = 0;
+    (void)bEncrypt;             /* CTR mode encrypt for both encryption and decryption */
+
+    memset(&ctr[0], 0, sizeof(ctr));
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_IS_BORINGSSL))
+    CRYPTO_ctr128_encrypt(indata, out_txt,
+                          inlen, aes_key, iv, ctr, &blk_ofs, (block128_f) AES_encrypt);
+#else
+    AES_ctr128_encrypt(indata, out_txt,
+                       inlen, aes_key, iv, ctr, &blk_ofs);
+#endif
+    return 0;
+}
+
+/*
+* Password-based Key Derivation Function
+*/
+int crysprOpenSSL_KmPbkdf2(
+    CRYSPR_cb *cryspr_cb,
+    char *passwd,           /* passphrase */
+    size_t passwd_len,      /* passphrase len */
+    unsigned char *salt,    /* salt */
+    size_t salt_len,        /* salt_len */
+    int itr,                /* iterations */
+    size_t key_len,         /* key_len */
+    unsigned char *out)     /* derived key */
+{
+    (void)cryspr_cb;
+    int rc = PKCS5_PBKDF2_HMAC_SHA1(passwd,passwd_len,salt,salt_len,itr,key_len,out);
+    return(rc == 1? 0 : -1);
+}
+
+#if CRYSPR_HAS_AESKWRAP
+int crysprOpenSSL_KmWrap(CRYSPR_cb *cryspr_cb,
+		unsigned char *wrap,
+		const unsigned char *sek,
+        unsigned int seklen)
+{
+    crysprOpenSSL_cb *aes_data = (crysprOpenSSL_cb *)cryspr_cb;
+    AES_KEY *kek = &aes_data->ccb.aes_kek; //key encrypting key
+
+    return(((seklen + HAICRYPT_WRAPKEY_SIGN_SZ) == (unsigned int)AES_wrap_key(kek, NULL, wrap, sek, seklen)) ? 0 : -1);
+}
+
+int crysprOpenSSL_KmUnwrap(
+        CRYSPR_cb *cryspr_cb,
+		unsigned char *sek,             //Stream encrypting key
+		const unsigned char *wrap,
+        unsigned int wraplen)
+{
+    crysprOpenSSL_cb *aes_data = (crysprOpenSSL_cb *)cryspr_cb;
+    AES_KEY *kek = &aes_data->ccb.aes_kek; //key encrypting key
+
+    return(((wraplen - HAICRYPT_WRAPKEY_SIGN_SZ) == (unsigned int)AES_unwrap_key(kek, NULL, sek, wrap, wraplen)) ? 0 : -1);
+}
+#endif /*CRYSPR_HAS_AESKWRAP*/
+
+
+static CRYSPR_methods crysprOpenSSL_methods;
+
+CRYSPR_methods *crysprOpenSSL(void)
+{
+    if(NULL == crysprOpenSSL_methods.open) {
+        crysprInit(&crysprOpenSSL_methods);    //Default/fallback methods
+
+        crysprOpenSSL_methods.prng           = crysprOpenSSL_Prng;
+    //--CryptoLib Primitive API-----------------------------------------------
+        crysprOpenSSL_methods.aes_set_key    = crysprOpenSSL_AES_SetKey;
+    #if CRYSPR_HAS_AESCTR
+        crysprOpenSSL_methods.aes_ctr_cipher = crysprOpenSSL_AES_CtrCipher;
+    #endif
+    #if !(CRYSPR_HAS_AESCTR && CRYSPR_HAS_AESKWRAP)
+        /* AES-ECB only required if cryspr has no AES-CTR and no AES KeyWrap */
+        /* OpenSSL has both AESCTR and AESKWRP and the AESECB wrapper is only used
+           to test the falback methods */
+        crysprOpenSSL_methods.aes_ecb_cipher = crysprOpenSSL_AES_EcbCipher;
+    #endif
+    #if !CRYSPR_HAS_PBKDF2
+        crysprOpenSSL_methods.sha1_msg_digest= NULL; //Required to use eventual default/fallback KmPbkdf2
+    #endif
+
+    //--Crypto Session API-----------------------------------------
+    //  crysprOpenSSL_methods.open     =
+    //  crysprOpenSSL_methods.close    =
+    //--Keying material (km) encryption
+
+#if CRYSPR_HAS_PBKDF2
+    	crysprOpenSSL_methods.km_pbkdf2  = crysprOpenSSL_KmPbkdf2;
+#else
+#error  There is no default/fallback method for PBKDF2
+#endif
+    //	crysprOpenSSL_methods.km_setkey  =
+#if CRYSPR_HAS_AESKWRAP
+        crysprOpenSSL_methods.km_wrap    = crysprOpenSSL_KmWrap;
+        crysprOpenSSL_methods.km_unwrap  = crysprOpenSSL_KmUnwrap;
+#endif
+
+    //--Media stream (ms) encryption
+    //  crysprOpenSSL_methods.ms_setkey  =
+    //	crysprOpenSSL_methods.ms_encrypt =
+    //	crysprOpenSSL_methods.ms_decrypt =
+    }
+    return(&crysprOpenSSL_methods);
+}
+
+

--- a/haicrypt/cryspr-openssl.h
+++ b/haicrypt/cryspr-openssl.h
@@ -1,0 +1,65 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+
+   2019-06-26 (jdube)
+        OpenSSL Direct AES CRYSPR/4SRT (CRYypto Service PRovider for SRT).
+*****************************************************************************/
+
+#ifndef CRYSPR_OPENSSL_H
+#define CRYSPR_OPENSSL_H
+
+#include <openssl/evp.h>	/* PKCS5_xxx() */
+#include <openssl/aes.h>	/* AES_xxx() */
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_IS_BORINGSSL))
+# include <openssl/modes.h>	/* CRYPTO_xxx() */
+#endif
+#include <openssl/rand.h>
+#include <openssl/err.h>
+#include <openssl/opensslv.h> /* OPENSSL_VERSION_NUMBER */
+
+/* Define CRYSPR_HAS_AESCTR to 1 if this CRYSPR has AESCTR cipher mode
+   if not set it 0 to use enable CTR cipher mode implementation using ECB cipher mode
+   and provide the aes_ecb_cipher method.
+*/
+#define CRYSPR_HAS_AESCTR 1
+
+/* Define CRYSPR_HAS_AESKWRAP to 1 if this CRYSPR has AES Key Wrap
+   if not set to 0 to enable default/fallback crysprFallback_AES_WrapKey/crysprFallback_AES_UnwrapKey methods
+   and provide the aes_ecb_cipher method  .
+*/
+#if (OPENSSL_VERSION_NUMBER < 0x0090808fL) //0.9.8h
+#define CRYSPR_HAS_AESKWRAP 0
+#else
+#define CRYSPR_HAS_AESKWRAP 1
+#endif
+
+/* Define CRYSPR_HAS_PBKDF2 to 1 if this CRYSPR has SHA1-HMAC Password-based Key Derivaion Function 2
+   if not set to 0 to enable not-yet-implemented/fallback crysprFallback.km_pbkdf2 method
+   and provide the sha1_msg_digest method.
+*/
+#define CRYSPR_HAS_PBKDF2 1             /* Define to 1 if CRYSPR has Password-based Key Derivaion Function 2 */
+
+/*
+#define CRYSPR_AESCTX to the CRYSPR specifix AES key context object.
+This type reserves room in the CRYPSPR control block for Haicrypt KEK and SEK
+It is set from hte keystring through CRYSPR_methods.aes_set_key and passed
+to CRYSPR_methods.aes_*.
+*/
+typedef AES_KEY CRYSPR_AESCTX;          /* CRYpto Service PRovider AES key context */
+
+struct tag_CRYSPR_methods *crysprOpenSSL(void);
+
+#endif /* CRYSPR_OPENSSL_H */
+

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -1,0 +1,710 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+
+   2019-06-28 (jdube)
+        CRYSPR/4SRT Initial implementation.
+*****************************************************************************/
+
+#include "hcrypt.h"
+#include "cryspr.h"
+
+#include <string.h>
+
+int crysprStub_Prng(unsigned char *rn, int len)
+{
+    (void)rn;
+    (void)len;
+    return(0);
+}
+
+int crysprStub_AES_SetKey(
+    bool bEncrypt,              /* true Enxcrypt key, false: decrypt */
+    const unsigned char *kstr,  /* key sttring*/
+    size_t kstr_len,            /* kstr len in  bytes (16, 24, or 32 bytes (for AES128,AES192, or AES256) */
+    CRYSPR_AESCTX *aes_key)     /* Cryptolib Specific AES key context */
+{
+    (void)bEncrypt;
+    (void)kstr;
+    (void)kstr_len;
+    (void)aes_key;
+
+    return(0);
+}
+
+int crysprStub_AES_EcbCipher(
+    bool bEncrypt,              /* true:encrypt, false:decrypt */
+    CRYSPR_AESCTX *aes_key,     /* AES context */
+    const unsigned char *indata,/* src (clear text)*/
+    size_t inlen,               /* length */
+    unsigned char *out_txt,     /* dst (cipher text) */
+    size_t *outlen)             /* dst len */
+{
+    (void)bEncrypt;
+    (void)aes_key;
+    (void)indata;
+    (void)inlen;
+    (void)out_txt;
+    (void)outlen;
+
+    return -1;
+}
+
+int crysprStub_AES_CtrCipher(
+    bool bEncrypt,              /* true:encrypt, false:decrypt */
+    CRYSPR_AESCTX *aes_key,     /* AES context */
+    unsigned char *iv,          /* iv */
+    const unsigned char *indata,/* src */
+    size_t inlen,               /* length */
+    unsigned char *out_txt)     /* dest */
+{
+    (void)bEncrypt;
+    (void)aes_key;
+    (void)iv;
+    (void)indata;
+    (void)inlen;
+    (void)out_txt;
+
+    return(-1);
+}
+
+unsigned char *crysprStub_SHA1_MsgDigest(
+    const unsigned char *m, /* in: message */
+    size_t m_len,           /* message length */
+    unsigned char *md)      /* out: message digest buffer *160 bytes */
+{
+    (void)m;
+    (void)m_len;
+    (void)md;
+
+    return(NULL);//return md;
+}
+
+/*
+* Password-based Key Derivation Function
+*/
+int crysprStub_KmPbkdf2(
+    CRYSPR_cb *cryspr_cb,
+    char *passwd,           /* passphrase */
+    size_t passwd_len,      /* passphrase len */
+    unsigned char *salt,    /* salt */
+    size_t salt_len,        /* salt_len */
+    int itr,                /* iterations */
+    size_t key_len,         /* key_len */
+    unsigned char *out)     /* derived key */
+{
+    (void)cryspr_cb;
+    (void)passwd;
+    (void)passwd_len;
+    (void)salt;
+    (void)salt_len;
+    (void)itr;
+    (void)key_len;
+    (void)out;
+
+    /* >>Todo:
+     * develop PBKDF2 using SHA1 primitive cryspr_cb->cryspr->sha1_msg_digest() for cryptolibs not providing it
+     */
+    return(-1);
+}
+
+static int crysprFallback_KmSetKey(CRYSPR_cb *cryspr_cb, bool bWrap, const unsigned char *kek, size_t kek_len)
+{
+	CRYSPR_AESCTX *aes_kek = &cryspr_cb->aes_kek;
+
+    if (cryspr_cb->cryspr->aes_set_key(bWrap, kek, kek_len, aes_kek)) {
+        HCRYPT_LOG(LOG_ERR, "AES_set_%s_key(kek) failed\n", bWrap? "encrypt": "decrypt");
+        return(-1);
+    }
+	return(0);
+}
+
+/*
+* AES_wrap_key()/AES_unwrap_key() introduced in openssl 0.9.8h
+* Here is an implementation using AES native API for cryspr not providing it.
+*/
+#include <openssl/bio.h>
+
+static const unsigned char default_iv[] = {
+  0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6,
+};
+int crysprFallback_AES_WrapKey(CRYSPR_cb *cryspr_cb,
+		unsigned char *out,
+		const unsigned char *in,
+        unsigned int inlen)
+	{
+	unsigned char *A, B[16], *R;
+    const unsigned char *iv = default_iv;
+	unsigned int i, j, t;
+	if ((inlen & 0x7) || (inlen < 8))
+		return -1;
+	A = B;
+	t = 1;
+	memcpy(out + 8, in, inlen);
+
+	memcpy(A, iv, 8);
+
+	for (j = 0; j < 6; j++)
+		{
+		R = out + 8;
+		for (i = 0; i < inlen; i += 8, t++, R += 8)
+			{
+			memcpy(B + 8, R, 8);
+            {
+                size_t outlen = 16;
+                cryspr_cb->cryspr->aes_ecb_cipher(true, &cryspr_cb->aes_kek, B, 16, B, &outlen);
+            }
+			A[7] ^= (unsigned char)(t & 0xff);
+			if (t > 0xff)	
+				{
+				A[6] ^= (unsigned char)((t >> 8) & 0xff);
+				A[5] ^= (unsigned char)((t >> 16) & 0xff);
+				A[4] ^= (unsigned char)((t >> 24) & 0xff);
+				}
+			memcpy(R, B + 8, 8);
+			}
+		}
+	memcpy(out, A, 8);
+	return inlen + 8;
+	}
+
+int crysprFallback_AES_UnwrapKey(CRYSPR_cb *cryspr_cb,
+		unsigned char *out,
+		const unsigned char *in,
+        unsigned int inlen)
+	{
+	unsigned char *A, B[16], *R;
+    const unsigned char *iv = default_iv;
+	unsigned int i, j, t;
+	inlen -= 8;
+	if (inlen & 0x7)
+		return -1;
+	if (inlen < 8)
+		return -1;
+	A = B;
+	t =  6 * (inlen >> 3);
+	memcpy(A, in, 8);
+	memcpy(out, in + 8, inlen);
+	for (j = 0; j < 6; j++)
+		{
+		R = out + inlen - 8;
+		for (i = 0; i < inlen; i += 8, t--, R -= 8)
+			{
+			A[7] ^= (unsigned char)(t & 0xff);
+			if (t > 0xff)	
+				{
+				A[6] ^= (unsigned char)((t >> 8) & 0xff);
+				A[5] ^= (unsigned char)((t >> 16) & 0xff);
+				A[4] ^= (unsigned char)((t >> 24) & 0xff);
+				}
+			memcpy(B + 8, R, 8);
+            {
+                size_t outlen = 16;
+                cryspr_cb->cryspr->aes_ecb_cipher(false, &cryspr_cb->aes_kek, B, 16, B, &outlen);
+            }
+			memcpy(R, B + 8, 8);
+			}
+		}
+	if (memcmp(A, iv, 8))
+		{
+		memset(out, 0, inlen);
+		return 0;
+		}
+	return inlen;
+}
+
+static unsigned char *_crysprFallback_GetOutbuf(CRYSPR_cb *cryspr_cb, size_t pfx_len, size_t out_len)
+{
+	unsigned char *out_buf;
+
+	if ((pfx_len + out_len) > (cryspr_cb->outbuf_siz - cryspr_cb->outbuf_ofs)) {
+		/* Not enough room left, circle buffers */
+		cryspr_cb->outbuf_ofs = 0;
+	}
+	out_buf = &cryspr_cb->outbuf[cryspr_cb->outbuf_ofs];
+	cryspr_cb->outbuf_ofs += (pfx_len + out_len);
+	return(out_buf);
+}
+
+static CRYSPR_cb *crysprFallback_Open(CRYSPR_methods *cryspr, size_t max_len)
+{
+	CRYSPR_cb *cryspr_cb;
+	unsigned char *membuf;
+	size_t memsiz, padded_len = hcryptMsg_PaddedLen(max_len, 128/8);
+
+	HCRYPT_LOG(LOG_DEBUG, "%s", "Using OpenSSL AES\n");
+
+	memsiz = sizeof(*cryspr_cb) + (CRYSPR_OUTMSGMAX * padded_len);
+#if !CRYSPR_HAS_AESCTR
+    memsiz += HCRYPT_CTR_STREAM_SZ;
+#endif /* !CRYSPR_HAS_AESCTR */
+
+	cryspr_cb = malloc(memsiz);
+	if (NULL == cryspr_cb) {
+		HCRYPT_LOG(LOG_ERR, "malloc(%zd) failed\n", memsiz);
+		return(NULL);
+	}
+	membuf = (unsigned char *)cryspr_cb;
+	membuf += sizeof(*cryspr_cb);
+
+#if !CRYSPR_HAS_AESCTR
+	cryspr_cb->ctr_stream = membuf;
+	membuf += HCRYPT_CTR_STREAM_SZ;
+	cryspr_cb->ctr_stream_siz = HCRYPT_CTR_STREAM_SZ;
+	cryspr_cb->ctr_stream_len = 0;
+#endif /* !CRYSPR_HAS_AESCTR */
+
+	cryspr_cb->outbuf = membuf;
+	cryspr_cb->outbuf_siz = CRYSPR_OUTMSGMAX * padded_len;
+	cryspr_cb->outbuf_ofs = 0;
+//	membuf += cryspr_cb->outbuf_siz;
+
+    cryspr_cb->cryspr=(CRYSPR_methods *)cryspr;
+
+	return(cryspr_cb);
+}
+
+static int crysprFallback_Close(CRYSPR_cb *cryspr_cb)
+{
+	if (NULL != cryspr_cb) {
+		free(cryspr_cb);
+	}
+	return(0);
+}
+
+static int crysprFallback_MsSetKey(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx, const unsigned char *key, size_t key_len)
+{
+	CRYSPR_AESCTX *aes_sek = &cryspr_cb->aes_sek[hcryptCtx_GetKeyIndex(ctx)]; /* Ctx tells if it's for odd or even key */
+
+	if ((ctx->flags & HCRYPT_CTX_F_ENCRYPT)        /* Encrypt key */
+	||  (ctx->mode == HCRYPT_CTX_MODE_AESCTR)) {   /* CTR mode decrypts using encryption methods */
+        if (cryspr_cb->cryspr->aes_set_key(true, key, key_len, aes_sek)) {
+			HCRYPT_LOG(LOG_ERR, "%s", "CRYSPR->set_encrypt_key(sek) failed\n");
+			return(-1);
+		}
+	} else {                                       /* Decrypt key */
+		if (cryspr_cb->cryspr->aes_set_key(false, key, key_len, aes_sek)) {
+			HCRYPT_LOG(LOG_ERR, "%s", "CRYSPR->set_decrypt_key(sek) failed\n");
+			return(-1);
+		}
+	}
+	return(0);
+}
+
+#if !CRYSPR_HAS_AESCTR
+static int _crysprFallback_AES_SetCtrStream(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx, size_t len, unsigned char *iv)
+{
+	/* Counter stream:
+	 *   0   1   2   3   4   5     nblk
+	 * +---+---+---+---+---+---+---+---+
+	 * |blk|blk|blk|blk|blk|blk|...|blk|
+	 * +---+---+---+---+---+---+---+---+
+	 */
+
+	/* IV (128-bit):
+	 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+	 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+	 * |                   0s                  |      pki      |  ctr  |
+	 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+	 *                            XOR
+	 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+	 * |                         nonce                         +
+	 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+	 *
+	 * pki    (32-bit): packet index
+	 * ctr    (16-bit): block counter
+	 * nonce (112-bit): number used once (salt)
+	 */
+	unsigned char ctr[HCRYPT_CTR_BLK_SZ];
+	unsigned nblk;
+
+	ASSERT(NULL != cryspr_cb);
+	ASSERT(NULL != ctx);
+
+	memcpy(ctr, iv, HCRYPT_CTR_BLK_SZ);
+
+	nblk = (len + (HCRYPT_CTR_BLK_SZ-1))/HCRYPT_CTR_BLK_SZ;
+	if ((nblk * HCRYPT_CTR_BLK_SZ) <= cryspr_cb->ctr_stream_siz) {
+		unsigned blk;
+		unsigned char *csp = &cryspr_cb->ctr_stream[0];
+
+		for(blk = 0; blk < nblk; blk++) {
+			memcpy(csp, ctr, HCRYPT_CTR_BLK_SZ);
+			csp += HCRYPT_CTR_BLK_SZ;
+			if (0 == ++(ctr[HCRYPT_CTR_BLK_SZ-1])) ++(ctr[HCRYPT_CTR_BLK_SZ-2]);
+		}
+		cryspr_cb->ctr_stream_len = nblk * HCRYPT_CTR_BLK_SZ;
+	} else {
+		HCRYPT_LOG(LOG_ERR, "packet too long(%zd)\n", len);
+		return(-1);
+	}
+	return(0);
+}
+#endif
+
+static int crysprFallback_MsEncrypt(
+	CRYSPR_cb *cryspr_cb,
+	hcrypt_Ctx *ctx,
+	hcrypt_DataDesc *in_data, int nbin ATR_UNUSED,
+	void *out_p[], size_t out_len_p[], int *nbout_p)
+{
+	unsigned char *out_msg;
+	size_t out_len = 0;	//payload size
+	int pfx_len;
+
+	ASSERT(NULL != ctx);
+	ASSERT(NULL != cryspr_cb);
+	ASSERT((NULL != in_data) || (1 == nbin)); //Only one in_data[] supported
+
+	/* 
+	* Get message prefix length
+	* to reserve room for unencrypted message header in output buffer
+	*/
+	pfx_len = ctx->msg_info->pfx_len;
+
+	/* Get buffer room from the internal circular output buffer */
+	out_msg = _crysprFallback_GetOutbuf(cryspr_cb, pfx_len, in_data[0].len);
+
+	if (NULL != out_msg) {
+		switch(ctx->mode) {
+		case HCRYPT_CTX_MODE_AESCTR: /* Counter mode */
+		{
+#if CRYSPR_HAS_AESCTR
+            /* Get current key (odd|even) from context */
+            CRYSPR_AESCTX *aes_key = &cryspr_cb->aes_sek[hcryptCtx_GetKeyIndex(ctx)];
+            unsigned char iv[CRYSPR_AESBLKSZ];
+
+            /* Get input packet index (in network order) */
+            hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
+
+            /*
+            * Compute the Initial Vector
+            * IV (128-bit):
+            *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            * |                   0s                  |      pki      |  ctr  |
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            *                            XOR
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            * |                         nonce                         +
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            *
+            * pki    (32-bit): packet index
+            * ctr    (16-bit): block counter
+            * nonce (112-bit): number used once (salt)
+            */
+            hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
+
+            cryspr_cb->cryspr->aes_ctr_cipher(true, aes_key, iv, in_data[0].payload, in_data[0].len,
+                                                  &out_msg[pfx_len]);
+#else /*CRYSPR_HAS_AESCTR*/
+            /* Get current key (odd|even) from context */
+            CRYSPR_AESCTX *aes_key = &cryspr_cb->aes_sek[hcryptCtx_GetKeyIndex(ctx)];
+            unsigned char iv[CRYSPR_AESBLKSZ];
+            int iret = 0;
+
+   			/* Get input packet index (in network order) */
+			hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
+
+			/*
+			* Compute the Initial Vector
+			* IV (128-bit):
+			*    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			* |                   0s                  |      pki      |  ctr  |
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			*                            XOR
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			* |                         nonce                         +
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			*
+			* pki    (32-bit): packet index
+			* ctr    (16-bit): block counter
+			* nonce (112-bit): number used once (salt)
+			*/
+			hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
+
+            /* Create CtrStream. May be longer than in_len (next cryspr block size boundary) */
+    		iret = _crysprFallback_AES_SetCtrStream(cryspr_cb, ctx, in_data[0].len, iv);
+    		if (iret) {
+    			return(iret);
+    		}
+    		/* Reserve output buffer for cryspr */
+    		out_msg = _crysprFallback_GetOutbuf(cryspr_cb, pfx_len, cryspr_cb->ctr_stream_len);
+
+    		/* Create KeyStream (encrypt CtrStream) */
+    		iret = cryspr_cb->cryspr->aes_ecb_cipher(true, aes_key,
+    			cryspr_cb->ctr_stream, cryspr_cb->ctr_stream_len,
+    			&out_msg[pfx_len], &out_len);
+    		if (iret) {
+    			HCRYPT_LOG(LOG_ERR, "%s", "hcOpenSSL_AES_ecb_cipher(encrypt, failed\n");
+    			return(iret);
+    		}
+#endif/*CRYSPR_HAS_AESCTR*/
+			/* Prepend packet prefix (clear text) in output buffer */
+			memcpy(out_msg, in_data[0].pfx, pfx_len);
+			/* CTR mode output length is same as input, no padding */
+			out_len = in_data[0].len;
+			break;
+		}
+		case HCRYPT_CTX_MODE_CLRTXT:    /* Clear text mode (transparent mode for tests) */
+			memcpy(&out_msg[pfx_len], in_data[0].payload, in_data[0].len);
+			memcpy(out_msg, in_data[0].pfx, pfx_len);
+			out_len = in_data[0].len;
+			break;
+		default:
+			/* Unsupported cipher mode */
+			return(-1);
+		}
+	} else {
+		/* input data too big */
+		return(-1);
+	}
+
+	if (out_len > 0) {
+        /* Encrypted messages have been produced */
+        if (NULL == out_p) {
+            /*
+            * Application did not provided output buffer,
+            * so copy encrypted message back in input buffer
+            */
+            memcpy(in_data[0].pfx, out_msg, pfx_len);
+            #if !CRYSPR_HAS_AESCTR
+            if (ctx->mode == HCRYPT_CTX_MODE_AESCTR) {
+                /* XOR KeyStream with input text directly in input buffer */
+                hcrypt_XorStream(in_data[0].payload, &out_msg[pfx_len], out_len);
+            }else{
+                /* Copy output data back in input buffer */
+                memcpy(in_data[0].payload, &out_msg[pfx_len], out_len);
+            }
+            #else /* CRYSPR_HAS_AESCTR */
+                /* Copy output data back in input buffer */
+                memcpy(in_data[0].payload, &out_msg[pfx_len], out_len);
+            #endif /* CRYSPR_HAS_AESCTR */
+        } else {
+            /* Copy header in output buffer if needed */
+            if (pfx_len > 0) memcpy(out_msg, in_data[0].pfx, pfx_len);
+            #if !CRYSPR_HAS_AESCTR
+            if (ctx->mode == HCRYPT_CTX_MODE_AESCTR) {
+                hcrypt_XorStream(&out_msg[pfx_len], in_data[0].payload, out_len);
+            }
+            #endif /* CRYSPR_HAS_AESCTR */
+            out_p[0] = out_msg;
+            out_len_p[0] = pfx_len + out_len;
+            *nbout_p = 1;
+        }
+	} else {
+		/*
+		* Nothing out
+		* This is not an error for implementations using deferred/async processing
+		* with co-processor, DSP, crypto hardware, etc.
+		* Submitted input data could be returned encrypted in a next call.
+		*/
+		if (nbout_p != NULL) *nbout_p = 0;
+		return(-1);
+	}
+	return(0);
+}
+
+static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
+	hcrypt_DataDesc *in_data, int nbin ATR_UNUSED, void *out_p[], size_t out_len_p[], int *nbout_p)
+{
+	unsigned char *out_txt;
+	size_t out_len;
+	int iret = 0;
+
+	ASSERT(NULL != cryspr_cb);
+	ASSERT(NULL != ctx);
+	ASSERT((NULL != in_data) || (1 == nbin)); //Only one in_data[] supported
+
+	/* Reserve output buffer (w/no header) */
+	out_txt = _crysprFallback_GetOutbuf(cryspr_cb, 0, in_data[0].len);
+
+	if (NULL != out_txt) {
+		switch(ctx->mode) {
+		case HCRYPT_CTX_MODE_AESCTR: 
+		{
+#if CRYSPR_HAS_AESCTR
+            /* Get current key (odd|even) from context */
+            CRYSPR_AESCTX *aes_key = &cryspr_cb->aes_sek[hcryptCtx_GetKeyIndex(ctx)];
+            unsigned char iv[CRYSPR_AESBLKSZ];
+
+            /* Get input packet index (in network order) */
+            hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
+
+            /*
+            * Compute the Initial Vector
+            * IV (128-bit):
+            *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            * |                   0s                  |      pki      |  ctr  |
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            *                            XOR
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            * |                         nonce                         +
+            * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+            *
+            * pki    (32-bit): packet index
+            * ctr    (16-bit): block counter
+            * nonce (112-bit): number used once (salt)
+            */
+            hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
+
+            cryspr_cb->cryspr->aes_ctr_cipher(false, aes_key, iv, in_data[0].payload, in_data[0].len,
+                                                  out_txt);
+            out_len = in_data[0].len;
+#else  /*CRYSPR_HAS_AESCTR*/
+            /* Get current key (odd|even) from context */
+            CRYSPR_AESCTX *aes_key = &cryspr_cb->aes_sek[hcryptCtx_GetKeyIndex(ctx)];
+            unsigned char iv[CRYSPR_AESBLKSZ];
+            int iret = 0;
+
+   			/* Get input packet index (in network order) */
+			hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
+
+			/*
+			* Compute the Initial Vector
+			* IV (128-bit):
+			*    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			* |                   0s                  |      pki      |  ctr  |
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			*                            XOR
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			* |                         nonce                         +
+			* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			*
+			* pki    (32-bit): packet index
+			* ctr    (16-bit): block counter
+			* nonce (112-bit): number used once (salt)
+			*/
+			hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
+
+            /* Create CtrStream. May be longer than in_len (next cipher block size boundary) */
+    		iret = _crysprFallback_AES_SetCtrStream(cryspr_cb, ctx, in_data[0].len, iv);
+    		if (iret) {
+    			return(iret);
+    		}
+    		/* Reserve output buffer for cryspr */
+    		out_txt = _crysprFallback_GetOutbuf(cryspr_cb, 0, cryspr_cb->ctr_stream_len);
+
+    		/* Create KeyStream (encrypt CtrStream) */
+    		iret = cryspr_cb->cryspr->aes_ecb_cipher(true, aes_key,
+    			cryspr_cb->ctr_stream, cryspr_cb->ctr_stream_len,
+    			out_txt, &out_len);
+    		if (iret) {
+    			HCRYPT_LOG(LOG_ERR, "%s", "crysprNatural_AES_ecb_cipher(encrypt failed\n");
+    			return(iret);
+    		}
+
+#endif /*CRYSPR_HAS_AESCTR*/
+			break;
+		}
+		case HCRYPT_CTX_MODE_CLRTXT:
+			memcpy(out_txt, in_data[0].payload, in_data[0].len);
+			out_len = in_data[0].len;
+			break;
+		default:
+			return(-1);
+		}
+	} else {
+		return(-1);
+	}
+
+	if (out_len > 0) {
+		if (NULL == out_p) {
+            /*
+            * Application did not provided output buffer,
+            * so copy encrypted message back in input buffer
+            */
+            #if !CRYSPR_HAS_AESCTR
+                if (ctx->mode == HCRYPT_CTX_MODE_AESCTR) {
+                    /* XOR KeyStream with input text directly in input buffer */
+                    hcrypt_XorStream(in_data[0].payload, out_txt, out_len);
+                }else{
+                    /* Copy output data back in input buffer */
+                    memcpy(in_data[0].payload, out_txt, out_len);
+                }
+            #else /* CRYSPR_HAS_AESCTR */
+                /* Copy output data back in input buffer */
+                memcpy(in_data[0].payload, out_txt, out_len);
+            #endif /* CRYSPR_HAS_AESCTR */
+        } else {
+            /* Copy header in output buffer if needed */
+            #if !CRYSPR_HAS_AESCTR
+                if (ctx->mode == HCRYPT_CTX_MODE_AESCTR) {
+                    hcrypt_XorStream(out_txt, in_data[0].payload, out_len);
+                }
+            #endif /* CRYSPR_HAS_AESCTR */
+            out_p[0] = out_txt;
+            out_len_p[0] = out_len;
+            *nbout_p = 1;
+        }
+		iret = 0;
+	} else {
+		if (NULL != nbout_p) *nbout_p = 0;
+		iret = -1;
+	}
+
+#if 0
+	{	/* Debug decryption errors */
+		static int nberr = 0;
+	
+		if (out_txt[0] != 0x47){
+			if ((++nberr == 1)
+			||  ((nberr > 500) && (0 == ((((unsigned char *)&MSmsg->pki)[2] & 0x0F)|((unsigned char *)&MSmsg->pki)[3])))) {
+				HCRYPT_LOG(LOG_DEBUG, "keyindex=%d\n", hcryptCtx_GetKeyIndex(ctx));
+				HCRYPT_PRINTKEY(ctx->sek, ctx->sek_len, "sek"); 
+				HCRYPT_PRINTKEY(ctx->salt, ctx->salt_len, "salt"); 
+			}
+		} else {
+			nberr = 0;
+		}
+	}
+#endif
+	return(iret);
+}
+
+
+CRYSPR_methods *crysprInit(CRYSPR_methods *cryspr)
+{
+    /* CryptoLib Primitive API */
+    cryspr->prng            = crysprStub_Prng;
+    cryspr->aes_set_key     = crysprStub_AES_SetKey;
+    cryspr->aes_ecb_cipher  = crysprStub_AES_EcbCipher;
+    cryspr->aes_ctr_cipher  = crysprStub_AES_CtrCipher;
+    cryspr->sha1_msg_digest = crysprStub_SHA1_MsgDigest;
+
+
+    /* Crypto Session API */
+    cryspr->open       = crysprFallback_Open;
+    cryspr->close      = crysprFallback_Close;
+    //Keying material (km) encryption
+	cryspr->km_pbkdf2  = crysprStub_KmPbkdf2;
+	cryspr->km_setkey  = crysprFallback_KmSetKey;
+    cryspr->km_wrap    = crysprFallback_AES_WrapKey;
+    cryspr->km_unwrap  = crysprFallback_AES_UnwrapKey;
+    //Media stream (ms) encryption
+    cryspr->ms_setkey  = crysprFallback_MsSetKey;
+	cryspr->ms_encrypt = crysprFallback_MsEncrypt;
+	cryspr->ms_decrypt = crysprFallback_MsDecrypt;
+
+	return(cryspr);
+}
+
+HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance(void)
+{
+    return((HaiCrypt_Cryspr)cryspr4SRT());
+}
+

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -247,7 +247,7 @@ static CRYSPR_cb *crysprFallback_Open(CRYSPR_methods *cryspr, size_t max_len)
 
 	memsiz = sizeof(*cryspr_cb) + (CRYSPR_OUTMSGMAX * padded_len);
 #if !CRYSPR_HAS_AESCTR
-    memsiz += HCRYPT_CTR_STREAM_SZ;
+	memsiz += HCRYPT_CTR_STREAM_SZ;
 #endif /* !CRYSPR_HAS_AESCTR */
 
 	cryspr_cb = malloc(memsiz);
@@ -270,7 +270,7 @@ static CRYSPR_cb *crysprFallback_Open(CRYSPR_methods *cryspr, size_t max_len)
 	cryspr_cb->outbuf_ofs = 0;
 //	membuf += cryspr_cb->outbuf_siz;
 
-    cryspr_cb->cryspr=(CRYSPR_methods *)cryspr;
+	cryspr_cb->cryspr=(CRYSPR_methods *)cryspr;
 
 	return(cryspr_cb);
 }
@@ -289,7 +289,7 @@ static int crysprFallback_MsSetKey(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx, const 
 
 	if ((ctx->flags & HCRYPT_CTX_F_ENCRYPT)        /* Encrypt key */
 	||  (ctx->mode == HCRYPT_CTX_MODE_AESCTR)) {   /* CTR mode decrypts using encryption methods */
-        if (cryspr_cb->cryspr->aes_set_key(true, key, key_len, aes_sek)) {
+        	if (cryspr_cb->cryspr->aes_set_key(true, key, key_len, aes_sek)) {
 			HCRYPT_LOG(LOG_ERR, "%s", "CRYSPR->set_encrypt_key(sek) failed\n");
 			return(-1);
 		}
@@ -679,24 +679,24 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 
 CRYSPR_methods *crysprInit(CRYSPR_methods *cryspr)
 {
-    /* CryptoLib Primitive API */
-    cryspr->prng            = crysprStub_Prng;
-    cryspr->aes_set_key     = crysprStub_AES_SetKey;
-    cryspr->aes_ecb_cipher  = crysprStub_AES_EcbCipher;
-    cryspr->aes_ctr_cipher  = crysprStub_AES_CtrCipher;
-    cryspr->sha1_msg_digest = crysprStub_SHA1_MsgDigest;
+	/* CryptoLib Primitive API */
+	cryspr->prng            = crysprStub_Prng;
+	cryspr->aes_set_key     = crysprStub_AES_SetKey;
+	cryspr->aes_ecb_cipher  = crysprStub_AES_EcbCipher;
+	cryspr->aes_ctr_cipher  = crysprStub_AES_CtrCipher;
+	cryspr->sha1_msg_digest = crysprStub_SHA1_MsgDigest;
 
 
-    /* Crypto Session API */
-    cryspr->open       = crysprFallback_Open;
-    cryspr->close      = crysprFallback_Close;
-    //Keying material (km) encryption
+	/* Crypto Session API */
+	cryspr->open       = crysprFallback_Open;
+	cryspr->close      = crysprFallback_Close;
+	//Keying material (km) encryption
 	cryspr->km_pbkdf2  = crysprStub_KmPbkdf2;
 	cryspr->km_setkey  = crysprFallback_KmSetKey;
-    cryspr->km_wrap    = crysprFallback_AES_WrapKey;
-    cryspr->km_unwrap  = crysprFallback_AES_UnwrapKey;
-    //Media stream (ms) encryption
-    cryspr->ms_setkey  = crysprFallback_MsSetKey;
+	cryspr->km_wrap    = crysprFallback_AES_WrapKey;
+	cryspr->km_unwrap  = crysprFallback_AES_UnwrapKey;
+	//Media stream (ms) encryption
+	cryspr->ms_setkey  = crysprFallback_MsSetKey;
 	cryspr->ms_encrypt = crysprFallback_MsEncrypt;
 	cryspr->ms_decrypt = crysprFallback_MsDecrypt;
 
@@ -707,5 +707,3 @@ HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance(void)
 {
     return((HaiCrypt_Cryspr)cryspr4SRT());
 }
-
-

--- a/haicrypt/cryspr.h
+++ b/haicrypt/cryspr.h
@@ -45,24 +45,24 @@ written by
 #define CRYSPR_AESBLKSZ 16              /* 128-bit */
 
 typedef struct tag_CRYSPR_cb {
-        CRYSPR_AESCTX   aes_kek;		/* Key Encrypting Key (KEK) */
-        CRYSPR_AESCTX   aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
+	CRYSPR_AESCTX   aes_kek;		/* Key Encrypting Key (KEK) */
+	CRYSPR_AESCTX   aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
 
-        struct tag_CRYSPR_methods *cryspr;
+	struct tag_CRYSPR_methods *cryspr;
 
 #if !CRYSPR_HAS_AESCTR
                                         /* Reserve room to build the counter stream ourself */
 #define HCRYPT_CTR_BLK_SZ       CRYSPR_AESBLKSZ
 #define HCRYPT_CTR_STREAM_SZ	2048
-		unsigned char * ctr_stream;
-		size_t          ctr_stream_len; /* Content size */
-		size_t          ctr_stream_siz; /* Allocated length */
+	unsigned char * ctr_stream;
+	size_t          ctr_stream_len; /* Content size */
+	size_t          ctr_stream_siz; /* Allocated length */
 #endif /* !CRYSPR_HAS_AESCTR */
 
 #define	CRYSPR_OUTMSGMAX		6
-        uint8_t *       outbuf; 		/* output circle buffer */
-        size_t          outbuf_ofs;		/* write offset in circle buffer */
-        size_t          outbuf_siz;		/* circle buffer size */
+	uint8_t *       outbuf; 		/* output circle buffer */
+	size_t          outbuf_ofs;		/* write offset in circle buffer */
+	size_t          outbuf_siz;		/* circle buffer size */
 } CRYSPR_cb;
 
 typedef struct tag_CRYSPR_methods {

--- a/haicrypt/cryspr.h
+++ b/haicrypt/cryspr.h
@@ -1,0 +1,205 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+
+/*****************************************************************************
+written by
+   Haivision Systems Inc.
+
+   2019-06-28 (jdube)
+        CRYSPR/4SRT Initial implementation.
+*****************************************************************************/
+
+#ifndef CRYSPR_H
+#define CRYSPR_H
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+#if !defined(HAISRT_VERSION_INT)
+#include "haicrypt.h"
+#include "hcrypt_msg.h"
+#else
+// Included by haisrt.h or similar
+#include "haisrt/haicrypt.h"
+#include "haisrt/hcrypt_msg.h"
+#endif
+
+#if defined(USE_OPENSSL)
+#include "cryspr-openssl.h"
+#define cryspr4SRT()  crysprOpenSSL()
+#elif defined(USE_GNUTLS)
+#include "cryspr-gnutls.h"
+#define cryspr4SRT()  crysprGnuTLS()
+#else
+#error No CRYSPR defined
+#endif
+
+#define CRYSPR_AESBLKSZ 16              /* 128-bit */
+
+typedef struct tag_CRYSPR_cb {
+        CRYSPR_AESCTX   aes_kek;		/* Key Encrypting Key (KEK) */
+        CRYSPR_AESCTX   aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
+
+        struct tag_CRYSPR_methods *cryspr;
+
+#if !CRYSPR_HAS_AESCTR
+                                        /* Reserve room to build the counter stream ourself */
+#define HCRYPT_CTR_BLK_SZ       CRYSPR_AESBLKSZ
+#define HCRYPT_CTR_STREAM_SZ	2048
+		unsigned char * ctr_stream;
+		size_t          ctr_stream_len; /* Content size */
+		size_t          ctr_stream_siz; /* Allocated length */
+#endif /* !CRYSPR_HAS_AESCTR */
+
+#define	CRYSPR_OUTMSGMAX		6
+        uint8_t *       outbuf; 		/* output circle buffer */
+        size_t          outbuf_ofs;		/* write offset in circle buffer */
+        size_t          outbuf_siz;		/* circle buffer size */
+} CRYSPR_cb;
+
+typedef struct tag_CRYSPR_methods {
+        /*
+        * prng:
+        * Pseudo-Random Number Generator
+        */
+        int (*prng)(
+            unsigned char *rn,      /* out: pseudo random number */
+            int rn_len);
+
+        int (*aes_set_key)(
+            bool bEncrypt,          /* true Enxcrypt key, false: decrypt */
+            const unsigned char *kstr,/* key string*/
+            size_t kstr_len,        /* kstr len in  bytes (16, 24, or 32 bytes (for AES128,AES192, or AES256) */
+            CRYSPR_AESCTX *aeskey); /* Cryptolib Specific AES key context */
+
+        int (*aes_ecb_cipher)(
+            bool bEncrypt,          /* true:encrypt false:decrypt */
+            CRYSPR_AESCTX *aes_key, /* ctx */
+            const unsigned char *indata,  /* src (clear text)*/
+            size_t inlen,           /* src length */
+            unsigned char *out_txt, /* dst (cipher text) */
+            size_t *outlen);        /* dst length */
+
+        int (*aes_ctr_cipher)(
+            bool bEncrypt,          /* true:encrypt false:decrypt (don't care with CTR) */
+            CRYSPR_AESCTX *aes_key, /* ctx */
+            unsigned char *iv,      /* iv */
+            const unsigned char *indata,  /* src (clear text) */
+            size_t inlen,           /* src length */
+            unsigned char *out_txt);/* dest */
+
+        unsigned char *(*sha1_msg_digest)(
+            const unsigned char *m, /* in: message */
+            size_t m_len,           /* message length */
+            unsigned char *md);     /* out: message digest buffer *160 bytes */
+
+        /*
+        * open:
+        * Create a cipher instance
+        * Allocate output buffers
+        */
+        CRYSPR_cb *(*open)(
+            struct tag_CRYSPR_methods *cryspr,
+            size_t max_len);                                /* Maximum packet length that will be encrypted/decrypted */
+
+        /*
+        * close:
+        * Release any cipher resources
+        */
+        int     (*close)(
+            CRYSPR_cb *cryspr_data);                /* Cipher handle, internal data */
+
+        /*
+        * pbkdf2_hmac_sha1
+        * Password-based Key Derivation Function 2
+        */
+        int (*km_pbkdf2)(
+            CRYSPR_cb *cryspr_cb,   /* Cryspr Control Block */
+            char *passwd,           /* passphrase */
+            size_t passwd_len,      /* passphrase len */
+            unsigned char *salt,    /* salt */
+            size_t salt_len,        /* salt_len */
+            int itr,                /* iterations */
+            size_t out_len,         /* key_len */
+            unsigned char *out);    /* derived key */
+
+        /*
+        * km_setkey:
+        * Set the Key Encypting Key for Wrap (Encryption) or UnWrap (Decryption).
+        * Context (ctx) tells if it's for Wrap or Unwrap
+        * A Context flags (ctx->flags) also tells if this is for wrap(encryption) or unwrap(decryption) context (HCRYPT_CTX_F_ENCRYPT)
+        */
+        int (*km_setkey)(
+            CRYSPR_cb *cryspr_cb,                       /* Cryspr Control Block */
+            bool bWrap,                                 /* True: Wrap KEK, False: Unwrap KEK */
+            const unsigned char *kek, size_t kek_len);  /* KEK: Key Encrypting Key */
+
+        /*
+        * km_wrap:
+        * wrap media stream key
+        */
+        int (*km_wrap)(CRYSPR_cb *cryspr_cb,
+            unsigned char *wrap,
+            const unsigned char *sek,
+            unsigned int seklen);
+
+        /*
+        * km_unwrap:
+        * wrap media stream key
+        */
+        int (*km_unwrap)(CRYSPR_cb *cryspr_cb,
+            unsigned char *sek,
+            const unsigned char *wrap,
+            unsigned int wraplen);
+        /*
+        * setkey:
+        * Set the Odd or Even, Encryption or Decryption key.
+        * Context (ctx) tells if it's for Odd or Even key (hcryptCtx_GetKeyIndex(ctx))
+        * A Context flags (ctx->flags) also tells if this is an encryption or decryption context (HCRYPT_CTX_F_ENCRYPT)
+        */
+        int (*ms_setkey)(
+            CRYSPR_cb *cryspr_cb,                           /* Cryspr Control Block */
+            hcrypt_Ctx *ctx,                                /* HaiCrypt Context (cipher, keys, Odd/Even, etc..) */
+            const unsigned char *key, size_t kwelen);       /* New Key */
+
+        /*
+        * encrypt:
+        * Submit a list of nbin clear transport packets (hcrypt_DataDesc *in_data) to encryption
+        * returns *nbout encrypted data packets of length out_len_p[] into out_p[]
+        *
+        * If cipher implements deferred encryption (co-processor, async encryption),
+        * it may return no encrypted packets, or encrypted packets for clear text packets of a previous call.  
+        */
+        int (*ms_encrypt)(
+            CRYSPR_cb *cryspr_cb,                           /* Cryspr Control Block */
+            hcrypt_Ctx *ctx,                                /* HaiCrypt Context (cipher, keys, Odd/Even, etc..) */
+            hcrypt_DataDesc *in_data, int nbin,             /* Clear text transport packets: header and payload */
+            void *out_p[], size_t out_len_p[], int *nbout); /* Encrypted packets */
+
+        /*
+        * decrypt:
+        * Submit a list of nbin encrypted transport packets (hcrypt_DataDesc *in_data) to decryption
+        * returns *nbout clear text data packets of length out_len_p[] into out_p[]
+        *
+        * If cipher implements deferred decryption (co-processor, async encryption),
+        * it may return no decrypted packets, or decrypted packets for encrypted packets of a previous call.
+        */
+        int (*ms_decrypt)(
+            CRYSPR_cb *cryspr_cb,                           /* Cryspr Control Block */
+            hcrypt_Ctx *ctx,                                /* HaiCrypt Context (cipher, keys, Odd/Even, etc..) */
+            hcrypt_DataDesc *in_data, int nbin,             /* Clear text transport packets: header and payload */
+            void *out_p[], size_t out_len_p[], int *nbout); /* Encrypted packets */
+
+} CRYSPR_methods;
+
+CRYSPR_methods *crysprInit(CRYSPR_methods *cryspr);
+
+#endif /* CRYSPR_H */

--- a/haicrypt/filelist-gnutls.maf
+++ b/haicrypt/filelist-gnutls.maf
@@ -9,11 +9,13 @@ hcrypt_msg.h
 
 PRIVATE HEADERS
 hcrypt.h
-hcrypt-gnutls.h
+cryspr.h
+cryspr-gnutls.h
 haicrypt_log.h
 
 SOURCES
-hc_nettle_aes.c
+cryspr.c
+cryspr-gnutls.c
 hcrypt.c
 hcrypt-gnutls.c
 hcrypt_ctx_rx.c

--- a/haicrypt/filelist.maf
+++ b/haicrypt/filelist.maf
@@ -7,13 +7,13 @@ hcrypt_msg.h
 
 PRIVATE HEADERS
 hcrypt.h
-hcrypt-openssl.h
+cryspr.h
+cryspr-openssl.h
 haicrypt_log.h
 
 SOURCES
-hc_openssl_aes.c
-hc_openssl_evp_cbc.c
-hc_openssl_evp_ctr.c
+cryspr.c
+cryspr-openssl.c
 hcrypt.c
 hcrypt_ctx_rx.c
 hcrypt_ctx_tx.c

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -42,21 +42,10 @@ extern "C" {
 #else
 #define HAICRYPT_API
 #endif
-/* 
- * Define (in Makefile) the HaiCrypt ciphers compiled in
- */
-//#define HAICRYPT_USE_OPENSSL_EVP 1    /* Preferred for most cases */
-//#define HAICRYPT_USE_OPENSSL_AES 1    /* Mandatory for key wrapping and prng */
 
-typedef void *HaiCrypt_Cipher;
+typedef void *HaiCrypt_Cryspr;
 
-HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_Get_Instance (void);     /* Return a efault cipher instance */
-
-HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP(void);       /* OpenSSL EVP interface (default to EVP_CTR) */
-HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CBC(void);   /* OpenSSL EVP interface for AES-CBC */
-HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_EVP_CTR(void);   /* OpenSSL EVP interface for AES-CTR */
-HAICRYPT_API HaiCrypt_Cipher HaiCryptCipher_OpenSSL_AES(void);   /* OpenSSL AES direct interface */
-
+HAICRYPT_API HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance (void);     /* Return a default cryspr instance */
 
 #define HAICRYPT_CIPHER_BLK_SZ      16  /* AES Block Size */
 
@@ -91,7 +80,7 @@ typedef struct {
 
         HaiCrypt_Secret secret;             /* Security Association */
 
-        HaiCrypt_Cipher cipher;             /* Media Stream cipher implementation */
+        HaiCrypt_Cryspr cryspr;             /* CRYSPR implementation */
 #define HAICRYPT_DEF_KEY_LENGTH 16          /* default key length (bytes) */
         size_t  key_len;                    /* SEK length (bytes) */
 #define HAICRYPT_DEF_DATA_MAX_LENGTH 1500   /* default packet data length (bytes) */

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -48,14 +48,8 @@ written by
 
 #include "haicrypt.h"
 #include "hcrypt_msg.h"
-
-#if defined(USE_GNUTLS)
-#include "hcrypt-gnutls.h"
-#else
-#include "hcrypt-openssl.h"
-#endif
-
 #include "hcrypt_ctx.h"
+#include "cryspr.h"
 
 //#define HCRYPT_DEV 1  /* Development: should not be defined in committed code */
 
@@ -80,8 +74,8 @@ typedef struct hcrypt_Session_str {
         hcrypt_Ctx          ctx_pair[2];    /* Even(0)/Odd(1) crypto contexts */
         hcrypt_Ctx *        ctx;            /* Current context */
 
-        hcrypt_Cipher *     cipher;
-        hcrypt_CipherData * cipher_data;
+        CRYSPR_methods *    cryspr;
+        CRYSPR_cb *         cryspr_cb;
 
         unsigned char *     inbuf;          /* allocated if cipher has no getinbuf() func */
         size_t              inbuf_siz;

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -22,6 +22,7 @@ written by
 #ifndef HCRYPT_CTX_H
 #define HCRYPT_CTX_H
 
+#include <stdbool.h>
 #include <sys/types.h>
 #include "hcrypt.h"
 
@@ -53,6 +54,8 @@ typedef struct tag_hcrypt_Ctx {
 #define HCRYPT_CTX_F_ANNOUNCE   0x0200  /* Announce KM */
 #define HCRYPT_CTX_F_TTSEND     0x0400  /* time to send */
         unsigned         flags;
+#define hcryptCtx_GetKeyFlags(ctx)      ((ctx)->flags & HCRYPT_CTX_F_xSEK)
+#define hcryptCtx_GetKeyIndex(ctx)      (((ctx)->flags & HCRYPT_CTX_F_xSEK)>>1)
 
 #define HCRYPT_CTX_S_INIT       1
 #define HCRYPT_CTX_S_SARDY      2   /* Security Association (KEK) ready */
@@ -79,8 +82,6 @@ typedef struct tag_hcrypt_Ctx {
         size_t           sek_len;
         unsigned char    sek[HAICRYPT_KEY_MAX_SZ];
 
-        AES_KEY          aes_kek;
-
         hcrypt_MsgInfo * msg_info;  /* Transport message handler */
         unsigned         pkt_cnt;   /* Key usage counter */
 
@@ -92,67 +93,5 @@ typedef struct tag_hcrypt_Ctx {
         unsigned char    MSpfx_cache[HCRYPT_CTX_MAX_MS_PFX_SZ];
 } hcrypt_Ctx;
 
-typedef void *hcrypt_CipherData;
-
-typedef struct {
-        /*
-        * open:
-        * Create a cipher instance
-        * Allocate output buffers 
-        */
-        hcrypt_CipherData *(*open)(
-            size_t max_len);                                /* Maximum packet length that will be encrypted/decrypted */
-
-        /*
-        * close:
-        * Release any cipher resources
-        */
-        int     (*close)(
-            hcrypt_CipherData *crypto_data);                /* Cipher handle, internal data */
-
-        /*
-        * setkey:
-        * Set the Odd or Even, Encryption or Decryption key.
-        * Context (ctx) tells if it's for Odd or Even key (hcryptCtx_GetKeyIndex(ctx))
-        * A Context flags (ctx->flags) also tells if this is an encryption or decryption context (HCRYPT_CTX_F_ENCRYPT)
-        */
-        int (*setkey)(
-            hcrypt_CipherData *crypto_data,                 /* Cipher handle, internal data */
-            hcrypt_Ctx *ctx,                                /* HaiCrypt Context (cipher, keys, Odd/Even, etc..) */
-            unsigned char *key, size_t key_len);            /* New Key */
-
-        /*
-        * encrypt:
-        * Submit a list of nbin clear transport packets (hcrypt_DataDesc *in_data) to encryption
-        * returns *nbout encrypted data packets of length out_len_p[] into out_p[]
-        *
-        * If cipher implements deferred encryption (co-processor, async encryption),
-        * it may return no encrypted packets, or encrypted packets for clear text packets of a previous call.  
-        */
-        int (*encrypt)(
-            hcrypt_CipherData *crypto_data,                 /* Cipher handle, internal data */
-            hcrypt_Ctx *ctx,                                /* HaiCrypt Context (cipher, keys, Odd/Even, etc..) */
-            hcrypt_DataDesc *in_data, int nbin,             /* Clear text transport packets: header and payload */
-            void *out_p[], size_t out_len_p[], int *nbout); /* Encrypted packets */
-
-        /*
-        * decrypt:
-        * Submit a list of nbin encrypted transport packets (hcrypt_DataDesc *in_data) to decryption
-        * returns *nbout clear text data packets of length out_len_p[] into out_p[]
-        *
-        * If cipher implements deferred decryption (co-processor, async encryption),
-        * it may return no decrypted packets, or decrypted packets for encrypted packets of a previous call.
-        */
-        int (*decrypt)(
-            hcrypt_CipherData *crypto_data,                 /* Cipher handle, internal data */
-            hcrypt_Ctx *ctx,                                /* HaiCrypt Context (cipher, keys, Odd/Even, etc..) */
-            hcrypt_DataDesc *in_data, int nbin,             /* Clear text transport packets: header and payload */
-            void *out_p[], size_t out_len_p[], int *nbout); /* Encrypted packets */
-
-        int     (*getinbuf)(hcrypt_CipherData *crypto_data, size_t hdr_len, size_t in_len, unsigned int pad_factor, unsigned char **in_pp);
-} hcrypt_Cipher;
-
-#define hcryptCtx_GetKeyFlags(ctx)      ((ctx)->flags & HCRYPT_CTX_F_xSEK)
-#define hcryptCtx_GetKeyIndex(ctx)      (((ctx)->flags & HCRYPT_CTX_F_xSEK)>>1)
 
 #endif /* HCRYPT_CTX_H */

--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -38,8 +38,8 @@ int hcryptCtx_Rx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 
 int hcryptCtx_Rx_Rekey(hcrypt_Session *crypto, hcrypt_Ctx *ctx, unsigned char *sek, size_t sek_len)
 {
-	if (crypto->cipher->setkey(crypto->cipher_data, ctx, sek, sek_len)) {
-		HCRYPT_LOG(LOG_ERR, "cipher setkey[%d](sek) failed\n", hcryptCtx_GetKeyIndex(ctx));
+	if (crypto->cryspr->ms_setkey(crypto->cryspr_cb, ctx, sek, sek_len)) {
+		HCRYPT_LOG(LOG_ERR, "cryspr setkey[%d](sek) failed\n", hcryptCtx_GetKeyIndex(ctx));
 		return(-1);
 	}
 	memcpy(ctx->sek, sek, sek_len);
@@ -157,7 +157,7 @@ int hcryptCtx_Rx_ParseKM(hcrypt_Session *crypto, unsigned char *km_msg, size_t m
 	}
 
 	/* Unwrap SEK(s) and set in context */
-	if (0 > hcrypt_UnwrapKey(&ctx->aes_kek, seks,
+	if (0 > crypto->cryspr->km_unwrap(crypto->cryspr_cb, seks,
 		&km_msg[HCRYPT_MSG_KM_OFS_SALT + salt_len], 
 		(sek_cnt * sek_len) + HAICRYPT_WRAPKEY_SIGN_SZ)) {
 		HCRYPT_LOG(LOG_WARNING, "%s", "unwrap key failed\n");
@@ -184,7 +184,7 @@ int hcryptCtx_Rx_ParseKM(hcrypt_Session *crypto, unsigned char *km_msg, size_t m
 		alt->salt_len = salt_len;
 
 		if (kek_len) { /* New or changed KEK */
-			memcpy(&alt->aes_kek, &ctx->aes_kek, sizeof(alt->aes_kek));
+//			memcpy(&alt->aes_kek, &ctx->aes_kek, sizeof(alt->aes_kek));
 			alt->status = HCRYPT_CTX_S_SARDY;
 		}
 

--- a/haicrypt/hcrypt_rx.c
+++ b/haicrypt/hcrypt_rx.c
@@ -39,19 +39,19 @@ int HaiCrypt_Rx_Data(HaiCrypt_Handle hhc,
 	ctx = &crypto->ctx_pair[hcryptMsg_GetKeyIndex(crypto->msg_info, in_pfx)];
 
 	ASSERT(NULL != ctx); /* Header check should prevent this error */
-	ASSERT(NULL != crypto->cipher); /* Header check should prevent this error */
+	ASSERT(NULL != crypto->cryspr); /* Header check should prevent this error */
 
 	crypto->ctx = ctx; /* Context of last received msg */
-	if (NULL == crypto->cipher->decrypt) {
-		HCRYPT_LOG(LOG_ERR, "%s", "cipher had no decryptor\n");
+	if (NULL == crypto->cryspr->ms_decrypt) {
+		HCRYPT_LOG(LOG_ERR, "%s", "cryspr had no decryptor\n");
 	} else if (ctx->status >= HCRYPT_CTX_S_KEYED) {
 		hcrypt_DataDesc indata;
 		indata.pfx      = in_pfx;
 		indata.payload  = data;
 		indata.len      = data_len;
 
-		if (0 > (nb = crypto->cipher->decrypt(crypto->cipher_data, ctx, &indata, 1, NULL, NULL, NULL))) {
-			HCRYPT_LOG(LOG_ERR, "%s", "cipher failed\n");
+		if (0 > (nb = crypto->cryspr->ms_decrypt(crypto->cryspr_cb, ctx, &indata, 1, NULL, NULL, NULL))) {
+			HCRYPT_LOG(LOG_ERR, "%s", "ms_decrypt failed\n");
 		} else {
 			nb = indata.len;
 		}
@@ -92,11 +92,11 @@ int HaiCrypt_Rx_Process(HaiCrypt_Handle hhc,
 			return(-1);
 		}
 		ASSERT(NULL != ctx); /* Header check should prevent this error */
-		ASSERT(NULL != crypto->cipher); /* Header check should prevent this error */
+		ASSERT(NULL != crypto->cryspr); /* Header check should prevent this error */
 
 		crypto->ctx = ctx; /* Context of last received msg */
-		if (NULL == crypto->cipher->decrypt) {
-			HCRYPT_LOG(LOG_ERR, "%s", "cipher had no decryptor\n");
+		if (NULL == crypto->cryspr->ms_decrypt) {
+			HCRYPT_LOG(LOG_ERR, "%s", "cryspr had no decryptor\n");
 			nbout = -1;
 		} else if (ctx->status >= HCRYPT_CTX_S_KEYED) {
 			hcrypt_DataDesc indata;
@@ -104,8 +104,8 @@ int HaiCrypt_Rx_Process(HaiCrypt_Handle hhc,
 			indata.payload  = &in_msg[crypto->msg_info->pfx_len];
 			indata.len      = in_len - crypto->msg_info->pfx_len;
 
-			if (crypto->cipher->decrypt(crypto->cipher_data, ctx, &indata, 1, out_p, out_len_p, &nbout)) {
-				HCRYPT_LOG(LOG_ERR, "%s", "cipher failed\n");
+			if (crypto->cryspr->ms_decrypt(crypto->cryspr_cb, ctx, &indata, 1, out_p, out_len_p, &nbout)) {
+				HCRYPT_LOG(LOG_ERR, "%s", "ms_decrypt failed\n");
 				nbout = -1;
 			}
 		} else { /* No key received yet */

--- a/haicrypt/hcrypt_sa.c
+++ b/haicrypt/hcrypt_sa.c
@@ -36,10 +36,12 @@ int hcryptCtx_SetSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_
 		ASSERT(secret->len <= HAICRYPT_KEY_MAX_SZ);
 		ctx->cfg.pwd_len = 0;
 		/* KEK: Key Encrypting Key */
-        if (0 > (iret = crypto->cryspr->km_setkey(crypto->cryspr_cb, (HCRYPT_CTX_F_ENCRYPT & ctx->flags ? true : false), secret->str, secret->len))) {
-            HCRYPT_LOG(LOG_ERR, "km_setkey(pdkek[%zd]) failed (rc=%d)\n", secret->len, iret);
-            return(-1);
-        }
+		if (0 > (iret = crypto->cryspr->km_setkey(crypto->cryspr_cb,
+							  (HCRYPT_CTX_F_ENCRYPT & ctx->flags ? true : false),
+							  secret->str, secret->len))) {
+			HCRYPT_LOG(LOG_ERR, "km_setkey(pdkek[%zd]) failed (rc=%d)\n", secret->len, iret);
+			return(-1);
+		}
 		ctx->status = HCRYPT_CTX_S_SARDY;
 		break;
 
@@ -73,22 +75,22 @@ int hcryptCtx_GenSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx)
 	int iret = 0;
 	(void)crypto;
 
-    iret = crypto->cryspr->km_pbkdf2(crypto->cryspr_cb, ctx->cfg.pwd, ctx->cfg.pwd_len,
+	iret = crypto->cryspr->km_pbkdf2(crypto->cryspr_cb, ctx->cfg.pwd, ctx->cfg.pwd_len,
 		&ctx->salt[ctx->salt_len - pbkdf_salt_len], pbkdf_salt_len, 
 		HAICRYPT_PBKDF2_ITER_CNT, kek_len, kek);
 
-    if(iret) {
-        HCRYPT_LOG(LOG_ERR, "km_pbkdf2() failed (rc=%d)\n", iret);
-        return(-1);
-    }
+	if(iret) {
+		HCRYPT_LOG(LOG_ERR, "km_pbkdf2() failed (rc=%d)\n", iret);
+		return(-1);
+	}
 	HCRYPT_PRINTKEY(ctx->cfg.pwd, ctx->cfg.pwd_len, "pwd");
 	HCRYPT_PRINTKEY(kek, kek_len, "kek");
 	
 	/* KEK: Key Encrypting Key */
-    if (0 > (iret = crypto->cryspr->km_setkey(crypto->cryspr_cb, (HCRYPT_CTX_F_ENCRYPT & ctx->flags ? true : false), kek, kek_len))) {
-        HCRYPT_LOG(LOG_ERR, "km_setkey(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
-        return(-1);
-    }
+	if (0 > (iret = crypto->cryspr->km_setkey(crypto->cryspr_cb, (HCRYPT_CTX_F_ENCRYPT & ctx->flags ? true : false), kek, kek_len))) {
+		HCRYPT_LOG(LOG_ERR, "km_setkey(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
+		return(-1);
+	}
 	return(0);
 }
 

--- a/haicrypt/hcrypt_sa.c
+++ b/haicrypt/hcrypt_sa.c
@@ -36,17 +36,10 @@ int hcryptCtx_SetSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_
 		ASSERT(secret->len <= HAICRYPT_KEY_MAX_SZ);
 		ctx->cfg.pwd_len = 0;
 		/* KEK: Key Encrypting Key */
-		if (HCRYPT_CTX_F_ENCRYPT & ctx->flags) {
-			iret = hcrypt_aes_set_encrypt_key(secret->str, secret->len * 8, &ctx->aes_kek);
-		} else {
-			iret = hcrypt_aes_set_decrypt_key(secret->str, secret->len * 8, &ctx->aes_kek);
-		}			
-		if (0 > iret) {
-		HCRYPT_LOG(LOG_ERR, "AES_set_%s_key(kek[%zd]) failed (rc=%d)\n", 
-				HCRYPT_CTX_F_ENCRYPT & ctx->flags ? "encrypt" : "decrypt",
-				secret->len, iret);
-			return(-1);
-		}
+        if (0 > (iret = crypto->cryspr->km_setkey(crypto->cryspr_cb, (HCRYPT_CTX_F_ENCRYPT & ctx->flags ? true : false), secret->str, secret->len))) {
+            HCRYPT_LOG(LOG_ERR, "km_setkey(pdkek[%zd]) failed (rc=%d)\n", secret->len, iret);
+            return(-1);
+        }
 		ctx->status = HCRYPT_CTX_S_SARDY;
 		break;
 
@@ -77,28 +70,25 @@ int hcryptCtx_GenSecret(hcrypt_Session *crypto, hcrypt_Ctx *ctx)
 	size_t pbkdf_salt_len = (ctx->salt_len >= HAICRYPT_PBKDF2_SALT_LEN
 		? HAICRYPT_PBKDF2_SALT_LEN 
 		: ctx->salt_len);
-	int iret;
+	int iret = 0;
 	(void)crypto;
 
-	hcrypt_pbkdf2_hmac_sha1(ctx->cfg.pwd, ctx->cfg.pwd_len, 
+    iret = crypto->cryspr->km_pbkdf2(crypto->cryspr_cb, ctx->cfg.pwd, ctx->cfg.pwd_len,
 		&ctx->salt[ctx->salt_len - pbkdf_salt_len], pbkdf_salt_len, 
 		HAICRYPT_PBKDF2_ITER_CNT, kek_len, kek);
 
+    if(iret) {
+        HCRYPT_LOG(LOG_ERR, "km_pbkdf2() failed (rc=%d)\n", iret);
+        return(-1);
+    }
 	HCRYPT_PRINTKEY(ctx->cfg.pwd, ctx->cfg.pwd_len, "pwd");
 	HCRYPT_PRINTKEY(kek, kek_len, "kek");
 	
 	/* KEK: Key Encrypting Key */
-	if (HCRYPT_CTX_F_ENCRYPT & ctx->flags) {
-		if (0 > (iret = hcrypt_aes_set_encrypt_key(kek, kek_len * 8, &ctx->aes_kek))) {
-		HCRYPT_LOG(LOG_ERR, "AES_set_encrypt_key(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
-			return(-1);
-		}
-	} else {
-		if (0 > (iret = hcrypt_aes_set_decrypt_key(kek, kek_len * 8, &ctx->aes_kek))) {
-		HCRYPT_LOG(LOG_ERR, "AES_set_decrypt_key(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
-			return(-1);
-		}
-	}
+    if (0 > (iret = crypto->cryspr->km_setkey(crypto->cryspr_cb, (HCRYPT_CTX_F_ENCRYPT & ctx->flags ? true : false), kek, kek_len))) {
+        HCRYPT_LOG(LOG_ERR, "km_setkey(pdkek[%zd]) failed (rc=%d)\n", kek_len, iret);
+        return(-1);
+    }
 	return(0);
 }
 

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -41,14 +41,14 @@ int HaiCrypt_Tx_GetBuf(HaiCrypt_Handle hhc, size_t data_len, unsigned char **in_
 	int pad_factor = (HCRYPT_CTX_MODE_AESECB == crypto->ctx->mode ? 128/8 : 1);
 
 #ifndef _WIN32
-    ASSERT(crypto->inbuf != NULL);
+	ASSERT(crypto->inbuf != NULL);
 #endif
-    size_t in_len = crypto->msg_info->pfx_len + hcryptMsg_PaddedLen(data_len, pad_factor);
-    *in_pp = crypto->inbuf;
-    if (in_len > crypto->inbuf_siz) {
-        *in_pp = NULL;
-        return(-1);
-    }
+	size_t in_len = crypto->msg_info->pfx_len + hcryptMsg_PaddedLen(data_len, pad_factor);
+	*in_pp = crypto->inbuf;
+	if (in_len > crypto->inbuf_siz) {
+		*in_pp = NULL;
+		return(-1);
+	}
 	return(crypto->msg_info->pfx_len);
 }
 

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -36,28 +36,19 @@ int HaiCrypt_Tx_GetBuf(HaiCrypt_Handle hhc, size_t data_len, unsigned char **in_
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
 
 	ASSERT(NULL != crypto);
-	ASSERT(NULL != crypto->cipher);
+	ASSERT(NULL != crypto->cryspr);
 
 	int pad_factor = (HCRYPT_CTX_MODE_AESECB == crypto->ctx->mode ? 128/8 : 1);
 
-	if (NULL != crypto->cipher->getinbuf) {
-		ASSERT(NULL != crypto->cipher_data);
-		if (0 >= crypto->cipher->getinbuf(crypto->cipher_data, crypto->msg_info->pfx_len, 
-			data_len, pad_factor, in_pp)) {
-			*in_pp = NULL;
-			return(-1);
-		}
-	} else {
 #ifndef _WIN32
-		ASSERT(crypto->inbuf != NULL);
+    ASSERT(crypto->inbuf != NULL);
 #endif
-		size_t in_len = crypto->msg_info->pfx_len + hcryptMsg_PaddedLen(data_len, pad_factor);
-		*in_pp = crypto->inbuf;
-		if (in_len > crypto->inbuf_siz) {
-			*in_pp = NULL;
-			return(-1);
-		}
-	}
+    size_t in_len = crypto->msg_info->pfx_len + hcryptMsg_PaddedLen(data_len, pad_factor);
+    *in_pp = crypto->inbuf;
+    if (in_len > crypto->inbuf_siz) {
+        *in_pp = NULL;
+        return(-1);
+    }
 	return(crypto->msg_info->pfx_len);
 }
 
@@ -123,8 +114,8 @@ int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
 		indata.payload  = in_data;
 		indata.len      = in_len;
 
-		if (0 > (nbout = crypto->cipher->encrypt(crypto->cipher_data, ctx, &indata, 1, NULL, NULL, NULL))) {
-			HCRYPT_LOG(LOG_ERR, "%s", "encrypt failed\n");
+		if (0 > (nbout = crypto->cryspr->ms_encrypt(crypto->cryspr_cb, ctx, &indata, 1, NULL, NULL, NULL))) {
+			HCRYPT_LOG(LOG_ERR, "%s", "ms_encrypt failed\n");
 			return(nbout);
 		}
 	}
@@ -171,8 +162,8 @@ int HaiCrypt_Tx_Process(HaiCrypt_Handle hhc,
 		indata.payload  = &in_msg[ctx->msg_info->pfx_len];
 		indata.len      = in_len - ctx->msg_info->pfx_len;
 
-		if (crypto->cipher->encrypt(crypto->cipher_data, ctx, &indata, 1, &out_p[nbout], &out_len_p[nbout], &nb)) {
-			HCRYPT_LOG(LOG_ERR, "%s", "encrypt failed\n");
+		if (crypto->cryspr->ms_encrypt(crypto->cryspr_cb, ctx, &indata, 1, &out_p[nbout], &out_len_p[nbout], &nb)) {
+			HCRYPT_LOG(LOG_ERR, "%s", "ms_encrypt failed\n");
 			return(nbout);
 		}
 	}

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -696,10 +696,13 @@ bool CCryptoControl::createCryptoCtx(ref_t<HaiCrypt_Handle> hCrypto, size_t keyl
 
     HaiCrypt_Cfg crypto_cfg;
     memset(&crypto_cfg, 0, sizeof(crypto_cfg));
-
+#if 0//test key refresh (fast rate)
+    m_KmRefreshRatePkt = 2000;
+    m_KmPreAnnouncePkt = 500;
+#endif
     crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (cdir == HAICRYPT_CRYPTO_DIR_TX ? HAICRYPT_CFG_F_TX : 0);
     crypto_cfg.xport = HAICRYPT_XPT_SRT;
-    crypto_cfg.cipher = HaiCryptCipher_Get_Instance();
+    crypto_cfg.cryspr = HaiCryptCryspr_Get_Instance();
     crypto_cfg.key_len = (size_t)keylen;
     crypto_cfg.data_max_len = HAICRYPT_DEF_DATA_MAX_LENGTH;    //MTU
     crypto_cfg.km_tx_period_ms = 0;//No HaiCrypt KM inject period, handled in SRT;
@@ -708,7 +711,7 @@ bool CCryptoControl::createCryptoCtx(ref_t<HaiCrypt_Handle> hCrypto, size_t keyl
     crypto_cfg.secret = m_KmSecret;
     //memcpy(&crypto_cfg.secret, &m_KmSecret, sizeof(crypto_cfg.secret));
 
-    HLOGC(mglog.Debug, log << "CRYPTO CFG: flags=" << CryptoFlags(crypto_cfg.flags) << " xport=" << crypto_cfg.xport << " cipher=" << crypto_cfg.cipher
+    HLOGC(mglog.Debug, log << "CRYPTO CFG: flags=" << CryptoFlags(crypto_cfg.flags) << " xport=" << crypto_cfg.xport << " cryspr=" << crypto_cfg.cryspr
         << " keylen=" << crypto_cfg.key_len << " passphrase_length=" << crypto_cfg.secret.len);
 
     if (HaiCrypt_Create(&crypto_cfg, &hCrypto.get()) != HAICRYPT_OK)


### PR DESCRIPTION
Preparatory work to use mbedTLS instead of OpenSSL or GnuTLS.
Cryspr/4SRT is to HaiCrypt what crispr/cas9 is to DNA.
Documentation will follow.