### PR TITLE
[core] Fixed SRTO_LOSSMAXTTL setting on accepted socket. Fixes #735.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -255,7 +255,6 @@ CUDT::CUDT()
    m_iSndCryptoKeyLen = 0;
    //Cfg
    m_bDataSender = false;       //Sender only if true: does not recv data
-   m_bTwoWayData = false;
    m_bOPT_TsbPd = true;        //Enable TsbPd on sender
    m_iOPT_TsbPdDelay = SRT_LIVE_DEF_LATENCY_MS;
    m_iOPT_PeerTsbPdDelay = 0;       //Peer's TsbPd delay as receiver (here is its minimum value, if used)
@@ -271,8 +270,6 @@ CUDT::CUDT()
    m_bRcvNakReport = true;      //Receiver's Periodic NAK Reports
    m_llInputBW = 0;             // Application provided input bandwidth (internal input rate sampling == 0)
    m_iOverheadBW = 25;          // Percent above input stream rate (applies if m_llMaxBW == 0)
-   m_bTwoWayData = false;
-
    m_pCache = NULL;
 
    // Default congctl is "live".
@@ -319,7 +316,6 @@ CUDT::CUDT(const CUDT& ancestor)
    m_llInputBW = ancestor.m_llInputBW;
    m_iOverheadBW = ancestor.m_iOverheadBW;
    m_bDataSender = ancestor.m_bDataSender;
-   m_bTwoWayData = ancestor.m_bTwoWayData;
    m_bOPT_TsbPd = ancestor.m_bOPT_TsbPd;
    m_iOPT_TsbPdDelay = ancestor.m_iOPT_TsbPdDelay;
    m_iOPT_PeerTsbPdDelay = ancestor.m_iOPT_PeerTsbPdDelay;
@@ -4752,9 +4748,6 @@ bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     // These data should probably be filled only upon
     // reception of the conclusion handshake - otherwise
     // they have outdated values.
-    if ( bidirectional )
-        m_bTwoWayData = true;
-
     m_pCryptoControl->setCryptoSecret(m_CryptoSecret);
 
     if ( bidirectional || m_bDataSender )

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -331,6 +331,7 @@ CUDT::CUDT(const CUDT& ancestor)
    m_bTLPktDrop = ancestor.m_bTLPktDrop;
    m_bMessageAPI = ancestor.m_bMessageAPI;
    m_iIpV6Only = ancestor.m_iIpV6Only;
+   m_iMaxReorderTolerance = ancestor.m_iMaxReorderTolerance;
    //Runtime
    m_bRcvNakReport = ancestor.m_bRcvNakReport;
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -543,11 +543,9 @@ private: // Identification
     HaiCrypt_Secret m_CryptoSecret;
     int m_iSndCryptoKeyLen;
 
-    // XXX Consider removing them. The m_bDataSender may stay here
+    // XXX Consider removing. The m_bDataSender stays here
     // in order to maintain the HS side selection in HSv4.
-    // m_bTwoWayData is unused.
     bool m_bDataSender;
-    bool m_bTwoWayData;
 
     // HSv4 (legacy handshake) support)
     uint64_t m_ullSndHsLastTime_us;	    //Last SRT handshake request time


### PR DESCRIPTION
When accepting an incomming connection, the copy constructor was not copying the `m_iMaxReorderTolerance` setting from the ancestor.

TODO:
- [x] Check other missing settings.

Fixes #735.