### PR TITLE
Add headers to let compiler know functions and structures.

### DIFF
--- a/haicrypt/cryspr-gnutls.h
+++ b/haicrypt/cryspr-gnutls.h
@@ -20,6 +20,7 @@ written by
 #ifndef CRYSPR_GNUTLS_H
 #define CRYSPR_GNUTLS_H
 
+#include <gnutls/gnutls.h>
 #include <gnutls/crypto.h>  //gnutls_rnd()
 
 #include <nettle/aes.h>     //has AES cipher

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -20,6 +20,7 @@ written by
 #include "hcrypt.h"
 #include "cryspr.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 int crysprStub_Prng(unsigned char *rn, int len)


### PR DESCRIPTION
To suppress compilation warnings