### PR TITLE
Added option to enforce smaller latency

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -232,7 +232,8 @@ const SocketOption srt_options [] {
     { "kmrefreshrate", 0, SRTO_KMREFRESHRATE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "kmpreannounce", 0, SRTO_KMPREANNOUNCE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "strictenc", 0, SRTO_STRICTENC, SocketOption::PRE, SocketOption::BOOL, nullptr },
-    { "peeridletimeo", 0, SRTO_PEERIDLETIMEO, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "peeridletimeo", 0, SRTO_PEERIDLETIMEO, SocketOption::PRE, SocketOption::INT, nullptr },
+    { "enforcedlatency", 0, SRTO_ENFORCEDLATENCY, SocketOption::PRE, SocketOption::BOOL, nullptr }
 };
 }
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -562,6 +562,7 @@ private: // Identification
     bool m_bOPT_StrictEncryption;    // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
     std::string m_sStreamName;
     int m_iOPT_PeerIdleTimeout;      // Timeout for hearing anything from the peer.
+    bool m_bOPT_ForceLatency;        // Higher latency rejected
 
     int m_iTsbPdDelay_ms;                           // Rx delay to absorb burst in milliseconds
     int m_iPeerTsbPdDelay_ms;                       // Tx delay that the peer uses to absorb burst in milliseconds

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -61,7 +61,8 @@ enum SrtOptions
     SRT_OPT_NAKREPORT = BIT(4), /* Periodic NAK report */
     SRT_OPT_REXMITFLG = BIT(5), // One bit in payload packet msgno is "retransmitted" flag
                                 // (this flag can be reused for something else, when pre-1.2.0 versions are all abandoned)
-    SRT_OPT_STREAM    = BIT(6)
+    SRT_OPT_STREAM    = BIT(6),
+    SRT_OPT_FORCELATENCY=BIT(7), // Responder getting that flag in HSREQ should adjust to smaller latency
 };
 
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -181,6 +181,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_STRICTENC,           // Connection to be rejected or quickly broken when one side encryption set or bad password
    SRTO_IPV6ONLY,            // IPV6_V6ONLY mode
    SRTO_PEERIDLETIMEO,       // Peer-idle timeout (max time of silence heard from peer) in [ms]
+   SRTO_ENFORCEDLATENCY,     // Do not accept higher latency from the peer
 } SRT_SOCKOPT;
 
 // DEPRECATED OPTIONS:


### PR DESCRIPTION
Changes:

1. User API
------------

New option `SRTO_ENFORCEDLATENCY` (bool). When set, the latency set on this agent (in both directions) will be in force for the connection, even if the peer wanted higher latency.

2. Implementation
--------------------

a. Added a new field to represent the option value

b. Added a handshake flag `SRT_OPT_FORCELATENCY` by which an INITIATOR informs a RESPONDER that it wants its latency settings enforced. This is because the latency value resolution happens exclusively on RESPONDER and therefore it's the only way to prevent the RESPONDER from fixing the latency if INITIATOR wants to preserve this value no matter what.

c. The fixing procedure:
* When the peer provided `SRT_OPT_FORCELATENCY`, accept the latency value of the peer if it is lower than that of the agent
* Otherwise, when the agent has set `SRTO_ENFORCEDLATENCY`, reject the latency provided by the peer if it is higher
* Otherwise perform the procedure of finding highest latency of agent and peer

NOTE: This feature won't work with clients of HSv4 (SRT version before 1.3.0). Note also that this is implemented almost exclusively on the RESPONDER side (that is, listener in HSv5 caller-listener arrangement), so with an earlier-version clients it will only work when the latency is enforced on most recent listener (older listeners simply don't handle the `SRT_OPT_FORCEATENCY` flag). Forcing it on a caller side when listener is outdated will not work.