### PR TITLE
[core] Minor ACK variables clean up.

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -339,7 +339,7 @@ int main(int argc, char** argv)
     //
     // Set global config variables
     //
-    if (cfg.chunk_size != -1)
+    if (cfg.chunk_size > 0)
         transmit_chunk_size = cfg.chunk_size;
     stats_writer = SrtStatsWriterFactory(cfg.stats_pf);
     transmit_bw_report = cfg.bw_report;

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -36,6 +36,7 @@ enum PrintFormat
 class SrtStatsWriter
 {
 public:
+    virtual ~SrtStatsWriter() { };
     virtual std::string WriteStats(int sid, const CBytePerfMon& mon) = 0;
     virtual std::string WriteBandwidth(double mbpsBandwidth) = 0;
 };

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -380,7 +380,7 @@ void CChannel::setIpToS(int tos)
 
 #endif
 
-int CChannel::ioctlQuery(int type) const
+int CChannel::ioctlQuery(int SRT_ATR_UNUSED type) const
 {
 #ifdef unix
     int value = 0;
@@ -391,7 +391,7 @@ int CChannel::ioctlQuery(int type) const
     return -1;
 }
 
-int CChannel::sockoptQuery(int level, int option) const
+int CChannel::sockoptQuery(int SRT_ATR_UNUSED level, int SRT_ATR_UNUSED option) const
 {
 #ifdef unix
     int value = 0;

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -210,7 +210,7 @@ struct EventVariant
     union U
     {
         CPacket* packet;
-        uint32_t ack;
+        int32_t ack;
         struct
         {
             int32_t* ptr;
@@ -238,7 +238,7 @@ struct EventVariant
     }
 
     void operator=(CPacket* arg) { Assign<PACKET>(arg); };
-    void operator=(uint32_t arg) { Assign<ACK>(arg); };
+    void operator=(int32_t  arg) { Assign<ACK>(arg); };
     void operator=(ECheckTimerStage arg) { Assign<STAGE>(arg); };
     void operator=(EInitEvent arg) { Assign<INIT>(arg); };
 
@@ -323,7 +323,7 @@ template<> struct EventVariant::VariantFor<EventVariant::PACKET>
 
 template<> struct EventVariant::VariantFor<EventVariant::ACK>
 {
-    typedef uint32_t type;
+    typedef int32_t type;
     static type U::*field() { return &U::ack; }
 };
 

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -248,9 +248,6 @@ class FileCC : public SrtCongestionControlBase
 {
     typedef FileCC Me; // Required by SSLOT macro
 
-    // Fields from CCC not used by FileCC
-    int m_iACKPeriod;
-
     // Fields from CUDTCC
     int m_iRCInterval;          // UDT Rate control interval
     uint64_t m_LastRCTime;      // last rate increase time
@@ -270,7 +267,6 @@ public:
 
     FileCC(CUDT* parent)
         : SrtCongestionControlBase(parent)
-        , m_iACKPeriod(CUDT::COMM_SYN_INTERVAL_US)
         , m_iRCInterval(CUDT::COMM_SYN_INTERVAL_US)
         , m_LastRCTime(CTimer::getTime())
         , m_bSlowStart(true)
@@ -497,13 +493,11 @@ private:
         m_bLoss = true;
 
         const int pktsInFlight = m_parent->RTT() / m_dPktSndPeriod;
-        const int ackSeqno = m_iLastAck;// m_parent->sndLastDataAck();
-        const int sentSeqno = m_parent->sndSeqNo();
         const int numPktsLost = m_parent->sndLossLength();
         const int lost_pcent_x10 = (numPktsLost * 1000) / pktsInFlight;
 
         HLOGC(mglog.Debug, log << "FileSmootherV2: LOSS: "
-            << "sent=" << CSeqNo::seqlen(ackSeqno, sentSeqno) << ", inFlight=" << pktsInFlight
+            << "sent=" << CSeqNo::seqlen(m_iLastAck, m_parent->sndSeqNo()) << ", inFlight=" << pktsInFlight
             << ", lost=" << numPktsLost << " ("
             << lost_pcent_x10 / 10 << "." << lost_pcent_x10 % 10 << "\%)");
         if (lost_pcent_x10 < 20)    // 2.0%

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -156,19 +156,17 @@ public:
     // If not, it will be internally calculated.
     virtual int RTO() { return 0; }
 
-    // How many packets to send one ACK, in packets.
-    // If user-defined, will return nonzero value.  It can enforce extra ACKs
-    // beside those calculated by ACK, sent only when the number of packets
-    // received since the last EXP that fired "fat" ACK does not exceed this
-    // value.
-    virtual int ACKInterval() { return 0; }
+    // Maximum number of packets to trigger ACK sending.
+    // Specifies the number of packets to receive before sending the ACK.
+    // Used by CUDT together with ACKTimeout_us() to trigger ACK packet sending.
+    virtual int ACKMaxPackets() const { return 0; }
 
-    // Periodical timer to send an ACK, in microseconds.
-    // If user-defined, this value in microseconds will be used to calculate
+    // Periodical interval to send an ACK, in microseconds.
+    // If user-defined, this value will be used to calculate
     // the next ACK time every time ACK is considered to be sent (see CUDT::checkTimers).
     // Otherwise this will be calculated internally in CUDT, normally taken
-    // from CPacket::SYN_INTERVAL.
-    virtual int ACKPeriod() { return 0; }
+    // from CUDT::COMM_SYN_INTERVAL_US.
+    virtual int ACKTimeout_us() const { return 0; }
 
     // Called when the settings concerning m_llMaxBW were changed.
     // Arg 1: value of CUDT::m_llMaxBW

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -822,7 +822,6 @@ private: // Timers
     uint64_t m_ullNextACKTime_tk;             // Next ACK time, in CPU clock cycles, same below
     uint64_t m_ullNextNAKTime_tk;             // Next NAK time
 
-    volatile uint64_t m_ullSYNInt_tk;         // SYN interval
     volatile uint64_t m_ullACKInt_tk;         // ACK interval
     volatile uint64_t m_ullNAKInt_tk;         // NAK interval
     volatile uint64_t m_ullLastRspTime_tk;    // time stamp of last response from the peer

--- a/srtcore/fec.h
+++ b/srtcore/fec.h
@@ -242,7 +242,7 @@ public:
     // So extra 4 bytes are needed, 2 for flags, 2 for length clip.
     static const size_t EXTRA_SIZE = 4;
 
-    virtual SRT_ARQLevel arqLevel() { return m_fallback_level; }
+    virtual SRT_ARQLevel arqLevel() ATR_OVERRIDE { return m_fallback_level; }
 };
 
 #endif

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -385,7 +385,7 @@ public:
    int32_t& m_iSeqNo;                   // alias: sequence number
    int32_t& m_iMsgNo;                   // alias: message number
    int32_t& m_iTimeStamp;               // alias: timestamp
-   int32_t& m_iID;			// alias: socket ID
+   int32_t& m_iID;                      // alias: socket ID
    char*& m_pcData;                     // alias: data/control information
 
    //static const int m_iPktHdrSize;	// packet header size

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -71,7 +71,6 @@ TEST(CEPoll, WaitEmptyCall)
     SRTSOCKET client_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     ASSERT_NE(client_sock, SRT_ERROR);
 
-    const int yes = 1;
     const int no = 0;
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -96,7 +95,6 @@ TEST(CEPoll, UWaitEmptyCall)
     SRTSOCKET client_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     ASSERT_NE(client_sock, SRT_ERROR);
 
-    const int yes = 1;
     const int no = 0;
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -186,12 +184,9 @@ TEST(CEPoll, WrongEpoll_idOnAddUSock)
     SRTSOCKET client_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     ASSERT_NE(client_sock, SRT_ERROR);
 
-    const int yes = 1;
-    const int no = 0;
+    const int no  = 0;
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
-    ASSERT_NE(srt_setsockflag(client_sock, SRTO_SENDER, &yes, sizeof yes), SRT_ERROR);
-    ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
 
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -495,7 +495,6 @@ TEST(CEPoll, ThreadedUpdate)
     SRTSOCKET client_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     EXPECT_NE(client_sock, SRT_ERROR);
 
-    const int yes = 1;
     const int no  = 0;
     EXPECT_NE(srt_setsockopt (client_sock, 0, SRTO_RCVSYN,    &no,  sizeof no),  SRT_ERROR); // for async connect
     EXPECT_NE(srt_setsockopt (client_sock, 0, SRTO_SNDSYN,    &no,  sizeof no),  SRT_ERROR); // for async connect

--- a/test/test_strict_encription.cpp
+++ b/test/test_strict_encription.cpp
@@ -243,7 +243,7 @@ public:
     int SetStrictEncryption(PEER_TYPE peer, bool value)
     {
         const SRTSOCKET &socket = peer == PEER_CALLER ? m_caller_socket : m_listener_socket;
-        return srt_setsockopt(socket, 0, SRTO_STRICTENC, value ? &s_yes : &s_no, sizeof s_yes);
+        return srt_setsockopt(socket, 0, SRTO_ENFORCEDENCRYPTION, value ? &s_yes : &s_no, sizeof s_yes);
     }
 
 
@@ -252,7 +252,7 @@ public:
         const SRTSOCKET socket = peer_type == PEER_CALLER ? m_caller_socket : m_listener_socket;
         int value = -1;
         int value_len = sizeof value;
-        EXPECT_EQ(srt_getsockopt(socket, 0, SRTO_STRICTENC, (void*)&value, &value_len), SRT_SUCCESS);
+        EXPECT_EQ(srt_getsockopt(socket, 0, SRTO_ENFORCEDENCRYPTION, (void*)&value, &value_len), SRT_SUCCESS);
         return value ? true : false;
     }
 
@@ -368,13 +368,12 @@ public:
                 EXPECT_EQ(GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE), expect.km_state[CHECK_SOCKET_ACCEPTED]);
                 if (m_is_tracing)
                 {
-                    std::cout << "Socket state accepted: " << m_socket_state[srt_getsockstate(accepted_socket)] << "\n";
-                    std::cout << "KM State accepted:     " << m_km_state[GetKMState(accepted_socket)] << '\n';
-                    std::cout << "RCV KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_RCVKMSTATE)] << '\n';
-                    std::cout << "SND KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE)] << '\n';
+                    std::cerr << "Socket state accepted: " << m_socket_state[srt_getsockstate(accepted_socket)] << "\n";
+                    std::cerr << "KM State accepted:     " << m_km_state[GetKMState(accepted_socket)] << '\n';
+                    std::cerr << "RCV KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_RCVKMSTATE)] << '\n';
+                    std::cerr << "SND KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE)] << '\n';
                 }
             }
-            std::cout << "srt_accept() thread finished\n";
         });
 
         if (is_blocking == false)
@@ -382,12 +381,12 @@ public:
 
         if (m_is_tracing)
         {
-            std::cout << "Socket state caller:   " << m_socket_state[srt_getsockstate(m_caller_socket)] << "\n";
-            std::cout << "Socket state listener: " << m_socket_state[srt_getsockstate(m_listener_socket)] << "\n";
-            std::cout << "KM State caller:       " << m_km_state[GetKMState(m_caller_socket)] << '\n';
-            std::cout << "RCV KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE)] << '\n';
-            std::cout << "SND KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_SNDKMSTATE)] << '\n';
-            std::cout << "KM State listener:     " << m_km_state[GetKMState(m_listener_socket)] << '\n';
+            std::cerr << "Socket state caller:   " << m_socket_state[srt_getsockstate(m_caller_socket)] << "\n";
+            std::cerr << "Socket state listener: " << m_socket_state[srt_getsockstate(m_listener_socket)] << "\n";
+            std::cerr << "KM State caller:       " << m_km_state[GetKMState(m_caller_socket)] << '\n';
+            std::cerr << "RCV KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE)] << '\n';
+            std::cerr << "SND KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_SNDKMSTATE)] << '\n';
+            std::cerr << "KM State listener:     " << m_km_state[GetKMState(m_listener_socket)] << '\n';
         }
 
         // If a blocking call to srt_connect() returned error, then the state is not valid,
@@ -403,7 +402,6 @@ public:
             // srt_accept() has no timeout, so we have to close the socket and wait for the thread to exit.
             // Just give it some time and close the socket.
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            std::cout << "Closing the listener socket\n";
             ASSERT_NE(srt_close(m_listener_socket), SRT_ERROR);
             accepting_thread.join();
         }
@@ -421,7 +419,7 @@ private:
     const int s_yes = 1;
     const int s_no  = 0;
 
-    const bool          m_is_tracing = true;
+    const bool          m_is_tracing = false;
     static const char*  m_km_state[];
     static const char*  m_socket_state[];
 };


### PR DESCRIPTION
- m_ullACKInt_tk used at initialization
- Removed unused `m_iACKPeriod` from FileCC
- ACK event variant type changed to signed integer
- `SrtCongestionControlBase`: renamed `ACKInterval()` -> `ACKMaxPackets()`
- `SrtCongestionControlBase`: renamed `ACKPeriod()` -> `ACKTimeout_us()`
- Added `ATR_OVERRIDE` to `FECFilterBuiltin::arqLevel()`

Fixes #253 - no warnings during build in Travis.