### PR TITLE
Fixed correct description for msgttl

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -579,8 +579,9 @@ sending messages (in `[ms]`). Not used for receiving messages. If this value
 is not negative, it defines the maximum time up to which this message should
 stay scheduled for sending for the sake of later retransmission. A message
 is always sent for the first time, but the UDP packet carrying it may be
-(also partially) lost. In this case, a message with a limited TTL will be
-given up retransmission and discarded, if this time passes.
+(also partially) lost, and if so, lacking packets will be retransmitted. If
+the message is not successfully resent before TTL expires, further retransmission
+is given up and the message is discarded.
 
 * `inorder`: [IN]. In **message mode** only, specifies that sent messages should 
 be extracted by the receiver in the order of sending. This can be meaningful if 

--- a/docs/API.md
+++ b/docs/API.md
@@ -193,7 +193,7 @@ following interpretation (except `flags` and `boundary` that are reserved for
 future use and should be 0):
 
 * `srt_sendmsg2`:
-    * msgttl: [IN] maximum time (in ms) to wait in sending buffer before being sent (-1 if unused)
+    * msgttl: [IN] maximum time (in ms) to wait for successful delivery (-1: indefinitely)
     * inorder: [IN] if false, the later sent message is allowed to be delivered earlier
     * srctime: [IN] timestamp to be used for sending (0 if current time)
     * pktseq: unused

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -570,7 +570,7 @@ SRT_API       int srt_setsockflag  (SRTSOCKET u, SRT_SOCKOPT opt, const void* op
 typedef struct SRT_MsgCtrl_
 {
    int flags;            // Left for future
-   int msgttl;           // TTL for a message, default -1 (delivered always)
+   int msgttl;           // TTL for a message, default -1 (no TTL limitation)
    int inorder;          // Whether a message is allowed to supersede partially lost one. Unused in stream and live mode.
    int boundary;         // 0:mid pkt, 1(01b):end of frame, 2(11b):complete frame, 3(10b): start of frame
    uint64_t srctime;     // source timestamp (usec), 0: use internal time     


### PR DESCRIPTION
Fixes #661 

There was a mistaken description of msgttl suggesting that the message will be waiting in the sender buffer for a chance to be sent and discarded completely after TTL passes. It was a wrong statement suggesting that the message may be not sent at all even once, which isn't true - the message is always sent at least once. The TTL value is considered only in the function that is used for retransmission.