### PR TITLE
[core] Fixed HS response timestamp

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7241,9 +7241,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
          if ( createSrtHandshake(Ref(response), Ref(initdata), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize) )
          {
              response.m_iID = m_PeerID;
-             uint64_t currtime_tk;
-             CTimer::rdtsc(currtime_tk);
-             response.m_iTimeStamp = int(currtime_tk/m_ullCPUFrequency - m_stats.startTime);
+             response.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
              int nbsent = m_pSndQueue->sendto(m_pPeerAddr, response);
              if (nbsent)
              {


### PR DESCRIPTION
`CTimer::getTime()` is used for a packet timestamp, except for this one place. This PR fixes it.