### PR TITLE
[core] Use monotonic clock for garbage collector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,13 @@ if (ENABLE_SHARED)
 	endforeach()
 endif()
 
+
+if(LINUX)
+include(GlibcDetect)
+	GLIBC_DETECT(GLIBC_VERSION)
+	message(STATUS "GLIBC_VERSION=${GLIBC_VERSION}")
+endif()
+
 # Manual handling of dependency on virtual library
 # By setting the target, all settings applied to the haicrypt target
 # will now apply to the dependent library.
@@ -552,6 +559,11 @@ if (srt_libspec_shared)
 	elseif (APPLE)
 		set_property(TARGET ${TARGET_srt}_shared PROPERTY MACOSX_RPATH ON)
 	endif()
+
+	if (${GLIBC_VERSION} AND ${GLIBC_VERSION} LESS 217)
+		target_link_libraries(${TARGET_srt}_shared PRIVATE librt)
+	endif()
+
 	if (USE_GNUSTL)
 		target_link_libraries(${TARGET_srt}_shared PRIVATE ${GNUSTL_LIBRARIES} ${GNUSTL_LDFLAGS})
 	endif()
@@ -583,6 +595,11 @@ if (srt_libspec_static)
 	elseif (MINGW)
 		target_link_libraries(${TARGET_srt}_static PRIVATE wsock32 ws2_32)
 	endif()
+
+	if (${GLIBC_VERSION} AND ${GLIBC_VERSION} LESS 217)
+		target_link_libraries(${TARGET_srt}_static PRIVATE librt)
+	endif()
+
 	if (USE_GNUSTL)
 		target_link_libraries(${TARGET_srt}_static PRIVATE ${GNUSTL_LIBRARIES} ${GNUSTL_LDFLAGS})
 	endif()

--- a/scripts/GlibcDetect.cmake
+++ b/scripts/GlibcDetect.cmake
@@ -1,0 +1,50 @@
+ ###############################################################
+ # 
+ # Copyright 2011 Red Hat, Inc. 
+ # 
+ # Licensed under the Apache License, Version 2.0 (the "License"); you 
+ # may not use this file except in compliance with the License.  You may 
+ # obtain a copy of the License at 
+ # 
+ #    http://www.apache.org/licenses/LICENSE-2.0 
+ # 
+ # Unless required by applicable law or agreed to in writing, software 
+ # distributed under the License is distributed on an "AS IS" BASIS, 
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and 
+ # limitations under the License. 
+ # 
+ ############################################################### 
+
+MACRO (GLIBC_DETECT _VERSION)
+
+# there are multiple ways to detect glibc, but given nmi's
+# cons'd up paths I will trust only gcc.  I guess I could also use
+# ldd --version to detect.
+
+set(_GLIB_SOURCE_DETECT "
+#include <limits.h>
+#include <stdio.h>
+int main()
+{
+  printf(\"%d%d\",__GLIBC__, __GLIBC_MINOR__);
+  return 0;
+}
+")
+
+file (WRITE ${CMAKE_CURRENT_BINARY_DIR}/build/cmake/glibc.cpp "${_GLIB_SOURCE_DETECT}\n")
+
+try_run(POST26_GLIBC_DETECTED
+		POST26_GLIBC_COMPILE
+        ${CMAKE_CURRENT_BINARY_DIR}/build/cmake
+		${CMAKE_CURRENT_BINARY_DIR}/build/cmake/glibc.cpp
+        RUN_OUTPUT_VARIABLE GLIBC_VERSION )
+
+if (GLIBC_VERSION AND POST26_GLIBC_COMPILE )
+	set(${_VERSION} ${GLIBC_VERSION})
+else()
+	message(STATUS "NOTE: Could not detect GLIBC_VERSION from compiler")
+endif()
+
+
+ENDMACRO (GLIBC_DETECT)

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -17,7 +17,7 @@ written by
 #define INC__SRT_UTILITIES_H
 
 
-#if (__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ > 17))
+#if (__GLIBC__)
 #define HAVE_POSIX_CLOCK_MONOTONIC 1
 #endif
 

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -17,6 +17,11 @@ written by
 #define INC__SRT_UTILITIES_H
 
 
+#if (__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ > 17))
+#define HAVE_POSIX_CLOCK_MONOTONIC 1
+#endif
+
+
 #ifdef __GNUG__
 #define ATR_UNUSED __attribute__((unused))
 #define ATR_DEPRECATED __attribute__((deprecated))


### PR DESCRIPTION
A third variant of monotonic clock usage for GC.

According to the `clock_gettime` man page, it was necessary to link with librt for glibc versions before 2.17. Later versions include it into `libc`.
So to avoid complicated detection of glibc with CMake, monotonic clock will be enabled only if glibc version is known to contain those.

Examples of detecting glib version with CMake, found by @rndi 
* [Trying to compile a sample without `librt`](https://github.com/Z3Prover/z3/commit/6a4f269563b82a0c34950a057052ac5e8dcc1755)
* [Running a compiled sample that prints out the version of GLib](https://github.com/htcondor/htcondor/blob/master/build/cmake/macros/GlibcDetect.cmake)


Fixes #729.
Closes #732. Closes #733.