### PR TITLE
[build] Fixed -std=c++11 flag usage with HAVE_COMPILER_GNU_COMPAT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -731,7 +731,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/srt.pc DESTINATION ${CMAKE_INSTALL_LIB
 
 # Applications
 
-if ( HAVE_COMPILER_GNU_COMPAT )
+if (HAVE_COMPILER_GNU_COMPAT AND ENABLE_CXX11)
 	message(STATUS "C++ VERSION: Setting C++11 compat flag for gnu compiler")
 	set (CFLAGS_CXX_STANDARD "-std=c++11")
 else()


### PR DESCRIPTION
`-std=c++11` flag is added to `CFLAGS_CXX_STANDARD` regardless of the `ENABLE_CXX11` option.
So the flag may be set even if `ENABLE_CXX11=OFF`.