### PR TITLE
move filter fields to end of CBytePerfMon to make CBytePerfMon backwa…

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -245,7 +245,7 @@ static const int SRT_LIVE_MAX_PLSIZE = 1456; // MTU(1500) - UDP.hdr(28) - SRT.hd
 // Latency for Live transmission: default is 120
 static const int SRT_LIVE_DEF_LATENCY_MS = 120;
 
-
+// Importrant note: please add new fields to this structure to the end and don't remove any existing fields 
 struct CBytePerfMon
 {
    // global measurements
@@ -264,12 +264,6 @@ struct CBytePerfMon
    int      pktSndDropTotal;            // number of too-late-to-send dropped packets
    int      pktRcvDropTotal;            // number of too-late-to play missing packets
    int      pktRcvUndecryptTotal;       // number of undecrypted packets
-
-   int      pktSndFilterExtraTotal;     // number of control packets supplied by packet filter
-   int      pktRcvFilterExtraTotal;     // number of control packets received and not supplied back
-   int      pktRcvFilterSupplyTotal;    // number of packets that the filter supplied extra (e.g. FEC rebuilt)
-   int      pktRcvFilterLossTotal;      // number of packet loss not coverable by filter
-
    uint64_t byteSentTotal;              // total number of sent data bytes, including retransmissions
    uint64_t byteRecvTotal;              // total number of received bytes
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
@@ -292,10 +286,6 @@ struct CBytePerfMon
    int      pktRecvACK;                 // number of received ACK packets
    int      pktSentNAK;                 // number of sent NAK packets
    int      pktRecvNAK;                 // number of received NAK packets
-   int      pktSndFilterExtra;          // number of control packets supplied by packet filter
-   int      pktRcvFilterExtra;          // number of control packets received and not supplied back
-   int      pktRcvFilterSupply;         // number of packets that the filter supplied extra (e.g. FEC rebuilt)
-   int      pktRcvFilterLoss;           // number of packet loss not coverable by filter
    double   mbpsSendRate;               // sending rate in Mb/s
    double   mbpsRecvRate;               // receiving rate in Mb/s
    int64_t  usSndDuration;              // busy sending time (i.e., idle time exclusive)
@@ -339,6 +329,16 @@ struct CBytePerfMon
    int      byteRcvBuf;                 // Undelivered bytes of UDT receiver
    int      msRcvBuf;                   // Undelivered timespan (msec) of UDT receiver
    int      msRcvTsbPdDelay;            // Timestamp-based Packet Delivery Delay
+
+   int      pktSndFilterExtraTotal;     // number of control packets supplied by packet filter
+   int      pktRcvFilterExtraTotal;     // number of control packets received and not supplied back
+   int      pktRcvFilterSupplyTotal;    // number of packets that the filter supplied extra (e.g. FEC rebuilt)
+   int      pktRcvFilterLossTotal;      // number of packet loss not coverable by filter
+
+   int      pktSndFilterExtra;          // number of control packets supplied by packet filter
+   int      pktRcvFilterExtra;          // number of control packets received and not supplied back
+   int      pktRcvFilterSupply;         // number of packets that the filter supplied extra (e.g. FEC rebuilt)
+   int      pktRcvFilterLoss;           // number of packet loss not coverable by filter   
    //<
 };
 


### PR DESCRIPTION
…rd compatible

Many srt applications use srt library dynamically.
If application compiled with 1.3.4 srt.h but then maintainer released srt 1.4.0 for this application everything will work fine as api is backward compatible, SRT_SOCKOPT is backward compatible, srt_setsockopt will just fail if you give it new unknown options etc.
But CBytePerfMon is not backward compatible now and this may be a problem if user want to switch from one srt version to another. This is very powerful option especially taking into account how fast SRT developed.
All we need to do is just add new options to the end of CBytePerfMon and don't remove old ones.

CBytePerfMon was the same from 1.3 till recent 1.4. Unfortunately I missed this commit before 1.4 was released but it's not late to move new "filter-related" params to the end of the structure and follow SRT_SOCKOPT-like rule for CBytePerfMon update