### PR TITLE
[core] prevent compile if stack unwinding when exception handling is off in MSVC

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -67,6 +67,10 @@ modified by
    #include <win/wintime.h>
 #endif
 
+#ifdef _MSC_VER
+   #pragma warning(error: 4530)
+#endif
+
 using namespace std;
 using namespace srt_logging;
 extern LogConfig srt_logger_config;


### PR DESCRIPTION
I met a problem that the srt_socket will drop into deadlock in srt_close if the remote server close the connection yesterday.

During debugging I found it's because cmake is misconfigured and the NMakefile generated not contains /EHsc option for MSVC, thus lockguard wasn't destructed when exception thrown.

Since SRT not work in an environment without unwind, I suggest treat C4530 as error in MSVC, preventing people from the same mistake.
