### PR TITLE
[build] Travis MinGW: updated OpenSSL to 1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,8 @@ matrix:
                 - gcc-mingw-w64
                 - g++-mingw-w64-x86-64
           before_script:
-            - git clone https://github.com/openssl/openssl.git
+            - git clone -b OpenSSL_1_1_1-stable https://github.com/openssl/openssl.git openssl
             - cd openssl
-            - git checkout origin/OpenSSL_1_1_0-stable -b OpenSSL_1_1_0-stable
             - ./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64
             - make
             - cd ..


### PR DESCRIPTION
Travis CI for MinGW fails for current master, probably after [this commit](https://github.com/openssl/openssl/commit/e32bc855a81a2d48d215c506bdeb4f598045f7e9) in OpenSSL 1.1.0.
Updated OpenSSL to 1.1.1.