### PR TITLE
Fix FreeBSD builds where the byte order conversion macros are defined…

### DIFF
--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -129,14 +129,26 @@ written by
 
 #	include <sys/endian.h>
 
+#ifndef be16toh
 #	define be16toh(x) betoh16(x)
+#endif
+#ifndef le16toh
 #	define le16toh(x) letoh16(x)
+#endif
 
+#ifndef be32toh
 #	define be32toh(x) betoh32(x)
+#endif
+#ifndef le32toh
 #	define le32toh(x) letoh32(x)
+#endif
 
+#ifndef be64toh
 #	define be64toh(x) betoh64(x)
+#endif
+#ifndef le64toh
 #	define le64toh(x) letoh64(x)
+#endif
 
 #elif defined(__WINDOWS__)
 


### PR DESCRIPTION
Fix FreeBSD builds where the byte order conversion macros are defined in sys/endian.h. These macros are defined in the the more recent versions of FreeBSD.