### PR TITLE
close Channel after stopping recv send queues

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1646,9 +1646,9 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
       // being currently done in the queues, if any.
       mx.m_pSndQueue->setClosing();
       mx.m_pRcvQueue->setClosing();
-      mx.m_pChannel->close();
       delete mx.m_pSndQueue;
       delete mx.m_pRcvQueue;
+      mx.m_pChannel->close();
       delete mx.m_pTimer;
       delete mx.m_pChannel;
       m_mMultiplexer.erase(m);


### PR DESCRIPTION
Channel is used by recv and send queues and possible blocked in I/O
operations.  Closing the channel while it is still in use causes
problems with the recv and send queues and may cause problems in other
threads of the application.
Fixes #306.