### PR TITLE
Refactor stats config to allow applications to write custom stats

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -688,7 +688,7 @@ int main(int argc, char** argv)
     //
     if (cfg.chunk_size != SRT_LIVE_MAX_PLSIZE)
         transmit_chunk_size = cfg.chunk_size;
-    printformat = cfg.stats_pf;
+    stats_writer = SrtStatsWriterFactory(cfg.stats_pf);
     transmit_bw_report = cfg.bw_report;
     transmit_stats_report = cfg.stats_report;
     transmit_total_stats = cfg.full_stats;
@@ -781,5 +781,3 @@ int main(int argc, char** argv)
 
     return 0;
 }
-
-

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -70,7 +70,7 @@
 #include "uriparser.hpp"  // UriParser
 #include "socketoptions.hpp"
 #include "logsupport.hpp"
-#include "transmitbase.hpp"
+#include "transmitmedia.hpp"
 #include "verbose.hpp"
 
 // NOTE: This is without "haisrt/" because it uses an internal path
@@ -341,7 +341,7 @@ int main(int argc, char** argv)
     //
     if (cfg.chunk_size != SRT_LIVE_DEF_PLSIZE)
         transmit_chunk_size = cfg.chunk_size;
-    printformat = cfg.stats_pf;
+    stats_writer = SrtStatsWriterFactory(cfg.stats_pf);
     transmit_bw_report = cfg.bw_report;
     transmit_stats_report = cfg.stats_report;
     transmit_total_stats = cfg.full_stats;
@@ -801,4 +801,3 @@ void TestLogHandler(void* opaque, int level, const char* file, int line, const c
 
     cerr << buf << endl;
 }
-

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -34,8 +34,8 @@ enum PrintFormat
 class SrtStatsWriter
 {
 public:
-    virtual std::string WriteStats(int sid, const CBytePerfMon& mon) const = 0;
-    virtual std::string WriteBandwidth(double mbpsBandwidth) const = 0;
+    virtual std::string WriteStats(int sid, const CBytePerfMon& mon) = 0;
+    virtual std::string WriteBandwidth(double mbpsBandwidth) = 0;
 };
 
 std::shared_ptr<SrtStatsWriter> SrtStatsWriterFactory(PrintFormat printformat);

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -30,7 +30,17 @@ enum PrintFormat
     PRINT_FORMAT_JSON,
     PRINT_FORMAT_CSV
 };
-extern PrintFormat printformat;
+
+class SrtStatsWriter
+{
+public:
+    virtual std::string WriteStats(int sid, const CBytePerfMon& mon) const = 0;
+    virtual std::string WriteBandwidth(double mbpsBandwidth) const = 0;
+};
+
+std::shared_ptr<SrtStatsWriter> SrtStatsWriterFactory(PrintFormat printformat);
+
+extern std::shared_ptr<SrtStatsWriter> stats_writer;
 
 class Location
 {
@@ -77,7 +87,5 @@ public:
     virtual int GetSysSocket() const { return -1; }
     virtual bool AcceptNewClient() { return false; }
 };
-
-
 
 #endif

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -16,6 +16,8 @@
 #include <vector>
 #include <iostream>
 #include <stdexcept>
+#include "srt.h"
+#include "uriparser.hpp"
 
 typedef std::vector<char> bytevector;
 extern bool transmit_total_stats;

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -106,7 +106,7 @@ shared_ptr<SrtStatsWriter> stats_writer;
 class SrtStatsJson : public SrtStatsWriter
 {
 public: 
-    string WriteStats(int sid, const CBytePerfMon& mon) const override { 
+    string WriteStats(int sid, const CBytePerfMon& mon) override { 
         std::ostringstream output;
         output << "{";
         output << "\"sid\":" << sid << ",";
@@ -145,7 +145,7 @@ public:
         return output.str();
     } 
 
-    string WriteBandwidth(double mbpsBandwidth) const override {
+    string WriteBandwidth(double mbpsBandwidth) override {
         std::ostringstream output;
         output << "{\"bandwidth\":" << mbpsBandwidth << '}' << endl;
         return output.str();
@@ -155,11 +155,12 @@ public:
 class SrtStatsCsv : public SrtStatsWriter
 {
 private:
-    mutable bool first_line_printed;
+    bool first_line_printed;
+
 public: 
     SrtStatsCsv() : first_line_printed(false) {}
 
-    string WriteStats(int sid, const CBytePerfMon& mon) const override { 
+    string WriteStats(int sid, const CBytePerfMon& mon) override { 
         std::ostringstream output;
         if (!first_line_printed)
         {
@@ -205,7 +206,7 @@ public:
         return output.str();
     }
 
-    string WriteBandwidth(double mbpsBandwidth) const override {
+    string WriteBandwidth(double mbpsBandwidth) override {
         std::ostringstream output;
         output << "+++/+++SRT BANDWIDTH: " << mbpsBandwidth << endl;
         return output.str();
@@ -215,7 +216,7 @@ public:
 class SrtStatsCols : public SrtStatsWriter
 {
 public: 
-    string WriteStats(int sid, const CBytePerfMon& mon) const override { 
+    string WriteStats(int sid, const CBytePerfMon& mon) override { 
         std::ostringstream output;
         output << "======= SRT STATS: sid=" << sid << endl;
         output << "PACKETS     SENT: " << setw(11) << mon.pktSent            << "  RECEIVED:   " << setw(11) << mon.pktRecv              << endl;
@@ -231,7 +232,7 @@ public:
         return output.str();
     } 
 
-    string WriteBandwidth(double mbpsBandwidth) const override {
+    string WriteBandwidth(double mbpsBandwidth) override {
         std::ostringstream output;
         output << "+++/+++SRT BANDWIDTH: " << mbpsBandwidth << endl;
         return output.str();

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -106,7 +106,8 @@ shared_ptr<SrtStatsWriter> stats_writer;
 class SrtStatsJson : public SrtStatsWriter
 {
 public: 
-    string WriteStats(int sid, const CBytePerfMon& mon) override { 
+    string WriteStats(int sid, const CBytePerfMon& mon) override 
+    { 
         std::ostringstream output;
         output << "{";
         output << "\"sid\":" << sid << ",";
@@ -145,7 +146,8 @@ public:
         return output.str();
     } 
 
-    string WriteBandwidth(double mbpsBandwidth) override {
+    string WriteBandwidth(double mbpsBandwidth) override 
+    {
         std::ostringstream output;
         output << "{\"bandwidth\":" << mbpsBandwidth << '}' << endl;
         return output.str();
@@ -160,7 +162,8 @@ private:
 public: 
     SrtStatsCsv() : first_line_printed(false) {}
 
-    string WriteStats(int sid, const CBytePerfMon& mon) override { 
+    string WriteStats(int sid, const CBytePerfMon& mon) override 
+    { 
         std::ostringstream output;
         if (!first_line_printed)
         {
@@ -206,7 +209,8 @@ public:
         return output.str();
     }
 
-    string WriteBandwidth(double mbpsBandwidth) override {
+    string WriteBandwidth(double mbpsBandwidth) override 
+    {
         std::ostringstream output;
         output << "+++/+++SRT BANDWIDTH: " << mbpsBandwidth << endl;
         return output.str();
@@ -216,7 +220,8 @@ public:
 class SrtStatsCols : public SrtStatsWriter
 {
 public: 
-    string WriteStats(int sid, const CBytePerfMon& mon) override { 
+    string WriteStats(int sid, const CBytePerfMon& mon) override 
+    { 
         std::ostringstream output;
         output << "======= SRT STATS: sid=" << sid << endl;
         output << "PACKETS     SENT: " << setw(11) << mon.pktSent            << "  RECEIVED:   " << setw(11) << mon.pktRecv              << endl;
@@ -232,7 +237,8 @@ public:
         return output.str();
     } 
 
-    string WriteBandwidth(double mbpsBandwidth) override {
+    string WriteBandwidth(double mbpsBandwidth) override 
+    {
         std::ostringstream output;
         output << "+++/+++SRT BANDWIDTH: " << mbpsBandwidth << endl;
         return output.str();

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -689,18 +689,15 @@ int SrtSource::Read(size_t chunk, bytevector& data, ostream &out_stats)
     {
         CBytePerfMon perf;
         srt_bstats(m_sock, &perf, need_stats_report && !transmit_total_stats);
-        if (need_bw_report)
+        if (stats_writer != nullptr) 
         {
-            cerr << stats_writer->WriteBandwidth(perf.mbpsBandwidth) << std::flush;
-        }
-        if (need_stats_report)
-        {
-            out_stats << stats_writer->WriteStats(m_sock, perf) << std::flush;
+            if (need_bw_report)
+                cerr << stats_writer->WriteBandwidth(perf.mbpsBandwidth) << std::flush;
+            if (need_stats_report)
+                out_stats << stats_writer->WriteStats(m_sock, perf) << std::flush;
         }
     }
-
     ++counter;
-
     return stat;
 }
 
@@ -739,18 +736,15 @@ int SrtTarget::Write(const char* data, size_t size, ostream &out_stats)
     {
         CBytePerfMon perf;
         srt_bstats(m_sock, &perf, need_stats_report && !transmit_total_stats);
-        if (need_bw_report)
+        if (stats_writer != nullptr)
         {
-            cerr << stats_writer->WriteBandwidth(perf.mbpsBandwidth) << std::flush;
-        }
-        if (need_stats_report)
-        {
-            out_stats << stats_writer->WriteStats(m_sock, perf) << std::flush;
+            if (need_bw_report)
+                cerr << stats_writer->WriteBandwidth(perf.mbpsBandwidth) << std::flush;
+            if (need_stats_report)
+                out_stats << stats_writer->WriteStats(m_sock, perf) << std::flush;
         }
     }
-
     ++counter;
-
     return stat;
 }
 


### PR DESCRIPTION
I'm building an application similar to srt-live-writer and ran into a couple of issues with implementing custom  stats output. This PR attempts to make custom application stats logging possible without making major changes to the code.

With this PR consumers of the library can implement the `SrtStatsWriter` interface to create their own custom stats output and set `stats_writer` so get custom stats output. Because both the live and file transmit applications use this I've replaced the existing code with `SrtStatsWriterFactory` to configure the existing apps. Other applications can replace the factory with their own code to set `stats_writer`.

I can think of other approaches to solving this problem. I largely picked this one because it results in fairly minimal code changes.