### PR TITLE
Fixed in FEC crash when a large number of dropped packets occur causi…

### DIFF
--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -696,7 +696,7 @@ bool FECFilterBuiltin::receive(const CPacket& rpkt, loss_seqs_t& loss_seqs)
         // be simultaneously also retransmitted. This may confuse the tables.
         int celloff = CSeqNo::seqoff(rcv.cell_base, rpkt.getSeqNo());
         bool past = celloff < 0;
-        bool exists = celloff < int(rcv.cells.size()) && rcv.cells[celloff];
+        bool exists = celloff < int(rcv.cells.size()) && celloff >= 0 && rcv.cells[celloff];
 
         if (past || exists)
         {

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -696,7 +696,7 @@ bool FECFilterBuiltin::receive(const CPacket& rpkt, loss_seqs_t& loss_seqs)
         // be simultaneously also retransmitted. This may confuse the tables.
         int celloff = CSeqNo::seqoff(rcv.cell_base, rpkt.getSeqNo());
         bool past = celloff < 0;
-        bool exists = celloff < int(rcv.cells.size()) && celloff >= 0 && rcv.cells[celloff];
+        bool exists = celloff < int(rcv.cells.size()) && !past && rcv.cells[celloff];
 
         if (past || exists)
         {


### PR DESCRIPTION
…ng celloff to become negative and therefore accessing out of bounds for rcv.cells deque. This crash can be reproduced by putting Clumsy.exe (Dropped packet / latency simulator) between two machines and turning on lag (200ms will do it) and then turning it off, this causes a consistent crash of SRT.

Following this, SRT does not recover it outputs the following errors:
17:04:49.149217*E:SRT.c: FEC/V: OFFSET=22 exceeds maximum col container size, SHRINKING container by 10
17:04:49.149331*E:SRT.c: FEC/V: IPE: removal of 10 rows ships no same seq: rowbase=%2098878350 colbase=%2098878250 -> %2098878058 - RESETTING ROWS

OR:
17:28:48.626315*E:SRT.c: FEC/V: OFFSET=29 exceeds maximum col container size, SHRINKING container by 10
17:28:48.626404*E:SRT.c: FEC/V: IPE: removal of 10 rows ships no same seq: rowbase=%601155798 colbase=%601155698 -> %601155504 - RESETTING ROWS

Where it gets into an non working state.
