### PR TITLE
travis: bump up osx_image version to 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,10 @@ matrix:
         - env: BUILD_TYPE=Debug
         - env: BUILD_TYPE=Release
         - os: osx
-          osx_image: xcode7.3
+          osx_image: xcode10.2
           env: BUILD_TYPE=Debug
-          before_install: brew update
-          install: brew install openssl gnutls nettle
         - os: osx
-          osx_image: xcode7.3
-          before_install: brew update
-          install: brew install openssl gnutls nettle
+          osx_image: xcode10.2
           env: BUILD_TYPE=Release
         - os: linux
           compiler: x86_64-w64-mingw32-g++


### PR DESCRIPTION
To avoid re-compiling homebrew dependencies.