### PR TITLE
[apps] srt-live-transmit default chunk size set to 1456

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -129,7 +129,7 @@ struct LiveTransmitConfig
 {
     int timeout = 0;
     int timeout_mode = 0;
-    int chunk_size = SRT_LIVE_DEF_PLSIZE;
+    int chunk_size = -1;
     bool quiet = false;
     srt_logging::LogLevel::type loglevel = srt_logging::LogLevel::error;
     set<srt_logging::LogFA> logfas;
@@ -232,7 +232,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         PrintOptionHelp(o_timeout_mode, "<mode=0>", "timeout mode (0 - since app start; 1 - like 0, but cancel on connect");
 #endif
         PrintOptionHelp(o_autorecon, "<enabled=yes>", "auto-reconnect mode [yes|no]");
-        PrintOptionHelp(o_chunk,     "<chunk=1316>", "max size of data read in one step");
+        PrintOptionHelp(o_chunk,     "<chunk=1456>", "max size of data read in one step, that can fit one SRT packet");
         PrintOptionHelp(o_bwreport,  "<every_n_packets=0>", "bandwidth report frequency");
         PrintOptionHelp(o_statsrep,  "<every_n_packets=0>", "frequency of status report");
         PrintOptionHelp(o_statsout,  "<filename>", "output stats to file");
@@ -267,7 +267,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
 
     cfg.timeout      = stoi(Option<OutString>(params, "0", o_timeout));
     cfg.timeout_mode = stoi(Option<OutString>(params, "0", o_timeout_mode));
-    cfg.chunk_size   = stoi(Option<OutString>(params, "1316", o_chunk));
+    cfg.chunk_size   = stoi(Option<OutString>(params, "-1", o_chunk));
     cfg.bw_report    = stoi(Option<OutString>(params, "0", o_bwreport));
     cfg.stats_report = stoi(Option<OutString>(params, "0", o_statsrep));
     cfg.stats_out    = Option<OutString>(params, "", o_statsout);
@@ -339,7 +339,7 @@ int main(int argc, char** argv)
     //
     // Set global config variables
     //
-    if (cfg.chunk_size != SRT_LIVE_DEF_PLSIZE)
+    if (cfg.chunk_size != -1)
         transmit_chunk_size = cfg.chunk_size;
     stats_writer = SrtStatsWriterFactory(cfg.stats_pf);
     transmit_bw_report = cfg.bw_report;
@@ -720,9 +720,9 @@ int main(int argc, char** argv)
                     while (dataqueue.size() < 10)
                     {
                         std::shared_ptr<bytevector> pdata(
-                            new bytevector(cfg.chunk_size));
+                            new bytevector(transmit_chunk_size));
 
-                        const int res = src->Read(cfg.chunk_size, *pdata, out_stats);
+                        const int res = src->Read(transmit_chunk_size, *pdata, out_stats);
 
                         if (res == SRT_ERROR && src->uri.type() == UriParser::SRT)
                         {

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -39,7 +39,7 @@ bool g_stats_are_printed_to_stdout = false;
 bool transmit_total_stats = false;
 unsigned long transmit_bw_report = 0;
 unsigned long transmit_stats_report = 0;
-unsigned long transmit_chunk_size = SRT_LIVE_DEF_PLSIZE;
+unsigned long transmit_chunk_size = SRT_LIVE_MAX_PLSIZE;
 
 class FileSource: public Source
 {
@@ -290,10 +290,10 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
     }
 
     m_mode = "default";
-    if ( par.count("mode") )
+    if (par.count("mode"))
         m_mode = par.at("mode");
 
-    if ( m_mode == "default" )
+    if (m_mode == "default")
     {
         // Use the following convention:
         // 1. Server for source, Client for target
@@ -313,13 +313,13 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
 
     par.erase("mode");
 
-    if ( par.count("timeout") )
+    if (par.count("timeout"))
     {
         m_timeout = stoi(par.at("timeout"), 0, 0);
         par.erase("timeout");
     }
 
-    if ( par.count("adapter") )
+    if (par.count("adapter"))
     {
         m_adapter = par.at("adapter");
         par.erase("adapter");
@@ -331,7 +331,7 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
         m_adapter = host;
     }
 
-    if ( par.count("tsbpd") && false_names.count(par.at("tsbpd")) )
+    if (par.count("tsbpd") && false_names.count(par.at("tsbpd")))
     {
         m_tsbpdmode = false;
     }
@@ -346,8 +346,7 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
     // Default mode is live, so check if the file mode was enforced
     if (par.count("transtype") == 0 || par["transtype"] != "file")
     {
-        // If the Live chunk size was nondefault, enforce the size.
-        if (transmit_chunk_size != SRT_LIVE_DEF_PLSIZE)
+        if (transmit_chunk_size > SRT_LIVE_DEF_PLSIZE)
         {
             if (transmit_chunk_size > SRT_LIVE_MAX_PLSIZE)
                 throw std::runtime_error("Chunk size in live mode exceeds 1456 bytes; this is not supported");
@@ -897,6 +896,11 @@ public:
         // We have to set it to the binary mode
         _setmode(_fileno(stdout), _O_BINARY);
 #endif
+    }
+
+    virtual ~ConsoleTarget()
+    {
+        cout.flush();
     }
 
     int Write(const char* data, size_t len, ostream &SRT_ATR_UNUSED = cout) override

--- a/docs/stransmit.md
+++ b/docs/stransmit.md
@@ -168,7 +168,7 @@ shell (using quotes or backslash).
     - The alarm is set up after the reading loop has started, **not when the application has started**. That is, a caller will still wait the standard timeout to connect, and a listener may wait infinitely until some peer connects; only after the connection is established is the alarm counting started. 
     - **The timeout mechanism doesn't work on Windows at all.** It behaves as if the timeout was set to **-1** and it's not modifiable.
 - **-timeout-mode, -tm** - timeout mode used. Default is 0 - timeout will happen after the specified time. Mode 1 cancels the timeout if the connection was established.
-- **-chunk, -c** - use given size of the buffer. When 0, it uses default 1316, which is the maximum size for a single SRT sending call
+- **-chunk, -c** - use given size of the buffer. The default size is 1456 bytes, which is the maximum payload size for a single SRT packet.
 - **-verbose, -v** - display additional information on the standard output. Note that it's not allowed to be combined with output specified as **file://con**
 - **-stats", -stats-report-frequency, -s** - Output periodic SRT statistics reports to the standard output or file (see **-statsout**).
 - **-statsout"** - SRT statistics output: filename. Without this option specified the statistics will be printed to standard output.


### PR DESCRIPTION
Default maximum payload size and chunk size for SRT live transmit is set to 1456 bytes.
Fixes #702
Closes #862