### PR TITLE
UriParser improvements

### DIFF
--- a/apps/uriparser.cpp
+++ b/apps/uriparser.cpp
@@ -116,7 +116,7 @@ void UriParser::Parse(const string& strUrl, DefaultExpect exp)
     if (idx != string::npos)
     {
         m_proto = m_host.substr(0, idx);
-        transform(m_proto.begin(), m_proto.end(), m_proto.begin(), ::tolower);
+        transform(m_proto.begin(), m_proto.end(), m_proto.begin(), [](char c){ return std::toupper(c); });
         m_host  = m_host.substr(idx + 3, m_host.size() - (idx + 3));
     }
 
@@ -228,7 +228,8 @@ using namespace std;
 
 int main( int argc, char** argv )
 {
-    if (argc < 2) {
+    if ( argc < 2 ) 
+    {
         return 0;
     }
     UriParser parser (argv[1]);

--- a/apps/uriparser.cpp
+++ b/apps/uriparser.cpp
@@ -8,8 +8,8 @@
  * 
  */
 
-
 // STL includes
+#include <algorithm>
 #include <map>
 #include <string>
 
@@ -23,9 +23,7 @@
 #include <iostream>
 #endif
 
-
 using namespace std;
-
 
 map<string, UriParser::Type> types;
 
@@ -34,12 +32,15 @@ struct UriParserInit
     UriParserInit()
     {
         types["file"] = UriParser::FILE;
-        types["srt"] = UriParser::SRT;
         types["udp"] = UriParser::UDP;
+        types["tcp"] = UriParser::TCP;
+        types["srt"] = UriParser::SRT;
+        types["rtmp"] = UriParser::RTMP;
+        types["http"] = UriParser::HTTP;
+        types["rtp"] = UriParser::RTP;
         types[""] = UriParser::UNKNOWN;
     }
 } g_uriparser_init;
-
 
 UriParser::UriParser(const string& strUrl, DefaultExpect exp)
 {
@@ -50,12 +51,12 @@ UriParser::~UriParser(void)
 {
 }
 
-string UriParser::proto(void)
+string UriParser::proto(void) const
 {
     return m_proto;
 }
 
-UriParser::Type UriParser::type()
+UriParser::Type UriParser::type() const
 {
     return m_uriType;
 }
@@ -86,14 +87,14 @@ unsigned short int UriParser::portno(void) const
     }
 }
 
-string UriParser::path(void)
+string UriParser::path(void) const
 {
     return m_path;
 }
 
-string UriParser::queryValue(const string& strKey)
+string UriParser::queryValue(const string& strKey) const
 {
-    return m_mapQuery[strKey];
+    return m_mapQuery.at(strKey);
 }
 
 void UriParser::Parse(const string& strUrl, DefaultExpect exp)
@@ -115,16 +116,16 @@ void UriParser::Parse(const string& strUrl, DefaultExpect exp)
     if (idx != string::npos)
     {
         m_proto = m_host.substr(0, idx);
+        transform(m_proto.begin(), m_proto.end(), m_proto.begin(), ::tolower);
         m_host  = m_host.substr(idx + 3, m_host.size() - (idx + 3));
     }
 
     idx = m_host.find("/");
     if (idx != string::npos)
     {
-        m_path  = m_host.substr(idx, m_host.size() - idx);
+        m_path = m_host.substr(idx, m_host.size() - idx);
         m_host = m_host.substr(0, idx);
     }
-
 
     // Check special things in the HOST entry.
     size_t atp = m_host.find('@');
@@ -223,11 +224,13 @@ void UriParser::Parse(const string& strUrl, DefaultExpect exp)
 
 #ifdef TEST
 
-
 using namespace std;
 
 int main( int argc, char** argv )
 {
+    if (argc < 2) {
+        return 0;
+    }
     UriParser parser (argv[1]);
     (void)argc;
 
@@ -238,10 +241,10 @@ int main( int argc, char** argv )
     cout << "PORT: " << parser.portno() << endl;
     cout << "PATH: " << parser.path() << endl;
     cout << "PARAMETERS:\n";
-    for (auto p: parser.parameters())
+    for (auto& p: parser.parameters()) {
         cout << "\t" << p.first << " = " << p.second << endl;
-
-
+    }
     return 0;
 }
+
 #endif

--- a/apps/uriparser.cpp
+++ b/apps/uriparser.cpp
@@ -116,7 +116,7 @@ void UriParser::Parse(const string& strUrl, DefaultExpect exp)
     if (idx != string::npos)
     {
         m_proto = m_host.substr(0, idx);
-        transform(m_proto.begin(), m_proto.end(), m_proto.begin(), [](char c){ return std::toupper(c); });
+        transform(m_proto.begin(), m_proto.end(), m_proto.begin(), [](char c){ return tolower(c); });
         m_host  = m_host.substr(idx + 3, m_host.size() - (idx + 3));
     }
 
@@ -242,7 +242,8 @@ int main( int argc, char** argv )
     cout << "PORT: " << parser.portno() << endl;
     cout << "PATH: " << parser.path() << endl;
     cout << "PARAMETERS:\n";
-    for (auto& p: parser.parameters()) {
+    for (auto& p: parser.parameters()) 
+    {
         cout << "\t" << p.first << " = " << p.second << endl;
     }
     return 0;

--- a/apps/uriparser.hpp
+++ b/apps/uriparser.hpp
@@ -29,7 +29,7 @@ public:
     enum DefaultExpect { EXPECT_FILE, EXPECT_HOST };
     enum Type
     {
-        UNKNOWN, FILE, UDP, TCP, SRT, RTMP, HTTP
+        UNKNOWN, FILE, UDP, TCP, SRT, RTMP, HTTP, RTP
     };
 
     UriParser(const std::string& strUrl, DefaultExpect exp = EXPECT_FILE);
@@ -37,21 +37,21 @@ public:
     virtual ~UriParser(void);
 
     // Some predefined types
-    Type type();
+    Type type() const;
 
     typedef MapProxy<std::string, std::string> ParamProxy;
 
 // Operations
 public:
-    std::string uri() { return m_origUri; }
-    std::string proto();
-    std::string scheme() { return proto(); }
+    std::string uri() const { return m_origUri; }
+    std::string proto() const;
+    std::string scheme() const { return proto(); }
     std::string host() const;
     std::string port() const;
     unsigned short int portno() const;
-    std::string hostport() { return host() + ":" + port(); }
-    std::string path();
-    std::string queryValue(const std::string& strKey);
+    std::string hostport() const { return host() + ":" + port(); }
+    std::string path() const;
+    std::string queryValue(const std::string& strKey) const;
     ParamProxy operator[](const std::string& key) { return ParamProxy(m_mapQuery, key); }
     const std::map<std::string, std::string>& parameters() const { return m_mapQuery; }
 


### PR DESCRIPTION
* Make property accessors const.
* Proto is converted to lower case. The current code assumes a lowercase
proto and will fail if the input is not lowercase.
* Type now supports all existing types.
* Type RTP added.
* Test code no longer crashes when called with no args.
* Fixed layout removing extraneous empty lines.