### PR TITLE
{FEC} Random refactoring and small bugfixes during FEC works.

### DIFF
--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -52,6 +52,7 @@ set cmake_options {
     enable-static "Should libsrt be built as a static library (default: ON)"
     enable-suflip "Should suflip tool be built (default: OFF)"
     enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
+    enable-unittests "Enable unit tests (default: OFF)"
     enable-thread-check "Enable #include <threadcheck.h> that implements THREAD_* macros"
     openssl-crypto-library=<filepath> "Path to a library."
     openssl-include-dir=<path> "Path to a file."

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -968,7 +968,7 @@ connection parties.
 
 #### SRT_REJ_FILTER
 
-The `SRTO_FILTER` option has been set differently on both connection
+The `SRTO_PACKETFILTER` option has been set differently on both connection
 parties (NOTE: this flag may not exist yet in this version).
 
 

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -769,6 +769,8 @@ int CRcvBuffer::addData(CUnit* unit, int offset)
       m_iMaxPos = offset + 1;
 
    if (m_pUnit[pos] != NULL) {
+      HLOGC(dlog.Debug, log << "addData: unit %" << unit->m_Packet.m_iSeqNo
+              << " rejected, already exists");
       return -1;
    }
    m_pUnit[pos] = unit;
@@ -776,67 +778,69 @@ int CRcvBuffer::addData(CUnit* unit, int offset)
 
    m_pUnitQueue->makeUnitGood(unit);
 
+   HLOGC(dlog.Debug, log << "addData: unit %" << unit->m_Packet.m_iSeqNo
+           << " accepted, off=" << offset << " POS=" << pos);
    return 0;
 }
 
 int CRcvBuffer::readBuffer(char* data, int len)
 {
-   int p = m_iStartPos;
-   int lastack = m_iLastAckPos;
-   int rs = len;
+    int p = m_iStartPos;
+    int lastack = m_iLastAckPos;
+    int rs = len;
 #if ENABLE_HEAVY_LOGGING
-   char* begin = data;
+    char* begin = data;
 #endif
 
-   const uint64_t now = (m_bTsbPdMode ? CTimer::getTime() : uint64_t());
+    const uint64_t now = (m_bTsbPdMode ? CTimer::getTime() : uint64_t());
 
-   HLOGC(dlog.Debug, log << CONID() << "readBuffer: start=" << p << " lastack=" << lastack);
-   while ((p != lastack) && (rs > 0))
-   {
-       if (m_pUnit[p] == NULL)
-       {
-           LOGC(dlog.Error, log << CONID() << " IPE readBuffer on null packet pointer");
-           return -1;
-       }
+    HLOGC(dlog.Debug, log << CONID() << "readBuffer: start=" << p << " lastack=" << lastack);
+    while ((p != lastack) && (rs > 0))
+    {
+        if (m_pUnit[p] == NULL)
+        {
+            LOGC(dlog.Error, log << CONID() << " IPE readBuffer on null packet pointer");
+            return -1;
+        }
 
-      if (m_bTsbPdMode)
-      {
-          HLOGC(dlog.Debug, log << CONID() << "readBuffer: chk if time2play: NOW=" << now << " PKT TS=" << getPktTsbPdTime(m_pUnit[p]->m_Packet.getMsgTimeStamp()));
-          if ((getPktTsbPdTime(m_pUnit[p]->m_Packet.getMsgTimeStamp()) > now))
-              break; /* too early for this unit, return whatever was copied */
-      }
+        if (m_bTsbPdMode)
+        {
+            HLOGC(dlog.Debug, log << CONID() << "readBuffer: chk if time2play: NOW=" << now << " PKT TS=" << getPktTsbPdTime(m_pUnit[p]->m_Packet.getMsgTimeStamp()));
+            if ((getPktTsbPdTime(m_pUnit[p]->m_Packet.getMsgTimeStamp()) > now))
+                break; /* too early for this unit, return whatever was copied */
+        }
 
-      int unitsize = (int) m_pUnit[p]->m_Packet.getLength() - m_iNotch;
-      if (unitsize > rs)
-         unitsize = rs;
+        int unitsize = (int) m_pUnit[p]->m_Packet.getLength() - m_iNotch;
+        if (unitsize > rs)
+            unitsize = rs;
 
-      HLOGC(dlog.Debug, log << CONID() << "readBuffer: copying buffer #" << p
-          << " targetpos=" << int(data-begin) << " sourcepos=" << m_iNotch << " size=" << unitsize << " left=" << (unitsize-rs));
-      memcpy(data, m_pUnit[p]->m_Packet.m_pcData + m_iNotch, unitsize);
-      data += unitsize;
+        HLOGC(dlog.Debug, log << CONID() << "readBuffer: copying buffer #" << p
+                << " targetpos=" << int(data-begin) << " sourcepos=" << m_iNotch << " size=" << unitsize << " left=" << (unitsize-rs));
+        memcpy(data, m_pUnit[p]->m_Packet.m_pcData + m_iNotch, unitsize);
+        data += unitsize;
 
-      if ((rs > unitsize) || (rs == int(m_pUnit[p]->m_Packet.getLength()) - m_iNotch))
-      {
-         CUnit* tmp = m_pUnit[p];
-         m_pUnit[p] = NULL;
-         m_pUnitQueue->makeUnitFree(tmp);
+        if ((rs > unitsize) || (rs == int(m_pUnit[p]->m_Packet.getLength()) - m_iNotch))
+        {
+            CUnit* tmp = m_pUnit[p];
+            m_pUnit[p] = NULL;
+            m_pUnitQueue->makeUnitFree(tmp);
 
-         if (++ p == m_iSize)
-            p = 0;
+            if (++ p == m_iSize)
+                p = 0;
 
-         m_iNotch = 0;
-      }
-      else
-         m_iNotch += rs;
+            m_iNotch = 0;
+        }
+        else
+            m_iNotch += rs;
 
-      rs -= unitsize;
-   }
+        rs -= unitsize;
+    }
 
-   /* we removed acked bytes form receive buffer */
-   countBytes(-1, -(len - rs), true);
-   m_iStartPos = p;
+    /* we removed acked bytes form receive buffer */
+    countBytes(-1, -(len - rs), true);
+    m_iStartPos = p;
 
-   return len - rs;
+    return len - rs;
 }
 
 int CRcvBuffer::readBufferToFile(fstream& ofs, int len)
@@ -936,10 +940,12 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passa
     /* Check the acknowledged packets */
     if (getRcvReadyMsg(r_tsbpdtime, r_curpktseq))
     {
+        HLOGC(dlog.Debug, log << "getRcvFirstMsg: ready CONTIG packet: %" << (*r_curpktseq));
         return true;
     }
     else if (*r_tsbpdtime != 0)
     {
+        HLOGC(dlog.Debug, log << "getRcvFirstMsg: no packets found");
         return false;
     }
 
@@ -993,6 +999,7 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passa
         {
             /* There are packets in the sequence not received yet */
             haslost = true;
+            HLOGC(dlog.Debug, log << "getRcvFirstMsg: empty hole at *" << i);
         }
         else
         {
@@ -1011,6 +1018,9 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passa
                     *r_curpktseq = skipseqno;
                 }
 
+                HLOGC(dlog.Debug, log << "getRcvFirstMsg: found ready packet, nSKIPPED: "
+                        << ((i - m_iLastAckPos + m_iSize) % m_iSize));
+
                 // NOTE: if haslost is not set, it means that this is the VERY FIRST
                 // packet, that is, packet currently at pos = m_iLastAckPos. There's no
                 // possibility that it is so otherwise because:
@@ -1018,6 +1028,8 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passa
                 // ...
                 return true;
             }
+            HLOGC(dlog.Debug, log << "getRcvFirstMsg: found NOT READY packet, nSKIPPED: "
+                    << ((i - m_iLastAckPos + m_iSize) % m_iSize));
             // ... and if this first good packet WASN'T ready to play, THIS HERE RETURNS NOW, TOO,
             // just states that there's no ready packet to play.
             // ...
@@ -1027,6 +1039,7 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passa
         // the 'haslost' is set, which means that it continues only to find the first valid
         // packet after stating that the very first packet isn't valid.
     }
+    HLOGC(dlog.Debug, log << "getRcvFirstMsg: found NO PACKETS");
     return false;
 }
 
@@ -1048,6 +1061,9 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
         /* Skip any invalid skipped/dropped packets */
         if (m_pUnit[i] == NULL)
         {
+            HLOGC(mglog.Debug, log << "getRcvReadyMsg: POS=" << i
+                    << " +" << ((i - m_iStartPos + m_iSize) % m_iSize)
+                    << " SKIPPED - no unit there");
             if (++ m_iStartPos == m_iSize)
                 m_iStartPos = 0;
             continue;
@@ -1057,6 +1073,9 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
 
         if (m_pUnit[i]->m_iFlag != CUnit::GOOD)
         {
+            HLOGC(mglog.Debug, log << "getRcvReadyMsg: POS=" << i
+                    << " +" << ((i - m_iStartPos + m_iSize) % m_iSize)
+                    << " SKIPPED - unit not good");
             freeunit = true;
         }
         else
@@ -1065,7 +1084,10 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
             int64_t towait = (*tsbpdtime - CTimer::getTime());
             if (towait > 0)
             {
-                HLOGC(mglog.Debug, log << "getRcvReadyMsg: found packet, but not ready to play (only in " << (towait/1000.0) << "ms)");
+                HLOGC(mglog.Debug, log << "getRcvReadyMsg: POS=" << i
+                        << " +" << ((i - m_iStartPos + m_iSize) % m_iSize)
+                        << " pkt %" << curpktseq.get()
+                        << " NOT ready to play (only in " << (towait/1000.0) << "ms)");
                 return false;
             }
 
@@ -1076,13 +1098,17 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
             }
             else
             {
-                HLOGC(mglog.Debug, log << "getRcvReadyMsg: packet seq=" << curpktseq.get() << " ready to play (delayed " << (-towait/1000.0) << "ms)");
+                HLOGC(mglog.Debug, log << "getRcvReadyMsg: POS=" << i
+                        << " +" << ((i - m_iStartPos + m_iSize) % m_iSize)
+                        << " pkt %" << curpktseq.get()
+                        << " ready to play (delayed " << (-towait/1000.0) << "ms)");
                 return true;
             }
         }
 
         if (freeunit)
         {
+            HLOGC(mglog.Debug, log << "getRcvReadyMsg: POS=" << i << " FREED");
             /* removed skipped, dropped, undecryptable bytes from rcv buffer */
             const int rmbytes = (int)m_pUnit[i]->m_Packet.getLength();
             countBytes(-1, -rmbytes, true);
@@ -1598,6 +1624,8 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 
         const int unitsize = ((rs >= 0) && (unitsize > rs)) ? rs : pktlen;
 
+        HLOGC(mglog.Debug, log << "readMsg: checking unit POS=" << p);
+
         if (unitsize > 0)
         {
             memcpy(data, m_pUnit[p]->m_Packet.m_pcData, unitsize);
@@ -1611,8 +1639,9 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
             {
                 static uint64_t prev_now;
                 static uint64_t prev_srctime;
+                CPacket& pkt = m_pUnit[p]->m_Packet;
 
-                int32_t seq = m_pUnit[p]->m_Packet.m_iSeqNo;
+                int32_t seq = pkt.m_iSeqNo;
 
                 uint64_t nowtime = CTimer::getTime();
                 //CTimer::rdtsc(nowtime);
@@ -1622,23 +1651,35 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
                 int64_t nowdiff = prev_now ? (nowtime - prev_now) : 0;
                 uint64_t srctimediff = prev_srctime ? (srctime - prev_srctime) : 0;
 
-                HLOGC(dlog.Debug, log << CONID() << "readMsg: DELIVERED seq=" << seq << " T=" << FormatTime(srctime) << " in " << (timediff/1000.0) << "ms - "
-                    "TIME-PREVIOUS: PKT: " << (srctimediff/1000.0) << " LOCAL: " << (nowdiff/1000.0));
+                HLOGC(dlog.Debug, log << CONID() << "readMsg: DELIVERED seq=" << seq
+                        << " from POS=" << p << " T="
+                        << FormatTime(srctime) << " in " << (timediff/1000.0)
+                        << "ms - TIME-PREVIOUS: PKT: " << (srctimediff/1000.0)
+                        << " LOCAL: " << (nowdiff/1000.0)
+                        << " !" << BufferStamp(pkt.m_pcData, pkt.getLength()));
 
                 prev_now = nowtime;
                 prev_srctime = srctime;
             }
 #endif
         }
+        else
+        {
+            HLOGC(dlog.Debug, log << CONID() << "readMsg: SKIPPED POS=" << p << " - ZERO SIZE UNIT");
+        }
 
         if (!passack)
         {
+            HLOGC(dlog.Debug, log << CONID() << "readMsg: FREEING UNIT POS=" << p);
             CUnit* tmp = m_pUnit[p];
             m_pUnit[p] = NULL;
             m_pUnitQueue->makeUnitFree(tmp);
         }
         else
+        {
+            HLOGC(dlog.Debug, log << CONID() << "readMsg: PASSACK UNIT POS=" << p);
             m_pUnit[p]->m_iFlag = CUnit::PASSACK;
+        }
 
         if (++ p == m_iSize)
             p = 0;

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -411,6 +411,14 @@ public:
    uint64_t getPktTsbPdTime(uint32_t timestamp);
    int debugGetSize() const;
    bool empty() const;
+
+   // Required by PacketFilter facility to use as a storage
+   // for provided packets
+   CUnitQueue* getUnitQueue()
+   {
+       return m_pUnitQueue;
+   }
+
 private:
 
    /// thread safe bytes counter of the Recv & Ack buffer

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -437,6 +437,66 @@ int CChannel::sendto(const sockaddr* addr, CPacket& packet) const
         << spec.str());
 #endif
 
+#ifdef SRT_TEST_FAKE_LOSS
+
+#define FAKELOSS_STRING_0(x) #x
+#define FAKELOSS_STRING(x) FAKELOSS_STRING_0(x)
+    const char* fakeloss_text = FAKELOSS_STRING(SRT_TEST_FAKE_LOSS);
+#undef FAKELOSS_STRING
+#undef FAKELOSS_WRAP
+
+    static int dcounter = 0;
+    static int flwcounter = 0;
+
+    struct FakelossConfig
+    {
+        pair<int,int> config;
+        FakelossConfig(const char* f)
+        {
+            vector<string> out;
+            Split(f, '+', back_inserter(out));
+
+            config.first = atoi(out[0].c_str());
+            config.second = out.size() > 1 ? atoi(out[1].c_str()) : 8;
+        }
+    };
+    static FakelossConfig fakeloss = fakeloss_text;
+
+    if (!packet.isControl())
+    {
+        if (dcounter == 0)
+        {
+            timeval tv;
+            gettimeofday(&tv, 0);
+            srand(tv.tv_usec & 0xFFFF);
+        }
+        ++dcounter;
+
+        if (flwcounter)
+        {
+            // This is a counter of how many packets in a row shall be lost
+            --flwcounter;
+            HLOGC(mglog.Debug, log << "CChannel: TEST: FAKE LOSS OF %" << packet.getSeqNo() << " (" << flwcounter << " more to drop)");
+            return packet.getLength(); // fake successful sendinf
+        }
+
+        if (dcounter > 8)
+        {
+            // Make a random number in the range between 8 and 24
+            int rnd = rand() % 16 + SRT_TEST_FAKE_LOSS;
+
+            if (dcounter > rnd)
+            {
+                dcounter = 1;
+                HLOGC(mglog.Debug, log << "CChannel: TEST: FAKE LOSS OF %" << packet.getSeqNo() << " (will drop " << fakeloss.config.first << " more)");
+                flwcounter = fakeloss.config.first;
+                return packet.getLength(); // fake successful sendinf
+            }
+        }
+    }
+
+#endif
+
    // convert control information into network order
    // XXX USE HtoNLA!
    if (packet.isControl())

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -589,12 +589,42 @@ public:
 class CSeqNo
 {
 public:
+
+   /// This behaves like seq1 - seq2, in comparison to numbers,
+   /// and with the statement that only the sign of the result matters.
+   /// That is, it returns a negative value if seq1 < seq2,
+   /// positive if seq1 > seq2, and zero if they are equal.
+   /// The only tolerable use of this function is only when you
+   /// compare two values and it works faster than seqoff, however
+   /// the result's meaning is only in its sign. DO NOT USE THE
+   /// VALUE for any other purpose and its not meant to be the
+   /// distance between two sequence numbers.
+   ///
+   /// Example: to check if (seq1 %> seq2): seqcmp(seq1, seq2) > 0.
    inline static int seqcmp(int32_t seq1, int32_t seq2)
    {return (abs(seq1 - seq2) < m_iSeqNoTH) ? (seq1 - seq2) : (seq2 - seq1);}
 
+   /// This function measures a length of the range from seq1 to seq2,
+   /// WITH A PRECONDITION that certainly @a seq1 is earlier than @a seq2.
+   /// This can also include an enormously large distance between them,
+   /// that is, exceeding the m_iSeqNoTH value (can be also used to test
+   /// if this distance is larger). Prior to calling this function the
+   /// caller must be certain that @a seq2 is a sequence coming from a
+   /// later time than @a seq1, and still, of course, this distance didn't
+   /// exceed m_iMaxSeqNo.
    inline static int seqlen(int32_t seq1, int32_t seq2)
    {return (seq1 <= seq2) ? (seq2 - seq1 + 1) : (seq2 - seq1 + m_iMaxSeqNo + 2);}
 
+   /// This behaves like seq2 - seq1, with the precondition that the true
+   /// distance between two sequence numbers never exceeds m_iSeqNoTH.
+   /// That is, if the difference in numeric values of these two arguments
+   /// exceeds m_iSeqNoTH, it is treated as if the later of these two
+   /// sequence numbers has overflown and actually a segment of the
+   /// MAX+1 value should be added to it to get the proper result.
+   ///
+   /// Note: this function does more calculations than seqcmp, so it should
+   /// be used if you need the exact distance between two sequences. If 
+   /// you are only interested with their relationship, use seqcmp.
    inline static int seqoff(int32_t seq1, int32_t seq2)
    {
       if (abs(seq1 - seq2) < m_iSeqNoTH)

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -315,7 +315,11 @@ public:
         // For FileCC, treat non-full-buffer situation as an end-of-message situation;
         // request ACK to be sent immediately.
         if (pkt.getLength() < m_parent->maxPayloadSize())
+        {
+            // This is not a regular fixed size packet...
+            // an irregular sized packet usually indicates the end of a message, so send an ACK immediately
             return true;
+        }
 
         return false;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -80,6 +80,13 @@ modified by
 
 using namespace std;
 
+#if ENABLE_HEAVY_LOGGING
+#define IF_HEAVY_LOGGING(instr) instr
+#else 
+#define IF_HEAVY_LOGGING(instr) (void)0
+#endif 
+
+
 namespace srt_logging
 {
 
@@ -1801,8 +1808,8 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
             return false;
         }
 
-        size_t wordsize = (m_sStreamName.size()+3)/4;
-        size_t aligned_bytesize = wordsize*4;
+        size_t wordsize = (m_sStreamName.size() + 3) / 4;
+        size_t aligned_bytesize = wordsize * 4;
 
         memset(p+offset, 0, aligned_bytesize);
         memcpy(p+offset, m_sStreamName.data(), m_sStreamName.size());
@@ -1831,8 +1838,8 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
         pcmdspec = p+offset;
         ++offset;
 
-        size_t wordsize = (sm.size()+3)/4;
-        size_t aligned_bytesize = wordsize*4;
+        size_t wordsize = (sm.size() + 3) / 4;
+        size_t aligned_bytesize = wordsize * 4;
 
         memset(p+offset, 0, aligned_bytesize);
 
@@ -4380,6 +4387,13 @@ void* CUDT::tsbpd(void* param)
           bool passack = true; //Get next packet to wait for even if not acked
 
           rxready = self->m_pRcvBuffer->getRcvFirstMsg(Ref(tsbpdtime), Ref(passack), Ref(skiptoseqno), Ref(current_pkt_seq));
+
+          HLOGC(tslog.Debug, log << boolalpha
+                  << "NEXT PKT CHECK: rdy=" << rxready
+                  << " passack=" << passack
+                  << " skipto=%" << skiptoseqno
+                  << " current=%" << current_pkt_seq
+                  << " buf-base=%" << self->m_iRcvLastSkipAck);
           /*
            * VALUES RETURNED:
            *
@@ -4669,7 +4683,14 @@ void CUDT::acceptAndRespond(const sockaddr* peer, CHandShake* hs, const CPacket&
        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
    }
 
-   setupCC();
+   SRT_REJECT_REASON rr = setupCC();
+   // UNKNOWN used as a "no error" value
+   if (rr != SRT_REJ_UNKNOWN)
+   {
+       hs->m_iReqType = URQFailure(rr);
+       m_RejectReason = rr;
+       throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+   }
 
    m_pPeerAddr = (AF_INET == m_iIPversion) ? (sockaddr*)new sockaddr_in : (sockaddr*)new sockaddr_in6;
    memcpy(m_pPeerAddr, peer, (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
@@ -4759,7 +4780,7 @@ bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     return m_pCryptoControl->init(side, bidirectional);
 }
 
-void CUDT::setupCC()
+SRT_REJECT_REASON CUDT::setupCC()
 {
     // Prepare configuration object,
     // Create the CCC object and configure it.
@@ -4775,7 +4796,11 @@ void CUDT::setupCC()
 
     // SrtCongestion will retrieve whatever parameters it needs
     // from *this.
-    m_CongCtl.configure(this);
+    if ( !m_CongCtl.configure(this))
+    {
+        return SRT_REJ_CONGESTION;
+    }
+
 
     // Override the value of minimum NAK interval, per SrtCongestion's wish.
     // When default 0 value is returned, the current value set by CUDT
@@ -4801,6 +4826,7 @@ void CUDT::setupCC()
         << " bw=" << m_iBandwidth);
 
     updateCC(TEV_INIT, TEV_INIT_RESET);
+    return SRT_REJ_UNKNOWN;
 }
 
 void CUDT::considerLegacySrtHandshake(uint64_t timebase)
@@ -6548,6 +6574,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
       {
          int acksize = CSeqNo::seqoff(m_iRcvLastSkipAck, ack);
 
+         IF_HEAVY_LOGGING(int32_t oldack = m_iRcvLastSkipAck);
          m_iRcvLastAck = ack;
          m_iRcvLastSkipAck = ack;
 
@@ -6565,6 +6592,8 @@ void CUDT::sendCtrl(UDTMessageType pkttype, void* lparam, void* rparam, int size
          // signal m_RcvTsbPdCond. This will kick in the tsbpd thread, which
          // will signal m_RecvDataCond when there's time to play for particular
          // data packet.
+         HLOGC(dlog.Debug, log << "ACK: clip %" << oldack << "-%" << ack
+                 << ", REVOKED " << acksize << " from RCV buffer");
 
          if (m_bTsbPd)
          {
@@ -7111,6 +7140,10 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
       // protect packet retransmission
       CGuard::enterCS(m_AckLock);
 
+      // This variable is used in "normal" logs, so it may cause a warning
+      // when logging is forcefully off.
+      int32_t wrong_loss SRT_ATR_UNUSED = CSeqNo::m_iMaxSeqNo;
+
       // decode loss list message and insert loss into the sender loss list
       for (int i = 0, n = (int)(ctrlpkt.getLength() / 4); i < n; ++ i)
       {
@@ -7129,6 +7162,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
             {
                // seq_a must not be greater than seq_b; seq_b must not be greater than the most recent sent seq
                secure = false;
+               wrong_loss = losslist_hi;
                // XXX leaveCS: really necessary? 'break' will break the 'for' loop, not the 'switch' statement.
                // and the leaveCS is done again next to the 'for' loop end.
                CGuard::leaveCS(m_AckLock);
@@ -7163,6 +7197,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
             {
                //seq_a must not be greater than the most recent sent seq
                secure = false;
+               wrong_loss = losslist[i];
                CGuard::leaveCS(m_AckLock);
                break;
             }
@@ -7181,7 +7216,7 @@ void CUDT::processCtrl(CPacket& ctrlpkt)
 
       if (!secure)
       {
-         HLOGF(mglog.Debug, "WARNING: out-of-band LOSSREPORT received; considered bug or attack");
+         LOGC(mglog.Warn, log << "out-of-band LOSSREPORT received; BUG or ATTACK - last sent %" << m_iSndCurrSeqNo << " vs loss %" << wrong_loss);
          //this should not happen: attack or bug
          m_bBroken = true;
          m_iBrokenCounter = 0;
@@ -7847,16 +7882,11 @@ int CUDT::processData(CUnit* unit)
       const int offset = CSeqNo::seqoff(m_iRcvLastSkipAck, packet.m_iSeqNo);
 
       bool excessive = false;
-#if ENABLE_HEAVY_LOGGING
-      const char* exc_type = "EXPECTED";
-#define IF_HEAVY_LOGGING(instr) instr
-#else 
-#define IF_HEAVY_LOGGING(instr) (void)0
-#endif 
+      IF_HEAVY_LOGGING(const char* exc_type = "EXPECTED");
 
       if (offset < 0)
       {
-          IF_HEAVY_LOGGING(exc_type = "EXPECTED");
+          IF_HEAVY_LOGGING(exc_type = "BELATED");
           excessive = true;
           uint64_t tsbpdtime = m_pRcvBuffer->getPktTsbPdTime(packet.getMsgTimeStamp());
           uint64_t bltime = CountIIR(
@@ -7884,10 +7914,11 @@ int CUDT::processData(CUnit* unit)
                   // lowest sequence in the empty buffer and the incoming sequence
                   // that exceeds the buffer size. Receiving data in this situation
                   // is no longer possible and this is a point of no return.
-
-                  LOGC(mglog.Error,
-                          log << CONID() <<
-                          "SEQUENCE DISCREPANCY, reception no longer possible. REQUESTING TO CLOSE.");
+                  LOGC(mglog.Error, log << CONID() << "SEQUENCE DISCREPANCY. BREAKING CONNECTION. offset="
+                          << offset << " avail=" << avail_bufsize
+                          << " ack.seq=" << m_iRcvLastSkipAck << " pkt.seq=" << packet.m_iSeqNo
+                          << " rcv-remain=" << m_pRcvBuffer->debugGetSize()
+                      );
 
                   // This is a scoped lock with AckLock, but for the moment
                   // when processClose() is called this lock must be taken out,

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3921,7 +3921,12 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
         m_iBandwidth = ib.m_iBandwidth;
     }
 
-    setupCC();
+    SRT_REJECT_REASON rr = setupCC();
+    if (rr != SRT_REJ_UNKNOWN)
+    {
+        m_RejectReason = rr;
+        return CONN_REJECT;
+    }
 
     // And, I am connected too.
     m_bConnecting = false;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -549,7 +549,7 @@ private: // Identification
     bool m_bDataSender;
 
     // HSv4 (legacy handshake) support)
-    uint64_t m_ullSndHsLastTime_us;	    //Last SRT handshake request time
+    uint64_t m_ullSndHsLastTime_us;  //Last SRT handshake request time
     int      m_iSndHsRetryCnt;       //SRT handshake retries left
 
     bool m_bMessageAPI;
@@ -706,7 +706,7 @@ private: // synchronization: mutexes and conditions
     void releaseSynch();
 
 private: // Common connection Congestion Control setup
-    void setupCC();
+    SRT_REJECT_REASON setupCC();
     void updateCC(ETransmissionEvent, EventVariant arg);
     bool createCrypter(HandshakeSide side, bool bidi);
 

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -473,8 +473,8 @@ CPacket* CPacket::clone() const
    return pkt;
 }
 
-#if ENABLE_LOGGING
-std::string CPacket::MessageFlagStr()
+// Useful for debugging
+std::string PacketMessageFlagStr(uint32_t msgno_field)
 {
     using namespace std;
 
@@ -485,11 +485,10 @@ std::string CPacket::MessageFlagStr()
     static const char* const crypto [] = { "EK_NOENC", "EK_EVEN", "EK_ODD", "EK*ERROR" };
     static const char* const rexmit [] = { "SN_ORIGINAL", "SN_REXMIT" };
 
-    out << boundary[int(getMsgBoundary())] << " ";
-    out << order[int(getMsgOrderFlag())] << " ";
-    out << crypto[int(getMsgCryptoFlags())] << " ";
-    out << rexmit[int(getRexmitFlag())];
+    out << boundary[MSGNO_PACKET_BOUNDARY::unwrap(msgno_field)] << " ";
+    out << order[MSGNO_PACKET_INORDER::unwrap(msgno_field)] << " ";
+    out << crypto[MSGNO_ENCKEYSPEC::unwrap(msgno_field)] << " ";
+    out << rexmit[MSGNO_REXMIT::unwrap(msgno_field)];
 
     return out.str();
 }
-#endif

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -211,6 +211,7 @@ inline EncryptionKeySpec GetEncryptionKeySpec(int32_t msgno)
 
 const int32_t PUMASK_SEQNO_PROBE = 0xF;
 
+std::string PacketMessageFlagStr(uint32_t msgno_field);
 
 class CChannel;
 
@@ -328,26 +329,6 @@ public:
    EncryptionKeySpec getMsgCryptoFlags() const;
    void setMsgCryptoFlags(EncryptionKeySpec spec);
 
-   /*
-      /// Encrypt packet if crypto context present
-      /// @param hcrypto  HaiCrypt handle.
-      /// @retval -1 encryption enabled and failed.
-      /// @retval 0 encryption deferred (parallel processing).
-      /// @retval >0 bytes in packet (clear text, encrypted current or older (deferred) packet).
-
-
-   EncryptionStatus encrypt(HaiCrypt_Handle hcrypto);
-
-      /// Decrypt packet if crypto context present
-      /// @param hcrypto  HaiCrypt handle.
-      /// @retval -1 packet encrypted but no crypto context or decryption failed.
-      /// @retval 0 decryption deferred (parallel processing).
-      /// @retval >0 bytes in packet (clear text oo decrypted current or older (deferred) packet).
-
-
-   EncryptionStatus decrypt(HaiCrypt_Handle hcrypto);
-   */
-
       /// Read the message time stamp.
       /// @return packet header field [2] (bit 0~31, bit 0-26 if SRT_DEBUG_TSBPD_WRAP).
 
@@ -436,7 +417,7 @@ public:
 
    std::string MessageFlagStr()
 #if ENABLE_LOGGING
-       ;
+   { return PacketMessageFlagStr(m_nHeader[PH_MSGNO]); }
 #else
    { return ""; }
 #endif

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1250,7 +1250,8 @@ static string PacketInfo(const CPacket& pkt)
         // This is only a log, nothing crucial, so we can risk displaying incorrect message number.
         // Declaring that the peer supports rexmit flag cuts off the highest bit from
         // the displayed number.
-        os << "DATA: msg=" << pkt.getMsgSeq(true) << " seq=" << pkt.getSeqNo() << " size=" << pkt.getLength();
+        os << "DATA: msg=" << pkt.getMsgSeq(true) << " seq=" << pkt.getSeqNo() << " size=" << pkt.getLength()
+           << " flags: " << PacketMessageFlagStr(pkt.m_iMsgNo);
     }
 
     return os.str();

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -90,6 +90,7 @@ written by
 #include <functional>
 #include <memory>
 #include <sstream>
+#include <iomanip>
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
@@ -445,6 +446,17 @@ public:
     { return *m_data; }
 };
 
+// This is required for Printable function if you have a container of pairs,
+// but this function has a different definition for C++11 and C++03.
+namespace srt_pair_op
+{
+    template <class Value1, class Value2>
+    std::ostream& operator<<(std::ostream& s, const std::pair<Value1, Value2>& v)
+    {
+        s << "{" << v.first << " " << v.second << "}";
+        return s;
+    }
+}
 
 #if HAVE_CXX11
 
@@ -491,6 +503,7 @@ using UniquePtr = std::unique_ptr<T>;
 template <class Container, class Value = typename Container::value_type, typename... Args> inline
 std::string Printable(const Container& in, Value /*pseudoargument*/, Args&&... args)
 {
+    using namespace srt_pair_op;
     std::ostringstream os;
     Print(os, args...);
     os << "[ ";
@@ -503,6 +516,7 @@ std::string Printable(const Container& in, Value /*pseudoargument*/, Args&&... a
 template <class Container> inline
 std::string Printable(const Container& in)
 {
+    using namespace srt_pair_op;
     using Value = typename Container::value_type;
     return Printable(in, Value());
 }
@@ -516,6 +530,13 @@ auto map_get(Map& m, const Key& key, typename Map::mapped_type def = typename Ma
 
 template<typename Map, typename Key>
 auto map_getp(Map& m, const Key& key) -> typename Map::mapped_type*
+{
+    auto it = m.find(key);
+    return it == m.end() ? nullptr : std::addressof(it->second);
+}
+
+template<typename Map, typename Key>
+auto map_getp(const Map& m, const Key& key) -> typename Map::mapped_type const*
 {
     auto it = m.find(key);
     return it == m.end() ? nullptr : std::addressof(it->second);
@@ -577,6 +598,48 @@ public:
     operator bool () { return 0!= get(); }
 };
 
+// A primitive one-argument version of Printable
+template <class Container> inline
+std::string Printable(const Container& in)
+{
+    using namespace srt_pair_op;
+    typedef typename Container::value_type Value;
+    std::ostringstream os;
+    os << "[ ";
+    for (typename Container::const_iterator i = in.begin(); i != in.end(); ++i)
+        os << Value(*i) << " ";
+    os << "]";
+
+    return os.str();
+}
+
+template<typename Map, typename Key>
+typename Map::mapped_type map_get(Map& m, const Key& key, typename Map::mapped_type def = typename Map::mapped_type())
+{
+    typename Map::iterator it = m.find(key);
+    return it == m.end() ? def : it->second;
+}
+
+template<typename Map, typename Key>
+typename Map::mapped_type map_get(const Map& m, const Key& key, typename Map::mapped_type def = typename Map::mapped_type())
+{
+    typename Map::const_iterator it = m.find(key);
+    return it == m.end() ? def : it->second;
+}
+
+template<typename Map, typename Key>
+typename Map::mapped_type* map_getp(Map& m, const Key& key)
+{
+    typename Map::iterator it = m.find(key);
+    return it == m.end() ? (typename Map::mapped_type*)0 : &(it->second);
+}
+
+template<typename Map, typename Key>
+typename Map::mapped_type const* map_getp(const Map& m, const Key& key)
+{
+    typename Map::const_iterator it = m.find(key);
+    return it == m.end() ? (typename Map::mapped_type*)0 : &(it->second);
+}
 
 #endif
 
@@ -764,6 +827,44 @@ struct MapProxy
     }
 };
 
+inline std::string BufferStamp(const char* mem, size_t size)
+{
+    using namespace std;
+
+    union
+    {
+        char spread[16];
+        uint32_t testin[4];
+    };
+    int n = 16-size;
+    if (n > 0)
+        memset(spread+16-n, 0, n);
+    memcpy(spread, mem, min(size_t(16), size));
+
+    // Now prepare 4 cells for uint32_t.
+    union
+    {
+        uint32_t sum;
+        char cells[4];
+    };
+    memset(cells, 0, 4);
+
+    for (size_t x = 0; x < 4; ++x)
+        for (size_t y = 0; y < 4; ++y)
+        {
+            cells[x] += spread[x+4*y];
+        }
+
+    // Convert to hex string
+
+    ostringstream os;
+
+    //os << hex << uppercase << setfill('0') << setw(8) << testin[3] << testin[2] << testin[1] << testin[0];
+    //os << "|";
+    os << hex << uppercase << setfill('0') << setw(8) << sum;
+
+    return os.str();
+}
 
 template <class OutputIterator>
 inline void Split(const std::string & str, char delimiter, OutputIterator tokens)
@@ -783,6 +884,28 @@ inline void Split(const std::string & str, char delimiter, OutputIterator tokens
                 (end == std::string::npos) ? std::string::npos : end - start);
         ++tokens;
     } while (end != std::string::npos);
+}
+
+inline std::string SelectNot(const std::string& unwanted, const std::string& s1, const std::string& s2)
+{
+    if (s1 == unwanted)
+        return s2; // might be unwanted, too, but then, there's nothing you can do anyway
+    if (s2 == unwanted)
+        return s1;
+
+    // Both have wanted values, so now compare if they are same
+    if (s1 == s2)
+        return s1; // occasionally there's a winner
+
+    // Irresolvable situation.
+    return std::string();
+}
+
+inline std::string SelectDefault(const std::string& checked, const std::string& def)
+{
+    if (checked == "")
+        return def;
+    return checked;
 }
 
 template <class It>

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -834,7 +834,7 @@ inline std::string BufferStamp(const char* mem, size_t size)
     union
     {
         char spread[16];
-        uint32_t testin[4];
+        //uint32_t testin[4];
     };
     int n = 16-size;
     if (n > 0)

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -830,12 +830,8 @@ struct MapProxy
 inline std::string BufferStamp(const char* mem, size_t size)
 {
     using namespace std;
+    char spread[16];
 
-    union
-    {
-        char spread[16];
-        //uint32_t testin[4];
-    };
     int n = 16-size;
     if (n > 0)
         memset(spread+16-n, 0, n);
@@ -859,8 +855,6 @@ inline std::string BufferStamp(const char* mem, size_t size)
 
     ostringstream os;
 
-    //os << hex << uppercase << setfill('0') << setw(8) << testin[3] << testin[2] << testin[1] << testin[0];
-    //os << "|";
     os << hex << uppercase << setfill('0') << setw(8) << sum;
 
     return os.str();

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -82,7 +82,7 @@ protected:
 protected:
 
     SOCKET m_udp_sock = INVALID_SOCKET;
-    sockaddr_in m_sa = {};
+    sockaddr_in m_sa = sockaddr_in();
 
 };
 

--- a/testing/utility-test.cpp
+++ b/testing/utility-test.cpp
@@ -16,6 +16,16 @@
 #include <utilities.h>
 #include <packet.h>
 #include <crypto.h>
+#include <common.h>
+
+void ShowDistance(int32_t s1, int32_t s2)
+{
+    using namespace std;
+
+    cout << "s1=" << s1 << "s2=" << s2 << " DISTANCE:\n";
+    cout << "seqcmp -> " << CSeqNo::seqcmp(s1, s2) << endl;
+    cout << "seqoff -> " << CSeqNo::seqoff(s2, s1) << endl;
+}
 
 int main()
 {
@@ -39,5 +49,16 @@ int main()
     cout << "Creating array of bytes: 10, 11, 20, 25 - FormatBinaryString: ";
     uint8_t array[4] = { 10, 11, 20, 25 };
     cout << FormatBinaryString(array, 4) << endl;
+
+    cout << "-------------------------------\n";
+    cout << "SEQUENCES:\n";
+    int32_t s1 = 100, s2 = 200;
+    ShowDistance(s1, s2);
+
+    cout << "GO BACK BY -150:\n";
+    s1 = CSeqNo::decseq(s1, 150);
+    s2 = CSeqNo::decseq(s2, 150);
+    ShowDistance(s1, s2);
+
     return 0;
 }


### PR DESCRIPTION
List of fixes:
=======

* Added official (lacking) option `--enable-unittests` to `configure-data.tcl`
* Formatting fixes and new log entries
* Added testing entry in `channel.cpp` to allow configure a fake packet loss
* Extra comments
* Better use of conditional `IF_HEAVY_LOGGING` for evaluations used for heavy logging only
* Fix: added error handling for `setupCC` that results in rejection
* Refax: packet content reporting function for logs
* Log support improvement: pairs and containers displayed with `Printable`
* New `BufferStamp` functions that allows putting a short string in the log that can report contents of a larger payload
* Minor new utilities
