### PR TITLE
Fixed a few warnings

### DIFF
--- a/srtcore/README.md
+++ b/srtcore/README.md
@@ -6,6 +6,7 @@ and internally by the library, this directory also contains:
 
  - common files: usually header files, which can be used also by other projects,
 even if they don't link against SRT
+
  - public and protected header files - header files for the library, which will
 be picked up from here
 

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1742,7 +1742,7 @@ void CUDTUnited::updateMux(
    {
       m.m_pChannel->close();
       delete m.m_pChannel;
-      throw e;
+      throw;
    }
 
    // XXX Simplify this. Use sockaddr_any.
@@ -2740,7 +2740,7 @@ SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
    {
       return s_UDTUnited.getStatus(u);
    }
-   catch (CUDTException e)
+   catch (CUDTException &e)
    {
       s_UDTUnited.setError(new CUDTException(e));
       return SRTS_NONEXIST;

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1023,7 +1023,13 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
     int rmpkts = 0; 
     int rmbytes = 0;
 
-    string reason = "NOT RECEIVED";
+#if ENABLE_HEAVY_LOGGING
+    const char* reason = "NOT RECEIVED";
+#define IF_HEAVY_LOGGING(instr) instr
+#else 
+#define IF_HEAVY_LOGGING(instr) (void)0
+#endif 
+
     for (int i = m_iStartPos, n = m_iLastAckPos; i != n; i = (i + 1) % m_iSize)
     {
         bool freeunit = false;
@@ -1054,7 +1060,7 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
 
             if (m_pUnit[i]->m_Packet.getMsgCryptoFlags() != EK_NOENC)
             {
-                reason = "DECRYPTION FAILED";
+                IF_HEAVY_LOGGING(reason = "DECRYPTION FAILED");
                 freeunit = true; /* packet not decrypted */
             }
             else

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -159,7 +159,8 @@ string CHandShake::show()
         << " cookie=" << hex << m_iCookie << dec
         << " srcIP=";
 
-    const unsigned char* p = (const unsigned char*)m_piPeerIP, * pe = p + 4*(sizeof (uint32_t));
+    const unsigned char* p  = (const unsigned char*)m_piPeerIP;
+    const unsigned char* pe = p + 4 * (sizeof(uint32_t));
 
     copy(p, pe, ostream_iterator<unsigned>(so, "."));
 

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1276,7 +1276,8 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
 
     }
 
-    ptr->uri = move(u);
+    if (ptr)
+        ptr->uri = move(u);
     return ptr;
 }
 


### PR DESCRIPTION
Fixed a few warnings
* Avoid copying exception, rethrow instead.
* Excluded variable, not used in case HEAVY logging is off.
* `srt-test-live` fixed handling of medium.