### PR TITLE
Prevented 0 pktsInFlight to be used in calculation for loss percentage

### DIFF
--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -494,7 +494,7 @@ private:
 
         const int pktsInFlight = m_parent->RTT() / m_dPktSndPeriod;
         const int numPktsLost = m_parent->sndLossLength();
-        const int lost_pcent_x10 = (numPktsLost * 1000) / pktsInFlight;
+        const int lost_pcent_x10 = pktsInFlight > 0 ? (numPktsLost * 1000) / pktsInFlight : 0;
 
         HLOGC(mglog.Debug, log << "FileSmootherV2: LOSS: "
             << "sent=" << CSeqNo::seqlen(m_iLastAck, m_parent->sndSeqNo()) << ", inFlight=" << pktsInFlight


### PR DESCRIPTION
Fixes #887 

`pktsInFlight` could be 0, and when so, the division by this without checking led to crash