### PR TITLE
[core] Update timers on connection established.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1313,13 +1313,12 @@ void CUDT::open()
 
    uint64_t currtime_tk;
    CTimer::rdtsc(currtime_tk);
-   m_ullLastRspTime_tk = currtime_tk;
-   m_ullNextACKTime_tk = currtime_tk + m_ullSYNInt_tk;
-   m_ullNextNAKTime_tk = currtime_tk + m_ullNAKInt_tk;
+   m_ullLastRspTime_tk    = currtime_tk;
+   m_ullNextACKTime_tk    = currtime_tk + m_ullSYNInt_tk;
+   m_ullNextNAKTime_tk    = currtime_tk + m_ullNAKInt_tk;
    m_ullLastRspAckTime_tk = currtime_tk;
+   m_ullLastSndTime_tk    = currtime_tk;
    m_iReXmitCount = 1;
-   // Fix keepalive
-   m_ullLastSndTime_tk = currtime_tk;
 
    m_iPktCount = 0;
    m_iLightACKCount = 1;
@@ -4710,6 +4709,16 @@ void CUDT::setupCC()
     uint64_t min_nak_tk = m_CongCtl->minNAKInterval();
     if ( min_nak_tk )
         m_ullMinNakInt_tk = min_nak_tk;
+
+    // Update timers 
+    uint64_t currtime_tk;
+    CTimer::rdtsc(currtime_tk);
+    m_ullLastRspTime_tk    = currtime_tk;
+    m_ullNextACKTime_tk    = currtime_tk + m_ullSYNInt_tk;
+    m_ullNextNAKTime_tk    = currtime_tk + m_ullNAKInt_tk;
+    m_ullLastRspAckTime_tk = currtime_tk;
+    m_ullLastSndTime_tk    = currtime_tk;
+
 
     HLOGC(mglog.Debug, log << "setupCC: setting parameters: mss=" << m_iMSS
         << " maxCWNDSize/FlowWindowSize=" << m_iFlowWindowSize


### PR DESCRIPTION
`CUDT::open` sets initial values for timers. However the connection itself is established later. Need to update the timers.

For example, wrong value of `m_ullLastRspTime_tk` influences the LATEREXMIT functionality at the start (before PR #741). With FileCC this stops the slow start period too early and triggers exsessive packet retransmission.
```
17:02:01.904791: CUDT::open
17:02:03.200710: Connection established
17:02:03.310795: ENFORCED LATEREXMIT by ACK-TMOUT (scheduling): 6985342-6985356 (15 packets)
17:02:03.310809: FileCC: CHKTIMER, SLOWSTART:OFF, sndperiod=62500us AS mega/rate (rate=16)
```