### PR TITLE
[core] Update SND loss list on lite ACK

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -192,6 +192,7 @@ void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint6
 
         // XXX unchecked condition: s->m_pNext == NULL.
         // Should never happen, as the call to increase() should ensure enough buffers.
+        SRT_ASSERT(s->m_pNext);
         s = s->m_pNext;
     }
     m_pLastBlock = s;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -705,7 +705,7 @@ private: // synchronization: mutexes and conditions
     pthread_mutex_t m_RcvBufferLock;             // Protects the state of the m_pRcvBuffer
 
     // Protects access to m_iSndCurrSeqNo, m_iSndLastAck
-    pthread_mutex_t m_RecvAckLock;               // Protects the state changes while processing incomming ACK
+    pthread_mutex_t m_RecvAckLock;               // Protects the state changes while processing incomming ACK (UDT_EPOLL_OUT)
 
 
     pthread_cond_t m_RecvDataCond;               // used to block "recv" when there is no data

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -724,9 +724,11 @@ private: // Common connection Congestion Control setup
     bool createCrypter(HandshakeSide side, bool bidi);
 
 private: // Generation and processing of packets
-    void sendCtrl(UDTMessageType pkttype, void* lparam = NULL, void* rparam = NULL, int size = 0);
+    void sendCtrl(UDTMessageType pkttype, const void* lparam = NULL, void* rparam = NULL, int size = 0);
+
     void processCtrl(CPacket& ctrlpkt);
     void sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& losslist);
+    void processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk);
 
     /// Pack a packet from a list of lost packets.
     ///

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -224,7 +224,7 @@ void CPacket::setLength(size_t len)
    m_PacketVector[PV_DATA].setLength(len);
 }
 
-void CPacket::pack(UDTMessageType pkttype, void* lparam, void* rparam, int size)
+void CPacket::pack(UDTMessageType pkttype, const void* lparam, void* rparam, int size)
 {
     // Set (bit-0 = 1) and (bit-1~15 = type)
     setControl(pkttype);

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -243,7 +243,7 @@ public:
       /// @param rparam [in] pointer to the second data structure, explained by the packet type.
       /// @param size [in] size of rparam, in number of bytes;
 
-   void pack(UDTMessageType pkttype, void* lparam = NULL, void* rparam = NULL, int size = 0);
+   void pack(UDTMessageType pkttype, const void* lparam = NULL, void* rparam = NULL, int size = 0);
 
       /// Read the packet vector.
       /// @return Pointer to the packet vector.


### PR DESCRIPTION
When the lite ACK is received, the sender's loss list is better to be updated as well to prevent retransmission of already acknowledged DATA packets.

Therefore, created the `CUDT::updateSndLossListOnACK()` function to handle this in one place.
Protected by `CUDT::m_RecvAckLock` mutex.

## Description

In short, [this epoll update](https://github.com/Haivision/srt/blob/master/srtcore/core.cpp#L6984) call does not really check the state of the sender's buffer.

It is expected that [`m_pSndBuffer->ackData(offset)`](https://github.com/Haivision/srt/blob/master/srtcore/core.cpp#L6908) removes some packets from the buffer, thus providing free space to add more packets.

However, after that `ackData()` in the receiving thread, the sender's buffer can be filled with all the remaining packets from [`sendmsg2()`](https://github.com/Haivision/srt/blob/master/srtcore/core.cpp#L5521), making that polling faulty.

However, this was unlikely to happen, because `m_pSndBuffer->ackData(offset)` and `m_EPoll.update_events()` were pretty close to each other. though still not protected by any mutex.

## PR contents

PR consists of the following commits:

* [core] Added `processCtrlAck()` function.
Just moves ACK processing to a separate function, does not change the behavior.
* [core] Small refactoring of `processCtrlAck()`.
Does not change the behavior.
* [core] Split m_AckLock into two: `m_RecvAckLock` and `m_RcvBufferLock`.
Does not change the handling of mutexes, but splits them into two. Fixes #820.
* [core] Update sender's loss list on lite ACK.
Also fixes #821 

## Issues Fixed

- [X] Fixes #820 
- [X] Fixes #821

## TODO

- [x] Apply changes in `CUDT::sendmsg2()` to `CUDT::sendfile()`