### PR TITLE
[core] MAXBW infinite value updated to 1 Gbps.

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -164,7 +164,7 @@ enum EConnectStatus
 std::string ConnectStatusStr(EConnectStatus est);
 
 
-const int64_t BW_INFINITE =  30000000/8;         //Infinite=> 30Mbps
+const int64_t BW_INFINITE =  1000000000/8;         //Infinite=> 1 Gbps
 
 
 enum ETransmissionEvent

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -72,7 +72,7 @@ public:
     LiveCC(CUDT* parent)
         : SrtCongestionControlBase(parent)
     {
-        m_llSndMaxBW = BW_INFINITE;    // 30Mbps in Bytes/sec BW_INFINITE
+        m_llSndMaxBW = BW_INFINITE;    // 1 Gbbps in Bytes/sec BW_INFINITE
         m_zMaxPayloadSize = parent->OPT_PayloadSize();
         if ( m_zMaxPayloadSize == 0 )
             m_zMaxPayloadSize = parent->maxPayloadSize();

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6277,7 +6277,7 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
             /*
              * On blocked transmitter (tx full) and until connection closes,
              * auto input rate falls to 0 but there may be still lot of packet to retransmit
-             * Calling updateBandwidth with 0 sets maxBW to default BW_INFINITE (30Mbps)
+             * Calling updateBandwidth with 0 sets maxBW to default BW_INFINITE (1 Gbps)
              * and sendrate skyrockets for retransmission.
              * Keep previously set maximum in that case (inputbw == 0).
              */


### PR DESCRIPTION
Related to issue #552. 
The limitation still exists, but it is increased to make more sense for the regular user.
Previous value was 30 Mbps.