### PR TITLE
Fix system priviledged port range, excluding port 1024 that is not reserved

### DIFF
--- a/ATTIC/srt-multiplex.cpp
+++ b/ATTIC/srt-multiplex.cpp
@@ -566,9 +566,9 @@ int main( int argc, char** argv )
     }
 
     int iport = atoi(up.port().c_str());
-    if ( iport <= 1024 )
+    if ( iport < 1024 )
     {
-        cerr << "Port value invalid: " << iport << " - must be >1024\n";
+        cerr << "Port value invalid: " << iport << " - must be >=1024\n";
         return 1;
     }
 

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -1213,9 +1213,9 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
 
     case UriParser::SRT:
         iport = atoi(u.port().c_str());
-        if ( iport <= 1024 )
+        if ( iport < 1024 )
         {
-            cerr << "Port value invalid: " << iport << " - must be >1024\n";
+            cerr << "Port value invalid: " << iport << " - must be >=1024\n";
             throw invalid_argument("Invalid port number");
         }
         ptr.reset( CreateSrt<Base>(u.host(), iport, u.parameters()) );
@@ -1224,9 +1224,9 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
 
     case UriParser::UDP:
         iport = atoi(u.port().c_str());
-        if ( iport <= 1024 )
+        if ( iport < 1024 )
         {
-            cerr << "Port value invalid: " << iport << " - must be >1024\n";
+            cerr << "Port value invalid: " << iport << " - must be >=1024\n";
             throw invalid_argument("Invalid port number");
         }
         ptr.reset( CreateUdp<Base>(u.host(), iport, u.parameters()) );

--- a/examples/suflip.cpp
+++ b/examples/suflip.cpp
@@ -624,7 +624,7 @@ int main( int argc, char** argv )
 
     if ( su.portno() < 1024 || tu.portno() < 1024 )
     {
-        cerr << "Port number must be > 1024\n";
+        cerr << "Port number must be >= 1024\n";
         return 1;
     }
 

--- a/testing/srt-test-multiplex.cpp
+++ b/testing/srt-test-multiplex.cpp
@@ -565,9 +565,9 @@ int main( int argc, char** argv )
     }
 
     int iport = atoi(up.port().c_str());
-    if ( iport <= 1024 )
+    if ( iport < 1024 )
     {
-        cerr << "Port value invalid: " << iport << " - must be >1024\n";
+        cerr << "Port value invalid: " << iport << " - must be >=1024\n";
         return 1;
     }
 

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1255,9 +1255,9 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
 
     case UriParser::SRT:
         iport = atoi(u.port().c_str());
-        if ( iport <= 1024 )
+        if ( iport < 1024 )
         {
-            cerr << "Port value invalid: " << iport << " - must be >1024\n";
+            cerr << "Port value invalid: " << iport << " - must be >=1024\n";
             throw invalid_argument("Invalid port number");
         }
         ptr.reset( CreateSrt<Base>(u.host(), iport, u.parameters()) );
@@ -1266,9 +1266,9 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
 
     case UriParser::UDP:
         iport = atoi(u.port().c_str());
-        if ( iport <= 1024 )
+        if ( iport < 1024 )
         {
-            cerr << "Port value invalid: " << iport << " - must be >1024\n";
+            cerr << "Port value invalid: " << iport << " - must be >=1024\n";
             throw invalid_argument("Invalid port number");
         }
         ptr.reset( CreateUdp<Base>(u.host(), iport, u.parameters()) );


### PR DESCRIPTION
Hi,
SRT is preventing the usage of system reserved/priviledged ports, following IANA standards. There is an error in the implementation of the standard, preventing the usage of port 1024 that should not be reserved.

https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml

```
System Ports (0-1023),
User Ports (1024-49151),
and the Dynamic and/or Private Ports (49152-65535)
```

This PR is here to allow the usage of port 1024.

Hope it helps,