### PR TITLE
Updated status badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
   </a>
 </p>
 
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/ruujele1yfsfsyer/branch/master?svg=true)](https://ci.appveyor.com/project/Haivision/srt) [![Build Status](https://travis-ci.org/Haivision/srt.svg?branch=master)](https://travis-ci.org/Haivision/srt)
+[![Build Status Linux and macOS][travis-badge]][travis]
+[![Build Status Windows][appveyor-badge]][appveyor]
+[![License: MPLv2.0][license-badge]](./LICENSE)
+[![Latest release][release-badge]][github releases]
 
 # Introduction
 
@@ -182,3 +185,14 @@ for example (remember that 'configure' script requires tcl8.5 package):
 
 The Cygwin platform isn't any important target platform for this project, but it's
 very useful to check if the project wouldn't be build-broken on Linux.
+
+
+
+[appveyor-badge]: https://img.shields.io/appveyor/ci/Haivision/srt/master.svg?label=Windows
+[appveyor]: https://ci.appveyor.com/project/Haivision/srt
+[travis-badge]: https://img.shields.io/travis/Haivision/srt/master.svg?label=Linux/macOS
+[travis]: https://travis-ci.org/Haivision/srt
+[license-badge]: https://img.shields.io/badge/License-MPLv2.0-blue
+
+[github releases]: https://github.com/Haivision/srt/releases
+[release-badge]: https://img.shields.io/github/release/Haivision/srt.svg


### PR DESCRIPTION
- Added license badge.
- Travis badge shows Linux and macOS label.
- AppVeyor's badge shows Windows label.
- Added latest release badge.

Screenshot:
![image](https://user-images.githubusercontent.com/12700120/61890190-417f3b80-af07-11e9-919d-26b50884de7c.png)
