### PR TITLE
travis: extend timeout to install packages on osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,17 @@ matrix:
           osx_image: xcode7.3
           env: BUILD_TYPE=Debug
           before_install: brew update
-          install: brew install openssl gnutls nettle
+          install: 
+            - brew install nettle
+            - brew install gnutls
+            - brew install openssl
         - os: osx
           osx_image: xcode7.3
           before_install: brew update
-          install: brew install openssl gnutls nettle
+          install:
+            - brew install nettle
+            - brew install gnutls
+            - brew install openssl
           env: BUILD_TYPE=Release
         - os: linux
           compiler: x86_64-w64-mingw32-g++


### PR DESCRIPTION
travis terminates build process on macosx due to timeout.