### PR TITLE
Refactoring of CSndQueue::worker(...), CRcvBuffer::isRcvDataReady(...), etc.

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -344,15 +344,13 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
 
     // That's kinda clumsy, but it must rely on the defaults.
     // Default mode is live, so check if the file mode was enforced
-    if (par.count("transtype") == 0 || par["transtype"] != "file")
+    if ((par.count("transtype") == 0 || par["transtype"] != "file")
+        && transmit_chunk_size > SRT_LIVE_DEF_PLSIZE)
     {
-        if (transmit_chunk_size > SRT_LIVE_DEF_PLSIZE)
-        {
-            if (transmit_chunk_size > SRT_LIVE_MAX_PLSIZE)
-                throw std::runtime_error("Chunk size in live mode exceeds 1456 bytes; this is not supported");
+        if (transmit_chunk_size > SRT_LIVE_MAX_PLSIZE)
+            throw std::runtime_error("Chunk size in live mode exceeds 1456 bytes; this is not supported");
 
-            par["payloadsize"] = Sprint(transmit_chunk_size);
-        }
+        par["payloadsize"] = Sprint(transmit_chunk_size);
     }
 
     // Assign the others here.

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -74,7 +74,7 @@ extern LogConfig srt_logger_config;
 
 CUDTSocket::CUDTSocket():
 m_Status(SRTS_INIT),
-m_TimeStamp(0),
+m_ClosureTimeStamp(0),
 m_iIPversion(0),
 m_pSelfAddr(NULL),
 m_pPeerAddr(NULL),
@@ -360,7 +360,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr* peer, CHan
       {
          // last connection from the "peer" address has been broken
          ns->m_Status = SRTS_CLOSED;
-         ns->m_TimeStamp = CTimer::getTime();
+         ns->m_ClosureTimeStamp = CTimer::getTime();
 
          CGuard::enterCS(ls->m_AcceptLock);
          ls->m_pQueuedSockets->erase(ns->m_SocketID);
@@ -529,7 +529,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr* peer, CHan
       SRTSOCKET id = ns->m_SocketID;
       ns->m_pUDT->close();
       ns->m_Status = SRTS_CLOSED;
-      ns->m_TimeStamp = CTimer::getTime();
+      ns->m_ClosureTimeStamp = CTimer::getTime();
       // The mapped socket should be now unmapped to preserve the situation that
       // was in the original UDT code.
       // In SRT additionally the acceptAndRespond() function (it was called probably
@@ -962,7 +962,7 @@ int CUDTUnited::close(const SRTSOCKET u)
       if (s->m_pUDT->m_bBroken)
          return 0;
 
-      s->m_TimeStamp = CTimer::getTime();
+      s->m_ClosureTimeStamp = CTimer::getTime();
       s->m_pUDT->m_bBroken = true;
 
       // Change towards original UDT: 
@@ -1011,7 +1011,7 @@ int CUDTUnited::close(const SRTSOCKET u)
        // in order to prevent other methods from accessing invalid address
        // a timer is started and the socket will be removed after approximately
        // 1 second
-       s->m_TimeStamp = CTimer::getTime();
+       s->m_ClosureTimeStamp = CTimer::getTime();
 
        m_Sockets.erase(s->m_SocketID);
        m_ClosedSockets[s->m_SocketID] = s;
@@ -1513,7 +1513,7 @@ void CUDTUnited::checkBrokenSockets()
       {
          if (s->m_Status == SRTS_LISTENING)
          {
-            uint64_t elapsed = CTimer::getTime() - s->m_TimeStamp;
+            uint64_t elapsed = CTimer::getTime() - s->m_ClosureTimeStamp;
             // for a listening socket, it should wait an extra 3 seconds
             // in case a client is connecting
             if (elapsed < 3000000) // XXX MAKE A SYMBOLIC CONSTANT HERE!
@@ -1543,7 +1543,7 @@ void CUDTUnited::checkBrokenSockets()
 
          //close broken connections and start removal timer
          s->m_Status = SRTS_CLOSED;
-         s->m_TimeStamp = CTimer::getTime();
+         s->m_ClosureTimeStamp = CTimer::getTime();
          tbc.push_back(i->first);
          m_ClosedSockets[i->first] = s;
 
@@ -1577,13 +1577,13 @@ void CUDTUnited::checkBrokenSockets()
          {
             j->second->m_pUDT->m_ullLingerExpiration = 0;
             j->second->m_pUDT->m_bClosing = true;
-            j->second->m_TimeStamp = CTimer::getTime();
+            j->second->m_ClosureTimeStamp = CTimer::getTime();
          }
       }
 
       // timeout 1 second to destroy a socket AND it has been removed from
       // RcvUList
-      if ((CTimer::getTime() - j->second->m_TimeStamp > 1000000)
+      if ((CTimer::getTime() - j->second->m_ClosureTimeStamp > 1000000)
          && ((!j->second->m_pUDT->m_pRNode)
             || !j->second->m_pUDT->m_pRNode->m_bOnList))
       {
@@ -1623,7 +1623,7 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
       {
          m_Sockets[*q]->m_pUDT->m_bBroken = true;
          m_Sockets[*q]->m_pUDT->close();
-         m_Sockets[*q]->m_TimeStamp = CTimer::getTime();
+         m_Sockets[*q]->m_ClosureTimeStamp = CTimer::getTime();
          m_Sockets[*q]->m_Status = SRTS_CLOSED;
          m_ClosedSockets[*q] = m_Sockets[*q];
          m_Sockets.erase(*q);
@@ -1929,7 +1929,7 @@ void* CUDTUnited::garbageCollect(void* p)
       i->second->m_pUDT->m_bBroken = true;
       i->second->m_pUDT->close();
       i->second->m_Status = SRTS_CLOSED;
-      i->second->m_TimeStamp = CTimer::getTime();
+      i->second->m_ClosureTimeStamp = CTimer::getTime();
       self->m_ClosedSockets[i->first] = i->second;
 
       // remove from listener's queue
@@ -1952,7 +1952,7 @@ void* CUDTUnited::garbageCollect(void* p)
    for (map<SRTSOCKET, CUDTSocket*>::iterator j = self->m_ClosedSockets.begin();
       j != self->m_ClosedSockets.end(); ++ j)
    {
-      j->second->m_TimeStamp = 0;
+      j->second->m_ClosureTimeStamp = 0;
    }
    CGuard::leaveCS(self->m_ControlLock);
 

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -75,7 +75,12 @@ public:
 
    SRT_SOCKSTATUS m_Status;                  //< current socket state
 
-   uint64_t m_TimeStamp;                     //< time when the socket is closed
+   /// Time when the socket is closed.
+   /// When the socket is closed, it is not removed immediately from the list
+   /// of sockets in order to prevent other methods from accessing invalid address.
+   /// A timer is started and the socket will be removed after approximately
+   /// 1 second (see CUDTUnited::checkBrokenSockets()).
+   uint64_t m_ClosureTimeStamp;
 
    int m_iIPversion;                         //< IP version
    sockaddr* m_pSelfAddr;                    //< pointer to the local address of the socket

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1365,61 +1365,62 @@ void CRcvBuffer::dropMsg(int32_t msgno, bool using_rexmit_flag)
          m_pUnit[i]->m_iFlag = CUnit::DROPPED;
 }
 
-uint64_t CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp)
+uint64_t CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp_us)
 {
-   /* 
-   * Packet timestamps wrap around every 01h11m35s (32-bit in usec)
-   * When added to the peer start time (base time), 
-   * wrapped around timestamps don't provide a valid local packet delevery time.
-   *
-   * A wrap check period starts 30 seconds before the wrap point.
-   * In this period, timestamps smaller than 30 seconds are considered to have wrapped around (then adjusted).
-   * The wrap check period ends 30 seconds after the wrap point, afterwhich time base has been adjusted.
-   */ 
-   uint64_t carryover = 0;
+    /*
+    * Packet timestamps wrap around every 01h11m35s (32-bit in usec)
+    * When added to the peer start time (base time),
+    * wrapped around timestamps don't provide a valid local packet delevery time.
+    *
+    * A wrap check period starts 30 seconds before the wrap point.
+    * In this period, timestamps smaller than 30 seconds are considered to have wrapped around (then adjusted).
+    * The wrap check period ends 30 seconds after the wrap point, afterwhich time base has been adjusted.
+    */
+    uint64_t carryover = 0;
 
-   // This function should generally return the timebase for the given timestamp.
-   // It's assumed that the timestamp, for which this function is being called,
-   // is received as monotonic clock. This function then traces the changes in the
-   // timestamps passed as argument and catches the moment when the 64-bit timebase
-   // should be increased by a "segment length" (MAX_TIMESTAMP+1).
+    // This function should generally return the timebase for the given timestamp_us.
+    // It's assumed that the timestamp_us, for which this function is being called,
+    // is received as monotonic clock. This function then traces the changes in the
+    // timestamps passed as argument and catches the moment when the 64-bit timebase
+    // should be increased by a "segment length" (MAX_TIMESTAMP+1).
 
-   // The checks will be provided for the following split:
-   // [INITIAL30][FOLLOWING30]....[LAST30] <-- == CPacket::MAX_TIMESTAMP
-   //
-   // The following actions should be taken:
-   // 1. Check if this is [LAST30]. If so, ENTER TSBPD-wrap-check state
-   // 2. Then, it should turn into [INITIAL30] at some point. If so, use carryover MAX+1.
-   // 3. Then it should switch to [FOLLOWING30]. If this is detected,
-   //    - EXIT TSBPD-wrap-check state
-   //    - save the carryover as the current time base.
+    // The checks will be provided for the following split:
+    // [INITIAL30][FOLLOWING30]....[LAST30] <-- == CPacket::MAX_TIMESTAMP
+    //
+    // The following actions should be taken:
+    // 1. Check if this is [LAST30]. If so, ENTER TSBPD-wrap-check state
+    // 2. Then, it should turn into [INITIAL30] at some point. If so, use carryover MAX+1.
+    // 3. Then it should switch to [FOLLOWING30]. If this is detected,
+    //    - EXIT TSBPD-wrap-check state
+    //    - save the carryover as the current time base.
 
-   if (m_bTsbPdWrapCheck) 
-   {
-       // Wrap check period.
+    if (m_bTsbPdWrapCheck)
+    {
+        // Wrap check period.
 
-       if (timestamp < TSBPD_WRAP_PERIOD)
-       {
-           carryover = uint64_t(CPacket::MAX_TIMESTAMP) + 1;
-       }
-       // 
-       else if ((timestamp >= TSBPD_WRAP_PERIOD)
-               &&  (timestamp <= (TSBPD_WRAP_PERIOD * 2)))
-       {
-           /* Exiting wrap check period (if for packet delivery head) */
-           m_bTsbPdWrapCheck = false;
-           m_ullTsbPdTimeBase += uint64_t(CPacket::MAX_TIMESTAMP) + 1;
-           tslog.Debug("tsbpd wrap period ends");
-       }
-   }
-   // Check if timestamp is in the last 30 seconds before reaching the MAX_TIMESTAMP.
-   else if (timestamp > (CPacket::MAX_TIMESTAMP - TSBPD_WRAP_PERIOD))
-   {
-      /* Approching wrap around point, start wrap check period (if for packet delivery head) */
-      m_bTsbPdWrapCheck = true;
-      tslog.Debug("tsbpd wrap period begins");
-   }
-   return(m_ullTsbPdTimeBase + carryover);
+        if (timestamp_us < TSBPD_WRAP_PERIOD)
+        {
+            carryover = uint64_t(CPacket::MAX_TIMESTAMP) + 1;
+        }
+        //
+        else if ((timestamp_us >= TSBPD_WRAP_PERIOD)
+            && (timestamp_us <= (TSBPD_WRAP_PERIOD * 2)))
+        {
+            /* Exiting wrap check period (if for packet delivery head) */
+            m_bTsbPdWrapCheck = false;
+            m_ullTsbPdTimeBase += uint64_t(CPacket::MAX_TIMESTAMP) + 1;
+            tslog.Debug("tsbpd wrap period ends");
+        }
+    }
+    // Check if timestamp_us is in the last 30 seconds before reaching the MAX_TIMESTAMP.
+    else if (timestamp_us > (CPacket::MAX_TIMESTAMP - TSBPD_WRAP_PERIOD))
+    {
+        /* Approching wrap around point, start wrap check period (if for packet delivery head) */
+        m_bTsbPdWrapCheck = true;
+        tslog.Debug("tsbpd wrap period begins");
+    }
+
+    return (m_ullTsbPdTimeBase + carryover);
 }
 
 uint64_t CRcvBuffer::getPktTsbPdTime(uint32_t timestamp)

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1139,27 +1139,26 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
 */
 bool CRcvBuffer::isRcvDataReady(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpktseq)
 {
-   *tsbpdtime = 0;
+    *tsbpdtime = 0;
 
-   if (m_bTsbPdMode)
-   {
-       CPacket* pkt = getRcvReadyPacket();
-       if ( pkt )
-       {
-            /* 
-            * Acknowledged data is available,
-            * Only say ready if time to deliver.
-            * Report the timestamp, ready or not.
-            */
-            *curpktseq = pkt->getSeqNo();
-            *tsbpdtime = getPktTsbPdTime(pkt->getMsgTimeStamp());
-            if (*tsbpdtime <= CTimer::getTime())
-               return true;
-       }
-       return false;
-   }
+    if (m_bTsbPdMode)
+    {
+        CPacket* pkt = getRcvReadyPacket();
+        if (!pkt)
+            return false;
 
-   return isRcvDataAvailable();
+        /*
+        * Acknowledged data is available,
+        * Only say ready if time to deliver.
+        * Report the timestamp, ready or not.
+        */
+        *curpktseq = pkt->getSeqNo();
+        *tsbpdtime = getPktTsbPdTime(pkt->getMsgTimeStamp());
+
+        return (*tsbpdtime <= CTimer::getTime());
+    }
+
+    return isRcvDataAvailable();
 }
 
 // XXX This function may be called only after checking

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -406,7 +406,7 @@ private:
       /// @param [in] timestamp packet timestamp (relative to peer StartTime), wrapping around every ~72 min
       /// @return local delivery time (usec)
 
-   uint64_t getTsbPdTimeBase(uint32_t timestamp);
+   uint64_t getTsbPdTimeBase(uint32_t timestamp_us);
 
       /// Get packet local delivery time
       /// @param [in] timestamp packet timestamp (relative to peer StartTime), wrapping around every ~72 min

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -73,6 +73,8 @@ public:
    CSndBuffer(int size = 32, int mss = 1500);
    ~CSndBuffer();
 
+public:
+
       /// Insert a user buffer into the sending list.
       /// @param [in] data pointer to the user data block.
       /// @param [in] len size of the block.
@@ -245,6 +247,9 @@ public:
    CRcvBuffer(CUnitQueue* queue, int bufsize_pkts = 65536);
    ~CRcvBuffer();
 
+
+public:
+
       /// Write data into the buffer.
       /// @param [in] unit pointer to a data unit containing new packet
       /// @param [in] offset offset from last ACK point.
@@ -304,7 +309,7 @@ public:
       /// Query how many data of the receive buffer is acknowledged.
       /// @param [in] now current time in us.
       /// @return none.
-
+   
    void updRcvAvgDataSize(uint64_t now);
 #endif /* SRT_ENABLE_RCVBUFSZ_MAVG */
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -51,15 +51,15 @@ modified by
 *****************************************************************************/
 
 #ifndef _WIN32
-   #include <unistd.h>
-   #include <netdb.h>
-   #include <arpa/inet.h>
-   #include <cerrno>
-   #include <cstring>
-   #include <cstdlib>
+#include <unistd.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <cstdlib>
 #else
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #endif
 #include <cmath>
 #include <sstream>
@@ -82,10 +82,9 @@ using namespace std;
 
 #if ENABLE_HEAVY_LOGGING
 #define IF_HEAVY_LOGGING(instr) instr
-#else 
+#else
 #define IF_HEAVY_LOGGING(instr) (void)0
-#endif 
-
+#endif
 
 namespace srt_logging
 {
@@ -96,7 +95,7 @@ struct AllFaOn
 
     AllFaOn()
     {
-//        allfa.set(SRT_LOGFA_BSTATS, true);
+        //        allfa.set(SRT_LOGFA_BSTATS, true);
         allfa.set(SRT_LOGFA_CONTROL, true);
         allfa.set(SRT_LOGFA_DATA, true);
         allfa.set(SRT_LOGFA_TSBPD, true);
@@ -107,37 +106,35 @@ struct AllFaOn
     }
 } logger_fa_all;
 
-}
+} // namespace srt_logging
 
 // We need it outside the namespace to preserve the global name.
 // It's a part of "hidden API" (used by applications)
-SRT_API srt_logging::LogConfig srt_logger_config (srt_logging::logger_fa_all.allfa);
+SRT_API srt_logging::LogConfig srt_logger_config(srt_logging::logger_fa_all.allfa);
 
 namespace srt_logging
 {
 
 Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
 // Unused. If not found useful, maybe reuse for another FA.
-//Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
+// Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
 Logger mglog(SRT_LOGFA_CONTROL, srt_logger_config, "SRT.c");
 Logger dlog(SRT_LOGFA_DATA, srt_logger_config, "SRT.d");
 Logger tslog(SRT_LOGFA_TSBPD, srt_logger_config, "SRT.t");
 Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
 
-}
+} // namespace srt_logging
 
 using namespace srt_logging;
 
 CUDTUnited CUDT::s_UDTUnited;
 
 const SRTSOCKET UDT::INVALID_SOCK = CUDT::INVALID_SOCK;
-const int UDT::ERROR = CUDT::ERROR;
+const int       UDT::ERROR        = CUDT::ERROR;
 
 // SRT Version constants
 #define SRT_VERSION_UNK     0
 #define SRT_VERSION_MAJ1    0x010000            /* Version 1 major */
-
-
 #define SRT_VERSION_MAJ(v) (0xFF0000 & (v))     /* Major number ensuring backward compatibility */
 #define SRT_VERSION_MIN(v) (0x00FF00 & (v))
 #define SRT_VERSION_PCH(v) (0x0000FF & (v))
@@ -145,12 +142,11 @@ const int UDT::ERROR = CUDT::ERROR;
 // NOTE: SRT_VERSION is primarily defined in the build file.
 const int32_t SRT_DEF_VERSION = SrtParseVersion(SRT_VERSION);
 
-
 //#define SRT_CMD_HSREQ       1           /* SRT Handshake Request (sender) */
-#define SRT_CMD_HSREQ_MINSZ 8           /* Minumum Compatible (1.x.x) packet size (bytes) */
-#define SRT_CMD_HSREQ_SZ    12          /* Current version packet size */
-#if     SRT_CMD_HSREQ_SZ > SRT_CMD_MAXSZ
-#error  SRT_CMD_MAXSZ too small
+#define SRT_CMD_HSREQ_MINSZ 8 /* Minumum Compatible (1.x.x) packet size (bytes) */
+#define SRT_CMD_HSREQ_SZ 12   /* Current version packet size */
+#if SRT_CMD_HSREQ_SZ > SRT_CMD_MAXSZ
+#error SRT_CMD_MAXSZ too small
 #endif
 /*      Handshake Request (Network Order)
         0[31..0]:   SRT version     SRT_DEF_VERSION
@@ -160,10 +156,10 @@ const int32_t SRT_DEF_VERSION = SrtParseVersion(SRT_VERSION);
 */
 
 //#define SRT_CMD_HSRSP       2           /* SRT Handshake Response (receiver) */
-#define SRT_CMD_HSRSP_MINSZ 8           /* Minumum Compatible (1.x.x) packet size (bytes) */
-#define SRT_CMD_HSRSP_SZ    12          /* Current version packet size */
-#if     SRT_CMD_HSRSP_SZ > SRT_CMD_MAXSZ
-#error  SRT_CMD_MAXSZ too small
+#define SRT_CMD_HSRSP_MINSZ 8 /* Minumum Compatible (1.x.x) packet size (bytes) */
+#define SRT_CMD_HSRSP_SZ 12   /* Current version packet size */
+#if SRT_CMD_HSRSP_SZ > SRT_CMD_MAXSZ
+#error SRT_CMD_MAXSZ too small
 #endif
 /*      Handshake Response (Network Order)
         0[31..0]:   SRT version     SRT_DEF_VERSION
@@ -173,14 +169,13 @@ const int32_t SRT_DEF_VERSION = SrtParseVersion(SRT_VERSION);
         2[15..0]:   TsbPD delay     [0..60000] msec
 */
 
-
 void CUDT::construct()
 {
-    m_pSndBuffer = NULL;
-    m_pRcvBuffer = NULL;
-    m_pSndLossList = NULL;
-    m_pRcvLossList = NULL;
-    m_iReorderTolerance = 0;
+    m_pSndBuffer           = NULL;
+    m_pRcvBuffer           = NULL;
+    m_pSndLossList         = NULL;
+    m_pRcvLossList         = NULL;
+    m_iReorderTolerance    = 0;
     m_iMaxReorderTolerance = 0; // Sensible optimal value is 10, 0 preserves old behavior
     m_iConsecEarlyDelivery = 0; // how many times so far the packet considered lost has been received before TTL expires
     m_iConsecOrderedDelivery = 0;
@@ -188,37 +183,37 @@ void CUDT::construct()
     m_pSndQueue = NULL;
     m_pRcvQueue = NULL;
     m_pPeerAddr = NULL;
-    m_pSNode = NULL;
-    m_pRNode = NULL;
+    m_pSNode    = NULL;
+    m_pRNode    = NULL;
 
     m_ullSndHsLastTime_us = 0;
-    m_iSndHsRetryCnt = SRT_MAX_HSRETRY+1; // Will be reset to 0 for HSv5, this value is important for HSv4
+    m_iSndHsRetryCnt      = SRT_MAX_HSRETRY + 1; // Will be reset to 0 for HSv5, this value is important for HSv4
 
     // Initial status
-    m_bOpened = false;
-    m_bListening = false;
-    m_bConnecting = false;
-    m_bConnected = false;
-    m_bClosing = false;
-    m_bShutdown = false;
-    m_bBroken = false;
-    m_bPeerHealth = true;
-    m_RejectReason = SRT_REJ_UNKNOWN;
+    m_bOpened             = false;
+    m_bListening          = false;
+    m_bConnecting         = false;
+    m_bConnected          = false;
+    m_bClosing            = false;
+    m_bShutdown           = false;
+    m_bBroken             = false;
+    m_bPeerHealth         = true;
+    m_RejectReason        = SRT_REJ_UNKNOWN;
     m_ullLingerExpiration = 0;
-    m_llLastReqTime = 0;
+    m_llLastReqTime       = 0;
 
-    m_lSrtVersion = SRT_DEF_VERSION;
-    m_lPeerSrtVersion = 0; // not defined until connected.
+    m_lSrtVersion            = SRT_DEF_VERSION;
+    m_lPeerSrtVersion        = 0; // not defined until connected.
     m_lMinimumPeerSrtVersion = SRT_VERSION_MAJ1;
 
-    m_iTsbPdDelay_ms = 0;
+    m_iTsbPdDelay_ms     = 0;
     m_iPeerTsbPdDelay_ms = 0;
 
-    m_bPeerTsbPd = false;
+    m_bPeerTsbPd         = false;
     m_iPeerTsbPdDelay_ms = 0;
-    m_bTsbPd = false;
-    m_bTsbPdAckWakeup = false;
-    m_bPeerTLPktDrop = false;
+    m_bTsbPd             = false;
+    m_bTsbPdAckWakeup    = false;
+    m_bPeerTLPktDrop     = false;
 
     m_uKmRefreshRatePkt = 0;
     m_uKmPreAnnouncePkt = 0;
@@ -229,172 +224,172 @@ void CUDT::construct()
 
 CUDT::CUDT()
 {
-   construct();
+    construct();
 
-   (void)SRT_DEF_VERSION;
+    (void)SRT_DEF_VERSION;
 
-   // Default UDT configurations
-   m_iMSS = 1500;
-   m_bSynSending = true;
-   m_bSynRecving = true;
-   m_iFlightFlagSize = 25600;
-   m_iSndBufSize = 8192;
-   m_iRcvBufSize = 8192; //Rcv buffer MUST NOT be bigger than Flight Flag size
+    // Default UDT configurations
+    m_iMSS            = 1500;
+    m_bSynSending     = true;
+    m_bSynRecving     = true;
+    m_iFlightFlagSize = 25600;
+    m_iSndBufSize     = 8192;
+    m_iRcvBufSize = 8192; // Rcv buffer MUST NOT be bigger than Flight Flag size
 
-   // Linger: LIVE mode defaults, please refer to `SRTO_TRANSTYPE` option
-   // for other modes.
-   m_Linger.l_onoff = 0;
-   m_Linger.l_linger = 0;
-   m_iUDPSndBufSize = 65536;
-   m_iUDPRcvBufSize = m_iRcvBufSize * m_iMSS;
-   m_iSockType = UDT_DGRAM;
-   m_iIPversion = AF_INET;
-   m_bRendezvous = false;
+    // Linger: LIVE mode defaults, please refer to `SRTO_TRANSTYPE` option
+    // for other modes.
+    m_Linger.l_onoff  = 0;
+    m_Linger.l_linger = 0;
+    m_iUDPSndBufSize  = 65536;
+    m_iUDPRcvBufSize  = m_iRcvBufSize * m_iMSS;
+    m_iSockType       = UDT_DGRAM;
+    m_iIPversion      = AF_INET;
+    m_bRendezvous     = false;
 #ifdef SRT_ENABLE_CONNTIMEO
-   m_iConnTimeOut = 3000;
+    m_iConnTimeOut = 3000;
 #endif
-   m_iSndTimeOut = -1;
-   m_iRcvTimeOut = -1;
-   m_bReuseAddr = true;
-   m_llMaxBW = -1;
+    m_iSndTimeOut = -1;
+    m_iRcvTimeOut = -1;
+    m_bReuseAddr  = true;
+    m_llMaxBW     = -1;
 #ifdef SRT_ENABLE_IPOPTS
-   m_iIpTTL = -1;
-   m_iIpToS = -1;
+    m_iIpTTL = -1;
+    m_iIpToS = -1;
 #endif
-   m_CryptoSecret.len = 0;
-   m_iSndCryptoKeyLen = 0;
-   //Cfg
-   m_bDataSender = false;       //Sender only if true: does not recv data
-   m_bOPT_TsbPd = true;        //Enable TsbPd on sender
-   m_iOPT_TsbPdDelay = SRT_LIVE_DEF_LATENCY_MS;
-   m_iOPT_PeerTsbPdDelay = 0;       //Peer's TsbPd delay as receiver (here is its minimum value, if used)
-   m_bOPT_TLPktDrop = true;
-   m_iOPT_SndDropDelay = 0;
-   m_bOPT_StrictEncryption = true;
-   m_iOPT_PeerIdleTimeout = COMM_RESPONSE_TIMEOUT_MS;
-   m_bTLPktDrop = true;         //Too-late Packet Drop
-   m_bMessageAPI = true;
-   m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
-   m_iIpV6Only = -1;
-   //Runtime
-   m_bRcvNakReport = true;      //Receiver's Periodic NAK Reports
-   m_llInputBW = 0;             // Application provided input bandwidth (internal input rate sampling == 0)
-   m_iOverheadBW = 25;          // Percent above input stream rate (applies if m_llMaxBW == 0)
-   m_OPT_PktFilterConfigString = "";
+    m_CryptoSecret.len = 0;
+    m_iSndCryptoKeyLen = 0;
+    // Cfg
+    m_bDataSender           = false; // Sender only if true: does not recv data
+    m_bOPT_TsbPd            = true;  // Enable TsbPd on sender
+    m_iOPT_TsbPdDelay       = SRT_LIVE_DEF_LATENCY_MS;
+    m_iOPT_PeerTsbPdDelay   = 0; // Peer's TsbPd delay as receiver (here is its minimum value, if used)
+    m_bOPT_TLPktDrop        = true;
+    m_iOPT_SndDropDelay     = 0;
+    m_bOPT_StrictEncryption = true;
+    m_iOPT_PeerIdleTimeout  = COMM_RESPONSE_TIMEOUT_MS;
+    m_bTLPktDrop            = true; // Too-late Packet Drop
+    m_bMessageAPI           = true;
+    m_zOPT_ExpPayloadSize   = SRT_LIVE_DEF_PLSIZE;
+    m_iIpV6Only             = -1;
+    // Runtime
+    m_bRcvNakReport             = true; // Receiver's Periodic NAK Reports
+    m_llInputBW                 = 0;    // Application provided input bandwidth (internal input rate sampling == 0)
+    m_iOverheadBW               = 25;   // Percent above input stream rate (applies if m_llMaxBW == 0)
+    m_OPT_PktFilterConfigString = "";
 
-   m_pCache = NULL;
+    m_pCache = NULL;
 
-   // Default congctl is "live".
-   // Available builtin congctl: "file".
-   // Other congctls can be registerred.
+    // Default congctl is "live".
+    // Available builtin congctl: "file".
+    // Other congctls can be registerred.
 
-   // Note that 'select' returns false if there's no such congctl.
-   // If so, congctl becomes unselected. Calling 'configure' on an
-   // unselected congctl results in exception.
-   m_CongCtl.select("live");
+    // Note that 'select' returns false if there's no such congctl.
+    // If so, congctl becomes unselected. Calling 'configure' on an
+    // unselected congctl results in exception.
+    m_CongCtl.select("live");
 }
 
-CUDT::CUDT(const CUDT& ancestor)
+CUDT::CUDT(const CUDT &ancestor)
 {
-   construct();
+    construct();
 
-   // XXX Consider all below fields (except m_bReuseAddr) to be put
-   // into a separate class for easier copying.
+    // XXX Consider all below fields (except m_bReuseAddr) to be put
+    // into a separate class for easier copying.
 
-   // Default UDT configurations
-   m_iMSS = ancestor.m_iMSS;
-   m_bSynSending = ancestor.m_bSynSending;
-   m_bSynRecving = ancestor.m_bSynRecving;
-   m_iFlightFlagSize = ancestor.m_iFlightFlagSize;
-   m_iSndBufSize = ancestor.m_iSndBufSize;
-   m_iRcvBufSize = ancestor.m_iRcvBufSize;
-   m_Linger = ancestor.m_Linger;
-   m_iUDPSndBufSize = ancestor.m_iUDPSndBufSize;
-   m_iUDPRcvBufSize = ancestor.m_iUDPRcvBufSize;
-   m_iSockType = ancestor.m_iSockType;
-   m_iIPversion = ancestor.m_iIPversion;
-   m_bRendezvous = ancestor.m_bRendezvous;
+    // Default UDT configurations
+    m_iMSS            = ancestor.m_iMSS;
+    m_bSynSending     = ancestor.m_bSynSending;
+    m_bSynRecving     = ancestor.m_bSynRecving;
+    m_iFlightFlagSize = ancestor.m_iFlightFlagSize;
+    m_iSndBufSize     = ancestor.m_iSndBufSize;
+    m_iRcvBufSize     = ancestor.m_iRcvBufSize;
+    m_Linger          = ancestor.m_Linger;
+    m_iUDPSndBufSize  = ancestor.m_iUDPSndBufSize;
+    m_iUDPRcvBufSize  = ancestor.m_iUDPRcvBufSize;
+    m_iSockType       = ancestor.m_iSockType;
+    m_iIPversion      = ancestor.m_iIPversion;
+    m_bRendezvous     = ancestor.m_bRendezvous;
 #ifdef SRT_ENABLE_CONNTIMEO
-   m_iConnTimeOut = ancestor.m_iConnTimeOut;
+    m_iConnTimeOut = ancestor.m_iConnTimeOut;
 #endif
-   m_iSndTimeOut = ancestor.m_iSndTimeOut;
-   m_iRcvTimeOut = ancestor.m_iRcvTimeOut;
-   m_bReuseAddr = true; // this must be true, because all accepted sockets share the same port with the listener
-   m_llMaxBW = ancestor.m_llMaxBW;
+    m_iSndTimeOut = ancestor.m_iSndTimeOut;
+    m_iRcvTimeOut = ancestor.m_iRcvTimeOut;
+    m_bReuseAddr  = true; // this must be true, because all accepted sockets share the same port with the listener
+    m_llMaxBW     = ancestor.m_llMaxBW;
 #ifdef SRT_ENABLE_IPOPTS
-   m_iIpTTL = ancestor.m_iIpTTL;
-   m_iIpToS = ancestor.m_iIpToS;
+    m_iIpTTL = ancestor.m_iIpTTL;
+    m_iIpToS = ancestor.m_iIpToS;
 #endif
-   m_llInputBW = ancestor.m_llInputBW;
-   m_iOverheadBW = ancestor.m_iOverheadBW;
-   m_bDataSender = ancestor.m_bDataSender;
-   m_bOPT_TsbPd = ancestor.m_bOPT_TsbPd;
-   m_iOPT_TsbPdDelay = ancestor.m_iOPT_TsbPdDelay;
-   m_iOPT_PeerTsbPdDelay = ancestor.m_iOPT_PeerTsbPdDelay;
-   m_bOPT_TLPktDrop = ancestor.m_bOPT_TLPktDrop;
-   m_iOPT_SndDropDelay = ancestor.m_iOPT_SndDropDelay;
-   m_bOPT_StrictEncryption = ancestor.m_bOPT_StrictEncryption;
-   m_iOPT_PeerIdleTimeout = ancestor.m_iOPT_PeerIdleTimeout;
-   m_zOPT_ExpPayloadSize = ancestor.m_zOPT_ExpPayloadSize;
-   m_bTLPktDrop = ancestor.m_bTLPktDrop;
-   m_bMessageAPI = ancestor.m_bMessageAPI;
-   m_iIpV6Only = ancestor.m_iIpV6Only;
-   m_iMaxReorderTolerance = ancestor.m_iMaxReorderTolerance;
-   //Runtime
-   m_bRcvNakReport = ancestor.m_bRcvNakReport;
-   m_OPT_PktFilterConfigString = ancestor.m_OPT_PktFilterConfigString;
+    m_llInputBW             = ancestor.m_llInputBW;
+    m_iOverheadBW           = ancestor.m_iOverheadBW;
+    m_bDataSender           = ancestor.m_bDataSender;
+    m_bOPT_TsbPd            = ancestor.m_bOPT_TsbPd;
+    m_iOPT_TsbPdDelay       = ancestor.m_iOPT_TsbPdDelay;
+    m_iOPT_PeerTsbPdDelay   = ancestor.m_iOPT_PeerTsbPdDelay;
+    m_bOPT_TLPktDrop        = ancestor.m_bOPT_TLPktDrop;
+    m_iOPT_SndDropDelay     = ancestor.m_iOPT_SndDropDelay;
+    m_bOPT_StrictEncryption = ancestor.m_bOPT_StrictEncryption;
+    m_iOPT_PeerIdleTimeout  = ancestor.m_iOPT_PeerIdleTimeout;
+    m_zOPT_ExpPayloadSize   = ancestor.m_zOPT_ExpPayloadSize;
+    m_bTLPktDrop            = ancestor.m_bTLPktDrop;
+    m_bMessageAPI           = ancestor.m_bMessageAPI;
+    m_iIpV6Only             = ancestor.m_iIpV6Only;
+    m_iMaxReorderTolerance  = ancestor.m_iMaxReorderTolerance;
+    // Runtime
+    m_bRcvNakReport             = ancestor.m_bRcvNakReport;
+    m_OPT_PktFilterConfigString = ancestor.m_OPT_PktFilterConfigString;
 
-   m_CryptoSecret = ancestor.m_CryptoSecret;
-   m_iSndCryptoKeyLen = ancestor.m_iSndCryptoKeyLen;
+    m_CryptoSecret     = ancestor.m_CryptoSecret;
+    m_iSndCryptoKeyLen = ancestor.m_iSndCryptoKeyLen;
 
-   m_uKmRefreshRatePkt = ancestor.m_uKmRefreshRatePkt;
-   m_uKmPreAnnouncePkt = ancestor.m_uKmPreAnnouncePkt;
+    m_uKmRefreshRatePkt = ancestor.m_uKmRefreshRatePkt;
+    m_uKmPreAnnouncePkt = ancestor.m_uKmPreAnnouncePkt;
 
-   m_pCache = ancestor.m_pCache;
+    m_pCache = ancestor.m_pCache;
 
-   // SrtCongestion's copy constructor copies the selection,
-   // but not the underlying congctl object. After
-   // copy-constructed, the 'configure' must be called on it again.
-   m_CongCtl = ancestor.m_CongCtl;
+    // SrtCongestion's copy constructor copies the selection,
+    // but not the underlying congctl object. After
+    // copy-constructed, the 'configure' must be called on it again.
+    m_CongCtl = ancestor.m_CongCtl;
 }
 
 CUDT::~CUDT()
 {
-   // release mutex/condtion variables
-   destroySynch();
+    // release mutex/condtion variables
+    destroySynch();
 
-   //Wipeout critical data
-   memset(&m_CryptoSecret, 0, sizeof(m_CryptoSecret));
+    // Wipeout critical data
+    memset(&m_CryptoSecret, 0, sizeof(m_CryptoSecret));
 
-   // destroy the data structures
-   delete m_pSndBuffer;
-   delete m_pRcvBuffer;
-   delete m_pSndLossList;
-   delete m_pRcvLossList;
-   delete m_pPeerAddr;
-   delete m_pSNode;
-   delete m_pRNode;
+    // destroy the data structures
+    delete m_pSndBuffer;
+    delete m_pRcvBuffer;
+    delete m_pSndLossList;
+    delete m_pRcvLossList;
+    delete m_pPeerAddr;
+    delete m_pSNode;
+    delete m_pRNode;
 }
 
 // This function is to make it possible for both C and C++
 // API to accept both bool and int types for boolean options.
 // (it's not that C couldn't use <stdbool.h>, it's that people
 // often forget to use correct type).
-static bool bool_int_value(const void* optval, int optlen)
+static bool bool_int_value(const void *optval, int optlen)
 {
-    if ( optlen == sizeof(bool) )
+    if (optlen == sizeof(bool))
     {
-        return *(bool*)optval;
+        return *(bool *)optval;
     }
 
-    if ( optlen == sizeof(int) )
+    if (optlen == sizeof(int))
     {
-        return 0!=  *(int*)optval; // 0!= is a windows warning-killer int-to-bool conversion
+        return 0 != *(int *)optval; // 0!= is a windows warning-killer int-to-bool conversion
     }
     return false;
 }
 
-void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
+void CUDT::setOpt(SRT_SOCKOPT optName, const void *optval, int optlen)
 {
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -409,10 +404,10 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
 
-        if (*(int*)optval < int(CPacket::UDP_HDR_SIZE + CHandShake::m_iContentSize))
+        if (*(int *)optval < int(CPacket::UDP_HDR_SIZE + CHandShake::m_iContentSize))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        m_iMSS = *(int*)optval;
+        m_iMSS = *(int *)optval;
 
         // Packet size cannot be greater than UDP buffer size
         if (m_iMSS > m_iUDPSndBufSize)
@@ -434,12 +429,12 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (m_bConnecting || m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-        if (*(int*)optval < 1)
+        if (*(int *)optval < 1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL);
 
         // Mimimum recv flight flag size is 32 packets
-        if (*(int*)optval > 32)
-            m_iFlightFlagSize = *(int*)optval;
+        if (*(int *)optval > 32)
+            m_iFlightFlagSize = *(int *)optval;
         else
             m_iFlightFlagSize = 32;
 
@@ -449,10 +444,10 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
 
-        if (*(int*)optval <= 0)
+        if (*(int *)optval <= 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        m_iSndBufSize = *(int*)optval / (m_iMSS - CPacket::UDP_HDR_SIZE);
+        m_iSndBufSize = *(int *)optval / (m_iMSS - CPacket::UDP_HDR_SIZE);
 
         break;
 
@@ -460,14 +455,14 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
 
-        if (*(int*)optval <= 0)
+        if (*(int *)optval <= 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         {
             // This weird cast through int is required because
             // API requires 'int', and internals require 'size_t';
             // their size is different on 64-bit systems.
-            size_t val = size_t(*(int*)optval);
+            size_t val = size_t(*(int *)optval);
 
             // Mimimum recv buffer size is 32 packets
             size_t mssin_size = m_iMSS - CPacket::UDP_HDR_SIZE;
@@ -486,14 +481,14 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_LINGER:
-        m_Linger = *(linger*)optval;
+        m_Linger = *(linger *)optval;
         break;
 
     case SRTO_UDP_SNDBUF:
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
 
-        m_iUDPSndBufSize = *(int*)optval;
+        m_iUDPSndBufSize = *(int *)optval;
 
         if (m_iUDPSndBufSize < m_iMSS)
             m_iUDPSndBufSize = m_iMSS;
@@ -504,7 +499,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
 
-        m_iUDPRcvBufSize = *(int*)optval;
+        m_iUDPRcvBufSize = *(int *)optval;
 
         if (m_iUDPRcvBufSize < m_iMSS)
             m_iUDPRcvBufSize = m_iMSS;
@@ -518,11 +513,11 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_SNDTIMEO:
-        m_iSndTimeOut = *(int*)optval;
+        m_iSndTimeOut = *(int *)optval;
         break;
 
     case SRTO_RCVTIMEO:
-        m_iRcvTimeOut = *(int*)optval;
+        m_iRcvTimeOut = *(int *)optval;
         break;
 
     case SRTO_REUSEADDR:
@@ -532,7 +527,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_MAXBW:
-        m_llMaxBW = *(int64_t*)optval;
+        m_llMaxBW = *(int64_t *)optval;
 
         // This can be done on both connected and unconnected socket.
         // When not connected, this will do nothing, however this
@@ -545,21 +540,20 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     case SRTO_IPTTL:
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
-        if (!(*(int*)optval == -1)
-                &&  !((*(int*)optval >= 1) && (*(int*)optval <= 255)))
+        if (!(*(int *)optval == -1) && !((*(int *)optval >= 1) && (*(int *)optval <= 255)))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        m_iIpTTL = *(int*)optval;
+        m_iIpTTL = *(int *)optval;
         break;
 
     case SRTO_IPTOS:
         if (m_bOpened)
             throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
-        m_iIpToS = *(int*)optval;
+        m_iIpToS = *(int *)optval;
         break;
 #endif
 
     case SRTO_INPUTBW:
-        m_llInputBW = *(int64_t*)optval;
+        m_llInputBW = *(int64_t *)optval;
         // (only if connected; if not, then the value
         // from m_iOverheadBW will be used initially)
         if (m_bConnected)
@@ -567,10 +561,9 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_OHEADBW:
-        if ((*(int*)optval < 5)
-                ||  (*(int*)optval > 100))
+        if ((*(int *)optval < 5) || (*(int *)optval > 100))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        m_iOverheadBW = *(int*)optval;
+        m_iOverheadBW = *(int *)optval;
 
         // Changed overhead BW, so spread the change
         // (only if connected; if not, then the value
@@ -594,20 +587,20 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     case SRTO_LATENCY:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-        m_iOPT_TsbPdDelay = *(int*)optval;
-        m_iOPT_PeerTsbPdDelay = *(int*)optval;
+        m_iOPT_TsbPdDelay     = *(int *)optval;
+        m_iOPT_PeerTsbPdDelay = *(int *)optval;
         break;
 
     case SRTO_RCVLATENCY:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-        m_iOPT_TsbPdDelay = *(int*)optval;
+        m_iOPT_TsbPdDelay = *(int *)optval;
         break;
 
     case SRTO_PEERLATENCY:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-        m_iOPT_PeerTsbPdDelay = *(int*)optval;
+        m_iOPT_PeerTsbPdDelay = *(int *)optval;
         break;
 
     case SRTO_TLPKTDROP:
@@ -619,7 +612,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     case SRTO_SNDDROPDELAY:
         // Surprise: you may be connected to alter this option.
         // The application may manipulate this option on sender while transmitting.
-        m_iOPT_SndDropDelay = *(int*)optval;
+        m_iOPT_SndDropDelay = *(int *)optval;
         break;
 
     case SRTO_PASSPHRASE:
@@ -631,7 +624,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
 #ifdef SRT_ENABLE_ENCRYPTION
         // Password must be 10-80 characters.
         // Or it can be empty to clear the password.
-        if ( (optlen != 0) && (optlen < 10 || optlen > HAICRYPT_SECRET_MAX_SZ) )
+        if ((optlen != 0) && (optlen < 10 || optlen > HAICRYPT_SECRET_MAX_SZ))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         memset(&m_CryptoSecret, 0, sizeof(m_CryptoSecret));
@@ -653,18 +646,18 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 #ifdef SRT_ENABLE_ENCRYPTION
         {
-            int v = *(int*)optval;
-            int allowed [4] = {
-                0,   // Default value, if this results for initiator, defaults to 16. See below.
+            int v          = *(int *)optval;
+            int allowed[4] = {
+                0,  // Default value, if this results for initiator, defaults to 16. See below.
                 16, // AES-128
                 24, // AES-192
                 32  // AES-256
             };
-            int* allowed_end = allowed+4;
+            int *allowed_end = allowed + 4;
             if (find(allowed, allowed_end, v) == allowed_end)
             {
-                LOGC(mglog.Error, log << "Invalid value for option SRTO_PBKEYLEN: " << v
-                        << "; allowed are: 0, 16, 24, 32");
+                LOGC(mglog.Error,
+                     log << "Invalid value for option SRTO_PBKEYLEN: " << v << "; allowed are: 0, 16, 24, 32");
                 throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
             }
 
@@ -715,24 +708,24 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
 
 #ifdef SRT_ENABLE_CONNTIMEO
     case SRTO_CONNTIMEO:
-        m_iConnTimeOut = *(int*)optval;
+        m_iConnTimeOut = *(int *)optval;
         break;
 #endif
 
     case SRTO_LOSSMAXTTL:
-        m_iMaxReorderTolerance = *(int*)optval;
+        m_iMaxReorderTolerance = *(int *)optval;
         break;
 
     case SRTO_VERSION:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-        m_lSrtVersion = *(uint32_t*)optval;
+        m_lSrtVersion = *(uint32_t *)optval;
         break;
 
     case SRTO_MINVERSION:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-        m_lMinimumPeerSrtVersion = *(uint32_t*)optval;
+        m_lMinimumPeerSrtVersion = *(uint32_t *)optval;
         break;
 
     case SRTO_STREAMID:
@@ -742,7 +735,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (size_t(optlen) > MAX_SID_LENGTH)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        m_sStreamName.assign((const char*)optval, optlen);
+        m_sStreamName.assign((const char *)optval, optlen);
         break;
 
     case SRTO_CONGESTION:
@@ -751,10 +744,10 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
 
         {
             string val;
-            if ( optlen == -1 )
-                val = (const char*)optval;
+            if (optlen == -1)
+                val = (const char *)optval;
             else
-                val.assign((const char*)optval, optlen);
+                val.assign((const char *)optval, optlen);
 
             // Translate alias
             if (val == "vod")
@@ -766,18 +759,18 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         }
         break;
 
-   case SRTO_MESSAGEAPI:
+    case SRTO_MESSAGEAPI:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
         m_bMessageAPI = bool_int_value(optval, optlen);
         break;
 
-   case SRTO_PAYLOADSIZE:
+    case SRTO_PAYLOADSIZE:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-        if (*(int*)optval > SRT_LIVE_MAX_PLSIZE)
+        if (*(int *)optval > SRT_LIVE_MAX_PLSIZE)
         {
             LOGC(mglog.Error, log << "SRTO_PAYLOADSIZE: value exceeds SRT_LIVE_MAX_PLSIZE, maximum payload per MTU.");
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -792,458 +785,459 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
             if (!ParseFilterConfig(m_OPT_PktFilterConfigString, fc))
             {
                 // Break silently. This should not happen
-                LOGC(mglog.Error,
-                        log << "SRTO_PAYLOADSIZE: IPE: failing filter configuration installed");
+                LOGC(mglog.Error, log << "SRTO_PAYLOADSIZE: IPE: failing filter configuration installed");
                 throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
             }
 
             size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
             if (m_zOPT_ExpPayloadSize > efc_max_payload_size)
             {
-                LOGC(mglog.Error, log << "SRTO_PAYLOADSIZE: value exceeds SRT_LIVE_MAX_PLSIZE decreased by "
-                        << fc.extra_size << " required for packet filter header");
+                LOGC(mglog.Error,
+                     log << "SRTO_PAYLOADSIZE: value exceeds SRT_LIVE_MAX_PLSIZE decreased by " << fc.extra_size
+                         << " required for packet filter header");
                 throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
             }
         }
 
-        m_zOPT_ExpPayloadSize = *(int*)optval;
+        m_zOPT_ExpPayloadSize = *(int *)optval;
         break;
 
-   case SRTO_TRANSTYPE:
+    case SRTO_TRANSTYPE:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-      // XXX Note that here the configuration for SRTT_LIVE
-      // is the same as DEFAULT VALUES for these fields set
-      // in CUDT::CUDT. 
-      switch (*(SRT_TRANSTYPE*)optval)
-      {
-      case SRTT_LIVE:
-          // Default live options:
-          // - tsbpd: on
-          // - latency: 120ms
-          // - linger: off
-          // - congctl: live
-          // - extraction method: message (reading call extracts one message)
-          m_bOPT_TsbPd = true;
-          m_iOPT_TsbPdDelay = SRT_LIVE_DEF_LATENCY_MS;
-          m_iOPT_PeerTsbPdDelay = 0;
-          m_bOPT_TLPktDrop = true;
-          m_iOPT_SndDropDelay = 0;
-          m_bMessageAPI = true;
-          m_bRcvNakReport = true;
-          m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
-          m_Linger.l_onoff = 0;
-          m_Linger.l_linger = 0;
-          m_CongCtl.select("live");
-          break;
+        // XXX Note that here the configuration for SRTT_LIVE
+        // is the same as DEFAULT VALUES for these fields set
+        // in CUDT::CUDT.
+        switch (*(SRT_TRANSTYPE *)optval)
+        {
+        case SRTT_LIVE:
+            // Default live options:
+            // - tsbpd: on
+            // - latency: 120ms
+            // - linger: off
+            // - congctl: live
+            // - extraction method: message (reading call extracts one message)
+            m_bOPT_TsbPd          = true;
+            m_iOPT_TsbPdDelay     = SRT_LIVE_DEF_LATENCY_MS;
+            m_iOPT_PeerTsbPdDelay = 0;
+            m_bOPT_TLPktDrop      = true;
+            m_iOPT_SndDropDelay   = 0;
+            m_bMessageAPI         = true;
+            m_bRcvNakReport       = true;
+            m_zOPT_ExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
+            m_Linger.l_onoff      = 0;
+            m_Linger.l_linger     = 0;
+            m_CongCtl.select("live");
+            break;
 
-      case SRTT_FILE:
-          // File transfer mode:
-          // - tsbpd: off
-          // - latency: 0
-          // - linger: 2 minutes (180s)
-          // - congctl: file (original UDT congestion control)
-          // - extraction method: stream (reading call extracts as many bytes as available and fits in buffer)
-          m_bOPT_TsbPd = false;
-          m_iOPT_TsbPdDelay = 0;
-          m_iOPT_PeerTsbPdDelay = 0;
-          m_bOPT_TLPktDrop = false;
-          m_iOPT_SndDropDelay = -1;
-          m_bMessageAPI = false;
-          m_bRcvNakReport = false;
-          m_zOPT_ExpPayloadSize = 0; // use maximum
-          m_Linger.l_onoff = 1;
-          m_Linger.l_linger = 180; // 2 minutes
-          m_CongCtl.select("file");
-          break;
+        case SRTT_FILE:
+            // File transfer mode:
+            // - tsbpd: off
+            // - latency: 0
+            // - linger: 2 minutes (180s)
+            // - congctl: file (original UDT congestion control)
+            // - extraction method: stream (reading call extracts as many bytes as available and fits in buffer)
+            m_bOPT_TsbPd          = false;
+            m_iOPT_TsbPdDelay     = 0;
+            m_iOPT_PeerTsbPdDelay = 0;
+            m_bOPT_TLPktDrop      = false;
+            m_iOPT_SndDropDelay   = -1;
+            m_bMessageAPI         = false;
+            m_bRcvNakReport       = false;
+            m_zOPT_ExpPayloadSize = 0; // use maximum
+            m_Linger.l_onoff      = 1;
+            m_Linger.l_linger     = 180; // 2 minutes
+            m_CongCtl.select("file");
+            break;
 
-      default:
-          throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-      }
-      break;
+        default:
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+        }
+        break;
 
-   case SRTO_KMREFRESHRATE:
-      if (m_bConnected)
-          throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+    case SRTO_KMREFRESHRATE:
+        if (m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-      // If you first change the KMREFRESHRATE, KMPREANNOUNCE
-      // will be set to the maximum allowed value
-      m_uKmRefreshRatePkt = *(int*)optval;
-      if (m_uKmPreAnnouncePkt == 0 || m_uKmPreAnnouncePkt > (m_uKmRefreshRatePkt-1)/2)
-      {
-          m_uKmPreAnnouncePkt = (m_uKmRefreshRatePkt-1)/2;
-          LOGC(mglog.Warn, log << "SRTO_KMREFRESHRATE=0x"
-                  << hex << m_uKmRefreshRatePkt << ": setting SRTO_KMPREANNOUNCE=0x"
-                  << hex << m_uKmPreAnnouncePkt);
-      }
-      break;
+        // If you first change the KMREFRESHRATE, KMPREANNOUNCE
+        // will be set to the maximum allowed value
+        m_uKmRefreshRatePkt = *(int *)optval;
+        if (m_uKmPreAnnouncePkt == 0 || m_uKmPreAnnouncePkt > (m_uKmRefreshRatePkt - 1) / 2)
+        {
+            m_uKmPreAnnouncePkt = (m_uKmRefreshRatePkt - 1) / 2;
+            LOGC(mglog.Warn,
+                 log << "SRTO_KMREFRESHRATE=0x" << hex << m_uKmRefreshRatePkt << ": setting SRTO_KMPREANNOUNCE=0x"
+                     << hex << m_uKmPreAnnouncePkt);
+        }
+        break;
 
-   case SRTO_KMPREANNOUNCE:
-      if (m_bConnected)
-          throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-      {
-          int val = *(int*)optval;
-          int kmref = m_uKmRefreshRatePkt == 0 ? HAICRYPT_DEF_KM_REFRESH_RATE : m_uKmRefreshRatePkt;
-          if (val > (kmref-1)/2)
-          {
-              LOGC(mglog.Error, log << "SRTO_KMPREANNOUNCE=0x" << hex << val
-                      << " exceeds KmRefresh/2, 0x" << ((kmref-1)/2) << " - OPTION REJECTED.");
-              throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-          }
+    case SRTO_KMPREANNOUNCE:
+        if (m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        {
+            int val   = *(int *)optval;
+            int kmref = m_uKmRefreshRatePkt == 0 ? HAICRYPT_DEF_KM_REFRESH_RATE : m_uKmRefreshRatePkt;
+            if (val > (kmref - 1) / 2)
+            {
+                LOGC(mglog.Error,
+                     log << "SRTO_KMPREANNOUNCE=0x" << hex << val << " exceeds KmRefresh/2, 0x" << ((kmref - 1) / 2)
+                         << " - OPTION REJECTED.");
+                throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+            }
 
-          m_uKmPreAnnouncePkt = val;
-      }
-      break;
+            m_uKmPreAnnouncePkt = val;
+        }
+        break;
 
-   case SRTO_ENFORCEDENCRYPTION:
-      if (m_bConnected)
-          throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+    case SRTO_ENFORCEDENCRYPTION:
+        if (m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
         m_bOPT_StrictEncryption = bool_int_value(optval, optlen);
         break;
 
-   case SRTO_PEERIDLETIMEO:
+    case SRTO_PEERIDLETIMEO:
 
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-        m_iOPT_PeerIdleTimeout = *(int*)optval;
+        m_iOPT_PeerIdleTimeout = *(int *)optval;
         break;
 
-   case SRTO_IPV6ONLY:
-      if (m_bConnected)
-         throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-      
-      m_iIpV6Only = *(int*)optval;
-      break;
+    case SRTO_IPV6ONLY:
+        if (m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-   case SRTO_PACKETFILTER:
-      if (m_bConnected)
-          throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        m_iIpV6Only = *(int *)optval;
+        break;
 
-      {
-          string arg ((char*)optval, optlen);
-          // Parse the configuration string prematurely
-          SrtFilterConfig fc;
-          if (!ParseFilterConfig(arg, fc))
-          {
-              LOGC(mglog.Error,
-                      log << "SRTO_FILTER: Incorrect syntax. Use: FILTERTYPE[,KEY:VALUE...]. "
-                      "FILTERTYPE (" << fc.type << ") must be installed (or builtin)");
-              throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-          }
+    case SRTO_PACKETFILTER:
+        if (m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-          size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
-          if (m_zOPT_ExpPayloadSize > efc_max_payload_size)
-          {
-              LOGC(mglog.Warn, log << "Due to filter-required extra " << fc.extra_size
-                      << " bytes, SRTO_PAYLOADSIZE fixed to " << efc_max_payload_size << " bytes");
-              m_zOPT_ExpPayloadSize = efc_max_payload_size;
-          }
+        {
+            string arg((char *)optval, optlen);
+            // Parse the configuration string prematurely
+            SrtFilterConfig fc;
+            if (!ParseFilterConfig(arg, fc))
+            {
+                LOGC(mglog.Error,
+                     log << "SRTO_FILTER: Incorrect syntax. Use: FILTERTYPE[,KEY:VALUE...]. "
+                            "FILTERTYPE ("
+                         << fc.type << ") must be installed (or builtin)");
+                throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+            }
 
-          m_OPT_PktFilterConfigString = arg;
-      }
-      break;
+            size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
+            if (m_zOPT_ExpPayloadSize > efc_max_payload_size)
+            {
+                LOGC(mglog.Warn,
+                     log << "Due to filter-required extra " << fc.extra_size << " bytes, SRTO_PAYLOADSIZE fixed to "
+                         << efc_max_payload_size << " bytes");
+                m_zOPT_ExpPayloadSize = efc_max_payload_size;
+            }
+
+            m_OPT_PktFilterConfigString = arg;
+        }
+        break;
 
     default:
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
     }
 }
 
-void CUDT::getOpt(SRT_SOCKOPT optName, void* optval, int& optlen)
+void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 {
-   CGuard cg(m_ConnectionLock);
+    CGuard cg(m_ConnectionLock);
 
-   switch (optName)
-   {
-   case SRTO_MSS:
-      *(int*)optval = m_iMSS;
-      optlen = sizeof(int);
-      break;
+    switch (optName)
+    {
+    case SRTO_MSS:
+        *(int *)optval = m_iMSS;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_SNDSYN:
-      *(bool*)optval = m_bSynSending;
-      optlen = sizeof(bool);
-      break;
+    case SRTO_SNDSYN:
+        *(bool *)optval = m_bSynSending;
+        optlen          = sizeof(bool);
+        break;
 
-   case SRTO_RCVSYN:
-      *(bool*)optval = m_bSynRecving;
-      optlen = sizeof(bool);
-      break;
+    case SRTO_RCVSYN:
+        *(bool *)optval = m_bSynRecving;
+        optlen          = sizeof(bool);
+        break;
 
-   case SRTO_ISN:
-      *(int*)optval = m_iISN;
-      optlen = sizeof(int);
-      break;
+    case SRTO_ISN:
+        *(int *)optval = m_iISN;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_FC:
-      *(int*)optval = m_iFlightFlagSize;
-      optlen = sizeof(int);
-      break;
+    case SRTO_FC:
+        *(int *)optval = m_iFlightFlagSize;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_SNDBUF:
-      *(int*)optval = m_iSndBufSize * (m_iMSS - CPacket::UDP_HDR_SIZE);
-      optlen = sizeof(int);
-      break;
+    case SRTO_SNDBUF:
+        *(int *)optval = m_iSndBufSize * (m_iMSS - CPacket::UDP_HDR_SIZE);
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_RCVBUF:
-      *(int*)optval = m_iRcvBufSize * (m_iMSS - CPacket::UDP_HDR_SIZE);
-      optlen = sizeof(int);
-      break;
+    case SRTO_RCVBUF:
+        *(int *)optval = m_iRcvBufSize * (m_iMSS - CPacket::UDP_HDR_SIZE);
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_LINGER:
-      if (optlen < (int)(sizeof(linger)))
-         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    case SRTO_LINGER:
+        if (optlen < (int)(sizeof(linger)))
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-      *(linger*)optval = m_Linger;
-      optlen = sizeof(linger);
-      break;
+        *(linger *)optval = m_Linger;
+        optlen            = sizeof(linger);
+        break;
 
-   case SRTO_UDP_SNDBUF:
-      *(int*)optval = m_iUDPSndBufSize;
-      optlen = sizeof(int);
-      break;
+    case SRTO_UDP_SNDBUF:
+        *(int *)optval = m_iUDPSndBufSize;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_UDP_RCVBUF:
-      *(int*)optval = m_iUDPRcvBufSize;
-      optlen = sizeof(int);
-      break;
+    case SRTO_UDP_RCVBUF:
+        *(int *)optval = m_iUDPRcvBufSize;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_RENDEZVOUS:
-      *(bool *)optval = m_bRendezvous;
-      optlen = sizeof(bool);
-      break;
+    case SRTO_RENDEZVOUS:
+        *(bool *)optval = m_bRendezvous;
+        optlen          = sizeof(bool);
+        break;
 
-   case SRTO_SNDTIMEO:
-      *(int*)optval = m_iSndTimeOut;
-      optlen = sizeof(int);
-      break;
+    case SRTO_SNDTIMEO:
+        *(int *)optval = m_iSndTimeOut;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_RCVTIMEO:
-      *(int*)optval = m_iRcvTimeOut;
-      optlen = sizeof(int);
-      break;
+    case SRTO_RCVTIMEO:
+        *(int *)optval = m_iRcvTimeOut;
+        optlen         = sizeof(int);
+        break;
 
-   case SRTO_REUSEADDR:
-      *(bool *)optval = m_bReuseAddr;
-      optlen = sizeof(bool);
-      break;
+    case SRTO_REUSEADDR:
+        *(bool *)optval = m_bReuseAddr;
+        optlen          = sizeof(bool);
+        break;
 
-   case SRTO_MAXBW:
-      *(int64_t*)optval = m_llMaxBW;
-      optlen = sizeof(int64_t);
-      break;
+    case SRTO_MAXBW:
+        *(int64_t *)optval = m_llMaxBW;
+        optlen             = sizeof(int64_t);
+        break;
 
-   case SRTO_STATE:
-      *(int32_t*)optval = s_UDTUnited.getStatus(m_SocketID);
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_STATE:
+        *(int32_t *)optval = s_UDTUnited.getStatus(m_SocketID);
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_EVENT:
-   {
-      int32_t event = 0;
-      if (m_bBroken)
-         event |= UDT_EPOLL_ERR;
-      else
-      {
-         CGuard::enterCS(m_RecvLock);
-         if (m_pRcvBuffer && m_pRcvBuffer->isRcvDataReady())
-            event |= UDT_EPOLL_IN;
-         CGuard::leaveCS(m_RecvLock);
-         if (m_pSndBuffer && (m_iSndBufSize > m_pSndBuffer->getCurrBufSize()))
-            event |= UDT_EPOLL_OUT;
-      }
-      *(int32_t*)optval = event;
-      optlen = sizeof(int32_t);
-      break;
-   }
+    case SRTO_EVENT:
+    {
+        int32_t event = 0;
+        if (m_bBroken)
+            event |= UDT_EPOLL_ERR;
+        else
+        {
+            CGuard::enterCS(m_RecvLock);
+            if (m_pRcvBuffer && m_pRcvBuffer->isRcvDataReady())
+                event |= UDT_EPOLL_IN;
+            CGuard::leaveCS(m_RecvLock);
+            if (m_pSndBuffer && (m_iSndBufSize > m_pSndBuffer->getCurrBufSize()))
+                event |= UDT_EPOLL_OUT;
+        }
+        *(int32_t *)optval = event;
+        optlen             = sizeof(int32_t);
+        break;
+    }
 
-   case SRTO_SNDDATA:
-      if (m_pSndBuffer)
-         *(int32_t*)optval = m_pSndBuffer->getCurrBufSize();
-      else
-         *(int32_t*)optval = 0;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_SNDDATA:
+        if (m_pSndBuffer)
+            *(int32_t *)optval = m_pSndBuffer->getCurrBufSize();
+        else
+            *(int32_t *)optval = 0;
+        optlen = sizeof(int32_t);
+        break;
 
-   case SRTO_RCVDATA:
-      if (m_pRcvBuffer)
-      {
-         CGuard::enterCS(m_RecvLock);
-         *(int32_t*)optval = m_pRcvBuffer->getRcvDataSize();
-         CGuard::leaveCS(m_RecvLock);
-      }
-      else
-         *(int32_t*)optval = 0;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_RCVDATA:
+        if (m_pRcvBuffer)
+        {
+            CGuard::enterCS(m_RecvLock);
+            *(int32_t *)optval = m_pRcvBuffer->getRcvDataSize();
+            CGuard::leaveCS(m_RecvLock);
+        }
+        else
+            *(int32_t *)optval = 0;
+        optlen = sizeof(int32_t);
+        break;
 
 #ifdef SRT_ENABLE_IPOPTS
-   case SRTO_IPTTL:
-      if (m_bOpened)
-         *(int32_t*)optval = m_pSndQueue->getIpTTL();
-      else
-         *(int32_t*)optval = m_iIpTTL;
-      break;
+    case SRTO_IPTTL:
+        if (m_bOpened)
+            *(int32_t *)optval = m_pSndQueue->getIpTTL();
+        else
+            *(int32_t *)optval = m_iIpTTL;
+        break;
 
-   case SRTO_IPTOS:
-      if (m_bOpened)
-         *(int32_t*)optval = m_pSndQueue->getIpToS();
-      else
-         *(int32_t*)optval = m_iIpToS;
-      break;
+    case SRTO_IPTOS:
+        if (m_bOpened)
+            *(int32_t *)optval = m_pSndQueue->getIpToS();
+        else
+            *(int32_t *)optval = m_iIpToS;
+        break;
 #endif
 
-   case SRTO_SENDER:
-      *(int32_t*)optval = m_bDataSender;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_SENDER:
+        *(int32_t *)optval = m_bDataSender;
+        optlen             = sizeof(int32_t);
+        break;
 
+    case SRTO_TSBPDMODE:
+        *(int32_t *)optval = m_bOPT_TsbPd;
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_TSBPDMODE:
-      *(int32_t*)optval = m_bOPT_TsbPd;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_LATENCY:
+    case SRTO_RCVLATENCY:
+        *(int32_t *)optval = m_iTsbPdDelay_ms;
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_LATENCY:
-   case SRTO_RCVLATENCY:
-      *(int32_t*)optval = m_iTsbPdDelay_ms;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_PEERLATENCY:
+        *(int32_t *)optval = m_iPeerTsbPdDelay_ms;
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_PEERLATENCY:
-      *(int32_t*)optval = m_iPeerTsbPdDelay_ms;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_TLPKTDROP:
+        *(int32_t *)optval = m_bTLPktDrop;
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_TLPKTDROP:
-      *(int32_t*)optval = m_bTLPktDrop;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_SNDDROPDELAY:
+        *(int32_t *)optval = m_iOPT_SndDropDelay;
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_SNDDROPDELAY:
-      *(int32_t*)optval = m_iOPT_SndDropDelay;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_PBKEYLEN:
+        if (m_pCryptoControl)
+            *(int32_t *)optval = m_pCryptoControl->KeyLen(); // Running Key length.
+        else
+            *(int32_t *)optval = m_iSndCryptoKeyLen; // May be 0.
+        optlen = sizeof(int32_t);
+        break;
 
-   case SRTO_PBKEYLEN:
-      if (m_pCryptoControl)
-         *(int32_t*)optval = m_pCryptoControl->KeyLen(); // Running Key length.
-      else
-         *(int32_t*)optval = m_iSndCryptoKeyLen; // May be 0.
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_KMSTATE:
+        if (!m_pCryptoControl)
+            *(int32_t *)optval = SRT_KM_S_UNSECURED;
+        else if (m_bDataSender)
+            *(int32_t *)optval = m_pCryptoControl->m_SndKmState;
+        else
+            *(int32_t *)optval = m_pCryptoControl->m_RcvKmState;
+        break;
 
-   case SRTO_KMSTATE:
-      if (!m_pCryptoControl)
-          *(int32_t*)optval = SRT_KM_S_UNSECURED;
-      else if (m_bDataSender)
-          *(int32_t*)optval = m_pCryptoControl->m_SndKmState;
-      else
-          *(int32_t*)optval = m_pCryptoControl->m_RcvKmState;
-      break;
+    case SRTO_SNDKMSTATE: // State imposed by Agent depending on PW and KMX
+        if (m_pCryptoControl)
+            *(int32_t *)optval = m_pCryptoControl->m_SndKmState;
+        else
+            *(int32_t *)optval = SRT_KM_S_UNSECURED;
+        optlen = sizeof(int32_t);
+        break;
 
-   case SRTO_SNDKMSTATE: // State imposed by Agent depending on PW and KMX
-      if (m_pCryptoControl)
-         *(int32_t*)optval = m_pCryptoControl->m_SndKmState;
-      else
-         *(int32_t*)optval = SRT_KM_S_UNSECURED;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_RCVKMSTATE: // State returned by Peer as informed during KMX
+        if (m_pCryptoControl)
+            *(int32_t *)optval = m_pCryptoControl->m_RcvKmState;
+        else
+            *(int32_t *)optval = SRT_KM_S_UNSECURED;
+        optlen = sizeof(int32_t);
+        break;
 
-   case SRTO_RCVKMSTATE: // State returned by Peer as informed during KMX
-      if (m_pCryptoControl)
-         *(int32_t*)optval = m_pCryptoControl->m_RcvKmState;
-      else
-         *(int32_t*)optval = SRT_KM_S_UNSECURED;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_NAKREPORT:
+        *(bool *)optval = m_bRcvNakReport;
+        optlen          = sizeof(bool);
+        break;
 
-   case SRTO_NAKREPORT:
-      *(bool*)optval = m_bRcvNakReport;
-      optlen = sizeof(bool);
-      break;
+    case SRTO_VERSION:
+        *(int32_t *)optval = m_lSrtVersion;
+        optlen             = sizeof(int32_t);
+        break;
 
-   case SRTO_VERSION:
-      *(int32_t*)optval = m_lSrtVersion;
-      optlen = sizeof(int32_t);
-      break;
-
-   case SRTO_PEERVERSION:
-      *(int32_t*)optval = m_lPeerSrtVersion;
-      optlen = sizeof(int32_t);
-      break;
+    case SRTO_PEERVERSION:
+        *(int32_t *)optval = m_lPeerSrtVersion;
+        optlen             = sizeof(int32_t);
+        break;
 
 #ifdef SRT_ENABLE_CONNTIMEO
-   case SRTO_CONNTIMEO:
-      *(int*)optval = m_iConnTimeOut;
-      optlen = sizeof(int);
-      break;
+    case SRTO_CONNTIMEO:
+        *(int *)optval = m_iConnTimeOut;
+        optlen         = sizeof(int);
+        break;
 #endif
 
-   case SRTO_MINVERSION:
-      *(uint32_t*)optval = m_lMinimumPeerSrtVersion;
-      optlen = sizeof(uint32_t);
-      break;
+    case SRTO_MINVERSION:
+        *(uint32_t *)optval = m_lMinimumPeerSrtVersion;
+        optlen              = sizeof(uint32_t);
+        break;
 
-   case SRTO_STREAMID:
-      if (size_t(optlen) < m_sStreamName.size()+1)
-          throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    case SRTO_STREAMID:
+        if (size_t(optlen) < m_sStreamName.size() + 1)
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-      strcpy((char*)optval, m_sStreamName.c_str());
-      optlen = m_sStreamName.size();
-      break;
+        strcpy((char *)optval, m_sStreamName.c_str());
+        optlen = m_sStreamName.size();
+        break;
 
-   case SRTO_CONGESTION:
-      {
-          string tt = m_CongCtl.selected_name();
-          strcpy((char*)optval, tt.c_str());
-          optlen = tt.size();
-      }
-      break;
+    case SRTO_CONGESTION:
+    {
+        string tt = m_CongCtl.selected_name();
+        strcpy((char *)optval, tt.c_str());
+        optlen = tt.size();
+    }
+    break;
 
-   case SRTO_MESSAGEAPI:
-      optlen = sizeof (bool);
-      *(bool*)optval = m_bMessageAPI;
-      break;
+    case SRTO_MESSAGEAPI:
+        optlen          = sizeof(bool);
+        *(bool *)optval = m_bMessageAPI;
+        break;
 
-   case SRTO_PAYLOADSIZE:
-      optlen = sizeof (int);
-      *(int*)optval = m_zOPT_ExpPayloadSize;
-      break;
+    case SRTO_PAYLOADSIZE:
+        optlen         = sizeof(int);
+        *(int *)optval = m_zOPT_ExpPayloadSize;
+        break;
 
-   case SRTO_ENFORCEDENCRYPTION:
-      optlen = sizeof (int32_t); // also with TSBPDMODE and SENDER
-      *(int32_t*)optval = m_bOPT_StrictEncryption;
-      break;
+    case SRTO_ENFORCEDENCRYPTION:
+        optlen             = sizeof(int32_t); // also with TSBPDMODE and SENDER
+        *(int32_t *)optval = m_bOPT_StrictEncryption;
+        break;
 
-   case SRTO_IPV6ONLY:
-      optlen = sizeof(int);
-      *(int*)optval = m_iIpV6Only;
-      break;
+    case SRTO_IPV6ONLY:
+        optlen         = sizeof(int);
+        *(int *)optval = m_iIpV6Only;
+        break;
 
-   case SRTO_PEERIDLETIMEO:
-      *(int*)optval = m_iOPT_PeerIdleTimeout;
-      optlen = sizeof(int);
-      break;
+    case SRTO_PEERIDLETIMEO:
+        *(int *)optval = m_iOPT_PeerIdleTimeout;
+        optlen         = sizeof(int);
+        break;
 
-      
-   case SRTO_PACKETFILTER:
-      if (size_t(optlen) < m_OPT_PktFilterConfigString.size()+1)
-          throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    case SRTO_PACKETFILTER:
+        if (size_t(optlen) < m_OPT_PktFilterConfigString.size() + 1)
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-      strcpy((char*)optval, m_OPT_PktFilterConfigString.c_str());
-      optlen = m_OPT_PktFilterConfigString.size();
-      break;
-      
-   default:
-      throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
-   }
+        strcpy((char *)optval, m_OPT_PktFilterConfigString.c_str());
+        optlen = m_OPT_PktFilterConfigString.size();
+        break;
+
+    default:
+        throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
+    }
 }
 
-bool CUDT::setstreamid(SRTSOCKET u, const std::string& sid)
+bool CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
 {
-    CUDT* that = getUDTHandle(u);
+    CUDT *that = getUDTHandle(u);
     if (!that)
         return false;
 
@@ -1259,7 +1253,7 @@ bool CUDT::setstreamid(SRTSOCKET u, const std::string& sid)
 
 std::string CUDT::getstreamid(SRTSOCKET u)
 {
-    CUDT* that = getUDTHandle(u);
+    CUDT *that = getUDTHandle(u);
     if (!that)
         return "";
 
@@ -1270,192 +1264,196 @@ std::string CUDT::getstreamid(SRTSOCKET u)
 // possibly using CUDT::construct.
 void CUDT::clearData()
 {
-   // Initial sequence number, loss, acknowledgement, etc.
-   int udpsize = m_iMSS - CPacket::UDP_HDR_SIZE;
+    // Initial sequence number, loss, acknowledgement, etc.
+    int udpsize = m_iMSS - CPacket::UDP_HDR_SIZE;
 
-   m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
+    m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
 
-   HLOGC(mglog.Debug, log << "clearData: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
+    HLOGC(mglog.Debug, log << "clearData: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
 
-   m_iEXPCount = 1;
-   m_iBandwidth = 1;    //pkts/sec
-   // XXX use some constant for this 16
-   m_iDeliveryRate = 16;
-   m_iByteDeliveryRate = 16 * m_iMaxSRTPayloadSize;
-   m_iAckSeqNo = 0;
-   m_ullLastAckTime_tk = 0;
+    m_iEXPCount  = 1;
+    m_iBandwidth = 1; // pkts/sec
+    // XXX use some constant for this 16
+    m_iDeliveryRate     = 16;
+    m_iByteDeliveryRate = 16 * m_iMaxSRTPayloadSize;
+    m_iAckSeqNo         = 0;
+    m_ullLastAckTime_tk = 0;
 
-   // trace information
-   CGuard::enterCS(m_StatsLock);
-   m_stats.startTime = CTimer::getTime();
-   m_stats.sentTotal = m_stats.recvTotal = m_stats.sndLossTotal = m_stats.rcvLossTotal = m_stats.retransTotal = m_stats.sentACKTotal = m_stats.recvACKTotal = m_stats.sentNAKTotal = m_stats.recvNAKTotal = 0;
-   m_stats.lastSampleTime = CTimer::getTime();
-   m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans = m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
-   m_stats.traceRcvRetrans = 0;
-   m_stats.traceReorderDistance = 0;
-   m_stats.traceBelatedTime = 0.0;
-   m_stats.traceRcvBelated          = 0;
+    // trace information
+    CGuard::enterCS(m_StatsLock);
+    m_stats.startTime = CTimer::getTime();
+    m_stats.sentTotal = m_stats.recvTotal = m_stats.sndLossTotal = m_stats.rcvLossTotal = m_stats.retransTotal =
+        m_stats.sentACKTotal = m_stats.recvACKTotal = m_stats.sentNAKTotal = m_stats.recvNAKTotal = 0;
+    m_stats.lastSampleTime                                                                        = CTimer::getTime();
+    m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans =
+        m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
+    m_stats.traceRcvRetrans                                                   = 0;
+    m_stats.traceReorderDistance                                              = 0;
+    m_stats.traceBelatedTime                                                  = 0.0;
+    m_stats.traceRcvBelated                                                   = 0;
 
-   m_stats.sndDropTotal             = 0;
-   m_stats.traceSndDrop             = 0;
-   m_stats.rcvDropTotal             = 0;
-   m_stats.traceRcvDrop             = 0;
+    m_stats.sndDropTotal = 0;
+    m_stats.traceSndDrop = 0;
+    m_stats.rcvDropTotal = 0;
+    m_stats.traceRcvDrop = 0;
 
-   m_stats.m_rcvUndecryptTotal      = 0;
-   m_stats.traceRcvUndecrypt        = 0;
+    m_stats.m_rcvUndecryptTotal = 0;
+    m_stats.traceRcvUndecrypt   = 0;
 
-   m_stats.bytesSentTotal           = 0;
-   m_stats.bytesRecvTotal           = 0;
-   m_stats.bytesRetransTotal        = 0;
-   m_stats.traceBytesSent           = 0;
-   m_stats.traceBytesRecv           = 0;
-   m_stats.sndFilterExtra = 0;
-   m_stats.rcvFilterExtra = 0;
-   m_stats.rcvFilterSupply = 0;
-   m_stats.rcvFilterLoss = 0;
+    m_stats.bytesSentTotal    = 0;
+    m_stats.bytesRecvTotal    = 0;
+    m_stats.bytesRetransTotal = 0;
+    m_stats.traceBytesSent    = 0;
+    m_stats.traceBytesRecv    = 0;
+    m_stats.sndFilterExtra    = 0;
+    m_stats.rcvFilterExtra    = 0;
+    m_stats.rcvFilterSupply   = 0;
+    m_stats.rcvFilterLoss     = 0;
 
-   m_stats.traceBytesRetrans        = 0;
+    m_stats.traceBytesRetrans = 0;
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-   m_stats.traceRcvBytesLoss        = 0;
+    m_stats.traceRcvBytesLoss = 0;
 #endif
-   m_stats.sndBytesDropTotal        = 0;
-   m_stats.rcvBytesDropTotal        = 0;
-   m_stats.traceSndBytesDrop        = 0;
-   m_stats.traceRcvBytesDrop        = 0;
-   m_stats.m_rcvBytesUndecryptTotal = 0;
-   m_stats.traceRcvBytesUndecrypt   = 0;
+    m_stats.sndBytesDropTotal        = 0;
+    m_stats.rcvBytesDropTotal        = 0;
+    m_stats.traceSndBytesDrop        = 0;
+    m_stats.traceRcvBytesDrop        = 0;
+    m_stats.m_rcvBytesUndecryptTotal = 0;
+    m_stats.traceRcvBytesUndecrypt   = 0;
 
-   m_stats.sndDuration = m_stats.m_sndDurationTotal = 0;
-   CGuard::leaveCS(m_StatsLock);
+    m_stats.sndDuration = m_stats.m_sndDurationTotal = 0;
+    CGuard::leaveCS(m_StatsLock);
 
+    // Resetting these data because this happens when agent isn't connected.
+    m_bPeerTsbPd         = false;
+    m_iPeerTsbPdDelay_ms = 0;
 
-   // Resetting these data because this happens when agent isn't connected.
-   m_bPeerTsbPd = false;
-   m_iPeerTsbPdDelay_ms = 0;
+    m_bTsbPd         = m_bOPT_TsbPd; // Take the values from user-configurable options
+    m_iTsbPdDelay_ms = m_iOPT_TsbPdDelay;
+    m_bTLPktDrop     = m_bOPT_TLPktDrop;
+    m_bPeerTLPktDrop = false;
 
-   m_bTsbPd = m_bOPT_TsbPd; // Take the values from user-configurable options
-   m_iTsbPdDelay_ms = m_iOPT_TsbPdDelay;
-   m_bTLPktDrop = m_bOPT_TLPktDrop;
-   m_bPeerTLPktDrop = false;
+    m_bPeerNakReport = false;
 
-   m_bPeerNakReport = false;
+    m_bPeerRexmitFlag = false;
 
-   m_bPeerRexmitFlag = false;
-
-
-   m_RdvState = CHandShake::RDV_INVALID;
-   m_ullRcvPeerStartTime = 0;
+    m_RdvState            = CHandShake::RDV_INVALID;
+    m_ullRcvPeerStartTime = 0;
 }
 
 void CUDT::open()
 {
-   CGuard cg(m_ConnectionLock);
+    CGuard cg(m_ConnectionLock);
 
-   clearData();
+    clearData();
 
-   // structures for queue
-   if (m_pSNode == NULL)
-      m_pSNode = new CSNode;
-   m_pSNode->m_pUDT = this;
-   m_pSNode->m_llTimeStamp_tk = 1;
-   m_pSNode->m_iHeapLoc = -1;
+    // structures for queue
+    if (m_pSNode == NULL)
+        m_pSNode = new CSNode;
+    m_pSNode->m_pUDT           = this;
+    m_pSNode->m_llTimeStamp_tk = 1;
+    m_pSNode->m_iHeapLoc       = -1;
 
-   if (m_pRNode == NULL)
-      m_pRNode = new CRNode;
-   m_pRNode->m_pUDT = this;
-   m_pRNode->m_llTimeStamp_tk = 1;
-   m_pRNode->m_pPrev = m_pRNode->m_pNext = NULL;
-   m_pRNode->m_bOnList = false;
+    if (m_pRNode == NULL)
+        m_pRNode = new CRNode;
+    m_pRNode->m_pUDT           = this;
+    m_pRNode->m_llTimeStamp_tk = 1;
+    m_pRNode->m_pPrev = m_pRNode->m_pNext = NULL;
+    m_pRNode->m_bOnList                   = false;
 
-   m_iRTT = 10 * COMM_SYN_INTERVAL_US;
-   m_iRTTVar = m_iRTT >> 1;
-   m_ullCPUFrequency = CTimer::getCPUFrequency();
+    m_iRTT            = 10 * COMM_SYN_INTERVAL_US;
+    m_iRTTVar         = m_iRTT >> 1;
+    m_ullCPUFrequency = CTimer::getCPUFrequency();
 
+    // set minimum NAK and EXP timeout to 300ms
+    /*
+       XXX This code is blocked because the value of
+       m_ullMinNakInt_tk will be overwritten again in setupCC.
+       And in setupCC it will have an opportunity to make the
+       value overridden according to the statements in the SrtCongestion.
 
-   // set minimum NAK and EXP timeout to 300ms
-   /*
-      XXX This code is blocked because the value of
-      m_ullMinNakInt_tk will be overwritten again in setupCC.
-      And in setupCC it will have an opportunity to make the
-      value overridden according to the statements in the SrtCongestion.
+ #ifdef SRT_ENABLE_NAKREPORT
+    if (m_bRcvNakReport)
+       m_ullMinNakInt_tk = m_iMinNakInterval_us * m_ullCPUFrequency;
+    else
+ #endif
+ */
+    // Set up timers
+    m_ullMinNakInt_tk = 300000 * m_ullCPUFrequency;
+    m_ullMinExpInt_tk = 300000 * m_ullCPUFrequency;
 
-#ifdef SRT_ENABLE_NAKREPORT
-   if (m_bRcvNakReport)
-      m_ullMinNakInt_tk = m_iMinNakInterval_us * m_ullCPUFrequency;
-   else
-#endif
-*/
-   // Set up timers
-   m_ullMinNakInt_tk = 300000 * m_ullCPUFrequency;
-   m_ullMinExpInt_tk = 300000 * m_ullCPUFrequency;
+    m_ullACKInt_tk = COMM_SYN_INTERVAL_US * m_ullCPUFrequency;
+    m_ullNAKInt_tk = m_ullMinNakInt_tk;
 
-   m_ullACKInt_tk = COMM_SYN_INTERVAL_US * m_ullCPUFrequency;
-   m_ullNAKInt_tk = m_ullMinNakInt_tk;
+    uint64_t currtime_tk;
+    CTimer::rdtsc(currtime_tk);
+    m_ullLastRspTime_tk    = currtime_tk;
+    m_ullNextACKTime_tk    = currtime_tk + m_ullACKInt_tk;
+    m_ullNextNAKTime_tk    = currtime_tk + m_ullNAKInt_tk;
+    m_ullLastRspAckTime_tk = currtime_tk;
+    m_ullLastSndTime_tk    = currtime_tk;
+    m_iReXmitCount         = 1;
 
-   uint64_t currtime_tk;
-   CTimer::rdtsc(currtime_tk);
-   m_ullLastRspTime_tk    = currtime_tk;
-   m_ullNextACKTime_tk    = currtime_tk + m_ullACKInt_tk;
-   m_ullNextNAKTime_tk    = currtime_tk + m_ullNAKInt_tk;
-   m_ullLastRspAckTime_tk = currtime_tk;
-   m_ullLastSndTime_tk    = currtime_tk;
-   m_iReXmitCount = 1;
+    m_iPktCount      = 0;
+    m_iLightACKCount = 1;
 
-   m_iPktCount = 0;
-   m_iLightACKCount = 1;
+    m_ullTargetTime_tk = 0;
+    m_ullTimeDiff_tk   = 0;
 
-   m_ullTargetTime_tk = 0;
-   m_ullTimeDiff_tk = 0;
-
-   // Now UDT is opened.
-   m_bOpened = true;
+    // Now UDT is opened.
+    m_bOpened = true;
 }
 
 void CUDT::setListenState()
 {
-   CGuard cg(m_ConnectionLock);
+    CGuard cg(m_ConnectionLock);
 
-   if (!m_bOpened)
-      throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
+    if (!m_bOpened)
+        throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
 
-   if (m_bConnecting || m_bConnected)
-      throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+    if (m_bConnecting || m_bConnected)
+        throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-   // listen can be called more than once
-   if (m_bListening)
-      return;
+    // listen can be called more than once
+    if (m_bListening)
+        return;
 
-   // if there is already another socket listening on the same port
-   if (m_pRcvQueue->setListener(this) < 0)
-      throw CUDTException(MJ_NOTSUP, MN_BUSY, 0);
+    // if there is already another socket listening on the same port
+    if (m_pRcvQueue->setListener(this) < 0)
+        throw CUDTException(MJ_NOTSUP, MN_BUSY, 0);
 
-   m_bListening = true;
+    m_bListening = true;
 }
 
-size_t CUDT::fillSrtHandshake(uint32_t* srtdata, size_t srtlen, int msgtype, int hs_version)
+size_t CUDT::fillSrtHandshake(uint32_t *srtdata, size_t srtlen, int msgtype, int hs_version)
 {
-    if ( srtlen < SRT_HS__SIZE )
+    if (srtlen < SRT_HS__SIZE)
     {
-        LOGC(mglog.Fatal, log << "IPE: fillSrtHandshake: buffer too small: " << srtlen << " (expected: " << SRT_HS__SIZE << ")");
+        LOGC(mglog.Fatal,
+             log << "IPE: fillSrtHandshake: buffer too small: " << srtlen << " (expected: " << SRT_HS__SIZE << ")");
         return 0;
     }
 
     srtlen = SRT_HS__SIZE; // We use only that much space.
 
-    memset(srtdata, 0, sizeof(uint32_t)*srtlen);
+    memset(srtdata, 0, sizeof(uint32_t) * srtlen);
     /* Current version (1.x.x) SRT handshake */
-    srtdata[SRT_HS_VERSION] = m_lSrtVersion;  /* Required version */
+    srtdata[SRT_HS_VERSION] = m_lSrtVersion; /* Required version */
     srtdata[SRT_HS_FLAGS] |= SrtVersionCapabilities();
 
     switch (msgtype)
     {
-    case SRT_CMD_HSREQ: return fillSrtHandshake_HSREQ(srtdata, srtlen, hs_version);
-    case SRT_CMD_HSRSP: return fillSrtHandshake_HSRSP(srtdata, srtlen, hs_version);
-    default: LOGC(mglog.Fatal, log << "IPE: createSrtHandshake/sendSrtMsg called with value " << msgtype); return 0;
+    case SRT_CMD_HSREQ:
+        return fillSrtHandshake_HSREQ(srtdata, srtlen, hs_version);
+    case SRT_CMD_HSRSP:
+        return fillSrtHandshake_HSRSP(srtdata, srtlen, hs_version);
+    default:
+        LOGC(mglog.Fatal, log << "IPE: createSrtHandshake/sendSrtMsg called with value " << msgtype);
+        return 0;
     }
 }
 
-size_t CUDT::fillSrtHandshake_HSREQ(uint32_t* srtdata, size_t /* srtlen - unused */, int hs_version)
+size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *srtdata, size_t /* srtlen - unused */, int hs_version)
 {
     // INITIATOR sends HSREQ.
 
@@ -1469,7 +1467,7 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t* srtdata, size_t /* srtlen - unused
     // (the latter is only in case of HSv5 and bidirectional connection).
     if (m_bOPT_TsbPd)
     {
-        m_iTsbPdDelay_ms = m_iOPT_TsbPdDelay;
+        m_iTsbPdDelay_ms     = m_iOPT_TsbPdDelay;
         m_iPeerTsbPdDelay_ms = m_iOPT_PeerTsbPdDelay;
         /*
          * Sent data is real-time, use Time-based Packet Delivery,
@@ -1477,7 +1475,7 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t* srtdata, size_t /* srtlen - unused
          */
         srtdata[SRT_HS_FLAGS] |= SRT_OPT_TSBPDSND;
 
-        if ( hs_version < CUDT::HS_VERSION_SRT1 )
+        if (hs_version < CUDT::HS_VERSION_SRT1)
         {
             // HSv4 - this uses only one value.
             srtdata[SRT_HS_LATENCY] = SRT_HS_LATENCY_LEG::wrap(m_iPeerTsbPdDelay_ms);
@@ -1511,14 +1509,15 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t* srtdata, size_t /* srtlen - unused
     if (!m_bMessageAPI)
         srtdata[SRT_HS_FLAGS] |= SRT_OPT_STREAM;
 
-    HLOGC(mglog.Debug, log << "HSREQ/snd: LATENCY[SND:" << SRT_HS_LATENCY_SND::unwrap(srtdata[SRT_HS_LATENCY])
-            << " RCV:" << SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]) << "] FLAGS["
-            << SrtFlagString(srtdata[SRT_HS_FLAGS]) << "]");
+    HLOGC(mglog.Debug,
+          log << "HSREQ/snd: LATENCY[SND:" << SRT_HS_LATENCY_SND::unwrap(srtdata[SRT_HS_LATENCY])
+              << " RCV:" << SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]) << "] FLAGS["
+              << SrtFlagString(srtdata[SRT_HS_FLAGS]) << "]");
 
     return 3;
 }
 
-size_t CUDT::fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t /* srtlen - unused */, int hs_version)
+size_t CUDT::fillSrtHandshake_HSRSP(uint32_t *srtdata, size_t /* srtlen - unused */, int hs_version)
 {
     // Setting m_ullRcvPeerStartTime is done in processSrtMsg_HSREQ(), so
     // this condition will be skipped only if this function is called without
@@ -1529,13 +1528,13 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t /* srtlen - unused
         // The peer doesn't have be disturbed by it anyway.
         if (m_bTsbPd)
         {
-            /* 
+            /*
              * We got and transposed peer start time (HandShake request timestamp),
              * we can support Timestamp-based Packet Delivery
              */
             srtdata[SRT_HS_FLAGS] |= SRT_OPT_TSBPDRCV;
 
-            if ( hs_version < HS_VERSION_SRT1 )
+            if (hs_version < HS_VERSION_SRT1)
             {
                 // HSv4 - this uses only one value
                 srtdata[SRT_HS_LATENCY] = SRT_HS_LATENCY_LEG::wrap(m_iTsbPdDelay_ms);
@@ -1554,19 +1553,21 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t /* srtlen - unused
 
         // Hsv5, only when peer has declared TSBPD mode.
         // The flag was already set, and the value already "maximized" in processSrtMsg_HSREQ().
-        if (m_bPeerTsbPd && hs_version >= HS_VERSION_SRT1 )
+        if (m_bPeerTsbPd && hs_version >= HS_VERSION_SRT1)
         {
             // HSv5 is bidirectional - so send the TSBPDSND flag, and place also the
             // peer's latency into SND field.
             srtdata[SRT_HS_FLAGS] |= SRT_OPT_TSBPDSND;
             srtdata[SRT_HS_LATENCY] |= SRT_HS_LATENCY_SND::wrap(m_iPeerTsbPdDelay_ms);
 
-            HLOGC(mglog.Debug, log << "HSRSP/snd: HSv5 peer uses TSBPD, responding TSBPDSND latency=" << m_iPeerTsbPdDelay_ms);
+            HLOGC(mglog.Debug,
+                  log << "HSRSP/snd: HSv5 peer uses TSBPD, responding TSBPDSND latency=" << m_iPeerTsbPdDelay_ms);
         }
         else
         {
-            HLOGC(mglog.Debug, log << "HSRSP/snd: HSv" << (hs_version == CUDT::HS_VERSION_UDT4 ? 4 : 5)
-                << " with peer TSBPD=" << (m_bPeerTsbPd ? "on" : "off") << " - NOT responding TSBPDSND");
+            HLOGC(mglog.Debug,
+                  log << "HSRSP/snd: HSv" << (hs_version == CUDT::HS_VERSION_UDT4 ? 4 : 5)
+                      << " with peer TSBPD=" << (m_bPeerTsbPd ? "on" : "off") << " - NOT responding TSBPDSND");
         }
 
         if (m_bTLPktDrop)
@@ -1577,7 +1578,6 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t /* srtlen - unused
         LOGC(mglog.Fatal, log << "IPE: fillSrtHandshake_HSRSP: m_ullRcvPeerStartTime NOT SET!");
         return 0;
     }
-
 
     if (m_bRcvNakReport)
     {
@@ -1597,7 +1597,7 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t /* srtlen - unused
             srtdata[SRT_HS_FLAGS] &= ~SRT_OPT_TLPKTDROP;
     }
 
-    if ( m_lSrtVersion >= SrtVersion(1, 2, 0) )
+    if (m_lSrtVersion >= SrtVersion(1, 2, 0))
     {
         if (!m_bPeerRexmitFlag)
         {
@@ -1609,32 +1609,36 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t /* srtlen - unused
         {
             // Request that the rexmit bit be used as a part of msgno.
             srtdata[SRT_HS_FLAGS] |= SRT_OPT_REXMITFLG;
-            HLOGF(mglog.Debug, "HSRSP/snd: AGENT UNDERSTANDS REXMIT flag and PEER reported that it does, too." );
+            HLOGF(mglog.Debug, "HSRSP/snd: AGENT UNDERSTANDS REXMIT flag and PEER reported that it does, too.");
         }
     }
     else
     {
-        // Since this is now in the code, it can occur only in case when you change the 
+        // Since this is now in the code, it can occur only in case when you change the
         // version specification in the build configuration.
-        HLOGF(mglog.Debug, "HSRSP/snd: AGENT DOES NOT UNDERSTAND REXMIT flag" );
+        HLOGF(mglog.Debug, "HSRSP/snd: AGENT DOES NOT UNDERSTAND REXMIT flag");
     }
 
-    HLOGC(mglog.Debug, log << "HSRSP/snd: LATENCY[SND:" << SRT_HS_LATENCY_SND::unwrap(srtdata[SRT_HS_LATENCY])
-        << " RCV:" << SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]) << "] FLAGS["
-        << SrtFlagString(srtdata[SRT_HS_FLAGS]) << "]");
+    HLOGC(mglog.Debug,
+          log << "HSRSP/snd: LATENCY[SND:" << SRT_HS_LATENCY_SND::unwrap(srtdata[SRT_HS_LATENCY])
+              << " RCV:" << SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]) << "] FLAGS["
+              << SrtFlagString(srtdata[SRT_HS_FLAGS]) << "]");
 
     return 3;
 }
 
-size_t CUDT::prepareSrtHsMsg(int cmd, uint32_t* srtdata, size_t size)
+size_t CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
 {
     size_t srtlen = fillSrtHandshake(srtdata, size, cmd, handshakeVersion());
-    HLOGF(mglog.Debug, "CMD:%s(%d) Len:%d Version: %s Flags: %08X (%s) sdelay:%d",
-            MessageTypeStr(UMSG_EXT, cmd).c_str(), cmd, (int)(srtlen * sizeof(int32_t)),
-            SrtVersionString(srtdata[SRT_HS_VERSION]).c_str(),
-            srtdata[SRT_HS_FLAGS],
-            SrtFlagString(srtdata[SRT_HS_FLAGS]).c_str(),
-            srtdata[SRT_HS_LATENCY]);
+    HLOGF(mglog.Debug,
+          "CMD:%s(%d) Len:%d Version: %s Flags: %08X (%s) sdelay:%d",
+          MessageTypeStr(UMSG_EXT, cmd).c_str(),
+          cmd,
+          (int)(srtlen * sizeof(int32_t)),
+          SrtVersionString(srtdata[SRT_HS_VERSION]).c_str(),
+          srtdata[SRT_HS_FLAGS],
+          SrtFlagString(srtdata[SRT_HS_FLAGS]).c_str(),
+          srtdata[SRT_HS_LATENCY]);
 
     return srtlen;
 }
@@ -1644,7 +1648,7 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
     CPacket srtpkt;
     int32_t srtcmd = (int32_t)cmd;
 
-    static const size_t SRTDATA_MAXSIZE = SRT_CMD_MAXSZ/sizeof(int32_t);
+    static const size_t SRTDATA_MAXSIZE = SRT_CMD_MAXSZ / sizeof(int32_t);
 
     // This is in order to issue a compile error if the SRT_CMD_MAXSZ is
     // too small to keep all the data. As this is "static const", declaring
@@ -1657,22 +1661,23 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
 
     int srtlen = 0;
 
-    if ( cmd == SRT_CMD_REJECT )
+    if (cmd == SRT_CMD_REJECT)
     {
         // This is a value returned by processSrtMsg underlying layer, potentially
         // to be reported here. Should this happen, just send a rejection message.
-        cmd = SRT_CMD_HSRSP;
+        cmd                     = SRT_CMD_HSRSP;
         srtdata[SRT_HS_VERSION] = 0;
     }
 
-    switch(cmd){
+    switch (cmd)
+    {
     case SRT_CMD_HSREQ:
     case SRT_CMD_HSRSP:
         srtlen = prepareSrtHsMsg(cmd, srtdata, SRTDATA_SIZE);
         break;
 
-    case SRT_CMD_KMREQ: //Sender
-    case SRT_CMD_KMRSP: //Receiver
+    case SRT_CMD_KMREQ: // Sender
+    case SRT_CMD_KMRSP: // Receiver
         srtlen = srtlen_in;
         /* Msg already in network order
          * But CChannel:sendto will swap again (assuming 32-bit fields)
@@ -1684,7 +1689,7 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
         break;
 
     default:
-        LOGF(mglog.Error,  "sndSrtMsg: cmd=%d unsupported", cmd);
+        LOGF(mglog.Error, "sndSrtMsg: cmd=%d unsupported", cmd);
         break;
     }
 
@@ -1696,17 +1701,18 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
     }
 }
 
-
-
 // PREREQUISITE:
 // pkt must be set the buffer and configured for UMSG_HANDSHAKE.
 // Note that this function replaces also serialization for the HSv4.
-bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
-        int srths_cmd, int srtkm_cmd,
-        const uint32_t* kmdata, size_t kmdata_wordsize /* IN WORDS, NOT BYTES!!! */)
+bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
+                              ref_t<CHandShake> r_hs,
+                              int               srths_cmd,
+                              int               srtkm_cmd,
+                              const uint32_t *  kmdata,
+                              size_t            kmdata_wordsize /* IN WORDS, NOT BYTES!!! */)
 {
-    CPacket& pkt = *r_pkt;
-    CHandShake& hs = *r_hs;
+    CPacket &   pkt = *r_pkt;
+    CHandShake &hs  = *r_hs;
 
     // This function might be called before the opposite version was recognized.
     // Check if the version is exactly 4 because this means that the peer has already
@@ -1715,7 +1721,7 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
     if (m_ConnRes.m_iVersion == HS_VERSION_UDT4)
     {
         hs.m_iVersion = HS_VERSION_UDT4;
-        hs.m_iType = UDT_DGRAM;
+        hs.m_iType    = UDT_DGRAM;
         if (hs.m_extension)
         {
             // Should be impossible
@@ -1728,10 +1734,10 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
         hs.m_iType = 0; // Prepare it for flags
     }
 
-    HLOGC(mglog.Debug, log << "createSrtHandshake: buf size=" << pkt.getLength()
-            << " hsx=" << MessageTypeStr(UMSG_EXT, srths_cmd)
-            << " kmx=" << MessageTypeStr(UMSG_EXT, srtkm_cmd)
-            << " kmdata_wordsize=" << kmdata_wordsize << " version=" << hs.m_iVersion);
+    HLOGC(mglog.Debug,
+          log << "createSrtHandshake: buf size=" << pkt.getLength() << " hsx=" << MessageTypeStr(UMSG_EXT, srths_cmd)
+              << " kmx=" << MessageTypeStr(UMSG_EXT, srtkm_cmd) << " kmdata_wordsize=" << kmdata_wordsize
+              << " version=" << hs.m_iVersion);
 
     // Once you are certain that the version is HSv5, set the enc type flags
     // to advertise pbkeylen. Otherwise make sure that the old interpretation
@@ -1746,7 +1752,9 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
         // PREVENT THIS HERE.
         if (hs.m_iReqType == URQ_CONCLUSION && srths_cmd == SRT_CMD_HSRSP && m_ullRcvPeerStartTime == 0)
         {
-            LOGC(mglog.Error, log << "createSrtHandshake: IPE (non-fatal): Attempting to craft HSRSP without received HSREQ. BLOCKING extensions.");
+            LOGC(mglog.Error,
+                 log << "createSrtHandshake: IPE (non-fatal): Attempting to craft HSRSP without received HSREQ. "
+                        "BLOCKING extensions.");
             hs.m_extension = false;
         }
 
@@ -1757,9 +1765,11 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
         //
         // Keep 0 in the SRT_HSTYPE_HSFLAGS field, but still advertise PBKEYLEN
         // in the SRT_HSTYPE_ENCFLAGS field.
-        hs.m_iType = SrtHSRequest::wrapFlags(false /*no magic in HSFLAGS*/, m_iSndCryptoKeyLen);
+        hs.m_iType                  = SrtHSRequest::wrapFlags(false /*no magic in HSFLAGS*/, m_iSndCryptoKeyLen);
         bool whether SRT_ATR_UNUSED = m_iSndCryptoKeyLen != 0;
-        HLOGC(mglog.Debug, log << "createSrtHandshake: " << (whether ? "" : "NOT ") << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
+        HLOGC(mglog.Debug,
+              log << "createSrtHandshake: " << (whether ? "" : "NOT ")
+                  << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
 
         // Note: This is required only when sending a HS message without SRT extensions.
         // When this is to be sent with SRT extensions, then KMREQ will be attached here
@@ -1773,7 +1783,8 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
     }
 
     // values > URQ_CONCLUSION include also error types
-    // if (hs.m_iVersion == HS_VERSION_UDT4 || hs.m_iReqType > URQ_CONCLUSION) <--- This condition was checked b4 and it's only valid for caller-listener mode
+    // if (hs.m_iVersion == HS_VERSION_UDT4 || hs.m_iReqType > URQ_CONCLUSION) <--- This condition was checked b4 and
+    // it's only valid for caller-listener mode
     if (!hs.m_extension)
     {
         // Serialize only the basic handshake, if this is predicted for
@@ -1795,23 +1806,22 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
 
     string logext = "HSX";
 
-    bool have_kmreq = false;
-    bool have_sid = false;
+    bool have_kmreq   = false;
+    bool have_sid     = false;
     bool have_congctl = false;
-    bool have_filter = false;
+    bool have_filter  = false;
 
     // Install the SRT extensions
     hs.m_iType |= CHandShake::HS_EXT_HSREQ;
 
-    if ( srths_cmd == SRT_CMD_HSREQ )
+    if (srths_cmd == SRT_CMD_HSREQ)
     {
-        if ( m_sStreamName != "" )
+        if (m_sStreamName != "")
         {
             have_sid = true;
             hs.m_iType |= CHandShake::HS_EXT_CONFIG;
             logext += ",SID";
         }
-
     }
 
     // If this is a response, we have also information
@@ -1878,61 +1888,66 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
     // Also, KMREQ may occur multiple times.
 
     // So, initially store the UDT legacy handshake.
-    size_t hs_size = pkt.getLength(), total_ra_size = (hs_size/sizeof(uint32_t)); // Maximum size of data
-    hs.store_to(pkt.m_pcData, Ref(hs_size)); // hs_size is updated
+    size_t hs_size = pkt.getLength(), total_ra_size = (hs_size / sizeof(uint32_t)); // Maximum size of data
+    hs.store_to(pkt.m_pcData, Ref(hs_size));                                        // hs_size is updated
 
-    size_t ra_size = hs_size/sizeof(int32_t);
+    size_t ra_size = hs_size / sizeof(int32_t);
 
     // Now attach the SRT handshake for HSREQ
-    size_t offset = ra_size;
-    uint32_t* p = reinterpret_cast<uint32_t*>(pkt.m_pcData);
+    size_t    offset = ra_size;
+    uint32_t *p      = reinterpret_cast<uint32_t *>(pkt.m_pcData);
     // NOTE: since this point, ra_size has a size in int32_t elements, NOT BYTES.
 
     // The first 4-byte item is the CMD/LENGTH spec.
-    uint32_t* pcmdspec = p+offset; // Remember the location to be filled later, when we know the length
+    uint32_t *pcmdspec = p + offset; // Remember the location to be filled later, when we know the length
     ++offset;
 
     // Now use the original function to store the actual SRT_HS data
     // ra_size after that
     // NOTE: so far, ra_size is m_iMaxSRTPayloadSize expressed in number of elements.
     // WILL BE CHANGED HERE.
-    ra_size = fillSrtHandshake(p+offset, total_ra_size - offset, srths_cmd, HS_VERSION_SRT1);
+    ra_size   = fillSrtHandshake(p + offset, total_ra_size - offset, srths_cmd, HS_VERSION_SRT1);
     *pcmdspec = HS_CMDSPEC_CMD::wrap(srths_cmd) | HS_CMDSPEC_SIZE::wrap(ra_size);
 
-    HLOGC(mglog.Debug, log << "createSrtHandshake: after HSREQ: offset=" << offset << " HSREQ size=" << ra_size << " space left: " << (total_ra_size - offset));
+    HLOGC(mglog.Debug,
+          log << "createSrtHandshake: after HSREQ: offset=" << offset << " HSREQ size=" << ra_size
+              << " space left: " << (total_ra_size - offset));
 
     if (have_sid)
     {
         // Use only in REQ phase and only if stream name is set
         offset += ra_size;
-        pcmdspec = p+offset;
+        pcmdspec = p + offset;
         ++offset;
 
         // Now prepare the string with 4-byte alignment. The string size is limited
         // to half the payload size. Just a sanity check to not pack too much into
         // the conclusion packet.
-        size_t size_limit = m_iMaxSRTPayloadSize/2;
+        size_t size_limit = m_iMaxSRTPayloadSize / 2;
 
-        if ( m_sStreamName.size() >= size_limit )
+        if (m_sStreamName.size() >= size_limit)
         {
             m_RejectReason = SRT_REJ_ROGUE;
-            LOGC(mglog.Error, log << "createSrtHandshake: stream id too long, limited to " << (size_limit-1) << " bytes");
+            LOGC(mglog.Error,
+                 log << "createSrtHandshake: stream id too long, limited to " << (size_limit - 1) << " bytes");
             return false;
         }
 
-        size_t wordsize = (m_sStreamName.size() + 3) / 4;
+        size_t wordsize         = (m_sStreamName.size() + 3) / 4;
         size_t aligned_bytesize = wordsize * 4;
 
-        memset(p+offset, 0, aligned_bytesize);
-        memcpy(p+offset, m_sStreamName.data(), m_sStreamName.size());
+        memset(p + offset, 0, aligned_bytesize);
+        memcpy(p + offset, m_sStreamName.data(), m_sStreamName.size());
         // Preswap to little endian (in place due to possible padding zeros)
-        HtoILA((uint32_t*)(p+offset), (uint32_t*)(p+offset), wordsize);
+        HtoILA((uint32_t *)(p + offset), (uint32_t *)(p + offset), wordsize);
 
-        ra_size = wordsize;
+        ra_size   = wordsize;
         *pcmdspec = HS_CMDSPEC_CMD::wrap(SRT_CMD_SID) | HS_CMDSPEC_SIZE::wrap(ra_size);
 
-        HLOGC(mglog.Debug, log << "createSrtHandshake: after SID [" << m_sStreamName << "] length=" << m_sStreamName.size() << " alignedln=" << aligned_bytesize
-            << ": offset=" << offset << " SID size=" << ra_size << " space left: " << (total_ra_size - offset));
+        HLOGC(mglog.Debug,
+              log << "createSrtHandshake: after SID [" << m_sStreamName << "] length=" << m_sStreamName.size()
+                  << " alignedln=" << aligned_bytesize << ": offset=" << offset << " SID size=" << ra_size
+                  << " space left: " << (total_ra_size - offset));
     }
 
     if (have_congctl)
@@ -1947,60 +1962,61 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
         // type differently for different connections, however with the same listener.
 
         offset += ra_size;
-        pcmdspec = p+offset;
+        pcmdspec = p + offset;
         ++offset;
 
-        size_t wordsize = (sm.size() + 3) / 4;
+        size_t wordsize         = (sm.size() + 3) / 4;
         size_t aligned_bytesize = wordsize * 4;
 
-        memset(p+offset, 0, aligned_bytesize);
+        memset(p + offset, 0, aligned_bytesize);
 
-        memcpy(p+offset, sm.data(), sm.size());
+        memcpy(p + offset, sm.data(), sm.size());
         // Preswap to little endian (in place due to possible padding zeros)
-        HtoILA((uint32_t*)(p+offset), (uint32_t*)(p+offset), wordsize);
+        HtoILA((uint32_t *)(p + offset), (uint32_t *)(p + offset), wordsize);
 
-        ra_size = wordsize;
+        ra_size   = wordsize;
         *pcmdspec = HS_CMDSPEC_CMD::wrap(SRT_CMD_CONGESTION) | HS_CMDSPEC_SIZE::wrap(ra_size);
 
-        HLOGC(mglog.Debug, log << "createSrtHandshake: after CONGCTL [" << sm << "] length=" << sm.size() << " alignedln=" << aligned_bytesize
-            << ": offset=" << offset << " CONGCTL size=" << ra_size << " space left: " << (total_ra_size - offset));
+        HLOGC(mglog.Debug,
+              log << "createSrtHandshake: after CONGCTL [" << sm << "] length=" << sm.size()
+                  << " alignedln=" << aligned_bytesize << ": offset=" << offset << " CONGCTL size=" << ra_size
+                  << " space left: " << (total_ra_size - offset));
     }
 
     if (have_filter)
     {
         offset += ra_size;
-        pcmdspec = p+offset;
+        pcmdspec = p + offset;
         ++offset;
 
-        size_t wordsize = (m_OPT_PktFilterConfigString.size() + 3) / 4;
+        size_t wordsize         = (m_OPT_PktFilterConfigString.size() + 3) / 4;
         size_t aligned_bytesize = wordsize * 4;
 
-        memset(p+offset, 0, aligned_bytesize);
-        memcpy(p+offset, m_OPT_PktFilterConfigString.data(), m_OPT_PktFilterConfigString.size());
+        memset(p + offset, 0, aligned_bytesize);
+        memcpy(p + offset, m_OPT_PktFilterConfigString.data(), m_OPT_PktFilterConfigString.size());
 
-        ra_size = wordsize;
+        ra_size   = wordsize;
         *pcmdspec = HS_CMDSPEC_CMD::wrap(SRT_CMD_FILTER) | HS_CMDSPEC_SIZE::wrap(ra_size);
 
-        HLOGC(mglog.Debug, log << "createSrtHandshake: after filter ["
-                << m_OPT_PktFilterConfigString
-                << "] length=" << m_OPT_PktFilterConfigString.size()
-                << " alignedln=" << aligned_bytesize
-                << ": offset=" << offset << " filter size=" << ra_size
-                << " space left: " << (total_ra_size - offset));
+        HLOGC(mglog.Debug,
+              log << "createSrtHandshake: after filter [" << m_OPT_PktFilterConfigString << "] length="
+                  << m_OPT_PktFilterConfigString.size() << " alignedln=" << aligned_bytesize << ": offset=" << offset
+                  << " filter size=" << ra_size << " space left: " << (total_ra_size - offset));
     }
 
     // When encryption turned on
     if (have_kmreq)
     {
-        HLOGC(mglog.Debug, log << "createSrtHandshake: "
-                << (m_CryptoSecret.len > 0 ? "Agent uses ENCRYPTION" : "Peer requires ENCRYPTION"));
-        if ( srtkm_cmd == SRT_CMD_KMREQ )
+        HLOGC(mglog.Debug,
+              log << "createSrtHandshake: "
+                  << (m_CryptoSecret.len > 0 ? "Agent uses ENCRYPTION" : "Peer requires ENCRYPTION"));
+        if (srtkm_cmd == SRT_CMD_KMREQ)
         {
             bool have_any_keys = false;
             for (size_t ki = 0; ki < 2; ++ki)
             {
                 // Skip those that have expired
-                if ( !m_pCryptoControl->getKmMsg_needSend(ki, false) )
+                if (!m_pCryptoControl->getKmMsg_needSend(ki, false))
                     continue;
 
                 m_pCryptoControl->getKmMsg_markSent(ki, false);
@@ -2019,11 +2035,12 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
                 // Copy the key - do the endian inversion because another endian inversion
                 // will be done for every control message before sending, and this KM message
                 // is ALREADY in network order.
-                const uint32_t* keydata = reinterpret_cast<const uint32_t*>(m_pCryptoControl->getKmMsg_data(ki));
+                const uint32_t *keydata = reinterpret_cast<const uint32_t *>(m_pCryptoControl->getKmMsg_data(ki));
 
-                HLOGC(mglog.Debug, log << "createSrtHandshake: KMREQ: adding key #" << ki
-                    << " length=" << ra_size << " words (KmMsg_size=" << msglen << ")");
-                    // XXX INSECURE ": [" << FormatBinaryString((uint8_t*)keydata, msglen) << "]";
+                HLOGC(mglog.Debug,
+                      log << "createSrtHandshake: KMREQ: adding key #" << ki << " length=" << ra_size
+                          << " words (KmMsg_size=" << msglen << ")");
+                // XXX INSECURE ": [" << FormatBinaryString((uint8_t*)keydata, msglen) << "]";
 
                 // Yes, I know HtoNLA and NtoHLA do exactly the same operation, but I want
                 // to be clear about the true intention.
@@ -2031,17 +2048,17 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
                 have_any_keys = true;
             }
 
-            if ( !have_any_keys )
+            if (!have_any_keys)
             {
                 m_RejectReason = SRT_REJ_IPE;
                 LOGC(mglog.Error, log << "createSrtHandshake: IPE: all keys have expired, no KM to send.");
                 return false;
             }
         }
-        else if ( srtkm_cmd == SRT_CMD_KMRSP )
+        else if (srtkm_cmd == SRT_CMD_KMRSP)
         {
-            uint32_t failure_kmrsp[] = { SRT_KM_S_UNSECURED };
-            const uint32_t* keydata = 0;
+            uint32_t        failure_kmrsp[] = {SRT_KM_S_UNSECURED};
+            const uint32_t *keydata         = 0;
 
             // Shift the starting point with the value of previously added block,
             // to start with the new one.
@@ -2049,12 +2066,13 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
 
             if (kmdata_wordsize == 0)
             {
-                LOGC(mglog.Error, log << "createSrtHandshake: Agent has PW, but Peer sent no KMREQ. Sending error KMRSP response");
+                LOGC(mglog.Error,
+                     log << "createSrtHandshake: Agent has PW, but Peer sent no KMREQ. Sending error KMRSP response");
                 ra_size = 1;
                 keydata = failure_kmrsp;
 
                 // Update the KM state as well
-                m_pCryptoControl->m_SndKmState = SRT_KM_S_NOSECRET; // Agent has PW, but Peer won't decrypt
+                m_pCryptoControl->m_SndKmState = SRT_KM_S_NOSECRET;  // Agent has PW, but Peer won't decrypt
                 m_pCryptoControl->m_RcvKmState = SRT_KM_S_UNSECURED; // Peer won't encrypt as well.
             }
             else
@@ -2066,13 +2084,15 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
                     return false;
                 }
                 ra_size = kmdata_wordsize;
-                keydata = reinterpret_cast<const uint32_t*>(kmdata);
+                keydata = reinterpret_cast<const uint32_t *>(kmdata);
             }
 
             *(p + offset) = HS_CMDSPEC_CMD::wrap(srtkm_cmd) | HS_CMDSPEC_SIZE::wrap(ra_size);
             ++offset; // Once cell, containting CMD spec and size
-            HLOGC(mglog.Debug, log << "createSrtHandshake: KMRSP: applying returned key length="
-                    << ra_size); // XXX INSECURE << " words: [" << FormatBinaryString((uint8_t*)kmdata, kmdata_wordsize*sizeof(uint32_t)) << "]";
+            HLOGC(mglog.Debug,
+                  log << "createSrtHandshake: KMRSP: applying returned key length="
+                      << ra_size); // XXX INSECURE << " words: [" << FormatBinaryString((uint8_t*)kmdata,
+                                   // kmdata_wordsize*sizeof(uint32_t)) << "]";
 
             NtoHLA(p + offset, keydata, ra_size);
         }
@@ -2088,25 +2108,26 @@ bool CUDT::createSrtHandshake(ref_t<CPacket> r_pkt, ref_t<CHandShake> r_hs,
     // Switch it again to byte unit.
     pkt.setLength((ra_size + offset) * sizeof(int32_t));
 
-    HLOGC(mglog.Debug, log << "createSrtHandshake: filled HSv5 handshake flags: "
-        << CHandShake::ExtensionFlagStr(hs.m_iType) << " length: " << pkt.getLength() << " bytes");
+    HLOGC(mglog.Debug,
+          log << "createSrtHandshake: filled HSv5 handshake flags: " << CHandShake::ExtensionFlagStr(hs.m_iType)
+              << " length: " << pkt.getLength() << " bytes");
 
     return true;
 }
 
-static int FindExtensionBlock(uint32_t* begin, size_t total_length,
-        ref_t<size_t> r_out_len, ref_t<uint32_t*> r_next_block)
+static int
+FindExtensionBlock(uint32_t *begin, size_t total_length, ref_t<size_t> r_out_len, ref_t<uint32_t *> r_next_block)
 {
     // Check if there's anything to process
     if (total_length == 0)
     {
         *r_next_block = NULL;
-        *r_out_len = 0;
+        *r_out_len    = 0;
         return SRT_CMD_NONE;
     }
 
-    size_t& out_len = *r_out_len;
-    uint32_t*& next_block = *r_next_block;
+    size_t &   out_len    = *r_out_len;
+    uint32_t *&next_block = *r_next_block;
     // This function extracts the block command from the block and its length.
     // The command value is returned as a function result.
     // The size of that command block is stored into out_len.
@@ -2124,15 +2145,15 @@ static int FindExtensionBlock(uint32_t* begin, size_t total_length,
     // When SRT_CMD_NONE is returned, it means that nothing has been extracted and nothing else
     // can be further extracted from this block.
 
-    int cmd = HS_CMDSPEC_CMD::unwrap(*begin);
+    int    cmd  = HS_CMDSPEC_CMD::unwrap(*begin);
     size_t size = HS_CMDSPEC_SIZE::unwrap(*begin);
 
-    if ( size + 1 > total_length )
+    if (size + 1 > total_length)
         return SRT_CMD_NONE;
 
     out_len = size;
 
-    if ( total_length == size + 1 )
+    if (total_length == size + 1)
         next_block = NULL;
     else
         next_block = begin + 1 + size;
@@ -2140,57 +2161,59 @@ static int FindExtensionBlock(uint32_t* begin, size_t total_length,
     return cmd;
 }
 
-static inline bool NextExtensionBlock(ref_t<uint32_t*> begin, uint32_t* next, ref_t<size_t> length)
+static inline bool NextExtensionBlock(ref_t<uint32_t *> begin, uint32_t *next, ref_t<size_t> length)
 {
     if (!next)
         return false;
 
     *length = *length - (next - *begin);
-    *begin = next;
+    *begin  = next;
     return true;
 }
 
 bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
 {
     uint32_t *srtdata = (uint32_t *)ctrlpkt->m_pcData;
-    size_t len = ctrlpkt->getLength();
-    int etype = ctrlpkt->getExtendedType();
-    uint32_t ts = ctrlpkt->m_iTimeStamp;
+    size_t    len     = ctrlpkt->getLength();
+    int       etype   = ctrlpkt->getExtendedType();
+    uint32_t  ts      = ctrlpkt->m_iTimeStamp;
 
     int res = SRT_CMD_NONE;
 
-    HLOGC(mglog.Debug, log << "Dispatching message type=" << etype << " data length=" << (len/sizeof(int32_t)));
+    HLOGC(mglog.Debug, log << "Dispatching message type=" << etype << " data length=" << (len / sizeof(int32_t)));
     switch (etype)
     {
     case SRT_CMD_HSREQ:
-        {
-            res = processSrtMsg_HSREQ(srtdata, len, ts, CUDT::HS_VERSION_UDT4);
-            break;
-        }
+    {
+        res = processSrtMsg_HSREQ(srtdata, len, ts, CUDT::HS_VERSION_UDT4);
+        break;
+    }
     case SRT_CMD_HSRSP:
-        {
-            res = processSrtMsg_HSRSP(srtdata, len, ts, CUDT::HS_VERSION_UDT4);
-            break;
-        }
+    {
+        res = processSrtMsg_HSRSP(srtdata, len, ts, CUDT::HS_VERSION_UDT4);
+        break;
+    }
     case SRT_CMD_KMREQ:
         // Special case when the data need to be processed here
         // and the appropriate message must be constructed for sending.
         // No further processing required
         {
             uint32_t srtdata_out[SRTDATA_MAXSIZE];
-            size_t len_out = 0;
+            size_t   len_out = 0;
             res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, srtdata_out, Ref(len_out), CUDT::HS_VERSION_UDT4);
-            if ( res == SRT_CMD_KMRSP )
+            if (res == SRT_CMD_KMRSP)
             {
                 if (len_out == 1)
                 {
                     if (m_bOPT_StrictEncryption)
                     {
-                        LOGC(mglog.Error, log << "KMREQ FAILURE: " << KmStateStr(SRT_KM_STATE(srtdata_out[0]))
-                                << " - rejecting per strict encryption");
+                        LOGC(mglog.Error,
+                             log << "KMREQ FAILURE: " << KmStateStr(SRT_KM_STATE(srtdata_out[0]))
+                                 << " - rejecting per strict encryption");
                         return false;
                     }
-                    HLOGC(mglog.Debug, log << "MKREQ -> KMRSP FAILURE state: " << KmStateStr(SRT_KM_STATE(srtdata_out[0])));
+                    HLOGC(mglog.Debug,
+                          log << "MKREQ -> KMRSP FAILURE state: " << KmStateStr(SRT_KM_STATE(srtdata_out[0])));
                 }
                 else
                 {
@@ -2209,17 +2232,17 @@ bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
         }
 
     case SRT_CMD_KMRSP:
-        {
-            // KMRSP doesn't expect any following action
-            m_pCryptoControl->processSrtMsg_KMRSP(srtdata, len, CUDT::HS_VERSION_UDT4);
-            return true; // nothing to do
-        }
+    {
+        // KMRSP doesn't expect any following action
+        m_pCryptoControl->processSrtMsg_KMRSP(srtdata, len, CUDT::HS_VERSION_UDT4);
+        return true; // nothing to do
+    }
 
     default:
         return false;
     }
 
-    if ( res == SRT_CMD_NONE )
+    if (res == SRT_CMD_NONE)
         return true;
 
     // Send the message that the message handler requested.
@@ -2228,7 +2251,7 @@ bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
     return true;
 }
 
-int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv)
+int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t len, uint32_t ts, int hsv)
 {
     // Set this start time in the beginning, regardless as to whether TSBPD is being
     // used or not. This must be done in the Initiator as well as Responder.
@@ -2238,7 +2261,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
      * This takes time zone, time drift into account.
      * Also includes current packet transit time (rtt/2)
      */
-#if 0                   //Debug PeerStartTime if not 1st HS packet
+#if 0 // Debug PeerStartTime if not 1st HS packet
     {
         uint64_t oldPeerStartTime = m_ullRcvPeerStartTime;
         m_ullRcvPeerStartTime = CTimer::getTime() - (uint64_t)((uint32_t)ts);
@@ -2254,98 +2277,104 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
 
     // Prepare the initial runtime values of latency basing on the option values.
     // They are going to get the value fixed HERE.
-    m_iTsbPdDelay_ms = m_iOPT_TsbPdDelay;
+    m_iTsbPdDelay_ms     = m_iOPT_TsbPdDelay;
     m_iPeerTsbPdDelay_ms = m_iOPT_PeerTsbPdDelay;
 
     if (len < SRT_CMD_HSREQ_MINSZ)
     {
         m_RejectReason = SRT_REJ_ROGUE;
         /* Packet smaller than minimum compatible packet size */
-        LOGF(mglog.Error,  "HSREQ/rcv: cmd=%d(HSREQ) len=%" PRIzu " invalid", SRT_CMD_HSREQ, len);
+        LOGF(mglog.Error, "HSREQ/rcv: cmd=%d(HSREQ) len=%" PRIzu " invalid", SRT_CMD_HSREQ, len);
         return SRT_CMD_NONE;
     }
 
-    LOGF(mglog.Note,  "HSREQ/rcv: cmd=%d(HSREQ) len=%" PRIzu " vers=0x%x opts=0x%x delay=%d", 
-            SRT_CMD_HSREQ, len, srtdata[SRT_HS_VERSION], srtdata[SRT_HS_FLAGS],
-            SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]));
+    LOGF(mglog.Note,
+         "HSREQ/rcv: cmd=%d(HSREQ) len=%" PRIzu " vers=0x%x opts=0x%x delay=%d",
+         SRT_CMD_HSREQ,
+         len,
+         srtdata[SRT_HS_VERSION],
+         srtdata[SRT_HS_FLAGS],
+         SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]));
 
     m_lPeerSrtVersion = srtdata[SRT_HS_VERSION];
-    m_lPeerSrtFlags = srtdata[SRT_HS_FLAGS];
+    m_lPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
 
-    if ( hsv == CUDT::HS_VERSION_UDT4 )
+    if (hsv == CUDT::HS_VERSION_UDT4)
     {
-        if ( m_lPeerSrtVersion >= SRT_VERSION_FEAT_HSv5 )
+        if (m_lPeerSrtVersion >= SRT_VERSION_FEAT_HSv5)
         {
             m_RejectReason = SRT_REJ_ROGUE;
-            LOGC(mglog.Error, log << "HSREQ/rcv: With HSv4 version >= "
-                << SrtVersionString(SRT_VERSION_FEAT_HSv5) << " is not acceptable.");
+            LOGC(mglog.Error,
+                 log << "HSREQ/rcv: With HSv4 version >= " << SrtVersionString(SRT_VERSION_FEAT_HSv5)
+                     << " is not acceptable.");
             return SRT_CMD_REJECT;
         }
     }
     else
     {
-        if ( m_lPeerSrtVersion < SRT_VERSION_FEAT_HSv5 )
+        if (m_lPeerSrtVersion < SRT_VERSION_FEAT_HSv5)
         {
             m_RejectReason = SRT_REJ_ROGUE;
-            LOGC(mglog.Error, log << "HSREQ/rcv: With HSv5 version must be >= "
-                << SrtVersionString(SRT_VERSION_FEAT_HSv5) << " .");
+            LOGC(mglog.Error,
+                 log << "HSREQ/rcv: With HSv5 version must be >= " << SrtVersionString(SRT_VERSION_FEAT_HSv5) << " .");
             return SRT_CMD_REJECT;
         }
     }
 
     // Check also if the version satisfies the minimum required version
-    if ( m_lPeerSrtVersion < m_lMinimumPeerSrtVersion )
+    if (m_lPeerSrtVersion < m_lMinimumPeerSrtVersion)
     {
         m_RejectReason = SRT_REJ_VERSION;
-        LOGC(mglog.Error, log << "HSREQ/rcv: Peer version: " << SrtVersionString(m_lPeerSrtVersion)
-                << " is too old for requested: " << SrtVersionString(m_lMinimumPeerSrtVersion) << " - REJECTING");
+        LOGC(mglog.Error,
+             log << "HSREQ/rcv: Peer version: " << SrtVersionString(m_lPeerSrtVersion)
+                 << " is too old for requested: " << SrtVersionString(m_lMinimumPeerSrtVersion) << " - REJECTING");
         return SRT_CMD_REJECT;
     }
 
-    HLOGC(mglog.Debug, log << "HSREQ/rcv: PEER Version: "
-            << SrtVersionString(m_lPeerSrtVersion)
-            << " Flags: " << m_lPeerSrtFlags
-            << "(" << SrtFlagString(m_lPeerSrtFlags) << ")");
+    HLOGC(mglog.Debug,
+          log << "HSREQ/rcv: PEER Version: " << SrtVersionString(m_lPeerSrtVersion) << " Flags: " << m_lPeerSrtFlags
+              << "(" << SrtFlagString(m_lPeerSrtFlags) << ")");
 
     m_bPeerRexmitFlag = IsSet(m_lPeerSrtFlags, SRT_OPT_REXMITFLG);
-    HLOGF(mglog.Debug, "HSREQ/rcv: peer %s REXMIT flag", m_bPeerRexmitFlag ? "UNDERSTANDS" : "DOES NOT UNDERSTAND" );
+    HLOGF(mglog.Debug, "HSREQ/rcv: peer %s REXMIT flag", m_bPeerRexmitFlag ? "UNDERSTANDS" : "DOES NOT UNDERSTAND");
 
     // Check if both use the same API type. Reject if not.
     bool peer_message_api = !IsSet(m_lPeerSrtFlags, SRT_OPT_STREAM);
-    if ( peer_message_api != m_bMessageAPI )
+    if (peer_message_api != m_bMessageAPI)
     {
         m_RejectReason = SRT_REJ_MESSAGEAPI;
-        LOGC(mglog.Error, log << "HSREQ/rcv: Agent uses "
-            << (m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, but the Peer declares "
-            << (peer_message_api ? "MESSAGE" : "STREAM") << " API. Not compatible transmission type, rejecting.");
+        LOGC(mglog.Error,
+             log << "HSREQ/rcv: Agent uses " << (m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, but the Peer declares "
+                 << (peer_message_api ? "MESSAGE" : "STREAM") << " API. Not compatible transmission type, rejecting.");
         return SRT_CMD_REJECT;
     }
 
-    if ( len < SRT_HS_LATENCY+1 )
+    if (len < SRT_HS_LATENCY + 1)
     {
         // 3 is the size when containing VERSION, FLAGS and LATENCY. Less size
         // makes it contain only the first two. Let's make it acceptable, as long
         // as the latency flags aren't set.
-        if ( IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND) || IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV) )
+        if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND) || IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
         {
             m_RejectReason = SRT_REJ_ROGUE;
-            LOGC(mglog.Error, log << "HSREQ/rcv: Peer sent only VERSION + FLAGS HSREQ, but TSBPD flags are set. Rejecting.");
+            LOGC(mglog.Error,
+                 log << "HSREQ/rcv: Peer sent only VERSION + FLAGS HSREQ, but TSBPD flags are set. Rejecting.");
             return SRT_CMD_REJECT;
         }
 
         LOGC(mglog.Warn, log << "HSREQ/rcv: Peer sent only VERSION + FLAGS HSREQ, not getting any TSBPD settings.");
         // Don't process any further settings in this case. Turn off TSBPD, just for a case.
-        m_bTsbPd = false;
+        m_bTsbPd     = false;
         m_bPeerTsbPd = false;
         return SRT_CMD_HSRSP;
     }
 
     uint32_t latencystr = srtdata[SRT_HS_LATENCY];
 
-    if ( IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND) )
+    if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND))
     {
-        //TimeStamp-based Packet Delivery feature enabled
-        if ( !m_bTsbPd )
+        // TimeStamp-based Packet Delivery feature enabled
+        if (!m_bTsbPd)
         {
             LOGC(mglog.Warn, log << "HSREQ/rcv: Agent did not set rcv-TSBPD - ignoring proposed latency from peer");
 
@@ -2356,7 +2385,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
         else
         {
             int peer_decl_latency;
-            if ( hsv < CUDT::HS_VERSION_SRT1 )
+            if (hsv < CUDT::HS_VERSION_SRT1)
             {
                 // In HSv4 there is only one value and this is the latency
                 // that the sender peer proposes for the agent.
@@ -2371,12 +2400,12 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
                 peer_decl_latency = SRT_HS_LATENCY_SND::unwrap(srtdata[SRT_HS_LATENCY]);
             }
 
-
             // Use the maximum latency out of latency from our settings and the latency
             // "proposed" by the peer.
             int maxdelay = std::max(m_iTsbPdDelay_ms, peer_decl_latency);
-            HLOGC(mglog.Debug, log << "HSREQ/rcv: LOCAL/RCV LATENCY: Agent:" << m_iTsbPdDelay_ms
-                << " Peer:" << peer_decl_latency << "  Selecting:" << maxdelay);
+            HLOGC(mglog.Debug,
+                  log << "HSREQ/rcv: LOCAL/RCV LATENCY: Agent:" << m_iTsbPdDelay_ms << " Peer:" << peer_decl_latency
+                      << "  Selecting:" << maxdelay);
             m_iTsbPdDelay_ms = maxdelay;
         }
     }
@@ -2390,7 +2419,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
     // that the peer INITIATOR will receive the data and informs about its predefined
     // latency. We need to maximize this with our setting of the peer's latency and
     // record as peer's latency, which will be then sent back with HSRSP.
-    if ( hsv > CUDT::HS_VERSION_UDT4 && IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV) )
+    if (hsv > CUDT::HS_VERSION_UDT4 && IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
     {
         // So, PEER uses TSBPD, set the flag.
         // NOTE: it doesn't matter, if AGENT uses TSBPD.
@@ -2400,9 +2429,10 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
         // used by it when receiving data. We take this as a peer's value,
         // and select the maximum of this one and our proposed latency for the peer.
         int peer_decl_latency = SRT_HS_LATENCY_RCV::unwrap(latencystr);
-        int maxdelay = std::max(m_iPeerTsbPdDelay_ms, peer_decl_latency);
-        HLOGC(mglog.Debug, log << "HSREQ/rcv: PEER/RCV LATENCY: Agent:" << m_iPeerTsbPdDelay_ms
-            << " Peer:" << peer_decl_latency << " Selecting:" << maxdelay);
+        int maxdelay          = std::max(m_iPeerTsbPdDelay_ms, peer_decl_latency);
+        HLOGC(mglog.Debug,
+              log << "HSREQ/rcv: PEER/RCV LATENCY: Agent:" << m_iPeerTsbPdDelay_ms << " Peer:" << peer_decl_latency
+                  << " Selecting:" << maxdelay);
         m_iPeerTsbPdDelay_ms = maxdelay;
     }
     else
@@ -2411,31 +2441,30 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, 
         HLOGC(mglog.Debug, log << "HSREQ/rcv: Peer DOES NOT USE latency for receiving - " << how_about_agent);
     }
 
-    if ( hsv > CUDT::HS_VERSION_UDT4 )
+    if (hsv > CUDT::HS_VERSION_UDT4)
     {
         // This is HSv5, do the same things as required for the sending party in HSv4,
         // as in HSv5 this can also be a sender.
         if (IsSet(m_lPeerSrtFlags, SRT_OPT_TLPKTDROP))
         {
-            //Too late packets dropping feature supported
+            // Too late packets dropping feature supported
             m_bPeerTLPktDrop = true;
         }
         if (IsSet(m_lPeerSrtFlags, SRT_OPT_NAKREPORT))
         {
-            //Peer will send Periodic NAK Reports
+            // Peer will send Periodic NAK Reports
             m_bPeerNakReport = true;
         }
     }
 
-
     return SRT_CMD_HSRSP;
 }
 
-int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv)
+int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t len, uint32_t ts, int hsv)
 {
     // XXX Check for mis-version
     // With HSv4 we accept only version less than 1.2.0
-    if ( hsv == CUDT::HS_VERSION_UDT4 && srtdata[SRT_HS_VERSION] >= SRT_VERSION_FEAT_HSv5 )
+    if (hsv == CUDT::HS_VERSION_UDT4 && srtdata[SRT_HS_VERSION] >= SRT_VERSION_FEAT_HSv5)
     {
         LOGC(mglog.Error, log << "HSRSP/rcv: With HSv4 version >= 1.2.0 is not acceptable.");
         return SRT_CMD_NONE;
@@ -2444,7 +2473,7 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
     if (len < SRT_CMD_HSRSP_MINSZ)
     {
         /* Packet smaller than minimum compatible packet size */
-        LOGF(mglog.Error,  "HSRSP/rcv: cmd=%d(HSRSP) len=%" PRIzu " invalid", SRT_CMD_HSRSP, len);
+        LOGF(mglog.Error, "HSRSP/rcv: cmd=%d(HSRSP) len=%" PRIzu " invalid", SRT_CMD_HSRSP, len);
         return SRT_CMD_NONE;
     }
 
@@ -2457,7 +2486,7 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
      * This takes time zone, time drift into account.
      * Also includes current packet transit time (rtt/2)
      */
-#if 0                   //Debug PeerStartTime if not 1st HS packet
+#if 0 // Debug PeerStartTime if not 1st HS packet
     {
         uint64_t oldPeerStartTime = m_ullRcvPeerStartTime;
         m_ullRcvPeerStartTime = CTimer::getTime() - (uint64_t)((uint32_t)ts);
@@ -2472,24 +2501,25 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
 #endif
 
     m_lPeerSrtVersion = srtdata[SRT_HS_VERSION];
-    m_lPeerSrtFlags = srtdata[SRT_HS_FLAGS];
+    m_lPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
 
-    HLOGF(mglog.Debug, "HSRSP/rcv: Version: %s Flags: SND:%08X (%s)",
-            SrtVersionString(m_lPeerSrtVersion).c_str(),
-            m_lPeerSrtFlags,
-            SrtFlagString(m_lPeerSrtFlags).c_str());
+    HLOGF(mglog.Debug,
+          "HSRSP/rcv: Version: %s Flags: SND:%08X (%s)",
+          SrtVersionString(m_lPeerSrtVersion).c_str(),
+          m_lPeerSrtFlags,
+          SrtFlagString(m_lPeerSrtFlags).c_str());
 
-
-    if ( hsv == CUDT::HS_VERSION_UDT4 )
+    if (hsv == CUDT::HS_VERSION_UDT4)
     {
         // The old HSv4 way: extract just one value and put it under peer.
         if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
         {
-            //TsbPd feature enabled
-            m_bPeerTsbPd = true;
+            // TsbPd feature enabled
+            m_bPeerTsbPd         = true;
             m_iPeerTsbPdDelay_ms = SRT_HS_LATENCY_LEG::unwrap(srtdata[SRT_HS_LATENCY]);
-            HLOGC(mglog.Debug, log << "HSRSP/rcv: LATENCY: Peer/snd:" << m_iPeerTsbPdDelay_ms
-                << " (Agent: declared:" << m_iTsbPdDelay_ms << " rcv:" << m_iTsbPdDelay_ms << ")");
+            HLOGC(mglog.Debug,
+                  log << "HSRSP/rcv: LATENCY: Peer/snd:" << m_iPeerTsbPdDelay_ms
+                      << " (Agent: declared:" << m_iTsbPdDelay_ms << " rcv:" << m_iTsbPdDelay_ms << ")");
         }
         // TSBPDSND isn't set in HSv4 by the RESPONDER, because HSv4 RESPONDER is always RECEIVER.
     }
@@ -2499,8 +2529,8 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
 
         if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
         {
-            //TsbPd feature enabled
-            m_bPeerTsbPd = true;
+            // TsbPd feature enabled
+            m_bPeerTsbPd         = true;
             m_iPeerTsbPdDelay_ms = SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]);
             HLOGC(mglog.Debug, log << "HSRSP/rcv: LATENCY: Peer/snd:" << m_iPeerTsbPdDelay_ms << "ms");
         }
@@ -2513,7 +2543,8 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
         {
             if (!m_bTsbPd)
             {
-                LOGC(mglog.Warn, log << "HSRSP/rcv: BUG? Peer (responder) declares sending latency, but Agent turned off TSBPD.");
+                LOGC(mglog.Warn,
+                     log << "HSRSP/rcv: BUG? Peer (responder) declares sending latency, but Agent turned off TSBPD.");
             }
             else
             {
@@ -2527,21 +2558,21 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
 
     if ((m_lSrtVersion >= SrtVersion(1, 0, 5)) && IsSet(m_lPeerSrtFlags, SRT_OPT_TLPKTDROP))
     {
-        //Too late packets dropping feature supported
+        // Too late packets dropping feature supported
         m_bPeerTLPktDrop = true;
     }
 
     if ((m_lSrtVersion >= SrtVersion(1, 1, 0)) && IsSet(m_lPeerSrtFlags, SRT_OPT_NAKREPORT))
     {
-        //Peer will send Periodic NAK Reports
+        // Peer will send Periodic NAK Reports
         m_bPeerNakReport = true;
     }
 
-    if ( m_lSrtVersion >= SrtVersion(1, 2, 0) )
+    if (m_lSrtVersion >= SrtVersion(1, 2, 0))
     {
-        if ( IsSet(m_lPeerSrtFlags, SRT_OPT_REXMITFLG) )
+        if (IsSet(m_lPeerSrtFlags, SRT_OPT_REXMITFLG))
         {
-            //Peer will use REXMIT flag in packet retransmission.
+            // Peer will use REXMIT flag in packet retransmission.
             m_bPeerRexmitFlag = true;
             HLOGP(mglog.Debug, "HSRSP/rcv: 1.2.0+ Agent understands REXMIT flag and so does peer.");
         }
@@ -2561,26 +2592,29 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, 
 }
 
 // This function is called only when the URQ_CONCLUSION handshake has been received from the peer.
-bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uint32_t* out_data SRT_ATR_UNUSED, size_t* out_len)
+bool CUDT::interpretSrtHandshake(const CHandShake &hs,
+                                 const CPacket &   hspkt,
+                                 uint32_t *out_data SRT_ATR_UNUSED,
+                                 size_t *           out_len)
 {
     // Initialize out_len to 0 to handle the unencrypted case
-    if ( out_len )
+    if (out_len)
         *out_len = 0;
 
     // The version=0 statement as rejection is used only since HSv5.
     // The HSv4 sends the AGREEMENT handshake message with version=0, do not misinterpret it.
-    if ( m_ConnRes.m_iVersion > HS_VERSION_UDT4 && hs.m_iVersion == 0 )
+    if (m_ConnRes.m_iVersion > HS_VERSION_UDT4 && hs.m_iVersion == 0)
     {
         m_RejectReason = SRT_REJ_PEER;
         LOGC(mglog.Error, log << "HS VERSION = 0, meaning the handshake has been rejected.");
         return false;
     }
 
-    if ( hs.m_iVersion < HS_VERSION_SRT1 )
+    if (hs.m_iVersion < HS_VERSION_SRT1)
         return true; // do nothing
 
     // Anyway, check if the handshake contains any extra data.
-    if ( hspkt.getLength() <= CHandShake::m_iContentSize )
+    if (hspkt.getLength() <= CHandShake::m_iContentSize)
     {
         m_RejectReason = SRT_REJ_ROGUE;
         // This would mean that the handshake was at least HSv5, but somehow no extras were added.
@@ -2591,83 +2625,88 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
 
     // We still believe it should work, let's check the flags.
     int ext_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(hs.m_iType);
-    if ( ext_flags == 0 )
+    if (ext_flags == 0)
     {
         m_RejectReason = SRT_REJ_ROGUE;
         LOGC(mglog.Error, log << "HS VERSION=" << hs.m_iVersion << " but no handshake extension flags are set!");
         return false;
     }
 
-    HLOGC(mglog.Debug, log << "HS VERSION=" << hs.m_iVersion << " EXTENSIONS: " << CHandShake::ExtensionFlagStr(ext_flags));
+    HLOGC(mglog.Debug,
+          log << "HS VERSION=" << hs.m_iVersion << " EXTENSIONS: " << CHandShake::ExtensionFlagStr(ext_flags));
 
     // Ok, now find the beginning of an int32_t array that follows the UDT handshake.
-    uint32_t* p = reinterpret_cast<uint32_t*>(hspkt.m_pcData + CHandShake::m_iContentSize);
-    size_t size = hspkt.getLength() - CHandShake::m_iContentSize; // Due to previous cond check we grant it's >0
+    uint32_t *p    = reinterpret_cast<uint32_t *>(hspkt.m_pcData + CHandShake::m_iContentSize);
+    size_t    size = hspkt.getLength() - CHandShake::m_iContentSize; // Due to previous cond check we grant it's >0
 
-    if ( IsSet(ext_flags, CHandShake::HS_EXT_HSREQ) )
+    if (IsSet(ext_flags, CHandShake::HS_EXT_HSREQ))
     {
         HLOGC(mglog.Debug, log << "interpretSrtHandshake: extracting HSREQ/RSP type extension");
-        uint32_t* begin = p;
-        uint32_t* next = 0;
-        size_t length = size / sizeof(uint32_t);
-        size_t blocklen = 0;
+        uint32_t *begin    = p;
+        uint32_t *next     = 0;
+        size_t    length   = size / sizeof(uint32_t);
+        size_t    blocklen = 0;
 
-        for(;;) // this is ONE SHOT LOOP
+        for (;;) // this is ONE SHOT LOOP
         {
             int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
 
-            size_t bytelen = blocklen*sizeof(uint32_t);
+            size_t bytelen = blocklen * sizeof(uint32_t);
 
-            if ( cmd == SRT_CMD_HSREQ )
+            if (cmd == SRT_CMD_HSREQ)
             {
                 // Set is the size as it should, then give it for interpretation for
                 // the proper function.
-                if ( blocklen < SRT_HS__SIZE )
+                if (blocklen < SRT_HS__SIZE)
                 {
                     m_RejectReason = SRT_REJ_ROGUE;
-                    LOGC(mglog.Error, log << "HS-ext HSREQ found but invalid size: " << bytelen
-                        << " (expected: " << SRT_HS__SIZE << ")");
+                    LOGC(mglog.Error,
+                         log << "HS-ext HSREQ found but invalid size: " << bytelen << " (expected: " << SRT_HS__SIZE
+                             << ")");
                     return false; // don't interpret
                 }
 
-                int rescmd = processSrtMsg_HSREQ(begin+1, bytelen, hspkt.m_iTimeStamp, HS_VERSION_SRT1);
+                int rescmd = processSrtMsg_HSREQ(begin + 1, bytelen, hspkt.m_iTimeStamp, HS_VERSION_SRT1);
                 // Interpreted? Then it should be responded with SRT_CMD_HSRSP.
-                if ( rescmd != SRT_CMD_HSRSP )
+                if (rescmd != SRT_CMD_HSRSP)
                 {
                     // m_RejectReason already set
-                    LOGC(mglog.Error, log << "interpretSrtHandshake: process HSREQ returned unexpected value " << rescmd);
+                    LOGC(mglog.Error,
+                         log << "interpretSrtHandshake: process HSREQ returned unexpected value " << rescmd);
                     return false;
                 }
                 handshakeDone();
                 updateAfterSrtHandshake(SRT_CMD_HSREQ, HS_VERSION_SRT1);
             }
-            else if ( cmd == SRT_CMD_HSRSP )
+            else if (cmd == SRT_CMD_HSRSP)
             {
                 // Set is the size as it should, then give it for interpretation for
                 // the proper function.
-                if ( blocklen < SRT_HS__SIZE )
+                if (blocklen < SRT_HS__SIZE)
                 {
                     m_RejectReason = SRT_REJ_ROGUE;
-                    LOGC(mglog.Error, log << "HS-ext HSRSP found but invalid size: " << bytelen
-                        << " (expected: " << SRT_HS__SIZE << ")");
+                    LOGC(mglog.Error,
+                         log << "HS-ext HSRSP found but invalid size: " << bytelen << " (expected: " << SRT_HS__SIZE
+                             << ")");
 
                     return false; // don't interpret
                 }
 
-                int rescmd = processSrtMsg_HSRSP(begin+1, bytelen, hspkt.m_iTimeStamp, HS_VERSION_SRT1);
+                int rescmd = processSrtMsg_HSRSP(begin + 1, bytelen, hspkt.m_iTimeStamp, HS_VERSION_SRT1);
                 // Interpreted? Then it should be responded with SRT_CMD_NONE.
                 // (nothing to be responded for HSRSP, unless there was some kinda problem)
-                if ( rescmd != SRT_CMD_NONE )
+                if (rescmd != SRT_CMD_NONE)
                 {
                     // Just formally; the current code doesn't seem to return anything else.
                     m_RejectReason = SRT_REJ_ROGUE;
-                    LOGC(mglog.Error, log << "interpretSrtHandshake: process HSRSP returned unexpected value " << rescmd);
+                    LOGC(mglog.Error,
+                         log << "interpretSrtHandshake: process HSRSP returned unexpected value " << rescmd);
                     return false;
                 }
                 handshakeDone();
                 updateAfterSrtHandshake(SRT_CMD_HSRSP, HS_VERSION_SRT1);
             }
-            else if ( cmd == SRT_CMD_NONE )
+            else if (cmd == SRT_CMD_NONE)
             {
                 m_RejectReason = SRT_REJ_ROGUE;
                 LOGC(mglog.Error, log << "interpretSrtHandshake: no HSREQ/HSRSP block found in the handshake msg!");
@@ -2695,7 +2734,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
 
     bool encrypted = false;
 
-    if ( IsSet(ext_flags, CHandShake::HS_EXT_KMREQ) )
+    if (IsSet(ext_flags, CHandShake::HS_EXT_KMREQ))
     {
         HLOGC(mglog.Debug, log << "interpretSrtHandshake: extracting KMREQ/RSP type extension");
 
@@ -2705,43 +2744,49 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
             if (m_bOPT_StrictEncryption)
             {
                 m_RejectReason = SRT_REJ_UNSECURE;
-                LOGC(mglog.Error, log << "HS KMREQ: Peer declares encryption, but agent does not - rejecting per strict requirement");
+                LOGC(
+                    mglog.Error,
+                    log << "HS KMREQ: Peer declares encryption, but agent does not - rejecting per strict requirement");
                 return false;
             }
 
-            LOGC(mglog.Error, log << "HS KMREQ: Peer declares encryption, but agent does not - still allowing connection.");
+            LOGC(mglog.Error,
+                 log << "HS KMREQ: Peer declares encryption, but agent does not - still allowing connection.");
 
             // Still allow for connection, and allow Agent to send unencrypted stream to the peer.
             // Also normally allow the key to be processed; worst case it will send the failure response.
         }
 
-        uint32_t* begin = p;
-        uint32_t* next = 0;
-        size_t length = size / sizeof(uint32_t);
-        size_t blocklen = 0;
+        uint32_t *begin    = p;
+        uint32_t *next     = 0;
+        size_t    length   = size / sizeof(uint32_t);
+        size_t    blocklen = 0;
 
-        for(;;) // This is one shot loop, unless REPEATED by 'continue'.
+        for (;;) // This is one shot loop, unless REPEATED by 'continue'.
         {
             int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
 
-            HLOGC(mglog.Debug, log << "interpretSrtHandshake: found extension: (" << cmd << ") " << MessageTypeStr(UMSG_EXT, cmd));
+            HLOGC(mglog.Debug,
+                  log << "interpretSrtHandshake: found extension: (" << cmd << ") " << MessageTypeStr(UMSG_EXT, cmd));
 
-            size_t bytelen = blocklen*sizeof(uint32_t);
-            if ( cmd == SRT_CMD_KMREQ )
+            size_t bytelen = blocklen * sizeof(uint32_t);
+            if (cmd == SRT_CMD_KMREQ)
             {
-                if ( !out_data || !out_len )
+                if (!out_data || !out_len)
                 {
                     m_RejectReason = SRT_REJ_IPE;
                     LOGC(mglog.Fatal, log << "IPE: HS/KMREQ extracted without passing target buffer!");
                     return false;
                 }
 
-                int res = m_pCryptoControl->processSrtMsg_KMREQ(begin+1, bytelen, out_data, Ref(*out_len), HS_VERSION_SRT1);
-                if ( res != SRT_CMD_KMRSP )
+                int res =
+                    m_pCryptoControl->processSrtMsg_KMREQ(begin + 1, bytelen, out_data, Ref(*out_len), HS_VERSION_SRT1);
+                if (res != SRT_CMD_KMRSP)
                 {
                     m_RejectReason = SRT_REJ_IPE;
                     // Something went wrong.
-                    HLOGC(mglog.Debug, log << "interpretSrtHandshake: IPE/EPE KMREQ processing failed - returned " << res);
+                    HLOGC(mglog.Debug,
+                          log << "interpretSrtHandshake: IPE/EPE KMREQ processing failed - returned " << res);
                     return false;
                 }
                 if (*out_len == 1)
@@ -2758,15 +2803,16 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
                         {
                             m_RejectReason = SRT_REJ_UNSECURE;
                         }
-                        LOGC(mglog.Error, log << "interpretSrtHandshake: KMREQ result abnornal - rejecting per strict encryption");
+                        LOGC(mglog.Error,
+                             log << "interpretSrtHandshake: KMREQ result abnornal - rejecting per strict encryption");
                         return false;
                     }
                 }
                 encrypted = true;
             }
-            else if ( cmd == SRT_CMD_KMRSP )
+            else if (cmd == SRT_CMD_KMRSP)
             {
-                int res = m_pCryptoControl->processSrtMsg_KMRSP(begin+1, bytelen, HS_VERSION_SRT1);
+                int res = m_pCryptoControl->processSrtMsg_KMRSP(begin + 1, bytelen, HS_VERSION_SRT1);
                 if (m_bOPT_StrictEncryption && res == -1)
                 {
                     m_RejectReason = SRT_REJ_UNSECURE;
@@ -2775,7 +2821,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
                 }
                 encrypted = true;
             }
-            else if ( cmd == SRT_CMD_NONE )
+            else if (cmd == SRT_CMD_NONE)
             {
                 m_RejectReason = SRT_REJ_ROGUE;
                 LOGC(mglog.Error, log << "HS KMREQ expected - none found!");
@@ -2797,46 +2843,52 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
         if (m_bOPT_StrictEncryption)
         {
             m_RejectReason = SRT_REJ_UNSECURE;
-            LOGC(mglog.Error, log << "HS KMREQ: Peer declares encryption, but agent didn't enable it at compile time - rejecting per strict requirement");
+            LOGC(mglog.Error,
+                 log << "HS KMREQ: Peer declares encryption, but agent didn't enable it at compile time - rejecting "
+                        "per strict requirement");
             return false;
         }
 
-        LOGC(mglog.Error, log << "HS KMREQ: Peer declares encryption, but agent didn't enable it at compile time - still allowing connection.");
+        LOGC(mglog.Error,
+             log << "HS KMREQ: Peer declares encryption, but agent didn't enable it at compile time - still allowing "
+                    "connection.");
         encrypted = true;
 #endif
     }
 
-    bool have_congctl = false;
-    bool have_filter = false;
-    string agsm = m_CongCtl.selected_name();
+    bool   have_congctl = false;
+    bool   have_filter  = false;
+    string agsm         = m_CongCtl.selected_name();
     if (agsm == "")
     {
         agsm = "live";
         m_CongCtl.select("live");
     }
 
-    if ( IsSet(ext_flags, CHandShake::HS_EXT_CONFIG) )
+    if (IsSet(ext_flags, CHandShake::HS_EXT_CONFIG))
     {
         HLOGC(mglog.Debug, log << "interpretSrtHandshake: extracting various CONFIG extensions");
 
-        uint32_t* begin = p;
-        uint32_t* next = 0;
-        size_t length = size / sizeof(uint32_t);
-        size_t blocklen = 0;
+        uint32_t *begin    = p;
+        uint32_t *next     = 0;
+        size_t    length   = size / sizeof(uint32_t);
+        size_t    blocklen = 0;
 
-        for(;;) // This is one shot loop, unless REPEATED by 'continue'.
+        for (;;) // This is one shot loop, unless REPEATED by 'continue'.
         {
             int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
 
-            HLOGC(mglog.Debug, log << "interpretSrtHandshake: found extension: (" << cmd << ") " << MessageTypeStr(UMSG_EXT, cmd));
+            HLOGC(mglog.Debug,
+                  log << "interpretSrtHandshake: found extension: (" << cmd << ") " << MessageTypeStr(UMSG_EXT, cmd));
 
-            const size_t bytelen = blocklen*sizeof(uint32_t);
+            const size_t bytelen = blocklen * sizeof(uint32_t);
             if (cmd == SRT_CMD_SID)
             {
                 if (!bytelen || bytelen > MAX_SID_LENGTH)
                 {
-                    LOGC(mglog.Error, log << "interpretSrtHandshake: STREAMID length " << bytelen
-                           << " is 0 or > " << +MAX_SID_LENGTH << " - PROTOCOL ERROR, REJECTING");
+                    LOGC(mglog.Error,
+                         log << "interpretSrtHandshake: STREAMID length " << bytelen << " is 0 or > " << +MAX_SID_LENGTH
+                             << " - PROTOCOL ERROR, REJECTING");
                     return false;
                 }
                 // Copied through a cleared array. This is because the length is aligned to 4
@@ -2847,15 +2899,17 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
                 // padding zeros. In all these cases in the resulting array we should have all
                 // subsequent characters of the string plus at least one '\0' at the end. This will
                 // make it a perfect NUL-terminated string, to be used to initialize a string.
-                char target[MAX_SID_LENGTH+1];
-                memset(target, 0, MAX_SID_LENGTH+1);
-                memcpy(target, begin+1, bytelen);
+                char target[MAX_SID_LENGTH + 1];
+                memset(target, 0, MAX_SID_LENGTH + 1);
+                memcpy(target, begin + 1, bytelen);
 
                 // Un-swap on big endian machines
-                ItoHLA((uint32_t*)target, (uint32_t*)target, blocklen);
+                ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
 
                 m_sStreamName = target;
-                HLOGC(mglog.Debug, log << "CONNECTOR'S REQUESTED SID [" << m_sStreamName << "] (bytelen=" << bytelen << " blocklen=" << blocklen << ")");
+                HLOGC(mglog.Debug,
+                      log << "CONNECTOR'S REQUESTED SID [" << m_sStreamName << "] (bytelen=" << bytelen
+                          << " blocklen=" << blocklen << ")");
             }
             else if (cmd == SRT_CMD_CONGESTION)
             {
@@ -2868,18 +2922,19 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
 
                 if (!bytelen || bytelen > MAX_SID_LENGTH)
                 {
-                    LOGC(mglog.Error, log << "interpretSrtHandshake: CONGESTION-control type length " << bytelen
-                           << " is 0 or > " << +MAX_SID_LENGTH << " - PROTOCOL ERROR, REJECTING");
+                    LOGC(mglog.Error,
+                         log << "interpretSrtHandshake: CONGESTION-control type length " << bytelen << " is 0 or > "
+                             << +MAX_SID_LENGTH << " - PROTOCOL ERROR, REJECTING");
                     return false;
                 }
                 // Declare that congctl has been received
                 have_congctl = true;
 
-                char target[MAX_SID_LENGTH+1];
-                memset(target, 0, MAX_SID_LENGTH+1);
-                memcpy(target, begin+1, bytelen);
+                char target[MAX_SID_LENGTH + 1];
+                memset(target, 0, MAX_SID_LENGTH + 1);
+                memcpy(target, begin + 1, bytelen);
                 // Un-swap on big endian machines
-                ItoHLA((uint32_t*)target, (uint32_t*)target, blocklen);
+                ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
 
                 string sm = target;
 
@@ -2889,13 +2944,16 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
                 if (sm != agsm)
                 {
                     m_RejectReason = SRT_REJ_CONGESTION;
-                    LOGC(mglog.Error, log << "PEER'S CONGCTL '" << sm << "' does not match AGENT'S CONGCTL '" << agsm << "'");
+                    LOGC(mglog.Error,
+                         log << "PEER'S CONGCTL '" << sm << "' does not match AGENT'S CONGCTL '" << agsm << "'");
                     return false;
                 }
 
-                HLOGC(mglog.Debug, log << "CONNECTOR'S CONGCTL [" << sm << "] (bytelen=" << bytelen << " blocklen=" << blocklen << ")");
+                HLOGC(mglog.Debug,
+                      log << "CONNECTOR'S CONGCTL [" << sm << "] (bytelen=" << bytelen << " blocklen=" << blocklen
+                          << ")");
             }
-            else if ( cmd == SRT_CMD_FILTER )
+            else if (cmd == SRT_CMD_FILTER)
             {
                 if (have_filter)
                 {
@@ -2909,19 +2967,20 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
                 // XXX This is the maximum string, but filter config
                 // shall be normally limited somehow, especially if used
                 // together with SID!
-                char target[MAX_SID_LENGTH+1];
-                memset(target, 0, MAX_SID_LENGTH+1);
-                memcpy(target, begin+1, bytelen);
+                char target[MAX_SID_LENGTH + 1];
+                memset(target, 0, MAX_SID_LENGTH + 1);
+                memcpy(target, begin + 1, bytelen);
                 string fltcfg = target;
 
-                HLOGC(mglog.Debug, log << "PEER'S FILTER CONFIG [" << fltcfg << "] (bytelen=" << bytelen << " blocklen=" << blocklen << ")");
+                HLOGC(mglog.Debug,
+                      log << "PEER'S FILTER CONFIG [" << fltcfg << "] (bytelen=" << bytelen << " blocklen=" << blocklen
+                          << ")");
 
                 if (!checkApplyFilterConfig(fltcfg))
                 {
                     LOGC(mglog.Error, log << "PEER'S FILTER CONFIG [" << fltcfg << "] has been rejected");
                     return false;
                 }
-
             }
             else if (cmd == SRT_CMD_NONE)
             {
@@ -2933,7 +2992,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
                 HLOGC(mglog.Debug, log << "interpretSrtHandshake: ... skipping " << MessageTypeStr(UMSG_EXT, cmd));
             }
 
-            if ( !NextExtensionBlock(Ref(begin), next, Ref(length)) )
+            if (!NextExtensionBlock(Ref(begin), next, Ref(length)))
                 break;
         }
     }
@@ -2945,16 +3004,20 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
         if (m_bOPT_StrictEncryption)
         {
             m_RejectReason = SRT_REJ_UNSECURE;
-            LOGC(mglog.Error, log << "HS EXT: Agent declares encryption, but Peer does not - rejecting connection per strict requirement.");
+            LOGC(mglog.Error,
+                 log << "HS EXT: Agent declares encryption, but Peer does not - rejecting connection per strict "
+                        "requirement.");
             return false;
         }
 
-        LOGC(mglog.Error, log << "HS EXT: Agent declares encryption, but Peer does not (Agent can still receive unencrypted packets from Peer).");
+        LOGC(mglog.Error,
+             log << "HS EXT: Agent declares encryption, but Peer does not (Agent can still receive unencrypted packets "
+                    "from Peer).");
 
         // This is required so that the sender is still allowed to send data, when encryption is required,
         // just this will be for waste because the receiver won't decrypt them anyway.
         m_pCryptoControl->createFakeSndContext();
-        m_pCryptoControl->m_SndKmState = SRT_KM_S_NOSECRET; // Because Peer did not send KMX, though Agent has pw
+        m_pCryptoControl->m_SndKmState = SRT_KM_S_NOSECRET;  // Because Peer did not send KMX, though Agent has pw
         m_pCryptoControl->m_RcvKmState = SRT_KM_S_UNSECURED; // Because Peer has no PW, as has sent no KMREQ.
         return true;
     }
@@ -2963,7 +3026,8 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
     if (agsm != "live" && !have_congctl)
     {
         m_RejectReason = SRT_REJ_CONGESTION;
-        LOGC(mglog.Error, log << "HS EXT: Agent uses '" << agsm << "' congctl, but peer DID NOT DECLARE congctl (assuming 'live').");
+        LOGC(mglog.Error,
+             log << "HS EXT: Agent uses '" << agsm << "' congctl, but peer DID NOT DECLARE congctl (assuming 'live').");
         return false;
     }
 
@@ -2971,7 +3035,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uin
     return true;
 }
 
-bool CUDT::checkApplyFilterConfig(const std::string& confstr)
+bool CUDT::checkApplyFilterConfig(const std::string &confstr)
 {
     SrtFilterConfig cfg;
     if (!ParseFilterConfig(confstr, cfg))
@@ -3005,8 +3069,7 @@ bool CUDT::checkApplyFilterConfig(const std::string& confstr)
         {
             // This is a caller, this should apply all parameters received
             // from the listener, forcefully.
-            for (map<string,string>::iterator x = cfg.parameters.begin();
-                    x != cfg.parameters.end(); ++x)
+            for (map<string, string>::iterator x = cfg.parameters.begin(); x != cfg.parameters.end(); ++x)
             {
                 mycfg.parameters[x->first] = x->second;
             }
@@ -3014,21 +3077,20 @@ bool CUDT::checkApplyFilterConfig(const std::string& confstr)
         else
         {
             // On a listener, only apply those that you haven't set
-            for (map<string,string>::iterator x = cfg.parameters.begin();
-                    x != cfg.parameters.end(); ++x)
+            for (map<string, string>::iterator x = cfg.parameters.begin(); x != cfg.parameters.end(); ++x)
             {
                 if (!mycfg.parameters.count(x->first))
                     mycfg.parameters[x->first] = x->second;
             }
         }
 
-        HLOGC(mglog.Debug, log << "checkApplyFilterConfig: param: LOCAL: "
-                << Printable(mycfg.parameters) << " FORGN: " << Printable(cfg.parameters));
+        HLOGC(mglog.Debug,
+              log << "checkApplyFilterConfig: param: LOCAL: " << Printable(mycfg.parameters)
+                  << " FORGN: " << Printable(cfg.parameters));
 
         ostringstream myos;
         myos << mycfg.type;
-        for (map<string,string>::iterator x = mycfg.parameters.begin();
-                x != mycfg.parameters.end(); ++x)
+        for (map<string, string>::iterator x = mycfg.parameters.begin(); x != mycfg.parameters.end(); ++x)
         {
             myos << "," << x->first << ":" << x->second;
         }
@@ -3047,15 +3109,16 @@ bool CUDT::checkApplyFilterConfig(const std::string& confstr)
     size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - cfg.extra_size;
     if (m_zOPT_ExpPayloadSize > efc_max_payload_size)
     {
-        LOGC(mglog.Warn, log << "Due to filter-required extra " << cfg.extra_size
-                << " bytes, SRTO_PAYLOADSIZE fixed to " << efc_max_payload_size << " bytes");
+        LOGC(mglog.Warn,
+             log << "Due to filter-required extra " << cfg.extra_size << " bytes, SRTO_PAYLOADSIZE fixed to "
+                 << efc_max_payload_size << " bytes");
         m_zOPT_ExpPayloadSize = efc_max_payload_size;
     }
 
     return true;
 }
 
-void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
+void CUDT::startConnect(const sockaddr *serv_addr, int32_t forced_isn)
 {
     CGuard cg(m_ConnectionLock);
 
@@ -3072,18 +3135,19 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
 
     // record peer/server address
     delete m_pPeerAddr;
-    m_pPeerAddr = (AF_INET == m_iIPversion) ? (sockaddr*)new sockaddr_in : (sockaddr*)new sockaddr_in6;
+    m_pPeerAddr = (AF_INET == m_iIPversion) ? (sockaddr *)new sockaddr_in : (sockaddr *)new sockaddr_in6;
     memcpy(m_pPeerAddr, serv_addr, (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
 
     // register this socket in the rendezvous queue
-    // RendezevousQueue is used to temporarily store incoming handshake, non-rendezvous connections also require this function
+    // RendezevousQueue is used to temporarily store incoming handshake, non-rendezvous connections also require this
+    // function
 #ifdef SRT_ENABLE_CONNTIMEO
     uint64_t ttl = m_iConnTimeOut * uint64_t(1000);
 #else
     uint64_t ttl = 3000000;
 #endif
     // XXX DEBUG
-    //ttl = 0x1000000000000000;
+    // ttl = 0x1000000000000000;
     // XXX
     if (m_bRendezvous)
         ttl *= 10;
@@ -3092,7 +3156,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
 
     // The m_iType is used in the INDUCTION for nothing. This value is only regarded
     // in CONCLUSION handshake, however this must be created after the handshake version
-    // is already known. UDT_DGRAM is the value that was the only valid in the old SRT 
+    // is already known. UDT_DGRAM is the value that was the only valid in the old SRT
     // with HSv4 (it supported only live transmission), for HSv5 it will be changed to
     // handle handshake extension flags.
     m_ConnReq.m_iType = UDT_DGRAM;
@@ -3109,16 +3173,18 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
         // has sent version 5 waveahand should the agent continue with HSv5
         // rendezvous.
         m_ConnReq.m_iVersion = HS_VERSION_SRT1;
-        //m_ConnReq.m_iVersion = HS_VERSION_UDT4; // <--- Change in order to do regression test.
+        // m_ConnReq.m_iVersion = HS_VERSION_UDT4; // <--- Change in order to do regression test.
         m_ConnReq.m_iReqType = URQ_WAVEAHAND;
-        m_ConnReq.m_iCookie = bake(serv_addr);
+        m_ConnReq.m_iCookie  = bake(serv_addr);
 
         // This will be also passed to a HSv4 rendezvous, but fortunately the old
         // SRT didn't read this field from URQ_WAVEAHAND message, only URQ_CONCLUSION.
-        m_ConnReq.m_iType = SrtHSRequest::wrapFlags(false /* no MAGIC here */, m_iSndCryptoKeyLen);
+        m_ConnReq.m_iType           = SrtHSRequest::wrapFlags(false /* no MAGIC here */, m_iSndCryptoKeyLen);
         bool whether SRT_ATR_UNUSED = m_iSndCryptoKeyLen != 0;
-        HLOGC(mglog.Debug, log << "startConnect (rnd): " << (whether ? "" : "NOT ") << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
-        m_RdvState = CHandShake::RDV_WAVING;
+        HLOGC(mglog.Debug,
+              log << "startConnect (rnd): " << (whether ? "" : "NOT ")
+                  << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
+        m_RdvState  = CHandShake::RDV_WAVING;
         m_SrtHsSide = HSD_DRAW; // initially not resolved.
     }
     else
@@ -3134,16 +3200,16 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
         // The HSv5 listener should only respond with INDUCTION with m_iVersion == HS_VERSION_SRT1.
         m_ConnReq.m_iVersion = HS_VERSION_UDT4;
         m_ConnReq.m_iReqType = URQ_INDUCTION;
-        m_ConnReq.m_iCookie = 0;
-        m_RdvState = CHandShake::RDV_INVALID;
+        m_ConnReq.m_iCookie  = 0;
+        m_RdvState           = CHandShake::RDV_INVALID;
     }
 
-    m_ConnReq.m_iMSS = m_iMSS;
-    m_ConnReq.m_iFlightFlagSize = (m_iRcvBufSize < m_iFlightFlagSize)? m_iRcvBufSize : m_iFlightFlagSize;
-    m_ConnReq.m_iID = m_SocketID;
+    m_ConnReq.m_iMSS            = m_iMSS;
+    m_ConnReq.m_iFlightFlagSize = (m_iRcvBufSize < m_iFlightFlagSize) ? m_iRcvBufSize : m_iFlightFlagSize;
+    m_ConnReq.m_iID             = m_SocketID;
     CIPAddress::ntop(serv_addr, m_ConnReq.m_piPeerIP, m_iIPversion);
 
-    if ( forced_isn == 0 )
+    if (forced_isn == 0)
     {
         // Random Initial Sequence Number (normal mode)
         srand((unsigned int)CTimer::getTime());
@@ -3155,12 +3221,12 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
         m_iISN = m_ConnReq.m_iISN = forced_isn;
     }
 
-    m_iLastDecSeq = m_iISN - 1;
-    m_iSndLastAck = m_iISN;
-    m_iSndLastDataAck = m_iISN;
-    m_iSndLastFullAck = m_iISN;
-    m_iSndCurrSeqNo = m_iISN - 1;
-    m_iSndLastAck2 = m_iISN;
+    m_iLastDecSeq        = m_iISN - 1;
+    m_iSndLastAck        = m_iISN;
+    m_iSndLastDataAck    = m_iISN;
+    m_iSndLastFullAck    = m_iISN;
+    m_iSndCurrSeqNo      = m_iISN - 1;
+    m_iSndLastAck2       = m_iISN;
     m_ullSndLastAck2Time = CTimer::getTime();
 
     // Inform the server my configurations.
@@ -3189,10 +3255,11 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
     // necessarily is to be the size of the data.
     reqpkt.setLength(hs_size);
 
-    uint64_t now = CTimer::getTime();
+    uint64_t now        = CTimer::getTime();
     reqpkt.m_iTimeStamp = int32_t(now - m_stats.startTime);
 
-    HLOGC(mglog.Debug, log << CONID() << "CUDT::startConnect: REQ-TIME set HIGH (" << now << "). SENDING HS: " << m_ConnReq.show());
+    HLOGC(mglog.Debug,
+          log << CONID() << "CUDT::startConnect: REQ-TIME set HIGH (" << now << "). SENDING HS: " << m_ConnReq.show());
 
     /*
      * Race condition if non-block connect response thread scheduled before we set m_bConnecting to true?
@@ -3200,7 +3267,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
      * Maybe m_ConnectionLock handling problem? Not used in CUDT::connect(const CPacket& response)
      */
     m_llLastReqTime = now;
-    m_bConnecting = true;
+    m_bConnecting   = true;
     m_pSndQueue->sendto(serv_addr, reqpkt);
 
     //
@@ -3228,7 +3295,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
     response.setControl(UMSG_HANDSHAKE);
     response.allocate(m_iMaxSRTPayloadSize);
 
-    CUDTException e;
+    CUDTException  e;
     EConnectStatus cst = CONN_CONTINUE;
 
     while (!m_bClosing)
@@ -3236,7 +3303,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
         int64_t tdiff = CTimer::getTime() - m_llLastReqTime;
         // avoid sending too many requests, at most 1 request per 250ms
 
-        // SHORT VERSION: 
+        // SHORT VERSION:
         // The immediate first run of this loop WILL SKIP THIS PART, so
         // the processing really begins AFTER THIS CONDITION.
         //
@@ -3245,7 +3312,8 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
         // the next iteration.
         if (tdiff > 250000)
         {
-            HLOGC(mglog.Debug, log << "startConnect: LOOP: time to send (" << tdiff << " > 250000). size=" << reqpkt.getLength());
+            HLOGC(mglog.Debug,
+                  log << "startConnect: LOOP: time to send (" << tdiff << " > 250000). size=" << reqpkt.getLength());
 
             if (m_bRendezvous)
                 reqpkt.m_iID = m_ConnRes.m_iID;
@@ -3255,11 +3323,13 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
             {
                 CHandShake debughs;
                 debughs.load_from(reqpkt.m_pcData, reqpkt.getLength());
-                HLOGC(mglog.Debug, log << CONID() << "startConnect: REQ-TIME HIGH (" << now << "). cont/sending HS to peer: " << debughs.show());
+                HLOGC(mglog.Debug,
+                      log << CONID() << "startConnect: REQ-TIME HIGH (" << now
+                          << "). cont/sending HS to peer: " << debughs.show());
             }
 #endif
 
-            m_llLastReqTime = now;
+            m_llLastReqTime     = now;
             reqpkt.m_iTimeStamp = int32_t(now - m_stats.startTime);
             m_pSndQueue->sendto(serv_addr, reqpkt);
         }
@@ -3296,7 +3366,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
             // The error exception should make the API connect() function fail, if blocking
             // or mark the failure for that socket in epoll, if non-blocking.
 
-            if ( cst == CONN_RENDEZVOUS )
+            if (cst == CONN_RENDEZVOUS)
             {
                 // When this function returned CONN_RENDEZVOUS, this requires
                 // very special processing for the Rendezvous-v5 algorithm. This MAY
@@ -3322,7 +3392,8 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
             // [[using assert(m_pCryptoControl != nullptr)]];
 
             // new request/response should be sent out immediately on receving a response
-            HLOGC(mglog.Debug, log << "startConnect: SYNC CONNECTION STATUS:" << ConnectStatusStr(cst) << ", REQ-TIME: LOW.");
+            HLOGC(mglog.Debug,
+                  log << "startConnect: SYNC CONNECTION STATUS:" << ConnectStatusStr(cst) << ", REQ-TIME: LOW.");
             m_llLastReqTime = 0;
 
             // Now serialize the handshake again to the existing buffer so that it's
@@ -3351,7 +3422,7 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
             //
             // Now that this is fixed, the handshake messages from RendezvousQueue
             // are sent only when there is a rendezvous mode or non-blocking mode.
-            if ( !createSrtHandshake(Ref(reqpkt), Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
+            if (!createSrtHandshake(Ref(reqpkt), Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
             {
                 LOGC(mglog.Error, log << "createSrtHandshake failed - REJECTING.");
                 cst = CONN_REJECT;
@@ -3364,13 +3435,15 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
             // listener should respond with HS_VERSION_SRT1, if it is HSv5 capable.
         }
 
-        HLOGC(mglog.Debug, log << "startConnect: timeout from Q:recvfrom, looping again; cst=" << ConnectStatusStr(cst));
+        HLOGC(mglog.Debug,
+              log << "startConnect: timeout from Q:recvfrom, looping again; cst=" << ConnectStatusStr(cst));
 
 #if ENABLE_HEAVY_LOGGING
         // Non-fatal assertion
         if (cst == CONN_REJECT) // Might be returned by processRendezvous
         {
-            LOGC(mglog.Error, log << "startConnect: IPE: cst=REJECT NOT EXPECTED HERE, the loop should've been interrupted!");
+            LOGC(mglog.Error,
+                 log << "startConnect: IPE: cst=REJECT NOT EXPECTED HERE, the loop should've been interrupted!");
             break;
         }
 #endif
@@ -3387,21 +3460,21 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
     // Here will fall the break when not CONN_CONTINUE.
     // CONN_RENDEZVOUS is handled by processRendezvous.
     // CONN_ACCEPT will skip this and pass on.
-    if ( cst == CONN_REJECT )
+    if (cst == CONN_REJECT)
     {
         e = CUDTException(MJ_SETUP, MN_REJECTED, 0);
     }
 
     if (e.getErrorCode() == 0)
     {
-        if (m_bClosing)                                                 // if the socket is closed before connection...
-            e = CUDTException(MJ_SETUP); // XXX NO MN ?
-        else if (m_ConnRes.m_iReqType > URQ_FAILURE_TYPES)                          // connection request rejected
+        if (m_bClosing)                                    // if the socket is closed before connection...
+            e = CUDTException(MJ_SETUP);                   // XXX NO MN ?
+        else if (m_ConnRes.m_iReqType > URQ_FAILURE_TYPES) // connection request rejected
         {
             m_RejectReason = RejectReasonForURQ(m_ConnRes.m_iReqType);
-            e = CUDTException(MJ_SETUP, MN_REJECTED, 0);
+            e              = CUDTException(MJ_SETUP, MN_REJECTED, 0);
         }
-        else if ((!m_bRendezvous) && (m_ConnRes.m_iISN != m_iISN))      // secuity check
+        else if ((!m_bRendezvous) && (m_ConnRes.m_iISN != m_iISN)) // secuity check
             e = CUDTException(MJ_SETUP, MN_SECURITY, 0);
     }
 
@@ -3417,32 +3490,35 @@ void CUDT::startConnect(const sockaddr* serv_addr, int32_t forced_isn)
     HLOGC(mglog.Debug, log << CONID() << "startConnect: handshake exchange succeeded");
 
     // Parameters at the end.
-    HLOGC(mglog.Debug, log << "startConnect: END. Parameters:"
-        " mss=" << m_iMSS <<
-        " max-cwnd-size=" << m_CongCtl->cgWindowMaxSize() <<
-        " cwnd-size=" << m_CongCtl->cgWindowSize() <<
-        " rtt=" << m_iRTT <<
-        " bw=" << m_iBandwidth);
+    HLOGC(mglog.Debug,
+          log << "startConnect: END. Parameters:"
+                 " mss="
+              << m_iMSS << " max-cwnd-size=" << m_CongCtl->cgWindowMaxSize()
+              << " cwnd-size=" << m_CongCtl->cgWindowSize() << " rtt=" << m_iRTT << " bw=" << m_iBandwidth);
 }
 
 // Asynchronous connection
-EConnectStatus CUDT::processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT
+EConnectStatus CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEPT
 {
     EConnectStatus cst = CONN_CONTINUE;
-    CUDTException e;
+    CUDTException  e;
 
     CGuard cg(m_ConnectionLock); // FIX
     HLOGC(mglog.Debug, log << CONID() << "processAsyncConnectResponse: got response for connect request, processing");
     cst = processConnectResponse(pkt, &e, false);
 
-    HLOGC(mglog.Debug, log << CONID() << "processAsyncConnectResponse: response processing result: "
-        << ConnectStatusStr(cst) << "REQ-TIME LOW to enforce immediate response");
+    HLOGC(mglog.Debug,
+          log << CONID() << "processAsyncConnectResponse: response processing result: " << ConnectStatusStr(cst)
+              << "REQ-TIME LOW to enforce immediate response");
     m_llLastReqTime = 0;
 
     return cst;
 }
 
-bool CUDT::processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const CPacket& response, const sockaddr* serv_addr)
+bool CUDT::processAsyncConnectRequest(EReadStatus     rst,
+                                      EConnectStatus  cst,
+                                      const CPacket & response,
+                                      const sockaddr *serv_addr)
 {
     // IMPORTANT!
 
@@ -3454,37 +3530,42 @@ bool CUDT::processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const
     CPacket request;
     request.setControl(UMSG_HANDSHAKE);
     request.allocate(m_iMaxSRTPayloadSize);
-    uint64_t now = CTimer::getTime();
+    uint64_t now         = CTimer::getTime();
     request.m_iTimeStamp = int(now - m_stats.startTime);
 
-    HLOGC(mglog.Debug, log << "processAsyncConnectRequest: REQ-TIME: HIGH (" << now << "). Should prevent too quick responses.");
+    HLOGC(mglog.Debug,
+          log << "processAsyncConnectRequest: REQ-TIME: HIGH (" << now << "). Should prevent too quick responses.");
     m_llLastReqTime = now;
     // ID = 0, connection request
     request.m_iID = !m_bRendezvous ? 0 : m_ConnRes.m_iID;
 
     bool status = true;
 
-    if ( cst == CONN_RENDEZVOUS )
+    if (cst == CONN_RENDEZVOUS)
     {
         HLOGC(mglog.Debug, log << "processAsyncConnectRequest: passing to processRendezvous");
         cst = processRendezvous(Ref(request), response, serv_addr, false /*asynchro*/, rst);
         if (cst == CONN_ACCEPT)
         {
-            HLOGC(mglog.Debug, log << "processAsyncConnectRequest: processRendezvous completed the process and responded by itself. Done.");
+            HLOGC(mglog.Debug,
+                  log << "processAsyncConnectRequest: processRendezvous completed the process and responded by itself. "
+                         "Done.");
             return true;
         }
 
         if (cst != CONN_CONTINUE)
         {
             // processRendezvous already set the reject reason
-            LOGC(mglog.Error, log << "processAsyncConnectRequest: REJECT reported from processRendezvous, not processing further.");
+            LOGC(mglog.Error,
+                 log << "processAsyncConnectRequest: REJECT reported from processRendezvous, not processing further.");
             status = false;
         }
     }
     else if (cst == CONN_REJECT)
     {
         // m_RejectReason already set at worker_ProcessAddressedPacket.
-        LOGC(mglog.Error, log << "processAsyncConnectRequest: REJECT reported from HS processing, not processing further.");
+        LOGC(mglog.Error,
+             log << "processAsyncConnectRequest: REJECT reported from HS processing, not processing further.");
         return false;
     }
     else
@@ -3499,8 +3580,9 @@ bool CUDT::processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const
         }
         else
         {
-            HLOGC(mglog.Debug, log << "processAsyncConnectRequest: sending HS reqtype=" << RequestTypeStr(m_ConnReq.m_iReqType)
-                    << " to socket " << request.m_iID << " size=" << request.getLength());
+            HLOGC(mglog.Debug,
+                  log << "processAsyncConnectRequest: sending HS reqtype=" << RequestTypeStr(m_ConnReq.m_iReqType)
+                      << " to socket " << request.m_iID << " size=" << request.getLength());
         }
     }
 
@@ -3508,7 +3590,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const
     {
         return false;
         /* XXX Shouldn't it send a single response packet for the rejection?
-        // Set the version to 0 as "handshake rejection" status and serialize it 
+        // Set the version to 0 as "handshake rejection" status and serialize it
         CHandShake zhs;
         size_t size = request.getLength();
         zhs.store_to(request.m_pcData, Ref(size));
@@ -3529,7 +3611,7 @@ void CUDT::cookieContest()
 
     HLOGC(mglog.Debug, log << "cookieContest: agent=" << m_ConnReq.m_iCookie << " peer=" << m_ConnRes.m_iCookie);
 
-    if ( m_ConnReq.m_iCookie == 0 || m_ConnRes.m_iCookie == 0 )
+    if (m_ConnReq.m_iCookie == 0 || m_ConnRes.m_iCookie == 0)
     {
         // Note that it's virtually impossible that Agent's cookie is not ready, this
         // shall be considered IPE.
@@ -3543,13 +3625,13 @@ void CUDT::cookieContest()
     // may change the state at some point.
     int better_cookie = m_ConnReq.m_iCookie - m_ConnRes.m_iCookie;
 
-    if ( better_cookie > 0 )
+    if (better_cookie > 0)
     {
         m_SrtHsSide = HSD_INITIATOR;
         return;
     }
 
-    if ( better_cookie < 0 )
+    if (better_cookie < 0)
     {
         m_SrtHsSide = HSD_RESPONDER;
         return;
@@ -3568,17 +3650,18 @@ void CUDT::cookieContest()
     m_SrtHsSide = HSD_DRAW;
 }
 
-EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& response, const sockaddr* serv_addr, bool synchro, EReadStatus rst)
+EConnectStatus CUDT::processRendezvous(
+    ref_t<CPacket> reqpkt, const CPacket &response, const sockaddr *serv_addr, bool synchro, EReadStatus rst)
 {
-    if ( m_RdvState == CHandShake::RDV_CONNECTED )
+    if (m_RdvState == CHandShake::RDV_CONNECTED)
     {
         HLOGC(mglog.Debug, log << "processRendezvous: already in CONNECTED state.");
         return CONN_ACCEPT;
     }
 
     uint32_t kmdata[SRTDATA_MAXSIZE];
-    size_t kmdatasize = SRTDATA_MAXSIZE;
-    CPacket& rpkt = *reqpkt;
+    size_t   kmdatasize = SRTDATA_MAXSIZE;
+    CPacket &rpkt       = *reqpkt;
 
     cookieContest();
 
@@ -3588,7 +3671,8 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     if (m_SrtHsSide == HSD_DRAW)
     {
         m_RejectReason = SRT_REJ_RDVCOOKIE;
-        LOGC(mglog.Error, log << "COOKIE CONTEST UNRESOLVED: can't assign connection roles, please wait another minute.");
+        LOGC(mglog.Error,
+             log << "COOKIE CONTEST UNRESOLVED: can't assign connection roles, please wait another minute.");
         return CONN_REJECT;
     }
 
@@ -3598,14 +3682,15 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     // is already serialized in m_ConnRes. Check extra flags that are meaningful
     // for further processing here.
 
-    int ext_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
+    int  ext_flags       = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
     bool needs_extension = ext_flags != 0; // Initial value: received HS has extensions.
     bool needs_hsrsp;
     rendezvousSwitchState(Ref(rsp_type), Ref(needs_extension), Ref(needs_hsrsp));
     if (rsp_type > URQ_FAILURE_TYPES)
     {
         m_RejectReason = RejectReasonForURQ(rsp_type);
-        HLOGC(mglog.Debug, log << "processRendezvous: rejecting due to switch-state response: " << RequestTypeStr(rsp_type));
+        HLOGC(mglog.Debug,
+              log << "processRendezvous: rejecting due to switch-state response: " << RequestTypeStr(rsp_type));
         return CONN_REJECT;
     }
     checkUpdateCryptoKeyLen("processRendezvous", m_ConnRes.m_iType);
@@ -3615,14 +3700,14 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     // 1. The agent is loser in attention state, it sends EMPTY conclusion (without extensions)
     // 2. The agent is loser in initiated state, it interprets incoming HSREQ and creates HSRSP
     // 3. The agent is winner in attention or fine state, it sends HSREQ extension
-    m_ConnReq.m_iReqType = rsp_type;
+    m_ConnReq.m_iReqType  = rsp_type;
     m_ConnReq.m_extension = needs_extension;
 
     // This must be done before prepareConnectionObjects().
     applyResponseSettings();
 
     // This must be done before interpreting and creating HSv5 extensions.
-    if ( !prepareConnectionObjects(m_ConnRes, m_SrtHsSide, 0))
+    if (!prepareConnectionObjects(m_ConnRes, m_SrtHsSide, 0))
     {
         // m_RejectReason already handled
         HLOGC(mglog.Debug, log << "processRendezvous: rejecting due to problems in prepareConnectionObjects.");
@@ -3630,7 +3715,7 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     }
 
     // Case 2.
-    if ( needs_hsrsp )
+    if (needs_hsrsp)
     {
         // This means that we have received HSREQ extension with the handshake, so we need to interpret
         // it and craft the response.
@@ -3642,13 +3727,15 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
             if (response.getLength() == size_t(-1))
             {
                 m_RejectReason = SRT_REJ_IPE;
-                LOGC(mglog.Fatal, log << "IPE: rst=RST_OK, but the packet has set -1 length - REJECTING (REQ-TIME: LOW)");
+                LOGC(mglog.Fatal,
+                     log << "IPE: rst=RST_OK, but the packet has set -1 length - REJECTING (REQ-TIME: LOW)");
                 return CONN_REJECT;
             }
 
-            if ( !interpretSrtHandshake(m_ConnRes, response, kmdata, &kmdatasize) )
+            if (!interpretSrtHandshake(m_ConnRes, response, kmdata, &kmdatasize))
             {
-                HLOGC(mglog.Debug, log << "processRendezvous: rejecting due to problems in interpretSrtHandshake REQ-TIME: LOW.");
+                HLOGC(mglog.Debug,
+                      log << "processRendezvous: rejecting due to problems in interpretSrtHandshake REQ-TIME: LOW.");
                 return CONN_REJECT;
             }
 
@@ -3673,15 +3760,16 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
                         // In this case as the KMRSP answer the "failure status" should be crafted.
                     case SRT_KM_S_NOSECRET:
                     case SRT_KM_S_BADSECRET:
-                        {
-                            HLOGC(mglog.Debug, log << "processRendezvous: No KMX recorded, status = NOSECRET. Respond with NOSECRET.");
+                    {
+                        HLOGC(mglog.Debug,
+                              log << "processRendezvous: No KMX recorded, status = NOSECRET. Respond with NOSECRET.");
 
-                            // Just do the same thing as in CCryptoControl::processSrtMsg_KMREQ for that case,
-                            // that is, copy the NOSECRET code into KMX message.
-                            memcpy(kmdata, &m_pCryptoControl->m_RcvKmState, sizeof(int32_t));
-                            kmdatasize = 1;
-                        }
-                        break;
+                        // Just do the same thing as in CCryptoControl::processSrtMsg_KMREQ for that case,
+                        // that is, copy the NOSECRET code into KMX message.
+                        memcpy(kmdata, &m_pCryptoControl->m_RcvKmState, sizeof(int32_t));
+                        kmdatasize = 1;
+                    }
+                    break;
 
                     default:
                         // Remaining values:
@@ -3692,9 +3780,10 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
                             m_RejectReason = SRT_REJ_IPE;
                             // Remaining situations:
                             // - password only on this site: shouldn't be considered to be sent to a no-password site
-                            LOGC(mglog.Error, log << "processRendezvous: IPE: PERIODIC HS: NO KMREQ RECORDED KMSTATE: RCV="
-                                    << KmStateStr(m_pCryptoControl->m_RcvKmState) << " SND="
-                                    << KmStateStr(m_pCryptoControl->m_SndKmState));
+                            LOGC(mglog.Error,
+                                 log << "processRendezvous: IPE: PERIODIC HS: NO KMREQ RECORDED KMSTATE: RCV="
+                                     << KmStateStr(m_pCryptoControl->m_RcvKmState)
+                                     << " SND=" << KmStateStr(m_pCryptoControl->m_SndKmState));
                             return CONN_REJECT;
                         }
                         break;
@@ -3702,16 +3791,18 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
                 }
                 else
                 {
-                    kmdatasize = msgsize/4;
-                    if (msgsize > kmdatasize*4)
+                    kmdatasize = msgsize / 4;
+                    if (msgsize > kmdatasize * 4)
                     {
                         // Sanity check
                         LOGC(mglog.Error, log << "IPE: KMX data not aligned to 4 bytes! size=" << msgsize);
-                        memset(kmdata+(kmdatasize*4), 0, msgsize - (kmdatasize*4));
+                        memset(kmdata + (kmdatasize * 4), 0, msgsize - (kmdatasize * 4));
                         ++kmdatasize;
                     }
 
-                    HLOGC(mglog.Debug, log << "processRendezvous: getting KM DATA from the fore-recorded KMX from KMREQ, size=" << kmdatasize);
+                    HLOGC(mglog.Debug,
+                          log << "processRendezvous: getting KM DATA from the fore-recorded KMX from KMREQ, size="
+                              << kmdatasize);
                     memcpy(kmdata, m_pCryptoControl->getKmMsg_data(0), msgsize);
                 }
             }
@@ -3726,12 +3817,14 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
         // when HSREQ was interpreted (to store HSRSP extension).
         m_ConnReq.m_extension = true;
 
-        HLOGC(mglog.Debug, log << "processRendezvous: HSREQ extension ok, creating HSRSP response. kmdatasize=" << kmdatasize);
+        HLOGC(mglog.Debug,
+              log << "processRendezvous: HSREQ extension ok, creating HSRSP response. kmdatasize=" << kmdatasize);
 
         rpkt.setLength(m_iMaxSRTPayloadSize);
         if (!createSrtHandshake(reqpkt, Ref(m_ConnReq), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
         {
-            HLOGC(mglog.Debug, log << "processRendezvous: rejecting due to problems in createSrtHandshake. REQ-TIME: LOW");
+            HLOGC(mglog.Debug,
+                  log << "processRendezvous: rejecting due to problems in createSrtHandshake. REQ-TIME: LOW");
             m_llLastReqTime = 0;
             return CONN_REJECT;
         }
@@ -3744,7 +3837,7 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     // Special case: if URQ_AGREEMENT is to be sent, when this side is INITIATOR,
     // then it must have received HSRSP, so it must interpret it. Otherwise it would
     // end up with URQ_DONE, which means that it is the other side to interpret HSRSP.
-    if ( m_SrtHsSide == HSD_INITIATOR && m_ConnReq.m_iReqType == URQ_AGREEMENT )
+    if (m_SrtHsSide == HSD_INITIATOR && m_ConnReq.m_iReqType == URQ_AGREEMENT)
     {
         // The same is done in CUDT::postConnect(), however this section will
         // not be done in case of rendezvous. The section in postConnect() is
@@ -3753,38 +3846,42 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
         if (rst != RST_OK || response.getLength() == size_t(-1))
         {
             // Actually the -1 length would be an IPE, but it's likely that this was reported already.
-            HLOGC(mglog.Debug, log << "processRendezvous: no INCOMING packet, NOT interpreting extensions (relying on exising data)");
+            HLOGC(
+                mglog.Debug,
+                log << "processRendezvous: no INCOMING packet, NOT interpreting extensions (relying on exising data)");
         }
         else
         {
-            HLOGC(mglog.Debug, log << "processRendezvous: INITIATOR, will send AGREEMENT - interpreting HSRSP extension");
-            if ( !interpretSrtHandshake(m_ConnRes, response, 0, 0) )
+            HLOGC(mglog.Debug,
+                  log << "processRendezvous: INITIATOR, will send AGREEMENT - interpreting HSRSP extension");
+            if (!interpretSrtHandshake(m_ConnRes, response, 0, 0))
             {
                 // m_RejectReason is already set, so set the reqtype accordingly
                 m_ConnReq.m_iReqType = URQFailure(m_RejectReason);
             }
         }
         // This should be false, make a kinda assert here.
-        if ( needs_extension )
+        if (needs_extension)
         {
             LOGC(mglog.Fatal, log << "IPE: INITIATOR responding AGREEMENT should declare no extensions to HS");
             m_ConnReq.m_extension = false;
         }
     }
 
-    HLOGC(mglog.Debug, log << CONID() << "processRendezvous: COOKIES Agent/Peer: "
-        << m_ConnReq.m_iCookie << "/" << m_ConnRes.m_iCookie
-        << " HSD:" << (m_SrtHsSide == HSD_INITIATOR ? "initiator" : "responder")
-        << " STATE:" << CHandShake::RdvStateStr(m_RdvState) << " ...");
+    HLOGC(mglog.Debug,
+          log << CONID() << "processRendezvous: COOKIES Agent/Peer: " << m_ConnReq.m_iCookie << "/"
+              << m_ConnRes.m_iCookie << " HSD:" << (m_SrtHsSide == HSD_INITIATOR ? "initiator" : "responder")
+              << " STATE:" << CHandShake::RdvStateStr(m_RdvState) << " ...");
 
-    if ( rsp_type == URQ_DONE )
+    if (rsp_type == URQ_DONE)
     {
         HLOGC(mglog.Debug, log << "... WON'T SEND any response, both sides considered connected");
     }
     else
     {
-        HLOGC(mglog.Debug, log << "... WILL SEND " << RequestTypeStr(rsp_type) << " "
-        << (m_ConnReq.m_extension ? "with" : "without") << " SRT HS extensions");
+        HLOGC(mglog.Debug,
+              log << "... WILL SEND " << RequestTypeStr(rsp_type) << " " << (m_ConnReq.m_extension ? "with" : "without")
+                  << " SRT HS extensions");
     }
 
     // This marks the information for the serializer that
@@ -3794,13 +3891,13 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     m_ConnReq.m_extension = needs_extension;
 
     rpkt.setLength(m_iMaxSRTPayloadSize);
-    if ( m_RdvState == CHandShake::RDV_CONNECTED )
+    if (m_RdvState == CHandShake::RDV_CONNECTED)
     {
         // When synchro=false, don't lock a mutex for rendezvous queue.
         // This is required when this function is called in the
         // receive queue worker thread - it would lock itself.
         int cst = postConnect(response, true, 0, synchro);
-        if ( cst == CONN_REJECT )
+        if (cst == CONN_REJECT)
         {
             // m_RejectReason already set
             HLOGC(mglog.Debug, log << "processRendezvous: rejecting due to problems in postConnect.");
@@ -3812,7 +3909,7 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     // If URQ_DONE, then there's nothing to be done, when URQ_AGREEMENT then return
     // CONN_CONTINUE to make the caller send again the contents if the packet buffer,
     // this time with URQ_AGREEMENT message, but still consider yourself connected.
-    if ( rsp_type == URQ_DONE )
+    if (rsp_type == URQ_DONE)
     {
         HLOGC(mglog.Debug, log << "processRendezvous: rsp=DONE, reporting ACCEPT (nothing to respond)");
         return CONN_ACCEPT;
@@ -3824,7 +3921,7 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     // needs_extension here distinguishes between cases 1 and 3.
     // NOTE: in case when interpretSrtHandshake was run under the conditions above (to interpret HSRSP),
     // then createSrtHandshake below will create only empty AGREEMENT message.
-    if ( !createSrtHandshake(reqpkt, Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
+    if (!createSrtHandshake(reqpkt, Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
     {
         // m_RejectReason already set
         LOGC(mglog.Error, log << "createSrtHandshake failed (IPE?), connection rejected. REQ-TIME: LOW");
@@ -3832,7 +3929,7 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
         return CONN_REJECT;
     }
 
-    if ( rsp_type == URQ_AGREEMENT && m_RdvState == CHandShake::RDV_CONNECTED )
+    if (rsp_type == URQ_AGREEMENT && m_RdvState == CHandShake::RDV_CONNECTED)
     {
         // We are using our own serialization method (not the one called after
         // processConnectResponse, this is skipped in case when this function
@@ -3849,9 +3946,11 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
         // AGREEMENT is missed, it may have kinda initial tearing.
 
         const uint64_t now = CTimer::getTime();
-        m_llLastReqTime = now;
-        rpkt.m_iTimeStamp = int32_t(now - m_stats.startTime);
-        HLOGC(mglog.Debug, log << "processRendezvous: rsp=AGREEMENT, reporting ACCEPT and sending just this one, REQ-TIME HIGH (" << now << ").");
+        m_llLastReqTime    = now;
+        rpkt.m_iTimeStamp  = int32_t(now - m_stats.startTime);
+        HLOGC(mglog.Debug,
+              log << "processRendezvous: rsp=AGREEMENT, reporting ACCEPT and sending just this one, REQ-TIME HIGH ("
+                  << now << ").");
 
         m_pSndQueue->sendto(serv_addr, rpkt);
 
@@ -3861,8 +3960,9 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     if (rst == RST_OK)
     {
         // the request time must be updated so that the next handshake can be sent out immediately
-        HLOGC(mglog.Debug, log << "processRendezvous: rsp=" << RequestTypeStr(m_ConnReq.m_iReqType)
-                << " REQ-TIME: LOW to send immediately, consider yourself conencted");
+        HLOGC(mglog.Debug,
+              log << "processRendezvous: rsp=" << RequestTypeStr(m_ConnReq.m_iReqType)
+                  << " REQ-TIME: LOW to send immediately, consider yourself conencted");
         m_llLastReqTime = 0;
     }
     else
@@ -3872,7 +3972,7 @@ EConnectStatus CUDT::processRendezvous(ref_t<CPacket> reqpkt, const CPacket& res
     return CONN_CONTINUE;
 }
 
-EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTException* eout, bool synchro) ATR_NOEXCEPT
+EConnectStatus CUDT::processConnectResponse(const CPacket &response, CUDTException *eout, bool synchro) ATR_NOEXCEPT
 {
     // NOTE: ASSUMED LOCK ON: m_ConnectionLock.
 
@@ -3882,253 +3982,259 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
     // - CONN_ACCEPT: the handshake is done and finished correctly
     // - CONN_CONTINUE: the induction handshake has been processed correctly, and expects CONCLUSION handshake
 
-   if (!m_bConnecting)
-      return CONN_REJECT;
+    if (!m_bConnecting)
+        return CONN_REJECT;
 
-   // This is required in HSv5 rendezvous, in which it should send the URQ_AGREEMENT message to
-   // the peer, however switch to connected state. 
-   HLOGC(mglog.Debug, log << "processConnectResponse: TYPE:" <<
-           (response.isControl() ?  MessageTypeStr(response.getType(), response.getExtendedType())
-            : string("DATA")));
-   //ConnectStatus res = CONN_REJECT; // used later for status - must be declared here due to goto POST_CONNECT.
+    // This is required in HSv5 rendezvous, in which it should send the URQ_AGREEMENT message to
+    // the peer, however switch to connected state.
+    HLOGC(mglog.Debug,
+          log << "processConnectResponse: TYPE:"
+              << (response.isControl() ? MessageTypeStr(response.getType(), response.getExtendedType())
+                                       : string("DATA")));
+    // ConnectStatus res = CONN_REJECT; // used later for status - must be declared here due to goto POST_CONNECT.
 
-   // For HSv4, the data sender is INITIATOR, and the data receiver is RESPONDER,
-   // regardless of the connecting side affiliation. This will be changed for HSv5.
-   bool bidirectional = false;
-   HandshakeSide hsd = m_bDataSender ? HSD_INITIATOR : HSD_RESPONDER;
-   // (defined here due to 'goto' below).
+    // For HSv4, the data sender is INITIATOR, and the data receiver is RESPONDER,
+    // regardless of the connecting side affiliation. This will be changed for HSv5.
+    bool          bidirectional = false;
+    HandshakeSide hsd           = m_bDataSender ? HSD_INITIATOR : HSD_RESPONDER;
+    // (defined here due to 'goto' below).
 
-   // SRT peer may send the SRT handshake private message (type 0x7fff) before a keep-alive.
+    // SRT peer may send the SRT handshake private message (type 0x7fff) before a keep-alive.
 
-   // This condition is checked when the current agent is trying to do connect() in rendezvous mode,
-   // but the peer was faster to send a handshake packet earlier. This makes it continue with connecting
-   // process if the peer is already behaving as if the connection was already established.
-   
-   // This value will check either the initial value, which is less than SRT1, or
-   // the value previously loaded to m_ConnReq during the previous handshake response.
-   // For the initial form this value should not be checked.
-   bool hsv5 = m_ConnRes.m_iVersion >= HS_VERSION_SRT1;
+    // This condition is checked when the current agent is trying to do connect() in rendezvous mode,
+    // but the peer was faster to send a handshake packet earlier. This makes it continue with connecting
+    // process if the peer is already behaving as if the connection was already established.
 
-   if (m_bRendezvous
-           && (
-               m_RdvState == CHandShake::RDV_CONNECTED // somehow Rendezvous-v5 switched it to CONNECTED.
-               || !response.isControl()                         // WAS A PAYLOAD PACKET.
-               || (response.getType() == UMSG_KEEPALIVE)    // OR WAS A UMSG_KEEPALIVE message.
-               || (response.getType() == UMSG_EXT)          // OR WAS a CONTROL packet of some extended type (i.e. any SRT specific)
-              )
-           // This may happen if this is an initial state in which the socket type was not yet set.
-           // If this is a field that holds the response handshake record from the peer, this means that it wasn't received yet.
-           // HSv5: added version check because in HSv5 the m_iType field has different meaning
-           // and it may be 0 in case when the handshake does not carry SRT extensions.
-           && ( hsv5 || m_ConnRes.m_iType != UDT_UNDEFINED))
-   {
-       //a data packet or a keep-alive packet comes, which means the peer side is already connected
-       // in this situation, the previously recorded response will be used
-       // In HSv5 this situation is theoretically possible if this party has missed the URQ_AGREEMENT message.
-       HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: already connected - pinning in");
-       if (hsv5)
-       {
-           m_RdvState = CHandShake::RDV_CONNECTED;
-       }
+    // This value will check either the initial value, which is less than SRT1, or
+    // the value previously loaded to m_ConnReq during the previous handshake response.
+    // For the initial form this value should not be checked.
+    bool hsv5 = m_ConnRes.m_iVersion >= HS_VERSION_SRT1;
 
-       return postConnect(response, hsv5, eout, synchro);
-   }
+    if (m_bRendezvous &&
+        (m_RdvState == CHandShake::RDV_CONNECTED   // somehow Rendezvous-v5 switched it to CONNECTED.
+         || !response.isControl()                  // WAS A PAYLOAD PACKET.
+         || (response.getType() == UMSG_KEEPALIVE) // OR WAS A UMSG_KEEPALIVE message.
+         || (response.getType() == UMSG_EXT) // OR WAS a CONTROL packet of some extended type (i.e. any SRT specific)
+         )
+        // This may happen if this is an initial state in which the socket type was not yet set.
+        // If this is a field that holds the response handshake record from the peer, this means that it wasn't received
+        // yet. HSv5: added version check because in HSv5 the m_iType field has different meaning and it may be 0 in
+        // case when the handshake does not carry SRT extensions.
+        && (hsv5 || m_ConnRes.m_iType != UDT_UNDEFINED))
+    {
+        // a data packet or a keep-alive packet comes, which means the peer side is already connected
+        // in this situation, the previously recorded response will be used
+        // In HSv5 this situation is theoretically possible if this party has missed the URQ_AGREEMENT message.
+        HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: already connected - pinning in");
+        if (hsv5)
+        {
+            m_RdvState = CHandShake::RDV_CONNECTED;
+        }
 
-   if (!response.isControl(UMSG_HANDSHAKE))
-   {
-       m_RejectReason = SRT_REJ_ROGUE;
-       if (!response.isControl())
-       {
-           LOGC(mglog.Error, log << CONID() << "processConnectResponse: received DATA while HANDSHAKE expected");
-       }
-       else
-       {
-           LOGC(mglog.Error, log << CONID()
-                   << "processConnectResponse: CONFUSED: expected UMSG_HANDSHAKE as connection not yet established, got: "
-                   << MessageTypeStr(response.getType(), response.getExtendedType()));
-       }
-       return CONN_CONFUSED;
-   }
+        return postConnect(response, hsv5, eout, synchro);
+    }
 
+    if (!response.isControl(UMSG_HANDSHAKE))
+    {
+        m_RejectReason = SRT_REJ_ROGUE;
+        if (!response.isControl())
+        {
+            LOGC(mglog.Error, log << CONID() << "processConnectResponse: received DATA while HANDSHAKE expected");
+        }
+        else
+        {
+            LOGC(mglog.Error,
+                 log << CONID()
+                     << "processConnectResponse: CONFUSED: expected UMSG_HANDSHAKE as connection not yet established, "
+                        "got: "
+                     << MessageTypeStr(response.getType(), response.getExtendedType()));
+        }
+        return CONN_CONFUSED;
+    }
 
-   if ( m_ConnRes.load_from(response.m_pcData, response.getLength()) == -1 )
-   {
-       m_RejectReason = SRT_REJ_ROGUE;
-       // Handshake data were too small to reach the Handshake structure. Reject.
-       LOGC(mglog.Error, log << CONID() << "processConnectResponse: HANDSHAKE data buffer too small - possible blueboxing. Rejecting.");
-       return CONN_REJECT;
-   }
+    if (m_ConnRes.load_from(response.m_pcData, response.getLength()) == -1)
+    {
+        m_RejectReason = SRT_REJ_ROGUE;
+        // Handshake data were too small to reach the Handshake structure. Reject.
+        LOGC(mglog.Error,
+             log << CONID()
+                 << "processConnectResponse: HANDSHAKE data buffer too small - possible blueboxing. Rejecting.");
+        return CONN_REJECT;
+    }
 
-   HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: HS RECEIVED: " << m_ConnRes.show());
-   if ( m_ConnRes.m_iReqType > URQ_FAILURE_TYPES )
-   {
-       m_RejectReason = RejectReasonForURQ(m_ConnRes.m_iReqType);
-       return CONN_REJECT;
-   }
+    HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: HS RECEIVED: " << m_ConnRes.show());
+    if (m_ConnRes.m_iReqType > URQ_FAILURE_TYPES)
+    {
+        m_RejectReason = RejectReasonForURQ(m_ConnRes.m_iReqType);
+        return CONN_REJECT;
+    }
 
-   if ( size_t(m_ConnRes.m_iMSS) > CPacket::ETH_MAX_MTU_SIZE )
-   {
-       // Yes, we do abort to prevent buffer overrun. Set your MSS correctly
-       // and you'll avoid problems.
-       m_RejectReason = SRT_REJ_ROGUE;
-       LOGC(mglog.Fatal, log << "MSS size " << m_iMSS << "exceeds MTU size!");
-       return CONN_REJECT;
-   }
+    if (size_t(m_ConnRes.m_iMSS) > CPacket::ETH_MAX_MTU_SIZE)
+    {
+        // Yes, we do abort to prevent buffer overrun. Set your MSS correctly
+        // and you'll avoid problems.
+        m_RejectReason = SRT_REJ_ROGUE;
+        LOGC(mglog.Fatal, log << "MSS size " << m_iMSS << "exceeds MTU size!");
+        return CONN_REJECT;
+    }
 
-   // (see createCrypter() call below)
-   //
-   // The CCryptoControl attached object must be created early
-   // because it will be required to create a conclusion handshake in HSv5
-   // 
-   if (m_bRendezvous)
-   {
-       // SANITY CHECK: A rendezvous socket should reject any caller requests (it's not a listener)
-       if (m_ConnRes.m_iReqType == URQ_INDUCTION)
-       {
-           m_RejectReason = SRT_REJ_ROGUE;
-           LOGC(mglog.Error, log << CONID() << "processConnectResponse: Rendezvous-point received INDUCTION handshake (expected WAVEAHAND). Rejecting.");
-           return CONN_REJECT;
-       }
+    // (see createCrypter() call below)
+    //
+    // The CCryptoControl attached object must be created early
+    // because it will be required to create a conclusion handshake in HSv5
+    //
+    if (m_bRendezvous)
+    {
+        // SANITY CHECK: A rendezvous socket should reject any caller requests (it's not a listener)
+        if (m_ConnRes.m_iReqType == URQ_INDUCTION)
+        {
+            m_RejectReason = SRT_REJ_ROGUE;
+            LOGC(mglog.Error,
+                 log << CONID()
+                     << "processConnectResponse: Rendezvous-point received INDUCTION handshake (expected WAVEAHAND). "
+                        "Rejecting.");
+            return CONN_REJECT;
+        }
 
-       // The procedure for version 5 is completely different and changes the states
-       // differently, so the old code will still maintain HSv4 the old way.
+        // The procedure for version 5 is completely different and changes the states
+        // differently, so the old code will still maintain HSv4 the old way.
 
-       if ( m_ConnRes.m_iVersion > HS_VERSION_UDT4 )
-       {
-           HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: Rendezvous HSv5 DETECTED.");
-           return CONN_RENDEZVOUS; // --> will continue in CUDT::processRendezvous().
-       }
+        if (m_ConnRes.m_iVersion > HS_VERSION_UDT4)
+        {
+            HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: Rendezvous HSv5 DETECTED.");
+            return CONN_RENDEZVOUS; // --> will continue in CUDT::processRendezvous().
+        }
 
-       HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: Rendsezvous HSv4 DETECTED.");
-       // So, here it has either received URQ_WAVEAHAND handshake message (while it should be in URQ_WAVEAHAND itself)
-       // or it has received URQ_CONCLUSION/URQ_AGREEMENT message while this box has already sent URQ_WAVEAHAND to the peer,
-       // and DID NOT send the URQ_CONCLUSION yet.
+        HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: Rendsezvous HSv4 DETECTED.");
+        // So, here it has either received URQ_WAVEAHAND handshake message (while it should be in URQ_WAVEAHAND itself)
+        // or it has received URQ_CONCLUSION/URQ_AGREEMENT message while this box has already sent URQ_WAVEAHAND to the
+        // peer, and DID NOT send the URQ_CONCLUSION yet.
 
-       if ( m_ConnReq.m_iReqType == URQ_WAVEAHAND
-               || m_ConnRes.m_iReqType == URQ_WAVEAHAND )
-       {
-           HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: REQ-TIME LOW. got HS RDV. Agent state:" << RequestTypeStr(m_ConnReq.m_iReqType)
-               << " Peer HS:" << m_ConnRes.show());
+        if (m_ConnReq.m_iReqType == URQ_WAVEAHAND || m_ConnRes.m_iReqType == URQ_WAVEAHAND)
+        {
+            HLOGC(mglog.Debug,
+                  log << CONID() << "processConnectResponse: REQ-TIME LOW. got HS RDV. Agent state:"
+                      << RequestTypeStr(m_ConnReq.m_iReqType) << " Peer HS:" << m_ConnRes.show());
 
-           // Here we could have received WAVEAHAND or CONCLUSION.
-           // For HSv4 simply switch to CONCLUSION for the sake of further handshake rolling.
-           // For HSv5, make the cookie contest and basing on this decide, which party
-           // should provide the HSREQ/KMREQ attachment.
+            // Here we could have received WAVEAHAND or CONCLUSION.
+            // For HSv4 simply switch to CONCLUSION for the sake of further handshake rolling.
+            // For HSv5, make the cookie contest and basing on this decide, which party
+            // should provide the HSREQ/KMREQ attachment.
 
+            if (!createCrypter(hsd, false /* unidirectional */))
+            {
+                m_RejectReason       = SRT_REJ_RESOURCE;
+                m_ConnReq.m_iReqType = URQFailure(SRT_REJ_RESOURCE);
+                // the request time must be updated so that the next handshake can be sent out immediately.
+                m_llLastReqTime = 0;
+                return CONN_REJECT;
+            }
 
-           if (!createCrypter(hsd, false /* unidirectional */))
-           {
-               m_RejectReason = SRT_REJ_RESOURCE;
-               m_ConnReq.m_iReqType = URQFailure(SRT_REJ_RESOURCE);
-               // the request time must be updated so that the next handshake can be sent out immediately.
-               m_llLastReqTime = 0;
-               return CONN_REJECT;
-           }
+            m_ConnReq.m_iReqType = URQ_CONCLUSION;
+            // the request time must be updated so that the next handshake can be sent out immediately.
+            m_llLastReqTime = 0;
+            return CONN_CONTINUE;
+        }
+        else
+        {
+            HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: Rendezvous HSv4 PAST waveahand");
+        }
+    }
+    else
+    {
+        // set cookie
+        if (m_ConnRes.m_iReqType == URQ_INDUCTION)
+        {
+            HLOGC(mglog.Debug,
+                  log << CONID() << "processConnectResponse: REQ-TIME LOW; got INDUCTION HS response (cookie:" << hex
+                      << m_ConnRes.m_iCookie << " version:" << dec << m_ConnRes.m_iVersion
+                      << "), sending CONCLUSION HS with this cookie");
 
-           m_ConnReq.m_iReqType = URQ_CONCLUSION;
-           // the request time must be updated so that the next handshake can be sent out immediately.
-           m_llLastReqTime = 0;
-           return CONN_CONTINUE;
-       }
-       else
-       {
-           HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: Rendezvous HSv4 PAST waveahand");
-       }
-   }
-   else
-   {
-      // set cookie
-      if (m_ConnRes.m_iReqType == URQ_INDUCTION)
-      {
-         HLOGC(mglog.Debug, log << CONID() << "processConnectResponse: REQ-TIME LOW; got INDUCTION HS response (cookie:"
-             << hex << m_ConnRes.m_iCookie << " version:" << dec << m_ConnRes.m_iVersion << "), sending CONCLUSION HS with this cookie");
+            m_ConnReq.m_iCookie  = m_ConnRes.m_iCookie;
+            m_ConnReq.m_iReqType = URQ_CONCLUSION;
 
-         m_ConnReq.m_iCookie = m_ConnRes.m_iCookie;
-         m_ConnReq.m_iReqType = URQ_CONCLUSION;
+            // Here test if the LISTENER has responded with version HS_VERSION_SRT1,
+            // it means that it is HSv5 capable. It can still accept the HSv4 handshake.
+            if (m_ConnRes.m_iVersion > HS_VERSION_UDT4)
+            {
+                int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
 
-         // Here test if the LISTENER has responded with version HS_VERSION_SRT1,
-         // it means that it is HSv5 capable. It can still accept the HSv4 handshake.
-         if ( m_ConnRes.m_iVersion > HS_VERSION_UDT4 )
-         {
-             int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
+                if (hs_flags != SrtHSRequest::SRT_MAGIC_CODE)
+                {
+                    LOGC(mglog.Warn, log << "processConnectResponse: Listener HSv5 did not set the SRT_MAGIC_CODE");
+                }
 
-             if (hs_flags != SrtHSRequest::SRT_MAGIC_CODE)
-             {
-                 LOGC(mglog.Warn, log << "processConnectResponse: Listener HSv5 did not set the SRT_MAGIC_CODE");
-             }
+                checkUpdateCryptoKeyLen("processConnectResponse", m_ConnRes.m_iType);
 
-             checkUpdateCryptoKeyLen("processConnectResponse", m_ConnRes.m_iType);
+                // This will catch HS_VERSION_SRT1 and any newer.
+                // Set your highest version.
+                m_ConnReq.m_iVersion = HS_VERSION_SRT1;
+                // CONTROVERSIAL: use 0 as m_iType according to the meaning in HSv5.
+                // The HSv4 client might not understand it, which means that agent
+                // must switch itself to HSv4 rendezvous, and this time iType sould
+                // be set to UDT_DGRAM value.
+                m_ConnReq.m_iType = 0;
 
-             // This will catch HS_VERSION_SRT1 and any newer.
-             // Set your highest version.
-             m_ConnReq.m_iVersion = HS_VERSION_SRT1;
-             // CONTROVERSIAL: use 0 as m_iType according to the meaning in HSv5.
-             // The HSv4 client might not understand it, which means that agent
-             // must switch itself to HSv4 rendezvous, and this time iType sould
-             // be set to UDT_DGRAM value.
-             m_ConnReq.m_iType = 0;
+                // This marks the information for the serializer that
+                // the SRT handshake extension is required.
+                // Rest of the data will be filled together with
+                // serialization.
+                m_ConnReq.m_extension = true;
 
-             // This marks the information for the serializer that
-             // the SRT handshake extension is required.
-             // Rest of the data will be filled together with
-             // serialization.
-             m_ConnReq.m_extension = true;
+                // For HSv5, the caller is INITIATOR and the listener is RESPONDER.
+                // The m_bDataSender value should be completely ignored and the
+                // connection is always bidirectional.
+                bidirectional = true;
+                hsd           = HSD_INITIATOR;
+            }
+            m_llLastReqTime = 0;
+            if (!createCrypter(hsd, bidirectional))
+            {
+                m_RejectReason = SRT_REJ_RESOURCE;
+                return CONN_REJECT;
+            }
+            // NOTE: This setup sets URQ_CONCLUSION and appropriate data in the handshake structure.
+            // The full handshake to be sent will be filled back in the caller function -- CUDT::startConnect().
+            return CONN_CONTINUE;
+        }
+    }
 
-             // For HSv5, the caller is INITIATOR and the listener is RESPONDER.
-             // The m_bDataSender value should be completely ignored and the
-             // connection is always bidirectional.
-             bidirectional = true;
-             hsd = HSD_INITIATOR;
-         }
-         m_llLastReqTime = 0;
-         if (!createCrypter(hsd, bidirectional))
-         {
-             m_RejectReason = SRT_REJ_RESOURCE;
-             return CONN_REJECT;
-         }
-         // NOTE: This setup sets URQ_CONCLUSION and appropriate data in the handshake structure.
-         // The full handshake to be sent will be filled back in the caller function -- CUDT::startConnect().
-         return CONN_CONTINUE;
-      }
-   }
-
-   return postConnect(response, false, eout, synchro);
+    return postConnect(response, false, eout, synchro);
 }
 
 void CUDT::applyResponseSettings()
 {
     // Re-configure according to the negotiated values.
-    m_iMSS = m_ConnRes.m_iMSS;
-    m_iFlowWindowSize = m_ConnRes.m_iFlightFlagSize;
-    int udpsize = m_iMSS - CPacket::UDP_HDR_SIZE;
+    m_iMSS               = m_ConnRes.m_iMSS;
+    m_iFlowWindowSize    = m_ConnRes.m_iFlightFlagSize;
+    int udpsize          = m_iMSS - CPacket::UDP_HDR_SIZE;
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
-    m_iPeerISN = m_ConnRes.m_iISN;
-    m_iRcvLastAck = m_ConnRes.m_iISN;
+    m_iPeerISN           = m_ConnRes.m_iISN;
+    m_iRcvLastAck        = m_ConnRes.m_iISN;
 #ifdef ENABLE_LOGGING
     m_iDebugPrevLastAck = m_iRcvLastAck;
 #endif
-    m_iRcvLastSkipAck = m_iRcvLastAck;
-    m_iRcvLastAckAck = m_ConnRes.m_iISN;
-    m_iRcvCurrSeqNo = m_ConnRes.m_iISN - 1;
+    m_iRcvLastSkipAck  = m_iRcvLastAck;
+    m_iRcvLastAckAck   = m_ConnRes.m_iISN;
+    m_iRcvCurrSeqNo    = m_ConnRes.m_iISN - 1;
     m_iRcvCurrPhySeqNo = m_ConnRes.m_iISN - 1;
-    m_PeerID = m_ConnRes.m_iID;
+    m_PeerID           = m_ConnRes.m_iID;
     memcpy(m_piSelfIP, m_ConnRes.m_piPeerIP, 16);
 
-    HLOGC(mglog.Debug, log << CONID() << "applyResponseSettings: HANSHAKE CONCLUDED. SETTING: payload-size=" << m_iMaxSRTPayloadSize
-        << " mss=" << m_ConnRes.m_iMSS
-        << " flw=" << m_ConnRes.m_iFlightFlagSize
-        << " isn=" << m_ConnRes.m_iISN
-        << " peerID=" << m_ConnRes.m_iID);
+    HLOGC(mglog.Debug,
+          log << CONID() << "applyResponseSettings: HANSHAKE CONCLUDED. SETTING: payload-size=" << m_iMaxSRTPayloadSize
+              << " mss=" << m_ConnRes.m_iMSS << " flw=" << m_ConnRes.m_iFlightFlagSize << " isn=" << m_ConnRes.m_iISN
+              << " peerID=" << m_ConnRes.m_iID);
 }
 
-EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro)
+EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTException *eout, bool synchro)
 {
-    if (m_ConnRes.m_iVersion < HS_VERSION_SRT1 )
+    if (m_ConnRes.m_iVersion < HS_VERSION_SRT1)
         m_ullRcvPeerStartTime = 0; // will be set correctly in SRT HS.
 
     // This procedure isn't being executed in rendezvous because
     // in rendezvous it's completed before calling this function.
-    if ( !rendezvous )
+    if (!rendezvous)
     {
         // NOTE: THIS function must be called before calling prepareConnectionObjects.
         // The reason why it's not part of prepareConnectionObjects is that the activities
@@ -4157,7 +4263,7 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
                 *eout = CUDTException(MJ_SETUP, MN_REJECTED, 0);
             }
         }
-        if ( !ok ) // m_RejectReason already set
+        if (!ok) // m_RejectReason already set
             return CONN_REJECT;
     }
 
@@ -4166,7 +4272,7 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
     CInfoBlock::convert(m_pPeerAddr, m_iIPversion, ib.m_piIP);
     if (m_pCache->lookup(&ib) >= 0)
     {
-        m_iRTT = ib.m_iRTT;
+        m_iRTT       = ib.m_iRTT;
         m_iBandwidth = ib.m_iBandwidth;
     }
 
@@ -4179,7 +4285,7 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
 
     // And, I am connected too.
     m_bConnecting = false;
-    m_bConnected = true;
+    m_bConnected  = true;
 
     // register this socket for receiving data packets
     m_pRNode->m_bOnList = true;
@@ -4218,7 +4324,7 @@ EConnectStatus CUDT::postConnect(const CPacket& response, bool rendezvous, CUDTE
     return CONN_ACCEPT;
 }
 
-void CUDT::checkUpdateCryptoKeyLen(const char* loghdr SRT_ATR_UNUSED, int32_t typefield)
+void CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t typefield)
 {
     int enc_flags = SrtHSRequest::SRT_HSTYPE_ENCFLAGS::unwrap(typefield);
 
@@ -4239,14 +4345,16 @@ void CUDT::checkUpdateCryptoKeyLen(const char* loghdr SRT_ATR_UNUSED, int32_t ty
             // the enforcement, otherwise simply let it win.
             if (!m_bDataSender)
             {
-                LOGC(mglog.Warn, log << loghdr << ": PBKEYLEN conflict - OVERRIDDEN " << m_iSndCryptoKeyLen
-                       << " by " << rcv_pbkeylen << " from PEER (as AGENT is not SRTO_SENDER)");
+                LOGC(mglog.Warn,
+                     log << loghdr << ": PBKEYLEN conflict - OVERRIDDEN " << m_iSndCryptoKeyLen << " by "
+                         << rcv_pbkeylen << " from PEER (as AGENT is not SRTO_SENDER)");
                 m_iSndCryptoKeyLen = rcv_pbkeylen;
             }
             else
             {
-                LOGC(mglog.Warn, log << loghdr << ": PBKEYLEN conflict - keep " << m_iSndCryptoKeyLen << "; peer-advertised PBKEYLEN "
-                        << rcv_pbkeylen << " rejected because Agent is SRTO_SENDER");
+                LOGC(mglog.Warn,
+                     log << loghdr << ": PBKEYLEN conflict - keep " << m_iSndCryptoKeyLen
+                         << "; peer-advertised PBKEYLEN " << rcv_pbkeylen << " rejected because Agent is SRTO_SENDER");
             }
         }
     }
@@ -4263,11 +4371,11 @@ void CUDT::checkUpdateCryptoKeyLen(const char* loghdr SRT_ATR_UNUSED, int32_t ty
 // Rendezvous
 void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> needs_extension, ref_t<bool> needs_hsrsp)
 {
-    UDTRequestType req = m_ConnRes.m_iReqType;
-    int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
-    bool has_extension = !!hs_flags; // it holds flags, if no flags, there are no extensions.
+    UDTRequestType req           = m_ConnRes.m_iReqType;
+    int            hs_flags      = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
+    bool           has_extension = !!hs_flags; // it holds flags, if no flags, there are no extensions.
 
-    const HandshakeSide& hsd = m_SrtHsSide;
+    const HandshakeSide &hsd = m_SrtHsSide;
     // Note important possibilities that are considered here:
 
     // 1. The serial arrangement. This happens when one party has missed the
@@ -4301,7 +4409,7 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
 
     // DEFAULT STATEMENT: don't attach extensions to URQ_CONCLUSION, neither HSREQ nor HSRSP.
     *needs_extension = false;
-    *needs_hsrsp = false;
+    *needs_hsrsp     = false;
 
     string reason;
 
@@ -4311,289 +4419,299 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
 
     struct LogAtTheEnd
     {
-        CHandShake::RendezvousState ost;
-        UDTRequestType orq;
-        const CHandShake::RendezvousState& nst;
-        const UDTRequestType& nrq;
-        bool& needext;
-        bool& needrsp;
-        string& reason;
+        CHandShake::RendezvousState        ost;
+        UDTRequestType                     orq;
+        const CHandShake::RendezvousState &nst;
+        const UDTRequestType &             nrq;
+        bool &                             needext;
+        bool &                             needrsp;
+        string &                           reason;
 
         ~LogAtTheEnd()
         {
-            HLOGC(mglog.Debug, log << "rendezvousSwitchState: STATE["
-                << CHandShake::RdvStateStr(ost) << "->" << CHandShake::RdvStateStr(nst) << "] REQTYPE["
-                << RequestTypeStr(orq) << "->" << RequestTypeStr(nrq) << "] "
-                << "ext:" << (needext ? (needrsp ? "HSRSP" : "HSREQ") : "NONE")
-                << (reason == "" ? string() : "reason:" + reason));
+            HLOGC(mglog.Debug,
+                  log << "rendezvousSwitchState: STATE[" << CHandShake::RdvStateStr(ost) << "->"
+                      << CHandShake::RdvStateStr(nst) << "] REQTYPE[" << RequestTypeStr(orq) << "->"
+                      << RequestTypeStr(nrq) << "] "
+                      << "ext:" << (needext ? (needrsp ? "HSRSP" : "HSREQ") : "NONE")
+                      << (reason == "" ? string() : "reason:" + reason));
         }
-      } l_logend = {m_RdvState, req, m_RdvState, *rsptype, *needs_extension, *needs_hsrsp, reason};
+    } l_logend = {m_RdvState, req, m_RdvState, *rsptype, *needs_extension, *needs_hsrsp, reason};
 
 #endif
 
     switch (m_RdvState)
     {
-    case CHandShake::RDV_INVALID: return;
+    case CHandShake::RDV_INVALID:
+        return;
 
     case CHandShake::RDV_WAVING:
+    {
+        if (req == URQ_WAVEAHAND)
         {
-            if ( req == URQ_WAVEAHAND )
-            {
-                m_RdvState = CHandShake::RDV_ATTENTION;
+            m_RdvState = CHandShake::RDV_ATTENTION;
 
-                // NOTE: if this->isWinner(), attach HSREQ
-                *rsptype = URQ_CONCLUSION;
-                if ( hsd == HSD_INITIATOR )
-                    *needs_extension = true;
-                return;
-            }
-
-            if ( req == URQ_CONCLUSION )
-            {
-                m_RdvState = CHandShake::RDV_FINE;
-                *rsptype = URQ_CONCLUSION;
-
-                *needs_extension = true; // (see below - this needs to craft either HSREQ or HSRSP)
-                // if this->isWinner(), then craft HSREQ for that response.
-                // if this->isLoser(), then this packet should bring HSREQ, so craft HSRSP for the response.
-                if ( hsd == HSD_RESPONDER )
-                    *needs_hsrsp = true;
-                return;
-            }
-
+            // NOTE: if this->isWinner(), attach HSREQ
+            *rsptype = URQ_CONCLUSION;
+            if (hsd == HSD_INITIATOR)
+                *needs_extension = true;
+            return;
         }
+
+        if (req == URQ_CONCLUSION)
+        {
+            m_RdvState = CHandShake::RDV_FINE;
+            *rsptype   = URQ_CONCLUSION;
+
+            *needs_extension = true; // (see below - this needs to craft either HSREQ or HSRSP)
+            // if this->isWinner(), then craft HSREQ for that response.
+            // if this->isLoser(), then this packet should bring HSREQ, so craft HSRSP for the response.
+            if (hsd == HSD_RESPONDER)
+                *needs_hsrsp = true;
+            return;
+        }
+    }
         reason = "WAVING -> WAVEAHAND or CONCLUSION";
         break;
 
     case CHandShake::RDV_ATTENTION:
+    {
+        if (req == URQ_WAVEAHAND)
         {
-            if ( req == URQ_WAVEAHAND )
-            {
-                // This is only possible if the URQ_CONCLUSION sent to the peer
-                // was lost on track. The peer is then simply unaware that the
-                // agent has switched to ATTENTION state and continues sending
-                // waveahands. In this case, just remain in ATTENTION state and
-                // retry with URQ_CONCLUSION, as normally.
-                *rsptype = URQ_CONCLUSION;
-                if ( hsd == HSD_INITIATOR )
-                    *needs_extension = true;
-                return;
-            }
-
-            if ( req == URQ_CONCLUSION )
-            {
-                // We have two possibilities here:
-                //
-                // WINNER (HSD_INITIATOR): send URQ_AGREEMENT
-                if ( hsd == HSD_INITIATOR )
-                {
-                    // WINNER should get a response with HSRSP, otherwise this is kinda empty conclusion.
-                    // If no HSRSP attached, stay in this state.
-                    if (hs_flags == 0)
-                    {
-                        HLOGC(mglog.Debug, log << "rendezvousSwitchState: "
-                            "{INITIATOR}[ATTENTION] awaits CONCLUSION+HSRSP, got CONCLUSION, remain in [ATTENTION]");
-                        *rsptype = URQ_CONCLUSION;
-                        *needs_extension = true; // If you expect to receive HSRSP, continue sending HSREQ
-                        return;
-                    }
-                    m_RdvState = CHandShake::RDV_CONNECTED;
-                    *rsptype = URQ_AGREEMENT;
-                    return;
-                }
-
-                // LOSER (HSD_RESPONDER): send URQ_CONCLUSION and attach HSRSP extension, then expect URQ_AGREEMENT
-                if ( hsd == HSD_RESPONDER )
-                {
-                    // If no HSREQ attached, stay in this state.
-                    // (Although this seems completely impossible).
-                    if (hs_flags == 0)
-                    {
-                        LOGC(mglog.Warn, log << "rendezvousSwitchState: (IPE!)"
-                            "{RESPONDER}[ATTENTION] awaits CONCLUSION+HSREQ, got CONCLUSION, remain in [ATTENTION]");
-                        *rsptype = URQ_CONCLUSION;
-                        *needs_extension = false; // If you received WITHOUT extensions, respond WITHOUT extensions (wait for the right message)
-                        return;
-                    }
-                    m_RdvState = CHandShake::RDV_INITIATED;
-                    *rsptype = URQ_CONCLUSION;
-                    *needs_extension = true;
-                    *needs_hsrsp = true;
-                    return;
-                }
-
-                LOGC(mglog.Error, log << "RENDEZVOUS COOKIE DRAW! Cannot resolve to a valid state.");
-                // Fallback for cookie draw
-                m_RdvState = CHandShake::RDV_INVALID;
-                *rsptype = URQFailure(SRT_REJ_RDVCOOKIE);
-                return;
-            }
-
-            if ( req == URQ_AGREEMENT )
-            {
-                // This means that the peer has received our URQ_CONCLUSION, but
-                // the agent missed the peer's URQ_CONCLUSION (received only initial
-                // URQ_WAVEAHAND).
-                if ( hsd == HSD_INITIATOR )
-                {
-                    // In this case the missed URQ_CONCLUSION was sent without extensions,
-                    // whereas the peer received our URQ_CONCLUSION with HSREQ, and therefore
-                    // it sent URQ_AGREEMENT already with HSRSP. This isn't a problem for
-                    // us, we can go on with it, especially that the peer is already switched
-                    // into CHandShake::RDV_CONNECTED state.
-                    m_RdvState = CHandShake::RDV_CONNECTED;
-
-                    // Both sides are connected, no need to send anything anymore.
-                    *rsptype = URQ_DONE;
-                    return;
-                }
-
-                if ( hsd == HSD_RESPONDER )
-                {
-                    // In this case the missed URQ_CONCLUSION was sent with extensions, so
-                    // we have to request this once again. Send URQ_CONCLUSION in order to
-                    // inform the other party that we need the conclusion message once again.
-                    // The ATTENTION state should be maintained.
-                    *rsptype = URQ_CONCLUSION;
-                    *needs_extension = true;
-                    *needs_hsrsp = true;
-                    return;
-                }
-            }
-
+            // This is only possible if the URQ_CONCLUSION sent to the peer
+            // was lost on track. The peer is then simply unaware that the
+            // agent has switched to ATTENTION state and continues sending
+            // waveahands. In this case, just remain in ATTENTION state and
+            // retry with URQ_CONCLUSION, as normally.
+            *rsptype = URQ_CONCLUSION;
+            if (hsd == HSD_INITIATOR)
+                *needs_extension = true;
+            return;
         }
+
+        if (req == URQ_CONCLUSION)
+        {
+            // We have two possibilities here:
+            //
+            // WINNER (HSD_INITIATOR): send URQ_AGREEMENT
+            if (hsd == HSD_INITIATOR)
+            {
+                // WINNER should get a response with HSRSP, otherwise this is kinda empty conclusion.
+                // If no HSRSP attached, stay in this state.
+                if (hs_flags == 0)
+                {
+                    HLOGC(
+                        mglog.Debug,
+                        log << "rendezvousSwitchState: "
+                               "{INITIATOR}[ATTENTION] awaits CONCLUSION+HSRSP, got CONCLUSION, remain in [ATTENTION]");
+                    *rsptype         = URQ_CONCLUSION;
+                    *needs_extension = true; // If you expect to receive HSRSP, continue sending HSREQ
+                    return;
+                }
+                m_RdvState = CHandShake::RDV_CONNECTED;
+                *rsptype   = URQ_AGREEMENT;
+                return;
+            }
+
+            // LOSER (HSD_RESPONDER): send URQ_CONCLUSION and attach HSRSP extension, then expect URQ_AGREEMENT
+            if (hsd == HSD_RESPONDER)
+            {
+                // If no HSREQ attached, stay in this state.
+                // (Although this seems completely impossible).
+                if (hs_flags == 0)
+                {
+                    LOGC(
+                        mglog.Warn,
+                        log << "rendezvousSwitchState: (IPE!)"
+                               "{RESPONDER}[ATTENTION] awaits CONCLUSION+HSREQ, got CONCLUSION, remain in [ATTENTION]");
+                    *rsptype         = URQ_CONCLUSION;
+                    *needs_extension = false; // If you received WITHOUT extensions, respond WITHOUT extensions (wait
+                                              // for the right message)
+                    return;
+                }
+                m_RdvState       = CHandShake::RDV_INITIATED;
+                *rsptype         = URQ_CONCLUSION;
+                *needs_extension = true;
+                *needs_hsrsp     = true;
+                return;
+            }
+
+            LOGC(mglog.Error, log << "RENDEZVOUS COOKIE DRAW! Cannot resolve to a valid state.");
+            // Fallback for cookie draw
+            m_RdvState = CHandShake::RDV_INVALID;
+            *rsptype   = URQFailure(SRT_REJ_RDVCOOKIE);
+            return;
+        }
+
+        if (req == URQ_AGREEMENT)
+        {
+            // This means that the peer has received our URQ_CONCLUSION, but
+            // the agent missed the peer's URQ_CONCLUSION (received only initial
+            // URQ_WAVEAHAND).
+            if (hsd == HSD_INITIATOR)
+            {
+                // In this case the missed URQ_CONCLUSION was sent without extensions,
+                // whereas the peer received our URQ_CONCLUSION with HSREQ, and therefore
+                // it sent URQ_AGREEMENT already with HSRSP. This isn't a problem for
+                // us, we can go on with it, especially that the peer is already switched
+                // into CHandShake::RDV_CONNECTED state.
+                m_RdvState = CHandShake::RDV_CONNECTED;
+
+                // Both sides are connected, no need to send anything anymore.
+                *rsptype = URQ_DONE;
+                return;
+            }
+
+            if (hsd == HSD_RESPONDER)
+            {
+                // In this case the missed URQ_CONCLUSION was sent with extensions, so
+                // we have to request this once again. Send URQ_CONCLUSION in order to
+                // inform the other party that we need the conclusion message once again.
+                // The ATTENTION state should be maintained.
+                *rsptype         = URQ_CONCLUSION;
+                *needs_extension = true;
+                *needs_hsrsp     = true;
+                return;
+            }
+        }
+    }
         reason = "ATTENTION -> WAVEAHAND(conclusion), CONCLUSION(agreement/conclusion), AGREEMENT (done/conclusion)";
         break;
 
     case CHandShake::RDV_FINE:
+    {
+        // In FINE state we can't receive URQ_WAVEAHAND because if the peer has already
+        // sent URQ_CONCLUSION, it's already in CHandShake::RDV_ATTENTION, and in this state it can
+        // only send URQ_CONCLUSION, whereas when it isn't in CHandShake::RDV_ATTENTION, it couldn't
+        // have sent URQ_CONCLUSION, and if it didn't, the agent wouldn't be in CHandShake::RDV_FINE state.
+
+        if (req == URQ_CONCLUSION)
         {
-            // In FINE state we can't receive URQ_WAVEAHAND because if the peer has already
-            // sent URQ_CONCLUSION, it's already in CHandShake::RDV_ATTENTION, and in this state it can
-            // only send URQ_CONCLUSION, whereas when it isn't in CHandShake::RDV_ATTENTION, it couldn't
-            // have sent URQ_CONCLUSION, and if it didn't, the agent wouldn't be in CHandShake::RDV_FINE state.
+            // There's only one case when it should receive CONCLUSION in FINE state:
+            // When it's the winner. If so, it should then contain HSREQ extension.
+            // In case of loser, it shouldn't receive CONCLUSION at all - it should
+            // receive AGREEMENT.
 
-            if ( req == URQ_CONCLUSION )
+            // The winner case, received CONCLUSION + HSRSP - switch to CONNECTED and send AGREEMENT.
+            // So, check first if HAS EXTENSION
+
+            bool correct_switch = false;
+            if (hsd == HSD_INITIATOR && !has_extension)
             {
-                // There's only one case when it should receive CONCLUSION in FINE state:
-                // When it's the winner. If so, it should then contain HSREQ extension.
-                // In case of loser, it shouldn't receive CONCLUSION at all - it should
-                // receive AGREEMENT.
+                // Received REPEATED empty conclusion that has initially switched it into FINE state.
+                // To exit FINE state we need the CONCLUSION message with HSRSP.
+                HLOGC(mglog.Debug,
+                      log << "rendezvousSwitchState: {INITIATOR}[FINE] <CONCLUSION without HSRSP. Stay in [FINE], "
+                             "await CONCLUSION+HSRSP");
+            }
+            else if (hsd == HSD_RESPONDER)
+            {
+                // In FINE state the RESPONDER expects only to be sent AGREEMENT.
+                // It has previously received CONCLUSION in WAVING state and this has switched
+                // it to FINE state. That CONCLUSION message should have contained extension,
+                // so if this is a repeated CONCLUSION+HSREQ, it should be responded with
+                // CONCLUSION+HSRSP.
+                HLOGC(mglog.Debug,
+                      log << "rendezvousSwitchState: {RESPONDER}[FINE] <CONCLUSION. Stay in [FINE], await AGREEMENT");
+            }
+            else
+            {
+                correct_switch = true;
+            }
 
-                // The winner case, received CONCLUSION + HSRSP - switch to CONNECTED and send AGREEMENT.
-                // So, check first if HAS EXTENSION
-
-                bool correct_switch = false;
-                if ( hsd == HSD_INITIATOR && !has_extension )
-                {
-                    // Received REPEATED empty conclusion that has initially switched it into FINE state.
-                    // To exit FINE state we need the CONCLUSION message with HSRSP.
-                    HLOGC(mglog.Debug, log << "rendezvousSwitchState: {INITIATOR}[FINE] <CONCLUSION without HSRSP. Stay in [FINE], await CONCLUSION+HSRSP");
-                }
-                else if ( hsd == HSD_RESPONDER )
-                {
-                    // In FINE state the RESPONDER expects only to be sent AGREEMENT.
-                    // It has previously received CONCLUSION in WAVING state and this has switched
-                    // it to FINE state. That CONCLUSION message should have contained extension,
-                    // so if this is a repeated CONCLUSION+HSREQ, it should be responded with
-                    // CONCLUSION+HSRSP.
-                    HLOGC(mglog.Debug, log << "rendezvousSwitchState: {RESPONDER}[FINE] <CONCLUSION. Stay in [FINE], await AGREEMENT");
-                }
-                else
-                {
-                    correct_switch = true;
-                }
-
-                if ( !correct_switch )
-                {
-                    *rsptype = URQ_CONCLUSION;
-                    // initiator should send HSREQ, responder HSRSP,
-                    // in both cases extension is needed
-                    *needs_extension = true;
-                    *needs_hsrsp = hsd == HSD_RESPONDER;
-                    return;
-                }
-
-                m_RdvState = CHandShake::RDV_CONNECTED;
-                *rsptype = URQ_AGREEMENT;
+            if (!correct_switch)
+            {
+                *rsptype = URQ_CONCLUSION;
+                // initiator should send HSREQ, responder HSRSP,
+                // in both cases extension is needed
+                *needs_extension = true;
+                *needs_hsrsp     = hsd == HSD_RESPONDER;
                 return;
             }
 
-            if ( req == URQ_AGREEMENT )
-            {
-                // The loser case, the agreement was sent in response to conclusion that
-                // already carried over the HSRSP extension.
-
-                // There's a theoretical case when URQ_AGREEMENT can be received in case of
-                // parallel arrangement, while the agent is already in CHandShake::RDV_CONNECTED state.
-                // This will be dispatched in the main loop and discarded.
-
-                m_RdvState = CHandShake::RDV_CONNECTED;
-                *rsptype = URQ_DONE;
-                return;
-            }
-
+            m_RdvState = CHandShake::RDV_CONNECTED;
+            *rsptype   = URQ_AGREEMENT;
+            return;
         }
+
+        if (req == URQ_AGREEMENT)
+        {
+            // The loser case, the agreement was sent in response to conclusion that
+            // already carried over the HSRSP extension.
+
+            // There's a theoretical case when URQ_AGREEMENT can be received in case of
+            // parallel arrangement, while the agent is already in CHandShake::RDV_CONNECTED state.
+            // This will be dispatched in the main loop and discarded.
+
+            m_RdvState = CHandShake::RDV_CONNECTED;
+            *rsptype   = URQ_DONE;
+            return;
+        }
+    }
 
         reason = "FINE -> CONCLUSION(agreement), AGREEMENT(done)";
         break;
     case CHandShake::RDV_INITIATED:
+    {
+        // In this state we just wait for URQ_AGREEMENT, which should cause it to
+        // switch to CONNECTED. No response required.
+        if (req == URQ_AGREEMENT)
         {
-            // In this state we just wait for URQ_AGREEMENT, which should cause it to
-            // switch to CONNECTED. No response required.
-            if ( req == URQ_AGREEMENT )
+            // No matter in which state we'd be, just switch to connected.
+            if (m_RdvState == CHandShake::RDV_CONNECTED)
             {
-                // No matter in which state we'd be, just switch to connected.
-                if (m_RdvState == CHandShake::RDV_CONNECTED)
-                {
-                    HLOGC(mglog.Debug, log << "<-- AGREEMENT: already connected");
-                }
-                else
-                {
-                    HLOGC(mglog.Debug, log << "<-- AGREEMENT: switched to connected");
-                }
-                m_RdvState = CHandShake::RDV_CONNECTED;
-                *rsptype = URQ_DONE;
-                return;
+                HLOGC(mglog.Debug, log << "<-- AGREEMENT: already connected");
             }
-
-            if ( req == URQ_CONCLUSION )
+            else
             {
-                // Receiving conclusion in this state means that the other party
-                // didn't get our conclusion, so send it again, the same as when
-                // exiting the ATTENTION state.
-                *rsptype = URQ_CONCLUSION;
-                if ( hsd == HSD_RESPONDER )
-                {
-                    HLOGC(mglog.Debug, log << "rendezvousSwitchState: "
-                        "{RESPONDER}[INITIATED] awaits AGREEMENT, "
-                        "got CONCLUSION, sending CONCLUSION+HSRSP");
-                    *needs_extension = true;
-                    *needs_hsrsp = true;
-                    return;
-                }
-
-                // Loser, initiated? This may only happen in parallel arrangement, where
-                // the agent exchanges empty conclusion messages with the peer, simultaneously
-                // exchanging HSREQ-HSRSP conclusion messages. Check if THIS message contained
-                // HSREQ, and set responding HSRSP in that case.
-                if ( hs_flags == 0 )
-                {
-                    HLOGC(mglog.Debug, log << "rendezvousSwitchState: "
-                        "{INITIATOR}[INITIATED] awaits AGREEMENT, "
-                        "got empty CONCLUSION, STILL RESPONDING CONCLUSION+HSRSP");
-                }
-                else
-                {
-
-                    HLOGC(mglog.Debug, log << "rendezvousSwitchState: "
-                            "{INITIATOR}[INITIATED] awaits AGREEMENT, "
-                            "got CONCLUSION+HSREQ, responding CONCLUSION+HSRSP");
-                }
-                *needs_extension = true;
-                *needs_hsrsp = true;
-                return;
+                HLOGC(mglog.Debug, log << "<-- AGREEMENT: switched to connected");
             }
+            m_RdvState = CHandShake::RDV_CONNECTED;
+            *rsptype   = URQ_DONE;
+            return;
         }
+
+        if (req == URQ_CONCLUSION)
+        {
+            // Receiving conclusion in this state means that the other party
+            // didn't get our conclusion, so send it again, the same as when
+            // exiting the ATTENTION state.
+            *rsptype = URQ_CONCLUSION;
+            if (hsd == HSD_RESPONDER)
+            {
+                HLOGC(mglog.Debug,
+                      log << "rendezvousSwitchState: "
+                             "{RESPONDER}[INITIATED] awaits AGREEMENT, "
+                             "got CONCLUSION, sending CONCLUSION+HSRSP");
+                *needs_extension = true;
+                *needs_hsrsp     = true;
+                return;
+            }
+
+            // Loser, initiated? This may only happen in parallel arrangement, where
+            // the agent exchanges empty conclusion messages with the peer, simultaneously
+            // exchanging HSREQ-HSRSP conclusion messages. Check if THIS message contained
+            // HSREQ, and set responding HSRSP in that case.
+            if (hs_flags == 0)
+            {
+                HLOGC(mglog.Debug,
+                      log << "rendezvousSwitchState: "
+                             "{INITIATOR}[INITIATED] awaits AGREEMENT, "
+                             "got empty CONCLUSION, STILL RESPONDING CONCLUSION+HSRSP");
+            }
+            else
+            {
+
+                HLOGC(mglog.Debug,
+                      log << "rendezvousSwitchState: "
+                             "{INITIATOR}[INITIATED] awaits AGREEMENT, "
+                             "got CONCLUSION+HSREQ, responding CONCLUSION+HSRSP");
+            }
+            *needs_extension = true;
+            *needs_hsrsp     = true;
+            return;
+        }
+    }
 
         reason = "INITIATED -> AGREEMENT(done)";
         break;
@@ -4607,172 +4725,175 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
     HLOGC(mglog.Debug, log << "rendezvousSwitchState: INVALID STATE TRANSITION, result: INVALID");
     // All others are treated as errors
     m_RdvState = CHandShake::RDV_WAVING;
-    *rsptype = URQFailure(SRT_REJ_ROGUE);
+    *rsptype   = URQFailure(SRT_REJ_ROGUE);
 }
 
 /*
-* Timestamp-based Packet Delivery (TsbPd) thread
-* This thread runs only if TsbPd mode is enabled
-* Hold received packets until its time to 'play' them, at PktTimeStamp + TsbPdDelay.
-*/
-void* CUDT::tsbpd(void* param)
+ * Timestamp-based Packet Delivery (TsbPd) thread
+ * This thread runs only if TsbPd mode is enabled
+ * Hold received packets until its time to 'play' them, at PktTimeStamp + TsbPdDelay.
+ */
+void *CUDT::tsbpd(void *param)
 {
-   CUDT* self = (CUDT*)param;
+    CUDT *self = (CUDT *)param;
 
-   THREAD_STATE_INIT("SRT:TsbPd");
+    THREAD_STATE_INIT("SRT:TsbPd");
 
-   CGuard::enterCS(self->m_RecvLock);
-   self->m_bTsbPdAckWakeup = true;
-   while (!self->m_bClosing)
-   {
-      int32_t current_pkt_seq = 0;
-      uint64_t tsbpdtime = 0;
-      bool rxready = false;
+    CGuard::enterCS(self->m_RecvLock);
+    self->m_bTsbPdAckWakeup = true;
+    while (!self->m_bClosing)
+    {
+        int32_t  current_pkt_seq = 0;
+        uint64_t tsbpdtime       = 0;
+        bool     rxready         = false;
 
-      CGuard::enterCS(self->m_RcvBufferLock);
+        CGuard::enterCS(self->m_RcvBufferLock);
 
 #ifdef SRT_ENABLE_RCVBUFSZ_MAVG
-      self->m_pRcvBuffer->updRcvAvgDataSize(CTimer::getTime());
+        self->m_pRcvBuffer->updRcvAvgDataSize(CTimer::getTime());
 #endif
 
-      if (self->m_bTLPktDrop)
-      {
-          int32_t skiptoseqno = -1;
-          bool passack = true; //Get next packet to wait for even if not acked
+        if (self->m_bTLPktDrop)
+        {
+            int32_t skiptoseqno = -1;
+            bool passack = true; // Get next packet to wait for even if not acked
 
-          rxready = self->m_pRcvBuffer->getRcvFirstMsg(Ref(tsbpdtime), Ref(passack), Ref(skiptoseqno), Ref(current_pkt_seq));
+            rxready = self->m_pRcvBuffer->getRcvFirstMsg(
+                Ref(tsbpdtime), Ref(passack), Ref(skiptoseqno), Ref(current_pkt_seq));
 
-          HLOGC(tslog.Debug, log << boolalpha
-                  << "NEXT PKT CHECK: rdy=" << rxready
-                  << " passack=" << passack
-                  << " skipto=%" << skiptoseqno
-                  << " current=%" << current_pkt_seq
-                  << " buf-base=%" << self->m_iRcvLastSkipAck);
-          /*
-           * VALUES RETURNED:
-           *
-           * rxready:     if true, packet at head of queue ready to play
-           * tsbpdtime:   timestamp of packet at head of queue, ready or not. 0 if none.
-           * passack:     if true, ready head of queue not yet acknowledged
-           * skiptoseqno: sequence number of packet at head of queue if ready to play but
-           *              some preceeding packets are missing (need to be skipped). -1 if none. 
-           */
-          if (rxready)
-          {
-             /* Packet ready to play according to time stamp but... */
-             int seqlen = CSeqNo::seqoff(self->m_iRcvLastSkipAck, skiptoseqno);
+            HLOGC(tslog.Debug,
+                  log << boolalpha << "NEXT PKT CHECK: rdy=" << rxready << " passack=" << passack << " skipto=%"
+                      << skiptoseqno << " current=%" << current_pkt_seq << " buf-base=%" << self->m_iRcvLastSkipAck);
+            /*
+             * VALUES RETURNED:
+             *
+             * rxready:     if true, packet at head of queue ready to play
+             * tsbpdtime:   timestamp of packet at head of queue, ready or not. 0 if none.
+             * passack:     if true, ready head of queue not yet acknowledged
+             * skiptoseqno: sequence number of packet at head of queue if ready to play but
+             *              some preceeding packets are missing (need to be skipped). -1 if none.
+             */
+            if (rxready)
+            {
+                /* Packet ready to play according to time stamp but... */
+                int seqlen = CSeqNo::seqoff(self->m_iRcvLastSkipAck, skiptoseqno);
 
-             if (skiptoseqno != -1 && seqlen > 0)
-             {
-                /* 
-                * skiptoseqno != -1,
-                * packet ready to play but preceeded by missing packets (hole).
-                */
+                if (skiptoseqno != -1 && seqlen > 0)
+                {
+                    /*
+                     * skiptoseqno != -1,
+                     * packet ready to play but preceeded by missing packets (hole).
+                     */
 
-                /* Update drop/skip stats */
-                CGuard::enterCS(self->m_StatsLock);
-                self->m_stats.rcvDropTotal += seqlen;
-                self->m_stats.traceRcvDrop += seqlen;
-                /* Estimate dropped/skipped bytes from average payload */
-                int avgpayloadsz = self->m_pRcvBuffer->getRcvAvgPayloadSize();
-                self->m_stats.rcvBytesDropTotal += seqlen * avgpayloadsz;
-                self->m_stats.traceRcvBytesDrop += seqlen * avgpayloadsz;
-                CGuard::leaveCS(self->m_StatsLock);
+                    /* Update drop/skip stats */
+                    CGuard::enterCS(self->m_StatsLock);
+                    self->m_stats.rcvDropTotal += seqlen;
+                    self->m_stats.traceRcvDrop += seqlen;
+                    /* Estimate dropped/skipped bytes from average payload */
+                    int avgpayloadsz = self->m_pRcvBuffer->getRcvAvgPayloadSize();
+                    self->m_stats.rcvBytesDropTotal += seqlen * avgpayloadsz;
+                    self->m_stats.traceRcvBytesDrop += seqlen * avgpayloadsz;
+                    CGuard::leaveCS(self->m_StatsLock);
 
-                self->dropFromLossLists(self->m_iRcvLastSkipAck, CSeqNo::decseq(skiptoseqno)); //remove(from,to-inclusive)
-                self->m_pRcvBuffer->skipData(seqlen);
+                    self->dropFromLossLists(self->m_iRcvLastSkipAck,
+                                            CSeqNo::decseq(skiptoseqno)); // remove(from,to-inclusive)
+                    self->m_pRcvBuffer->skipData(seqlen);
 
-                self->m_iRcvLastSkipAck = skiptoseqno;
+                    self->m_iRcvLastSkipAck = skiptoseqno;
 
 #if ENABLE_LOGGING
-                int64_t timediff = 0;
-                if ( tsbpdtime )
-                     timediff = int64_t(tsbpdtime) - int64_t(CTimer::getTime());
+                    int64_t timediff = 0;
+                    if (tsbpdtime)
+                        timediff = int64_t(tsbpdtime) - int64_t(CTimer::getTime());
 #if ENABLE_HEAVY_LOGGING
-                HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: DROPSEQ: up to seq=" << CSeqNo::decseq(skiptoseqno)
-                    << " (" << seqlen << " packets) playable at " << FormatTime(tsbpdtime) << " delayed "
-                    << (timediff/1000) << "." << (timediff%1000) << " ms");
+                    HLOGC(tslog.Debug,
+                          log << self->CONID() << "tsbpd: DROPSEQ: up to seq=" << CSeqNo::decseq(skiptoseqno) << " ("
+                              << seqlen << " packets) playable at " << FormatTime(tsbpdtime) << " delayed "
+                              << (timediff / 1000) << "." << (timediff % 1000) << " ms");
 #endif
-                LOGC(dlog.Debug, log << "RCV-DROPPED packet delay=" << (timediff/1000) << "ms");
+                    LOGC(dlog.Debug, log << "RCV-DROPPED packet delay=" << (timediff / 1000) << "ms");
 #endif
 
-                tsbpdtime = 0; //Next sent ack will unblock
-                rxready = false;
-             }
-             else if (passack)
-             {
-                /* Packets ready to play but not yet acknowledged (should happen within 10ms) */
-                rxready = false;
-                tsbpdtime = 0; //Next sent ack will unblock
-             } /* else packet ready to play */
-          } /* else packets not ready to play */
-      }
-      else
-      {
-          rxready = self->m_pRcvBuffer->isRcvDataReady(Ref(tsbpdtime), Ref(current_pkt_seq));
-      }
-      CGuard::leaveCS(self->m_RcvBufferLock);
+                    tsbpdtime = 0; // Next sent ack will unblock
+                    rxready   = false;
+                }
+                else if (passack)
+                {
+                    /* Packets ready to play but not yet acknowledged (should happen within 10ms) */
+                    rxready   = false;
+                    tsbpdtime = 0; // Next sent ack will unblock
+                }                  /* else packet ready to play */
+            }                      /* else packets not ready to play */
+        }
+        else
+        {
+            rxready = self->m_pRcvBuffer->isRcvDataReady(Ref(tsbpdtime), Ref(current_pkt_seq));
+        }
+        CGuard::leaveCS(self->m_RcvBufferLock);
 
-      if (rxready)
-      {
-          HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: PLAYING PACKET seq=" << current_pkt_seq
-              << " (belated " << ((CTimer::getTime() - tsbpdtime)/1000.0) << "ms)");
-         /*
-         * There are packets ready to be delivered
-         * signal a waiting "recv" call if there is any data available
-         */
-         if (self->m_bSynRecving)
-         {
-             pthread_cond_signal(&self->m_RecvDataCond);
-         }
-         /*
-         * Set EPOLL_IN to wakeup any thread waiting on epoll
-         */
-         self->s_UDTUnited.m_EPoll.update_events(self->m_SocketID, self->m_sPollID, UDT_EPOLL_IN, true);
-         CTimer::triggerEvent();
-         tsbpdtime = 0;
-      }
+        if (rxready)
+        {
+            HLOGC(tslog.Debug,
+                  log << self->CONID() << "tsbpd: PLAYING PACKET seq=" << current_pkt_seq << " (belated "
+                      << ((CTimer::getTime() - tsbpdtime) / 1000.0) << "ms)");
+            /*
+             * There are packets ready to be delivered
+             * signal a waiting "recv" call if there is any data available
+             */
+            if (self->m_bSynRecving)
+            {
+                pthread_cond_signal(&self->m_RecvDataCond);
+            }
+            /*
+             * Set EPOLL_IN to wakeup any thread waiting on epoll
+             */
+            self->s_UDTUnited.m_EPoll.update_events(self->m_SocketID, self->m_sPollID, UDT_EPOLL_IN, true);
+            CTimer::triggerEvent();
+            tsbpdtime = 0;
+        }
 
-      if (tsbpdtime != 0)
-      {
-         int64_t timediff = int64_t(tsbpdtime) - int64_t(CTimer::getTime());
-         /*
-         * Buffer at head of queue is not ready to play.
-         * Schedule wakeup when it will be.
-         */
-          self->m_bTsbPdAckWakeup = false;
-          THREAD_PAUSED();
-          HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: FUTURE PACKET seq=" << current_pkt_seq
-              << " T=" << FormatTime(tsbpdtime) << " - waiting " << (timediff/1000.0) << "ms");
-          CTimer::condTimedWaitUS(&self->m_RcvTsbPdCond, &self->m_RecvLock, timediff);
-          THREAD_RESUMED();
-      }
-      else
-      {
-         /*
-         * We have just signaled epoll; or
-         * receive queue is empty; or
-         * next buffer to deliver is not in receive queue (missing packet in sequence).
-         *
-         * Block until woken up by one of the following event:
-         * - All ready-to-play packets have been pulled and EPOLL_IN cleared (then loop to block until next pkt time if any)
-         * - New buffers ACKed
-         * - Closing the connection
-         */
-         HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: no data, scheduling wakeup at ack");
-         self->m_bTsbPdAckWakeup = true;
-         THREAD_PAUSED();
-         pthread_cond_wait(&self->m_RcvTsbPdCond, &self->m_RecvLock);
-         THREAD_RESUMED();
-      }
-   }
-   CGuard::leaveCS(self->m_RecvLock);
-   THREAD_EXIT();
-   HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: EXITING");
-   return NULL;
+        if (tsbpdtime != 0)
+        {
+            int64_t timediff = int64_t(tsbpdtime) - int64_t(CTimer::getTime());
+            /*
+             * Buffer at head of queue is not ready to play.
+             * Schedule wakeup when it will be.
+             */
+            self->m_bTsbPdAckWakeup = false;
+            THREAD_PAUSED();
+            HLOGC(tslog.Debug,
+                  log << self->CONID() << "tsbpd: FUTURE PACKET seq=" << current_pkt_seq
+                      << " T=" << FormatTime(tsbpdtime) << " - waiting " << (timediff / 1000.0) << "ms");
+            CTimer::condTimedWaitUS(&self->m_RcvTsbPdCond, &self->m_RecvLock, timediff);
+            THREAD_RESUMED();
+        }
+        else
+        {
+            /*
+             * We have just signaled epoll; or
+             * receive queue is empty; or
+             * next buffer to deliver is not in receive queue (missing packet in sequence).
+             *
+             * Block until woken up by one of the following event:
+             * - All ready-to-play packets have been pulled and EPOLL_IN cleared (then loop to block until next pkt time
+             * if any)
+             * - New buffers ACKed
+             * - Closing the connection
+             */
+            HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: no data, scheduling wakeup at ack");
+            self->m_bTsbPdAckWakeup = true;
+            THREAD_PAUSED();
+            pthread_cond_wait(&self->m_RcvTsbPdCond, &self->m_RecvLock);
+            THREAD_RESUMED();
+        }
+    }
+    CGuard::leaveCS(self->m_RecvLock);
+    THREAD_EXIT();
+    HLOGC(tslog.Debug, log << self->CONID() << "tsbpd: EXITING");
+    return NULL;
 }
 
-bool CUDT::prepareConnectionObjects(const CHandShake& hs, HandshakeSide hsd, CUDTException* eout)
+bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout)
 {
     // This will be lazily created due to being the common
     // code with HSv5 rendezvous, in which this will be run
@@ -4785,7 +4906,7 @@ bool CUDT::prepareConnectionObjects(const CHandShake& hs, HandshakeSide hsd, CUD
     }
 
     bool bidirectional = false;
-    if ( hs.m_iVersion > HS_VERSION_UDT4 )
+    if (hs.m_iVersion > HS_VERSION_UDT4)
     {
         bidirectional = true; // HSv5 is always bidirectional
     }
@@ -4794,11 +4915,11 @@ bool CUDT::prepareConnectionObjects(const CHandShake& hs, HandshakeSide hsd, CUD
     // If this side is caller with HSv5, HSD_INITIATOR should be passed.
     // If this is a rendezvous connection with HSv5, the handshake role
     // is taken from m_SrtHsSide field.
-    if ( hsd == HSD_DRAW )
+    if (hsd == HSD_DRAW)
     {
-        if ( bidirectional )
+        if (bidirectional)
         {
-            hsd = HSD_RESPONDER;   // In HSv5, listener is always RESPONDER and caller always INITIATOR.
+            hsd = HSD_RESPONDER; // In HSv5, listener is always RESPONDER and caller always INITIATOR.
         }
         else
         {
@@ -4816,8 +4937,8 @@ bool CUDT::prepareConnectionObjects(const CHandShake& hs, HandshakeSide hsd, CUD
     }
     catch (...)
     {
-        // Simply reject. 
-        if ( eout )
+        // Simply reject.
+        if (eout)
         {
             *eout = CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
         }
@@ -4834,172 +4955,172 @@ bool CUDT::prepareConnectionObjects(const CHandShake& hs, HandshakeSide hsd, CUD
     return true;
 }
 
-void CUDT::acceptAndRespond(const sockaddr* peer, CHandShake* hs, const CPacket& hspkt)
+void CUDT::acceptAndRespond(const sockaddr *peer, CHandShake *hs, const CPacket &hspkt)
 {
-   HLOGC(mglog.Debug, log << "acceptAndRespond: setting up data according to handshake");
+    HLOGC(mglog.Debug, log << "acceptAndRespond: setting up data according to handshake");
 
-   CGuard cg(m_ConnectionLock);
+    CGuard cg(m_ConnectionLock);
 
-   m_ullRcvPeerStartTime = 0; // will be set correctly at SRT HS
+    m_ullRcvPeerStartTime = 0; // will be set correctly at SRT HS
 
-   // Uses the smaller MSS between the peers
-   if (hs->m_iMSS > m_iMSS)
-      hs->m_iMSS = m_iMSS;
-   else
-      m_iMSS = hs->m_iMSS;
+    // Uses the smaller MSS between the peers
+    if (hs->m_iMSS > m_iMSS)
+        hs->m_iMSS = m_iMSS;
+    else
+        m_iMSS = hs->m_iMSS;
 
-   // exchange info for maximum flow window size
-   m_iFlowWindowSize = hs->m_iFlightFlagSize;
-   hs->m_iFlightFlagSize = (m_iRcvBufSize < m_iFlightFlagSize)? m_iRcvBufSize : m_iFlightFlagSize;
+    // exchange info for maximum flow window size
+    m_iFlowWindowSize     = hs->m_iFlightFlagSize;
+    hs->m_iFlightFlagSize = (m_iRcvBufSize < m_iFlightFlagSize) ? m_iRcvBufSize : m_iFlightFlagSize;
 
-   m_iPeerISN = hs->m_iISN;
+    m_iPeerISN = hs->m_iISN;
 
-   m_iRcvLastAck = hs->m_iISN;
+    m_iRcvLastAck = hs->m_iISN;
 #ifdef ENABLE_LOGGING
-   m_iDebugPrevLastAck = m_iRcvLastAck;
+    m_iDebugPrevLastAck = m_iRcvLastAck;
 #endif
-   m_iRcvLastSkipAck = m_iRcvLastAck;
-   m_iRcvLastAckAck = hs->m_iISN;
-   m_iRcvCurrSeqNo = hs->m_iISN - 1;
-   m_iRcvCurrPhySeqNo = hs->m_iISN - 1;
+    m_iRcvLastSkipAck  = m_iRcvLastAck;
+    m_iRcvLastAckAck   = hs->m_iISN;
+    m_iRcvCurrSeqNo    = hs->m_iISN - 1;
+    m_iRcvCurrPhySeqNo = hs->m_iISN - 1;
 
-   m_PeerID = hs->m_iID;
-   hs->m_iID = m_SocketID;
+    m_PeerID  = hs->m_iID;
+    hs->m_iID = m_SocketID;
 
-   // use peer's ISN and send it back for security check
-   m_iISN = hs->m_iISN;
+    // use peer's ISN and send it back for security check
+    m_iISN = hs->m_iISN;
 
-   m_iLastDecSeq = m_iISN - 1;
-   m_iSndLastAck = m_iISN;
-   m_iSndLastDataAck = m_iISN;
-   m_iSndLastFullAck = m_iISN;
-   m_iSndCurrSeqNo = m_iISN - 1;
-   m_iSndLastAck2 = m_iISN;
-   m_ullSndLastAck2Time = CTimer::getTime();
+    m_iLastDecSeq        = m_iISN - 1;
+    m_iSndLastAck        = m_iISN;
+    m_iSndLastDataAck    = m_iISN;
+    m_iSndLastFullAck    = m_iISN;
+    m_iSndCurrSeqNo      = m_iISN - 1;
+    m_iSndLastAck2       = m_iISN;
+    m_ullSndLastAck2Time = CTimer::getTime();
 
-   // this is a reponse handshake
-   hs->m_iReqType = URQ_CONCLUSION;
+    // this is a reponse handshake
+    hs->m_iReqType = URQ_CONCLUSION;
 
-   if ( hs->m_iVersion > HS_VERSION_UDT4 )
-   {
-       // The version is agreed; this code is executed only in case
-       // when AGENT is listener. In this case, conclusion response
-       // must always contain HSv5 handshake extensions.
-       hs->m_extension = true;
-   }
+    if (hs->m_iVersion > HS_VERSION_UDT4)
+    {
+        // The version is agreed; this code is executed only in case
+        // when AGENT is listener. In this case, conclusion response
+        // must always contain HSv5 handshake extensions.
+        hs->m_extension = true;
+    }
 
-   // get local IP address and send the peer its IP address (because UDP cannot get local IP address)
-   memcpy(m_piSelfIP, hs->m_piPeerIP, 16);
-   CIPAddress::ntop(peer, hs->m_piPeerIP, m_iIPversion);
+    // get local IP address and send the peer its IP address (because UDP cannot get local IP address)
+    memcpy(m_piSelfIP, hs->m_piPeerIP, 16);
+    CIPAddress::ntop(peer, hs->m_piPeerIP, m_iIPversion);
 
-   int udpsize = m_iMSS - CPacket::UDP_HDR_SIZE;
-   m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
-   HLOGC(mglog.Debug, log << "acceptAndRespond: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
+    int udpsize          = m_iMSS - CPacket::UDP_HDR_SIZE;
+    m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
+    HLOGC(mglog.Debug, log << "acceptAndRespond: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
 
-   // Prepare all structures
-   if (!prepareConnectionObjects(*hs, HSD_DRAW, 0))
-   {
-       HLOGC(mglog.Debug, log << "acceptAndRespond: prepareConnectionObjects failed - responding with REJECT.");
-       // If the SRT Handshake extension was provided and wasn't interpreted
-       // correctly, the connection should be rejected.
-       //
-       // Respond with the rejection message and exit with exception
-       // so that the caller will know that this new socket should be deleted.
-       hs->m_iReqType = URQFailure(m_RejectReason);
-       throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
-   }
-   // Since now you can use m_pCryptoControl
+    // Prepare all structures
+    if (!prepareConnectionObjects(*hs, HSD_DRAW, 0))
+    {
+        HLOGC(mglog.Debug, log << "acceptAndRespond: prepareConnectionObjects failed - responding with REJECT.");
+        // If the SRT Handshake extension was provided and wasn't interpreted
+        // correctly, the connection should be rejected.
+        //
+        // Respond with the rejection message and exit with exception
+        // so that the caller will know that this new socket should be deleted.
+        hs->m_iReqType = URQFailure(m_RejectReason);
+        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+    }
+    // Since now you can use m_pCryptoControl
 
-   CInfoBlock ib;
-   ib.m_iIPversion = m_iIPversion;
-   CInfoBlock::convert(peer, m_iIPversion, ib.m_piIP);
-   if (m_pCache->lookup(&ib) >= 0)
-   {
-      m_iRTT = ib.m_iRTT;
-      m_iBandwidth = ib.m_iBandwidth;
-   }
+    CInfoBlock ib;
+    ib.m_iIPversion = m_iIPversion;
+    CInfoBlock::convert(peer, m_iIPversion, ib.m_piIP);
+    if (m_pCache->lookup(&ib) >= 0)
+    {
+        m_iRTT       = ib.m_iRTT;
+        m_iBandwidth = ib.m_iBandwidth;
+    }
 
-   // This should extract the HSREQ and KMREQ portion in the handshake packet.
-   // This could still be a HSv4 packet and contain no such parts, which will leave
-   // this entity as "non-SRT-handshaken", and await further HSREQ and KMREQ sent
-   // as UMSG_EXT.
-   uint32_t kmdata[SRTDATA_MAXSIZE];
-   size_t kmdatasize = SRTDATA_MAXSIZE;
-   if ( !interpretSrtHandshake(*hs, hspkt, kmdata, &kmdatasize) )
-   {
-       HLOGC(mglog.Debug, log << "acceptAndRespond: interpretSrtHandshake failed - responding with REJECT.");
-       // If the SRT Handshake extension was provided and wasn't interpreted
-       // correctly, the connection should be rejected.
-       //
-       // Respond with the rejection message and return false from
-       // this function so that the caller will know that this new
-       // socket should be deleted.
-       hs->m_iReqType = URQFailure(m_RejectReason);
-       throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
-   }
+    // This should extract the HSREQ and KMREQ portion in the handshake packet.
+    // This could still be a HSv4 packet and contain no such parts, which will leave
+    // this entity as "non-SRT-handshaken", and await further HSREQ and KMREQ sent
+    // as UMSG_EXT.
+    uint32_t kmdata[SRTDATA_MAXSIZE];
+    size_t   kmdatasize = SRTDATA_MAXSIZE;
+    if (!interpretSrtHandshake(*hs, hspkt, kmdata, &kmdatasize))
+    {
+        HLOGC(mglog.Debug, log << "acceptAndRespond: interpretSrtHandshake failed - responding with REJECT.");
+        // If the SRT Handshake extension was provided and wasn't interpreted
+        // correctly, the connection should be rejected.
+        //
+        // Respond with the rejection message and return false from
+        // this function so that the caller will know that this new
+        // socket should be deleted.
+        hs->m_iReqType = URQFailure(m_RejectReason);
+        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+    }
 
-   SRT_REJECT_REASON rr = setupCC();
-   // UNKNOWN used as a "no error" value
-   if (rr != SRT_REJ_UNKNOWN)
-   {
-       hs->m_iReqType = URQFailure(rr);
-       m_RejectReason = rr;
-       throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
-   }
+    SRT_REJECT_REASON rr = setupCC();
+    // UNKNOWN used as a "no error" value
+    if (rr != SRT_REJ_UNKNOWN)
+    {
+        hs->m_iReqType = URQFailure(rr);
+        m_RejectReason = rr;
+        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+    }
 
-   m_pPeerAddr = (AF_INET == m_iIPversion) ? (sockaddr*)new sockaddr_in : (sockaddr*)new sockaddr_in6;
-   memcpy(m_pPeerAddr, peer, (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
+    m_pPeerAddr = (AF_INET == m_iIPversion) ? (sockaddr *)new sockaddr_in : (sockaddr *)new sockaddr_in6;
+    memcpy(m_pPeerAddr, peer, (AF_INET == m_iIPversion) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
 
-   // And of course, it is connected.
-   m_bConnected = true;
+    // And of course, it is connected.
+    m_bConnected = true;
 
-   // register this socket for receiving data packets
-   m_pRNode->m_bOnList = true;
-   m_pRcvQueue->setNewEntry(this);
+    // register this socket for receiving data packets
+    m_pRNode->m_bOnList = true;
+    m_pRcvQueue->setNewEntry(this);
 
-   //send the response to the peer, see listen() for more discussions about this
-   // XXX Here create CONCLUSION RESPONSE with:
-   // - just the UDT handshake, if HS_VERSION_UDT4,
-   // - if higher, the UDT handshake, the SRT HSRSP, the SRT KMRSP
-   size_t size = m_iMaxSRTPayloadSize;
-   // Allocate the maximum possible memory for an SRT payload.
-   // This is a maximum you can send once.
-   CPacket response;
-   response.setControl(UMSG_HANDSHAKE);
-   response.allocate(size);
+    // send the response to the peer, see listen() for more discussions about this
+    // XXX Here create CONCLUSION RESPONSE with:
+    // - just the UDT handshake, if HS_VERSION_UDT4,
+    // - if higher, the UDT handshake, the SRT HSRSP, the SRT KMRSP
+    size_t size = m_iMaxSRTPayloadSize;
+    // Allocate the maximum possible memory for an SRT payload.
+    // This is a maximum you can send once.
+    CPacket response;
+    response.setControl(UMSG_HANDSHAKE);
+    response.allocate(size);
 
-   // This will serialize the handshake according to its current form.
-   HLOGC(mglog.Debug, log << "acceptAndRespond: creating CONCLUSION response (HSv5: with HSRSP/KMRSP) buffer size=" << size);
-   if (!createSrtHandshake(Ref(response), Ref(*hs), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
-   {
-       LOGC(mglog.Error, log << "acceptAndRespond: error creating handshake response");
-       throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
-   }
+    // This will serialize the handshake according to its current form.
+    HLOGC(mglog.Debug,
+          log << "acceptAndRespond: creating CONCLUSION response (HSv5: with HSRSP/KMRSP) buffer size=" << size);
+    if (!createSrtHandshake(Ref(response), Ref(*hs), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
+    {
+        LOGC(mglog.Error, log << "acceptAndRespond: error creating handshake response");
+        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+    }
 
-   // Set target socket ID to the value from received handshake's source ID.
-   response.m_iID = m_PeerID;
+    // Set target socket ID to the value from received handshake's source ID.
+    response.m_iID = m_PeerID;
 
 #if ENABLE_HEAVY_LOGGING
-   {
-       // To make sure what REALLY is being sent, parse back the handshake
-       // data that have been just written into the buffer.
-       CHandShake debughs;
-       debughs.load_from(response.m_pcData, response.getLength());
-       HLOGC(mglog.Debug, log << CONID() << "acceptAndRespond: sending HS to peer, reqtype="
-           << RequestTypeStr(debughs.m_iReqType) << " version=" << debughs.m_iVersion
-           << " (connreq:" << RequestTypeStr(m_ConnReq.m_iReqType)
-           << "), target_socket=" << response.m_iID << ", my_socket=" << debughs.m_iID);
-   }
+    {
+        // To make sure what REALLY is being sent, parse back the handshake
+        // data that have been just written into the buffer.
+        CHandShake debughs;
+        debughs.load_from(response.m_pcData, response.getLength());
+        HLOGC(mglog.Debug,
+              log << CONID() << "acceptAndRespond: sending HS to peer, reqtype=" << RequestTypeStr(debughs.m_iReqType)
+                  << " version=" << debughs.m_iVersion << " (connreq:" << RequestTypeStr(m_ConnReq.m_iReqType)
+                  << "), target_socket=" << response.m_iID << ", my_socket=" << debughs.m_iID);
+    }
 #endif
 
-   // NOTE: BLOCK THIS instruction in order to cause the final
-   // handshake to be missed and cause the problem solved in PR #417.
-   // When missed this message, the caller should not accept packets
-   // coming as connected, but continue repeated handshake until finally
-   // received the listener's handshake.
-   m_pSndQueue->sendto(peer, response);
+    // NOTE: BLOCK THIS instruction in order to cause the final
+    // handshake to be missed and cause the problem solved in PR #417.
+    // When missed this message, the caller should not accept packets
+    // coming as connected, but continue repeated handshake until finally
+    // received the listener's handshake.
+    m_pSndQueue->sendto(peer, response);
 }
-
 
 // This function is required to be called when a caller receives an INDUCTION
 // response from the listener and would like to create a CONCLUSION that includes
@@ -5012,7 +5133,7 @@ void CUDT::acceptAndRespond(const sockaddr* peer, CHandShake* hs, const CPacket&
 bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
 {
     // Lazy initialization
-    if ( m_pCryptoControl )
+    if (m_pCryptoControl)
         return true;
 
     // Write back this value, when it was just determined.
@@ -5026,7 +5147,7 @@ bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     // they have outdated values.
     m_pCryptoControl->setCryptoSecret(m_CryptoSecret);
 
-    if ( bidirectional || m_bDataSender )
+    if (bidirectional || m_bDataSender)
     {
         HLOGC(mglog.Debug, log << "createCrypter: setting RCV/SND KeyLen=" << m_iSndCryptoKeyLen);
         m_pCryptoControl->setCryptoKeylen(m_iSndCryptoKeyLen);
@@ -5046,12 +5167,12 @@ SRT_REJECT_REASON CUDT::setupCC()
     // XXX Not sure about that. May happen that AGENT wants
     // tsbpd mode, but PEER doesn't, even in bidirectional mode.
     // This way, the reception side should get precedense.
-    //if (bidirectional || m_bDataSender || m_bTwoWayData)
+    // if (bidirectional || m_bDataSender || m_bTwoWayData)
     //    m_bPeerTsbPd = m_bOPT_TsbPd;
 
     // SrtCongestion will retrieve whatever parameters it needs
     // from *this.
-    if ( !m_CongCtl.configure(this))
+    if (!m_CongCtl.configure(this))
     {
         return SRT_REJ_CONGESTION;
     }
@@ -5082,10 +5203,10 @@ SRT_REJECT_REASON CUDT::setupCC()
     // When default 0 value is returned, the current value set by CUDT
     // is preserved.
     uint64_t min_nak_tk = m_CongCtl->minNAKInterval();
-    if ( min_nak_tk )
+    if (min_nak_tk)
         m_ullMinNakInt_tk = min_nak_tk;
 
-    // Update timers 
+    // Update timers
     uint64_t currtime_tk;
     CTimer::rdtsc(currtime_tk);
     m_ullLastRspTime_tk    = currtime_tk;
@@ -5094,12 +5215,10 @@ SRT_REJECT_REASON CUDT::setupCC()
     m_ullLastRspAckTime_tk = currtime_tk;
     m_ullLastSndTime_tk    = currtime_tk;
 
-
-    HLOGC(mglog.Debug, log << "setupCC: setting parameters: mss=" << m_iMSS
-        << " maxCWNDSize/FlowWindowSize=" << m_iFlowWindowSize
-        << " rcvrate=" << m_iDeliveryRate << "p/s (" << m_iByteDeliveryRate << "B/S)"
-        << " rtt=" << m_iRTT
-        << " bw=" << m_iBandwidth);
+    HLOGC(mglog.Debug,
+          log << "setupCC: setting parameters: mss=" << m_iMSS << " maxCWNDSize/FlowWindowSize=" << m_iFlowWindowSize
+              << " rcvrate=" << m_iDeliveryRate << "p/s (" << m_iByteDeliveryRate << "B/S)"
+              << " rtt=" << m_iRTT << " bw=" << m_iBandwidth);
 
     updateCC(TEV_INIT, TEV_INIT_RESET);
     return SRT_REJ_UNKNOWN;
@@ -5110,7 +5229,7 @@ void CUDT::considerLegacySrtHandshake(uint64_t timebase)
     // Do a fast pre-check first - this simply declares that agent uses HSv5
     // and the legacy SRT Handshake is not to be done. Second check is whether
     // agent is sender (=initiator in HSv4).
-    if ( !isTsbPd() || !m_bDataSender )
+    if (!isTsbPd() || !m_bDataSender)
         return;
 
     if (m_iSndHsRetryCnt <= 0)
@@ -5133,7 +5252,7 @@ void CUDT::considerLegacySrtHandshake(uint64_t timebase)
          * - last sent handshake req should have been replied (RTT*1.5 elapsed); and
          * then (re-)send handshake request.
          */
-        if ( timebase > now ) // too early
+        if (timebase > now) // too early
         {
             HLOGC(mglog.Debug, log << "Legacy HSREQ: TOO EARLY, will still retry " << m_iSndHsRetryCnt << " times");
             return;
@@ -5141,9 +5260,11 @@ void CUDT::considerLegacySrtHandshake(uint64_t timebase)
     }
     // If 0 timebase, it means that this is the initial sending with the very first
     // payload packet sent. Send only if this is still set to maximum+1 value.
-    else if (m_iSndHsRetryCnt < SRT_MAX_HSRETRY+1)
+    else if (m_iSndHsRetryCnt < SRT_MAX_HSRETRY + 1)
     {
-        HLOGC(mglog.Debug, log << "Legacy HSREQ: INITIAL, REPEATED, so not to be done. Will repeat on sending " << m_iSndHsRetryCnt << " times");
+        HLOGC(mglog.Debug,
+              log << "Legacy HSREQ: INITIAL, REPEATED, so not to be done. Will repeat on sending " << m_iSndHsRetryCnt
+                  << " times");
         return;
     }
 
@@ -5159,12 +5280,13 @@ void CUDT::checkSndTimers(Whether2RegenKm regen)
     {
         HLOGC(mglog.Debug, log << "checkSndTimers: HS SIDE: INITIATOR, considering legacy handshake with timebase");
         // Legacy method for HSREQ, only if initiator.
-        considerLegacySrtHandshake(m_ullSndHsLastTime_us + m_iRTT*3/2);
+        considerLegacySrtHandshake(m_ullSndHsLastTime_us + m_iRTT * 3 / 2);
     }
     else
     {
-        HLOGC(mglog.Debug, log << "checkSndTimers: HS SIDE: " << (m_SrtHsSide == HSD_RESPONDER ? "RESPONDER" : "DRAW (IPE?)")
-                << " - not considering legacy handshake");
+        HLOGC(mglog.Debug,
+              log << "checkSndTimers: HS SIDE: " << (m_SrtHsSide == HSD_RESPONDER ? "RESPONDER" : "DRAW (IPE?)")
+                  << " - not considering legacy handshake");
     }
 
     // This must be done always on sender, regardless of HS side.
@@ -5180,161 +5302,161 @@ void CUDT::checkSndTimers(Whether2RegenKm regen)
     }
 }
 
-void CUDT::addressAndSend(CPacket& pkt)
+void CUDT::addressAndSend(CPacket &pkt)
 {
-    pkt.m_iID = m_PeerID;
+    pkt.m_iID        = m_PeerID;
     pkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
 
     m_pSndQueue->sendto(m_pPeerAddr, pkt);
 }
 
-
 bool CUDT::close()
 {
-   // NOTE: this function is called from within the garbage collector thread.
+    // NOTE: this function is called from within the garbage collector thread.
 
-   if (!m_bOpened)
-   {
-      return false;
-   }
+    if (!m_bOpened)
+    {
+        return false;
+    }
 
-   HLOGC(mglog.Debug, log << CONID() << " - closing socket:");
+    HLOGC(mglog.Debug, log << CONID() << " - closing socket:");
 
-   if (m_Linger.l_onoff != 0)
-   {
-      uint64_t entertime = CTimer::getTime();
+    if (m_Linger.l_onoff != 0)
+    {
+        uint64_t entertime = CTimer::getTime();
 
-      HLOGC(mglog.Debug, log << CONID() << " ... (linger)");
-      while (!m_bBroken && m_bConnected && (m_pSndBuffer->getCurrBufSize() > 0)
-              && (CTimer::getTime() - entertime < m_Linger.l_linger * uint64_t(1000000)))
-      {
-         // linger has been checked by previous close() call and has expired
-         if (m_ullLingerExpiration >= entertime)
-            break;
+        HLOGC(mglog.Debug, log << CONID() << " ... (linger)");
+        while (!m_bBroken && m_bConnected && (m_pSndBuffer->getCurrBufSize() > 0) &&
+               (CTimer::getTime() - entertime < m_Linger.l_linger * uint64_t(1000000)))
+        {
+            // linger has been checked by previous close() call and has expired
+            if (m_ullLingerExpiration >= entertime)
+                break;
 
-         if (!m_bSynSending)
-         {
-            // if this socket enables asynchronous sending, return immediately and let GC to close it later
-            if (m_ullLingerExpiration == 0)
-               m_ullLingerExpiration = entertime + m_Linger.l_linger * uint64_t(1000000);
+            if (!m_bSynSending)
+            {
+                // if this socket enables asynchronous sending, return immediately and let GC to close it later
+                if (m_ullLingerExpiration == 0)
+                    m_ullLingerExpiration = entertime + m_Linger.l_linger * uint64_t(1000000);
 
-            HLOGC(mglog.Debug, log << "CUDT::close: linger-nonblocking, setting expire time T="
-                    << FormatTime(m_ullLingerExpiration));
+                HLOGC(mglog.Debug,
+                      log << "CUDT::close: linger-nonblocking, setting expire time T="
+                          << FormatTime(m_ullLingerExpiration));
 
-            return false;
-         }
+                return false;
+            }
 
-         #ifndef _WIN32
+#ifndef _WIN32
             timespec ts;
-            ts.tv_sec = 0;
+            ts.tv_sec  = 0;
             ts.tv_nsec = 1000000;
             nanosleep(&ts, NULL);
-         #else
+#else
             Sleep(1);
-         #endif
-      }
-   }
+#endif
+        }
+    }
 
-   // remove this socket from the snd queue
-   if (m_bConnected)
-      m_pSndQueue->m_pSndUList->remove(this);
+    // remove this socket from the snd queue
+    if (m_bConnected)
+        m_pSndQueue->m_pSndUList->remove(this);
 
-   /*
-    * update_events below useless
-    * removing usock for EPolls right after (remove_usocks) clears it (in other HAI patch).
-    *
-    * What is in EPoll shall be the responsibility of the application, if it want local close event,
-    * it would remove the socket from the EPoll after close.
-    */
-   // trigger any pending IO events.
-   s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_ERR, true);
-   // then remove itself from all epoll monitoring
-   try
-   {
-      for (set<int>::iterator i = m_sPollID.begin(); i != m_sPollID.end(); ++ i)
-         s_UDTUnited.m_EPoll.remove_usock(*i, m_SocketID);
-   }
-   catch (...)
-   {
-   }
+    /*
+     * update_events below useless
+     * removing usock for EPolls right after (remove_usocks) clears it (in other HAI patch).
+     *
+     * What is in EPoll shall be the responsibility of the application, if it want local close event,
+     * it would remove the socket from the EPoll after close.
+     */
+    // trigger any pending IO events.
+    s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_ERR, true);
+    // then remove itself from all epoll monitoring
+    try
+    {
+        for (set<int>::iterator i = m_sPollID.begin(); i != m_sPollID.end(); ++i)
+            s_UDTUnited.m_EPoll.remove_usock(*i, m_SocketID);
+    }
+    catch (...)
+    {
+    }
 
-   // XXX What's this, could any of the above actions make it !m_bOpened?
-   if (!m_bOpened)
-   {
-      return true;
-   }
+    // XXX What's this, could any of the above actions make it !m_bOpened?
+    if (!m_bOpened)
+    {
+        return true;
+    }
 
-   // Inform the threads handler to stop.
-   m_bClosing = true;
+    // Inform the threads handler to stop.
+    m_bClosing = true;
 
-   HLOGC(mglog.Debug, log << CONID() << "CLOSING STATE. Acquiring connection lock");
+    HLOGC(mglog.Debug, log << CONID() << "CLOSING STATE. Acquiring connection lock");
 
-   CGuard cg(m_ConnectionLock);
+    CGuard cg(m_ConnectionLock);
 
-   // Signal the sender and recver if they are waiting for data.
-   releaseSynch();
+    // Signal the sender and recver if they are waiting for data.
+    releaseSynch();
 
-   HLOGC(mglog.Debug, log << CONID() << "CLOSING, removing from listener/connector");
+    HLOGC(mglog.Debug, log << CONID() << "CLOSING, removing from listener/connector");
 
-   if (m_bListening)
-   {
-      m_bListening = false;
-      m_pRcvQueue->removeListener(this);
-   }
-   else if (m_bConnecting)
-   {
-       m_pRcvQueue->removeConnector(m_SocketID);
-   }
+    if (m_bListening)
+    {
+        m_bListening = false;
+        m_pRcvQueue->removeListener(this);
+    }
+    else if (m_bConnecting)
+    {
+        m_pRcvQueue->removeConnector(m_SocketID);
+    }
 
-   if (m_bConnected)
-   {
-      if (!m_bShutdown)
-      {
-          HLOGC(mglog.Debug, log << CONID() << "CLOSING - sending SHUTDOWN to the peer");
-          sendCtrl(UMSG_SHUTDOWN);
-      }
+    if (m_bConnected)
+    {
+        if (!m_bShutdown)
+        {
+            HLOGC(mglog.Debug, log << CONID() << "CLOSING - sending SHUTDOWN to the peer");
+            sendCtrl(UMSG_SHUTDOWN);
+        }
 
-      m_pCryptoControl->close();
+        m_pCryptoControl->close();
 
-      // Store current connection information.
-      CInfoBlock ib;
-      ib.m_iIPversion = m_iIPversion;
-      CInfoBlock::convert(m_pPeerAddr, m_iIPversion, ib.m_piIP);
-      ib.m_iRTT = m_iRTT;
-      ib.m_iBandwidth = m_iBandwidth;
-      m_pCache->update(&ib);
+        // Store current connection information.
+        CInfoBlock ib;
+        ib.m_iIPversion = m_iIPversion;
+        CInfoBlock::convert(m_pPeerAddr, m_iIPversion, ib.m_piIP);
+        ib.m_iRTT       = m_iRTT;
+        ib.m_iBandwidth = m_iBandwidth;
+        m_pCache->update(&ib);
 
-      m_bConnected = false;
-   }
+        m_bConnected = false;
+    }
 
-   if ( m_bTsbPd  && !pthread_equal(m_RcvTsbPdThread, pthread_t()))
-   {
-       HLOGC(mglog.Debug, log << "CLOSING, joining TSBPD thread...");
-       void* retval;
-       int ret SRT_ATR_UNUSED = pthread_join(m_RcvTsbPdThread, &retval);
-       HLOGC(mglog.Debug, log << "... " << (ret == 0 ? "SUCCEEDED" : "FAILED"));
-   }
+    if (m_bTsbPd && !pthread_equal(m_RcvTsbPdThread, pthread_t()))
+    {
+        HLOGC(mglog.Debug, log << "CLOSING, joining TSBPD thread...");
+        void *retval;
+        int ret SRT_ATR_UNUSED = pthread_join(m_RcvTsbPdThread, &retval);
+        HLOGC(mglog.Debug, log << "... " << (ret == 0 ? "SUCCEEDED" : "FAILED"));
+    }
 
-   HLOGC(mglog.Debug, log << "CLOSING, joining send/receive threads");
+    HLOGC(mglog.Debug, log << "CLOSING, joining send/receive threads");
 
-   // waiting all send and recv calls to stop
-   CGuard sendguard(m_SendLock);
-   CGuard recvguard(m_RecvLock);
+    // waiting all send and recv calls to stop
+    CGuard sendguard(m_SendLock);
+    CGuard recvguard(m_RecvLock);
 
-   // Locking m_RcvBufferLock to protect calling to m_pCryptoControl->decrypt(Ref(packet))
-   // from the processData(...) function while resetting Crypto Control.
-   CGuard::enterCS(m_RcvBufferLock);
-   m_pCryptoControl.reset();
-   CGuard::leaveCS(m_RcvBufferLock);
+    // Locking m_RcvBufferLock to protect calling to m_pCryptoControl->decrypt(Ref(packet))
+    // from the processData(...) function while resetting Crypto Control.
+    CGuard::enterCS(m_RcvBufferLock);
+    m_pCryptoControl.reset();
+    CGuard::leaveCS(m_RcvBufferLock);
 
-   m_lSrtVersion = SRT_DEF_VERSION;
-   m_lPeerSrtVersion = SRT_VERSION_UNK;
-   m_lMinimumPeerSrtVersion = SRT_VERSION_MAJ1;
-   m_ullRcvPeerStartTime = 0;
+    m_lSrtVersion            = SRT_DEF_VERSION;
+    m_lPeerSrtVersion        = SRT_VERSION_UNK;
+    m_lMinimumPeerSrtVersion = SRT_VERSION_MAJ1;
+    m_ullRcvPeerStartTime    = 0;
 
-   m_bOpened = false;
+    m_bOpened = false;
 
-   return true;
+    return true;
 }
 
 /*
@@ -5437,7 +5559,7 @@ int CUDT::send(const char* data, int len)
 }
 */
 
-int CUDT::receiveBuffer(char* data, int len)
+int CUDT::receiveBuffer(char *data, int len)
 {
     if (!m_CongCtl->checkTransArgs(SrtCongestion::STA_BUFFER, SrtCongestion::STAD_RECV, data, len, -1, false))
         throw CUDTException(MJ_NOTSUP, MN_INVALBUFFERAPI, 0);
@@ -5468,10 +5590,11 @@ int CUDT::receiveBuffer(char* data, int len)
             HLOGC(mglog.Debug, log << "STREAM API, SHUTDOWN: marking as EOF");
             return 0;
         }
-        HLOGC(mglog.Debug, log << (m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown?"":"no") << " SHUTDOWN. Reporting as BROKEN.");
+        HLOGC(mglog.Debug,
+              log << (m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown ? "" : "no")
+                  << " SHUTDOWN. Reporting as BROKEN.");
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
     }
-
 
     if (!m_pRcvBuffer->isRcvDataReady())
     {
@@ -5486,7 +5609,7 @@ int CUDT::receiveBuffer(char* data, int len)
             {
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
                 {
-                    //Do not block forever, check connection status each 1 sec.
+                    // Do not block forever, check connection status each 1 sec.
                     CTimer::condTimedWaitUS(&m_RecvDataCond, &m_RecvLock, 1000000);
                 }
             }
@@ -5515,7 +5638,9 @@ int CUDT::receiveBuffer(char* data, int len)
             HLOGC(mglog.Debug, log << "STREAM API, SHUTDOWN: marking as EOF");
             return 0;
         }
-        HLOGC(mglog.Debug, log << (m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown?"":"no") << " SHUTDOWN. Reporting as BROKEN.");
+        HLOGC(mglog.Debug,
+              log << (m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown ? "" : "no")
+                  << " SHUTDOWN. Reporting as BROKEN.");
 
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
     }
@@ -5529,7 +5654,6 @@ int CUDT::receiveBuffer(char* data, int len)
         pthread_cond_signal(&m_RcvTsbPdCond);
     }
 
-
     if (!m_pRcvBuffer->isRcvDataReady())
     {
         // read is not available any more
@@ -5541,7 +5665,6 @@ int CUDT::receiveBuffer(char* data, int len)
 
     return res;
 }
-
 
 void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
 {
@@ -5567,7 +5690,8 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
     int threshold_ms = 0;
     if (m_iOPT_SndDropDelay >= 0)
     {
-        threshold_ms = std::max(m_iPeerTsbPdDelay_ms + m_iOPT_SndDropDelay, +SRT_TLPKTDROP_MINTHRESHOLD_MS) + (2*COMM_SYN_INTERVAL_US/1000);
+        threshold_ms = std::max(m_iPeerTsbPdDelay_ms + m_iOPT_SndDropDelay, +SRT_TLPKTDROP_MINTHRESHOLD_MS) +
+                       (2 * COMM_SYN_INTERVAL_US / 1000);
     }
 
     if (threshold_ms && timespan_ms > threshold_ms)
@@ -5575,12 +5699,12 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
         // protect packet retransmission
         CGuard::enterCS(m_RecvAckLock);
         int dbytes;
-        int dpkts = m_pSndBuffer->dropLateData(dbytes,  CTimer::getTime() - (threshold_ms * 1000));
+        int dpkts = m_pSndBuffer->dropLateData(dbytes, CTimer::getTime() - (threshold_ms * 1000));
         if (dpkts > 0)
         {
             CGuard::enterCS(m_StatsLock);
-            m_stats.traceSndDrop        += dpkts;
-            m_stats.sndDropTotal        += dpkts;
+            m_stats.traceSndDrop += dpkts;
+            m_stats.sndDropTotal += dpkts;
             m_stats.traceSndBytesDrop += dbytes;
             m_stats.sndBytesDropTotal += dbytes;
             CGuard::leaveCS(m_StatsLock);
@@ -5590,7 +5714,7 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
 #endif
             int32_t fakeack = CSeqNo::incseq(m_iSndLastDataAck, dpkts);
 
-            m_iSndLastAck = fakeack;
+            m_iSndLastAck     = fakeack;
             m_iSndLastDataAck = fakeack;
 
             int32_t minlastack = CSeqNo::decseq(m_iSndLastDataAck);
@@ -5603,37 +5727,35 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
             }
             LOGC(dlog.Error, log << "SND-DROPPED " << dpkts << " packets - lost delaying for " << timespan_ms << "ms");
 
-            HLOGC(dlog.Debug, log << "drop,now " <<
-                    CTimer::getTime() << "us," <<
-                    realack << "-" <<  m_iSndCurrSeqNo << " seqs," <<
-                    dpkts << " pkts," <<  dbytes << " bytes," <<  timespan_ms << " ms");
-
+            HLOGC(dlog.Debug,
+                  log << "drop,now " << CTimer::getTime() << "us," << realack << "-" << m_iSndCurrSeqNo << " seqs,"
+                      << dpkts << " pkts," << dbytes << " bytes," << timespan_ms << " ms");
         }
         *bCongestion = true;
         CGuard::leaveCS(m_RecvAckLock);
     }
-    else if (timespan_ms > (m_iPeerTsbPdDelay_ms/2))
+    else if (timespan_ms > (m_iPeerTsbPdDelay_ms / 2))
     {
-        HLOGC(mglog.Debug, log << "cong, NOW: " << CTimer::getTime() << "us, BYTES " <<  bytes << ", TMSPAN " <<  timespan_ms << "ms");
+        HLOGC(mglog.Debug,
+              log << "cong, NOW: " << CTimer::getTime() << "us, BYTES " << bytes << ", TMSPAN " << timespan_ms << "ms");
 
         *bCongestion = true;
     }
 }
 
-
-int CUDT::sendmsg(const char* data, int len, int msttl, bool inorder, uint64_t srctime)
+int CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, uint64_t srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
-    mctrl.msgttl = msttl;
-    mctrl.inorder = inorder;
-    mctrl.srctime = srctime;
+    mctrl.msgttl      = msttl;
+    mctrl.inorder     = inorder;
+    mctrl.srctime     = srctime;
     return this->sendmsg2(data, len, Ref(mctrl));
 }
 
-int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
+int CUDT::sendmsg2(const char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 {
-    SRT_MSGCTRL& mctrl = *r_mctrl;
-    bool bCongestion = false;
+    SRT_MSGCTRL &mctrl       = *r_mctrl;
+    bool         bCongestion = false;
 
     // throw an exception if not connected
     if (m_bBroken || m_bClosing)
@@ -5647,7 +5769,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
         return 0;
     }
 
-    int msttl = mctrl.msgttl;
+    int  msttl   = mctrl.msgttl;
     bool inorder = mctrl.inorder;
 
     // Sendmsg isn't restricted to the congctl type, however the congctl
@@ -5655,11 +5777,11 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     // NOTE: SrtCongestion is also allowed to throw CUDTException() by itself!
     {
         SrtCongestion::TransAPI api = SrtCongestion::STA_MESSAGE;
-        CodeMinor mn = MN_INVALMSGAPI;
-        if ( !m_bMessageAPI )
+        CodeMinor               mn  = MN_INVALMSGAPI;
+        if (!m_bMessageAPI)
         {
             api = SrtCongestion::STA_BUFFER;
-            mn = MN_INVALBUFFERAPI;
+            mn  = MN_INVALBUFFERAPI;
         }
 
         if (!m_CongCtl->checkTransArgs(api, SrtCongestion::STAD_SEND, data, len, msttl, inorder))
@@ -5686,8 +5808,9 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
     if (m_bMessageAPI && len > int(m_iSndBufSize * m_iMaxSRTPayloadSize))
     {
-        LOGC(dlog.Error, log << "Message length (" << len << ") exceeds the size of sending buffer: "
-            << (m_iSndBufSize * m_iMaxSRTPayloadSize) << ". Use SRTO_SNDBUF if needed.");
+        LOGC(dlog.Error,
+             log << "Message length (" << len << ") exceeds the size of sending buffer: "
+                 << (m_iSndBufSize * m_iMaxSRTPayloadSize) << ". Use SRTO_SNDBUF if needed.");
         throw CUDTException(MJ_NOTSUP, MN_XSIZE, 0);
     }
 
@@ -5696,8 +5819,8 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
        must be at least conditional because it breaks backward compat.
     if (!m_pCryptoControl || !m_pCryptoControl->isSndEncryptionOK())
     {
-        LOGC(dlog.Error, log << "Encryption is required, but the peer did not supply correct credentials. Sending rejected.");
-        throw CUDTException(MJ_SETUP, MN_SECURITY, 0);
+        LOGC(dlog.Error, log << "Encryption is required, but the peer did not supply correct credentials. Sending
+    rejected."); throw CUDTException(MJ_SETUP, MN_SECURITY, 0);
     }
     */
 
@@ -5711,7 +5834,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
         CGuard ack_lock(m_RecvAckLock);
         m_ullLastRspAckTime_tk = currtime_tk; // (fix keepalive)
-        m_iReXmitCount = 1; // can be modified in checkRexmitTimer and processCtrlAck (receiver's thread)
+        m_iReXmitCount         = 1; // can be modified in checkRexmitTimer and processCtrlAck (receiver's thread)
     }
 
     // checkNeedDrop(...) may lock m_RecvAckLock
@@ -5723,7 +5846,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     {
         // For MESSAGE API the minimum outgoing buffer space required is
         // the size that can carry over the whole message as passed here.
-        minlen = (len+m_iMaxSRTPayloadSize-1)/m_iMaxSRTPayloadSize;
+        minlen = (len + m_iMaxSRTPayloadSize - 1) / m_iMaxSRTPayloadSize;
     }
 
     if (sndBuffersLeft() < minlen)
@@ -5739,19 +5862,14 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
             if (m_iSndTimeOut < 0)
             {
-                while (stillConnected()
-                        && sndBuffersLeft() < minlen
-                        && m_bPeerHealth)
+                while (stillConnected() && sndBuffersLeft() < minlen && m_bPeerHealth)
                     pthread_cond_wait(&m_SendBlockCond, &m_SendBlockLock);
             }
             else
             {
                 const uint64_t exptime = CTimer::getTime() + m_iSndTimeOut * uint64_t(1000);
 
-                while (stillConnected()
-                        && sndBuffersLeft() < minlen
-                        && m_bPeerHealth
-                        && exptime > CTimer::getTime())
+                while (stillConnected() && sndBuffersLeft() < minlen && m_bPeerHealth && exptime > CTimer::getTime())
                     CTimer::condTimedWaitUS(&m_SendBlockCond, &m_SendBlockLock, m_iSndTimeOut * uint64_t(1000));
             }
         }
@@ -5767,7 +5885,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
             throw CUDTException(MJ_PEERERROR);
         }
 
-        /* 
+        /*
          * The code below is to return ETIMEOUT when blocking mode could not get free buffer in time.
          * If no free buffer available in non-blocking mode, we alredy returned. If buffer availaible,
          * we test twice if this code is outside the else section.
@@ -5792,7 +5910,9 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
             //    - m_bPeerHealth condition is checked and responded with PEERERROR
             //
             // ERGO: never happens?
-            LOGC(mglog.Fatal, log << "IPE: sendmsg: the loop exited, while not enough size, still connected, peer healthy. Impossible.");
+            LOGC(mglog.Fatal,
+                 log << "IPE: sendmsg: the loop exited, while not enough size, still connected, peer healthy. "
+                        "Impossible.");
 
             return 0;
         }
@@ -5842,7 +5962,7 @@ int CUDT::sendmsg2(const char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     return size;
 }
 
-int CUDT::recv(char* data, int len)
+int CUDT::recv(char *data, int len)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -5862,7 +5982,7 @@ int CUDT::recv(char* data, int len)
     return receiveBuffer(data, len);
 }
 
-int CUDT::recvmsg(char* data, int len, uint64_t& srctime)
+int CUDT::recvmsg(char *data, int len, uint64_t &srctime)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -5876,15 +5996,15 @@ int CUDT::recvmsg(char* data, int len, uint64_t& srctime)
     if (m_bMessageAPI)
     {
         SRT_MSGCTRL mctrl = srt_msgctrl_default;
-        int ret = receiveMessage(data, len, Ref(mctrl));
-        srctime = mctrl.srctime;
+        int         ret   = receiveMessage(data, len, Ref(mctrl));
+        srctime           = mctrl.srctime;
         return ret;
     }
 
     return receiveBuffer(data, len);
 }
 
-int CUDT::recvmsg2(char* data, int len, ref_t<SRT_MSGCTRL> mctrl)
+int CUDT::recvmsg2(char *data, int len, ref_t<SRT_MSGCTRL> mctrl)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -5901,9 +6021,9 @@ int CUDT::recvmsg2(char* data, int len, ref_t<SRT_MSGCTRL> mctrl)
     return receiveBuffer(data, len);
 }
 
-int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
+int CUDT::receiveMessage(char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 {
-    SRT_MSGCTRL& mctrl = *r_mctrl;
+    SRT_MSGCTRL &mctrl = *r_mctrl;
     // Recvmsg isn't restricted to the congctl type, it's the most
     // basic method of passing the data. You can retrieve data as
     // they come in, however you need to match the size of the buffer.
@@ -5927,7 +6047,7 @@ int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
     if (m_bBroken || m_bClosing)
     {
-        int res = m_pRcvBuffer->readMsg(data, len);
+        int res       = m_pRcvBuffer->readMsg(data, len);
         mctrl.srctime = 0;
 
         /* Kick TsbPd thread to schedule next wakeup (if running) */
@@ -5978,16 +6098,18 @@ int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
                 s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_IN, false);
 
                 // After signaling the tsbpd for ready data, report the bandwidth.
-                double bw SRT_ATR_UNUSED = Bps2Mbps( m_iBandwidth * m_iMaxSRTPayloadSize );
-                HLOGC(mglog.Debug, log << CONID() << "CURRENT BANDWIDTH: " << bw << "Mbps (" << m_iBandwidth << " buffers per second)");
+                double bw SRT_ATR_UNUSED = Bps2Mbps(m_iBandwidth * m_iMaxSRTPayloadSize);
+                HLOGC(mglog.Debug,
+                      log << CONID() << "CURRENT BANDWIDTH: " << bw << "Mbps (" << m_iBandwidth
+                          << " buffers per second)");
             }
             return res;
         }
     }
 
-    int res = 0;
+    int  res     = 0;
     bool timeout = false;
-    //Do not block forever, check connection status each 1 sec.
+    // Do not block forever, check connection status each 1 sec.
     uint64_t recvtmo = m_iRcvTimeOut < 0 ? 1000 : m_iRcvTimeOut;
 
     do
@@ -6055,7 +6177,7 @@ int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     }
 
     // Unblock when required
-    //LOGC(tslog.Debug, "RECVMSG/EXIT RES " << res << " RCVTIMEOUT");
+    // LOGC(tslog.Debug, "RECVMSG/EXIT RES " << res << " RCVTIMEOUT");
 
     if ((res <= 0) && (m_iRcvTimeOut >= 0))
         throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
@@ -6063,7 +6185,7 @@ int CUDT::receiveMessage(char* data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     return res;
 }
 
-int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
+int64_t CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int block)
 {
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -6078,7 +6200,8 @@ int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
 
     if (!m_pCryptoControl || !m_pCryptoControl->isSndEncryptionOK())
     {
-        LOGC(dlog.Error, log << "Encryption is required, but the peer did not supply correct credentials. Sending rejected.");
+        LOGC(dlog.Error,
+             log << "Encryption is required, but the peer did not supply correct credentials. Sending rejected.");
         throw CUDTException(MJ_SETUP, MN_SECURITY, 0);
     }
 
@@ -6091,7 +6214,7 @@ int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
         CTimer::rdtsc(currtime_tk);
         // (fix keepalive) m_ullLastRspTime_tk = currtime_tk;
         m_ullLastRspAckTime_tk = currtime_tk;
-        m_iReXmitCount = 1;
+        m_iReXmitCount         = 1;
     }
 
     // positioning...
@@ -6123,7 +6246,7 @@ int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
     }
 
     int64_t tosend = size;
-    int unitsize;
+    int     unitsize;
 
     // sending block by block
     while (tosend > 0)
@@ -6163,7 +6286,7 @@ int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
         }
 
         {
-            CGuard recvAckLock(m_RecvAckLock);
+            CGuard        recvAckLock(m_RecvAckLock);
             const int64_t sentsize = m_pSndBuffer->addBufferFromFile(ifs, unitsize);
 
             if (sentsize > 0)
@@ -6186,7 +6309,7 @@ int64_t CUDT::sendfile(fstream& ifs, int64_t& offset, int64_t size, int block)
     return size - tosend;
 }
 
-int64_t CUDT::recvfile(fstream& ofs, int64_t& offset, int64_t size, int block)
+int64_t CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -6252,9 +6375,9 @@ int64_t CUDT::recvfile(fstream& ofs, int64_t& offset, int64_t size, int block)
         throw CUDTException(MJ_FILESYSTEM, MN_SEEKPFAIL);
     }
 
-    int64_t torecv = size;
-    int unitsize = block;
-    int recvsize;
+    int64_t torecv   = size;
+    int     unitsize = block;
+    int     recvsize;
 
     // receiving... "recvfile" is always blocking
     while (torecv > 0)
@@ -6302,306 +6425,306 @@ int64_t CUDT::recvfile(fstream& ofs, int64_t& offset, int64_t size, int block)
     return size - torecv;
 }
 
-void CUDT::sample(CPerfMon* perf, bool clear)
+void CUDT::sample(CPerfMon *perf, bool clear)
 {
-   if (!m_bConnected)
-      throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
-   if (m_bBroken || m_bClosing)
-      throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
+    if (!m_bConnected)
+        throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
+    if (m_bBroken || m_bClosing)
+        throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-   CGuard statsLock(m_StatsLock);
-   uint64_t currtime = CTimer::getTime();
-   perf->msTimeStamp = (currtime - m_stats.startTime) / 1000;
+    CGuard   statsLock(m_StatsLock);
+    uint64_t currtime = CTimer::getTime();
+    perf->msTimeStamp = (currtime - m_stats.startTime) / 1000;
 
-   perf->pktSent = m_stats.traceSent;
-   perf->pktRecv = m_stats.traceRecv;
-   perf->pktSndLoss = m_stats.traceSndLoss;
-   perf->pktRcvLoss = m_stats.traceRcvLoss;
-   perf->pktRetrans = m_stats.traceRetrans;
-   perf->pktRcvRetrans = m_stats.traceRcvRetrans;
-   perf->pktSentACK = m_stats.sentACK;
-   perf->pktRecvACK = m_stats.recvACK;
-   perf->pktSentNAK = m_stats.sentNAK;
-   perf->pktRecvNAK = m_stats.recvNAK;
-   perf->usSndDuration = m_stats.sndDuration;
-   perf->pktReorderDistance = m_stats.traceReorderDistance;
-   perf->pktRcvAvgBelatedTime = m_stats.traceBelatedTime;
-   perf->pktRcvBelated = m_stats.traceRcvBelated;
+    perf->pktSent              = m_stats.traceSent;
+    perf->pktRecv              = m_stats.traceRecv;
+    perf->pktSndLoss           = m_stats.traceSndLoss;
+    perf->pktRcvLoss           = m_stats.traceRcvLoss;
+    perf->pktRetrans           = m_stats.traceRetrans;
+    perf->pktRcvRetrans        = m_stats.traceRcvRetrans;
+    perf->pktSentACK           = m_stats.sentACK;
+    perf->pktRecvACK           = m_stats.recvACK;
+    perf->pktSentNAK           = m_stats.sentNAK;
+    perf->pktRecvNAK           = m_stats.recvNAK;
+    perf->usSndDuration        = m_stats.sndDuration;
+    perf->pktReorderDistance   = m_stats.traceReorderDistance;
+    perf->pktRcvAvgBelatedTime = m_stats.traceBelatedTime;
+    perf->pktRcvBelated        = m_stats.traceRcvBelated;
 
-   perf->pktSentTotal = m_stats.sentTotal;
-   perf->pktRecvTotal = m_stats.recvTotal;
-   perf->pktSndLossTotal = m_stats.sndLossTotal;
-   perf->pktRcvLossTotal = m_stats.rcvLossTotal;
-   perf->pktRetransTotal = m_stats.retransTotal;
-   perf->pktSentACKTotal = m_stats.sentACKTotal;
-   perf->pktRecvACKTotal = m_stats.recvACKTotal;
-   perf->pktSentNAKTotal = m_stats.sentNAKTotal;
-   perf->pktRecvNAKTotal = m_stats.recvNAKTotal;
-   perf->usSndDurationTotal = m_stats.m_sndDurationTotal;
+    perf->pktSentTotal       = m_stats.sentTotal;
+    perf->pktRecvTotal       = m_stats.recvTotal;
+    perf->pktSndLossTotal    = m_stats.sndLossTotal;
+    perf->pktRcvLossTotal    = m_stats.rcvLossTotal;
+    perf->pktRetransTotal    = m_stats.retransTotal;
+    perf->pktSentACKTotal    = m_stats.sentACKTotal;
+    perf->pktRecvACKTotal    = m_stats.recvACKTotal;
+    perf->pktSentNAKTotal    = m_stats.sentNAKTotal;
+    perf->pktRecvNAKTotal    = m_stats.recvNAKTotal;
+    perf->usSndDurationTotal = m_stats.m_sndDurationTotal;
 
-   double interval = double(currtime - m_stats.lastSampleTime);
+    double interval = double(currtime - m_stats.lastSampleTime);
 
-   perf->mbpsSendRate = double(m_stats.traceSent) * m_iMaxSRTPayloadSize * 8.0 / interval;
-   perf->mbpsRecvRate = double(m_stats.traceRecv) * m_iMaxSRTPayloadSize * 8.0 / interval;
+    perf->mbpsSendRate = double(m_stats.traceSent) * m_iMaxSRTPayloadSize * 8.0 / interval;
+    perf->mbpsRecvRate = double(m_stats.traceRecv) * m_iMaxSRTPayloadSize * 8.0 / interval;
 
-   perf->usPktSndPeriod = m_ullInterval_tk / double(m_ullCPUFrequency);
-   perf->pktFlowWindow = m_iFlowWindowSize;
-   perf->pktCongestionWindow = (int)m_dCongestionWindow;
-   perf->pktFlightSize = CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
-   perf->msRTT = m_iRTT/1000.0;
-   perf->mbpsBandwidth = Bps2Mbps( m_iBandwidth * m_iMaxSRTPayloadSize );
+    perf->usPktSndPeriod      = m_ullInterval_tk / double(m_ullCPUFrequency);
+    perf->pktFlowWindow       = m_iFlowWindowSize;
+    perf->pktCongestionWindow = (int)m_dCongestionWindow;
+    perf->pktFlightSize       = CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
+    perf->msRTT               = m_iRTT / 1000.0;
+    perf->mbpsBandwidth       = Bps2Mbps(m_iBandwidth * m_iMaxSRTPayloadSize);
 
-   if (pthread_mutex_trylock(&m_ConnectionLock) == 0)
-   {
-      perf->byteAvailSndBuf = (m_pSndBuffer == NULL) ? 0 
-          : sndBuffersLeft() * m_iMSS;
-      perf->byteAvailRcvBuf = (m_pRcvBuffer == NULL) ? 0 
-          : m_pRcvBuffer->getAvailBufSize() * m_iMSS;
+    if (pthread_mutex_trylock(&m_ConnectionLock) == 0)
+    {
+        perf->byteAvailSndBuf = (m_pSndBuffer == NULL) ? 0 : sndBuffersLeft() * m_iMSS;
+        perf->byteAvailRcvBuf = (m_pRcvBuffer == NULL) ? 0 : m_pRcvBuffer->getAvailBufSize() * m_iMSS;
 
-      pthread_mutex_unlock(&m_ConnectionLock);
-   }
-   else
-   {
-      perf->byteAvailSndBuf = 0;
-      perf->byteAvailRcvBuf = 0;
-   }
+        pthread_mutex_unlock(&m_ConnectionLock);
+    }
+    else
+    {
+        perf->byteAvailSndBuf = 0;
+        perf->byteAvailRcvBuf = 0;
+    }
 
-   if (clear)
-   {
-      m_stats.traceSndDrop        = 0;
-      m_stats.traceRcvDrop        = 0;
-      m_stats.traceSndBytesDrop = 0;
-      m_stats.traceRcvBytesDrop = 0;
-      m_stats.traceRcvUndecrypt        = 0;
-      m_stats.traceRcvBytesUndecrypt = 0;
-      //new>
-      m_stats.traceBytesSent = m_stats.traceBytesRecv = m_stats.traceBytesRetrans = 0;
-      //<
-      m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans = m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
-      m_stats.sndDuration = 0;
-      m_stats.traceRcvRetrans = 0;
-      m_stats.traceRcvBelated = 0;
+    if (clear)
+    {
+        m_stats.traceSndDrop           = 0;
+        m_stats.traceRcvDrop           = 0;
+        m_stats.traceSndBytesDrop      = 0;
+        m_stats.traceRcvBytesDrop      = 0;
+        m_stats.traceRcvUndecrypt      = 0;
+        m_stats.traceRcvBytesUndecrypt = 0;
+        // new>
+        m_stats.traceBytesSent = m_stats.traceBytesRecv = m_stats.traceBytesRetrans = 0;
+        //<
+        m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans =
+            m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
+        m_stats.sndDuration                                                       = 0;
+        m_stats.traceRcvRetrans                                                   = 0;
+        m_stats.traceRcvBelated                                                   = 0;
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-      m_stats.traceRcvBytesLoss = 0;
+        m_stats.traceRcvBytesLoss = 0;
 #endif
 
-      m_stats.sndFilterExtra = 0;
-      m_stats.rcvFilterExtra = 0;
+        m_stats.sndFilterExtra = 0;
+        m_stats.rcvFilterExtra = 0;
 
-      m_stats.rcvFilterSupply = 0;
-      m_stats.rcvFilterLoss = 0;
+        m_stats.rcvFilterSupply = 0;
+        m_stats.rcvFilterLoss   = 0;
 
-      m_stats.lastSampleTime = currtime;
-   }
+        m_stats.lastSampleTime = currtime;
+    }
 }
 
-void CUDT::bstats(CBytePerfMon* perf, bool clear, bool instantaneous)
+void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 {
-   if (!m_bConnected)
-      throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
-   if (m_bBroken || m_bClosing)
-      throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
+    if (!m_bConnected)
+        throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
+    if (m_bBroken || m_bClosing)
+        throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-   CGuard statsguard(m_StatsLock);
+    CGuard statsguard(m_StatsLock);
 
-   uint64_t currtime = CTimer::getTime();
-   perf->msTimeStamp = (currtime - m_stats.startTime) / 1000;
+    uint64_t currtime = CTimer::getTime();
+    perf->msTimeStamp = (currtime - m_stats.startTime) / 1000;
 
-   perf->pktSent = m_stats.traceSent;
-   perf->pktRecv = m_stats.traceRecv;
-   perf->pktSndLoss = m_stats.traceSndLoss;
-   perf->pktRcvLoss = m_stats.traceRcvLoss;
-   perf->pktRetrans = m_stats.traceRetrans;
-   perf->pktRcvRetrans = m_stats.traceRcvRetrans;
-   perf->pktSentACK = m_stats.sentACK;
-   perf->pktRecvACK = m_stats.recvACK;
-   perf->pktSentNAK = m_stats.sentNAK;
-   perf->pktRecvNAK = m_stats.recvNAK;
-   perf->usSndDuration = m_stats.sndDuration;
-   perf->pktReorderDistance = m_stats.traceReorderDistance;
-   perf->pktRcvAvgBelatedTime = m_stats.traceBelatedTime;
-   perf->pktRcvBelated = m_stats.traceRcvBelated;
+    perf->pktSent              = m_stats.traceSent;
+    perf->pktRecv              = m_stats.traceRecv;
+    perf->pktSndLoss           = m_stats.traceSndLoss;
+    perf->pktRcvLoss           = m_stats.traceRcvLoss;
+    perf->pktRetrans           = m_stats.traceRetrans;
+    perf->pktRcvRetrans        = m_stats.traceRcvRetrans;
+    perf->pktSentACK           = m_stats.sentACK;
+    perf->pktRecvACK           = m_stats.recvACK;
+    perf->pktSentNAK           = m_stats.sentNAK;
+    perf->pktRecvNAK           = m_stats.recvNAK;
+    perf->usSndDuration        = m_stats.sndDuration;
+    perf->pktReorderDistance   = m_stats.traceReorderDistance;
+    perf->pktRcvAvgBelatedTime = m_stats.traceBelatedTime;
+    perf->pktRcvBelated        = m_stats.traceRcvBelated;
 
-   perf->pktSndFilterExtra = m_stats.sndFilterExtra;
-   perf->pktRcvFilterExtra = m_stats.rcvFilterExtra;
-   perf->pktRcvFilterSupply = m_stats.rcvFilterSupply;
-   perf->pktRcvFilterLoss = m_stats.rcvFilterLoss;
+    perf->pktSndFilterExtra  = m_stats.sndFilterExtra;
+    perf->pktRcvFilterExtra  = m_stats.rcvFilterExtra;
+    perf->pktRcvFilterSupply = m_stats.rcvFilterSupply;
+    perf->pktRcvFilterLoss   = m_stats.rcvFilterLoss;
 
-   /* perf byte counters include all headers (SRT+UDP+IP) */
-   const int pktHdrSize = CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE;
-   perf->byteSent = m_stats.traceBytesSent + (m_stats.traceSent * pktHdrSize);
-   perf->byteRecv = m_stats.traceBytesRecv + (m_stats.traceRecv * pktHdrSize);
-   perf->byteRetrans = m_stats.traceBytesRetrans + (m_stats.traceRetrans * pktHdrSize);
+    /* perf byte counters include all headers (SRT+UDP+IP) */
+    const int pktHdrSize = CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE;
+    perf->byteSent       = m_stats.traceBytesSent + (m_stats.traceSent * pktHdrSize);
+    perf->byteRecv       = m_stats.traceBytesRecv + (m_stats.traceRecv * pktHdrSize);
+    perf->byteRetrans    = m_stats.traceBytesRetrans + (m_stats.traceRetrans * pktHdrSize);
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-   perf->byteRcvLoss = m_stats.traceRcvBytesLoss + (m_stats.traceRcvLoss * pktHdrSize);
+    perf->byteRcvLoss = m_stats.traceRcvBytesLoss + (m_stats.traceRcvLoss * pktHdrSize);
 #endif
 
-   perf->pktSndDrop = m_stats.traceSndDrop;
-   perf->pktRcvDrop = m_stats.traceRcvDrop + m_stats.traceRcvUndecrypt;
-   perf->byteSndDrop = m_stats.traceSndBytesDrop + (m_stats.traceSndDrop * pktHdrSize);
-   perf->byteRcvDrop = m_stats.traceRcvBytesDrop + (m_stats.traceRcvDrop * pktHdrSize) + m_stats.traceRcvBytesUndecrypt;
-   perf->pktRcvUndecrypt = m_stats.traceRcvUndecrypt;
-   perf->byteRcvUndecrypt = m_stats.traceRcvBytesUndecrypt;
+    perf->pktSndDrop  = m_stats.traceSndDrop;
+    perf->pktRcvDrop  = m_stats.traceRcvDrop + m_stats.traceRcvUndecrypt;
+    perf->byteSndDrop = m_stats.traceSndBytesDrop + (m_stats.traceSndDrop * pktHdrSize);
+    perf->byteRcvDrop =
+        m_stats.traceRcvBytesDrop + (m_stats.traceRcvDrop * pktHdrSize) + m_stats.traceRcvBytesUndecrypt;
+    perf->pktRcvUndecrypt  = m_stats.traceRcvUndecrypt;
+    perf->byteRcvUndecrypt = m_stats.traceRcvBytesUndecrypt;
 
-   perf->pktSentTotal = m_stats.sentTotal;
-   perf->pktRecvTotal = m_stats.recvTotal;
-   perf->pktSndLossTotal = m_stats.sndLossTotal;
-   perf->pktRcvLossTotal = m_stats.rcvLossTotal;
-   perf->pktRetransTotal = m_stats.retransTotal;
-   perf->pktSentACKTotal = m_stats.sentACKTotal;
-   perf->pktRecvACKTotal = m_stats.recvACKTotal;
-   perf->pktSentNAKTotal = m_stats.sentNAKTotal;
-   perf->pktRecvNAKTotal = m_stats.recvNAKTotal;
-   perf->usSndDurationTotal = m_stats.m_sndDurationTotal;
+    perf->pktSentTotal       = m_stats.sentTotal;
+    perf->pktRecvTotal       = m_stats.recvTotal;
+    perf->pktSndLossTotal    = m_stats.sndLossTotal;
+    perf->pktRcvLossTotal    = m_stats.rcvLossTotal;
+    perf->pktRetransTotal    = m_stats.retransTotal;
+    perf->pktSentACKTotal    = m_stats.sentACKTotal;
+    perf->pktRecvACKTotal    = m_stats.recvACKTotal;
+    perf->pktSentNAKTotal    = m_stats.sentNAKTotal;
+    perf->pktRecvNAKTotal    = m_stats.recvNAKTotal;
+    perf->usSndDurationTotal = m_stats.m_sndDurationTotal;
 
-   perf->byteSentTotal = m_stats.bytesSentTotal + (m_stats.sentTotal * pktHdrSize);
-   perf->byteRecvTotal = m_stats.bytesRecvTotal + (m_stats.recvTotal * pktHdrSize);
-   perf->byteRetransTotal = m_stats.bytesRetransTotal + (m_stats.retransTotal * pktHdrSize);
-   perf->pktSndFilterExtraTotal = m_stats.sndFilterExtraTotal;
-   perf->pktRcvFilterExtraTotal = m_stats.rcvFilterExtraTotal;
-   perf->pktRcvFilterSupplyTotal = m_stats.rcvFilterSupplyTotal;
-   perf->pktRcvFilterLossTotal = m_stats.rcvFilterLossTotal;
+    perf->byteSentTotal           = m_stats.bytesSentTotal + (m_stats.sentTotal * pktHdrSize);
+    perf->byteRecvTotal           = m_stats.bytesRecvTotal + (m_stats.recvTotal * pktHdrSize);
+    perf->byteRetransTotal        = m_stats.bytesRetransTotal + (m_stats.retransTotal * pktHdrSize);
+    perf->pktSndFilterExtraTotal  = m_stats.sndFilterExtraTotal;
+    perf->pktRcvFilterExtraTotal  = m_stats.rcvFilterExtraTotal;
+    perf->pktRcvFilterSupplyTotal = m_stats.rcvFilterSupplyTotal;
+    perf->pktRcvFilterLossTotal   = m_stats.rcvFilterLossTotal;
 
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-   perf->byteRcvLossTotal = m_stats.rcvBytesLossTotal + (m_stats.rcvLossTotal * pktHdrSize);
+    perf->byteRcvLossTotal = m_stats.rcvBytesLossTotal + (m_stats.rcvLossTotal * pktHdrSize);
 #endif
-   perf->pktSndDropTotal = m_stats.sndDropTotal;
-   perf->pktRcvDropTotal = m_stats.rcvDropTotal + m_stats.m_rcvUndecryptTotal;
-   perf->byteSndDropTotal = m_stats.sndBytesDropTotal + (m_stats.sndDropTotal * pktHdrSize);
-   perf->byteRcvDropTotal = m_stats.rcvBytesDropTotal + (m_stats.rcvDropTotal * pktHdrSize) + m_stats.m_rcvBytesUndecryptTotal;
-   perf->pktRcvUndecryptTotal = m_stats.m_rcvUndecryptTotal;
-   perf->byteRcvUndecryptTotal = m_stats.m_rcvBytesUndecryptTotal;
-   //<
+    perf->pktSndDropTotal  = m_stats.sndDropTotal;
+    perf->pktRcvDropTotal  = m_stats.rcvDropTotal + m_stats.m_rcvUndecryptTotal;
+    perf->byteSndDropTotal = m_stats.sndBytesDropTotal + (m_stats.sndDropTotal * pktHdrSize);
+    perf->byteRcvDropTotal =
+        m_stats.rcvBytesDropTotal + (m_stats.rcvDropTotal * pktHdrSize) + m_stats.m_rcvBytesUndecryptTotal;
+    perf->pktRcvUndecryptTotal  = m_stats.m_rcvUndecryptTotal;
+    perf->byteRcvUndecryptTotal = m_stats.m_rcvBytesUndecryptTotal;
+    //<
 
-   double interval = double(currtime - m_stats.lastSampleTime);
+    double interval = double(currtime - m_stats.lastSampleTime);
 
-   //>mod
-   perf->mbpsSendRate = double(perf->byteSent) * 8.0 / interval;
-   perf->mbpsRecvRate = double(perf->byteRecv) * 8.0 / interval;
-   //<
+    //>mod
+    perf->mbpsSendRate = double(perf->byteSent) * 8.0 / interval;
+    perf->mbpsRecvRate = double(perf->byteRecv) * 8.0 / interval;
+    //<
 
-   perf->usPktSndPeriod = m_ullInterval_tk / double(m_ullCPUFrequency);
-   perf->pktFlowWindow = m_iFlowWindowSize;
-   perf->pktCongestionWindow = (int)m_dCongestionWindow;
-   perf->pktFlightSize = CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
-   perf->msRTT = (double)m_iRTT/1000.0;
-   //>new
-   perf->msSndTsbPdDelay = m_bPeerTsbPd ? m_iPeerTsbPdDelay_ms : 0;
-   perf->msRcvTsbPdDelay = m_bTsbPd ? m_iTsbPdDelay_ms : 0;
-   perf->byteMSS = m_iMSS;
+    perf->usPktSndPeriod      = m_ullInterval_tk / double(m_ullCPUFrequency);
+    perf->pktFlowWindow       = m_iFlowWindowSize;
+    perf->pktCongestionWindow = (int)m_dCongestionWindow;
+    perf->pktFlightSize       = CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
+    perf->msRTT               = (double)m_iRTT / 1000.0;
+    //>new
+    perf->msSndTsbPdDelay = m_bPeerTsbPd ? m_iPeerTsbPdDelay_ms : 0;
+    perf->msRcvTsbPdDelay = m_bTsbPd ? m_iTsbPdDelay_ms : 0;
+    perf->byteMSS         = m_iMSS;
 
-   perf->mbpsMaxBW = m_llMaxBW > 0 ? Bps2Mbps(m_llMaxBW)
-       : m_CongCtl.ready() ? Bps2Mbps(m_CongCtl->sndBandwidth())
-       : 0;
+    perf->mbpsMaxBW = m_llMaxBW > 0 ? Bps2Mbps(m_llMaxBW) : m_CongCtl.ready() ? Bps2Mbps(m_CongCtl->sndBandwidth()) : 0;
 
-   //<
-   uint32_t availbw = (uint64_t)(m_iBandwidth == 1 ? m_RcvTimeWindow.getBandwidth() : m_iBandwidth);
+    //<
+    uint32_t availbw = (uint64_t)(m_iBandwidth == 1 ? m_RcvTimeWindow.getBandwidth() : m_iBandwidth);
 
-   perf->mbpsBandwidth = Bps2Mbps( availbw * (m_iMaxSRTPayloadSize + pktHdrSize) );
+    perf->mbpsBandwidth = Bps2Mbps(availbw * (m_iMaxSRTPayloadSize + pktHdrSize));
 
-   if (pthread_mutex_trylock(&m_ConnectionLock) == 0)
-   {
-      if (m_pSndBuffer)
-      {
+    if (pthread_mutex_trylock(&m_ConnectionLock) == 0)
+    {
+        if (m_pSndBuffer)
+        {
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
-         if (instantaneous)
-         {
-             /* Get instant SndBuf instead of moving average for application-based Algorithm
-                (such as NAE) in need of fast reaction to network condition changes. */
-             perf->pktSndBuf = m_pSndBuffer->getCurrBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
-         }
-         else
-         {
-             perf->pktSndBuf = m_pSndBuffer->getAvgBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
-         }
+            if (instantaneous)
+            {
+                /* Get instant SndBuf instead of moving average for application-based Algorithm
+                   (such as NAE) in need of fast reaction to network condition changes. */
+                perf->pktSndBuf = m_pSndBuffer->getCurrBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
+            }
+            else
+            {
+                perf->pktSndBuf = m_pSndBuffer->getAvgBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
+            }
 #else
-         perf->pktSndBuf = m_pSndBuffer->getCurrBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
+            perf->pktSndBuf = m_pSndBuffer->getCurrBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
 #endif
-         perf->byteSndBuf += (perf->pktSndBuf * pktHdrSize);
-         //<
-         perf->byteAvailSndBuf = (m_iSndBufSize - perf->pktSndBuf) * m_iMSS;
-      }
-      else
-      {
-         perf->byteAvailSndBuf = 0;
-         //new>
-         perf->pktSndBuf = 0;
-         perf->byteSndBuf = 0;
-         perf->msSndBuf = 0;
-         //<
-      }
+            perf->byteSndBuf += (perf->pktSndBuf * pktHdrSize);
+            //<
+            perf->byteAvailSndBuf = (m_iSndBufSize - perf->pktSndBuf) * m_iMSS;
+        }
+        else
+        {
+            perf->byteAvailSndBuf = 0;
+            // new>
+            perf->pktSndBuf  = 0;
+            perf->byteSndBuf = 0;
+            perf->msSndBuf   = 0;
+            //<
+        }
 
-      if (m_pRcvBuffer)
-      {
-         perf->byteAvailRcvBuf = m_pRcvBuffer->getAvailBufSize() * m_iMSS;
-         //new>
+        if (m_pRcvBuffer)
+        {
+            perf->byteAvailRcvBuf = m_pRcvBuffer->getAvailBufSize() * m_iMSS;
+            // new>
 #ifdef SRT_ENABLE_RCVBUFSZ_MAVG
-         if (instantaneous) //no need for historical API for Rcv side
-         {
-             perf->pktRcvBuf = m_pRcvBuffer->getRcvDataSize(perf->byteRcvBuf, perf->msRcvBuf);
-         }
-         else
-         {
-             perf->pktRcvBuf = m_pRcvBuffer->getRcvAvgDataSize(perf->byteRcvBuf, perf->msRcvBuf);
-         }
+            if (instantaneous) // no need for historical API for Rcv side
+            {
+                perf->pktRcvBuf = m_pRcvBuffer->getRcvDataSize(perf->byteRcvBuf, perf->msRcvBuf);
+            }
+            else
+            {
+                perf->pktRcvBuf = m_pRcvBuffer->getRcvAvgDataSize(perf->byteRcvBuf, perf->msRcvBuf);
+            }
 #else
-         perf->pktRcvBuf = m_pRcvBuffer->getRcvDataSize(perf->byteRcvBuf, perf->msRcvBuf);
+            perf->pktRcvBuf = m_pRcvBuffer->getRcvDataSize(perf->byteRcvBuf, perf->msRcvBuf);
 #endif
-         //<
-      }
-      else
-      {
-         perf->byteAvailRcvBuf = 0;
-         //new>
-         perf->pktRcvBuf = 0;
-         perf->byteRcvBuf = 0;
-         perf->msRcvBuf = 0;
-         //<
-      }
+            //<
+        }
+        else
+        {
+            perf->byteAvailRcvBuf = 0;
+            // new>
+            perf->pktRcvBuf  = 0;
+            perf->byteRcvBuf = 0;
+            perf->msRcvBuf   = 0;
+            //<
+        }
 
-      pthread_mutex_unlock(&m_ConnectionLock);
-   }
-   else
-   {
-      perf->byteAvailSndBuf = 0;
-      perf->byteAvailRcvBuf = 0;
-      //new>
-      perf->pktSndBuf = 0;
-      perf->byteSndBuf = 0;
-      perf->msSndBuf = 0;
+        pthread_mutex_unlock(&m_ConnectionLock);
+    }
+    else
+    {
+        perf->byteAvailSndBuf = 0;
+        perf->byteAvailRcvBuf = 0;
+        // new>
+        perf->pktSndBuf  = 0;
+        perf->byteSndBuf = 0;
+        perf->msSndBuf   = 0;
 
-      perf->byteRcvBuf = 0;
-      perf->msRcvBuf = 0;
-      //<
-   }
+        perf->byteRcvBuf = 0;
+        perf->msRcvBuf   = 0;
+        //<
+    }
 
-   if (clear)
-   {
-      m_stats.traceSndDrop        = 0;
-      m_stats.traceRcvDrop        = 0;
-      m_stats.traceSndBytesDrop = 0;
-      m_stats.traceRcvBytesDrop = 0;
-      m_stats.traceRcvUndecrypt        = 0;
-      m_stats.traceRcvBytesUndecrypt = 0;
-      //new>
-      m_stats.traceBytesSent = m_stats.traceBytesRecv = m_stats.traceBytesRetrans = 0;
-      //<
-      m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans = m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
-      m_stats.sndDuration = 0;
-      m_stats.traceRcvRetrans = 0;
-      m_stats.traceRcvBelated = 0;
+    if (clear)
+    {
+        m_stats.traceSndDrop           = 0;
+        m_stats.traceRcvDrop           = 0;
+        m_stats.traceSndBytesDrop      = 0;
+        m_stats.traceRcvBytesDrop      = 0;
+        m_stats.traceRcvUndecrypt      = 0;
+        m_stats.traceRcvBytesUndecrypt = 0;
+        // new>
+        m_stats.traceBytesSent = m_stats.traceBytesRecv = m_stats.traceBytesRetrans = 0;
+        //<
+        m_stats.traceSent = m_stats.traceRecv = m_stats.traceSndLoss = m_stats.traceRcvLoss = m_stats.traceRetrans =
+            m_stats.sentACK = m_stats.recvACK = m_stats.sentNAK = m_stats.recvNAK = 0;
+        m_stats.sndDuration                                                       = 0;
+        m_stats.traceRcvRetrans                                                   = 0;
+        m_stats.traceRcvBelated                                                   = 0;
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT
-      m_stats.traceRcvBytesLoss = 0;
+        m_stats.traceRcvBytesLoss = 0;
 #endif
 
-      m_stats.sndFilterExtra = 0;
-      m_stats.rcvFilterExtra = 0;
+        m_stats.sndFilterExtra = 0;
+        m_stats.rcvFilterExtra = 0;
 
-      m_stats.rcvFilterSupply = 0;
-      m_stats.rcvFilterLoss = 0;
+        m_stats.rcvFilterSupply = 0;
+        m_stats.rcvFilterLoss   = 0;
 
-      m_stats.lastSampleTime = currtime;
-   }
+        m_stats.lastSampleTime = currtime;
+    }
 }
 
 void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
@@ -6614,10 +6737,9 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
     // time when the sending buffer. For sanity check, check both first.
     if (!m_CongCtl.ready() || !m_pSndBuffer)
     {
-        LOGC(mglog.Error, log << "updateCC: CAN'T DO UPDATE - congctl "
-            << (m_CongCtl.ready() ? "ready" : "NOT READY")
-            << "; sending buffer "
-            << (m_pSndBuffer ? "NOT CREATED" : "created"));
+        LOGC(mglog.Error,
+             log << "updateCC: CAN'T DO UPDATE - congctl " << (m_CongCtl.ready() ? "ready" : "NOT READY")
+                 << "; sending buffer " << (m_pSndBuffer ? "NOT CREATED" : "created"));
 
         return;
     }
@@ -6645,9 +6767,9 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
             // - if SRTO_MAXBW == 0, use SRTO_INPUTBW + SRTO_OHEADBW
             // - if SRTO_INPUTBW == 0, pass 0 to requst in-buffer sampling
             // Bytes/s
-            int bw = m_llMaxBW != 0 ? m_llMaxBW : // When used SRTO_MAXBW
-                m_llInputBW != 0 ? withOverhead(m_llInputBW) : // SRTO_INPUTBW + SRT_OHEADBW
-                0; // When both MAXBW and INPUTBW are 0, request in-buffer sampling
+            int bw = m_llMaxBW != 0 ? m_llMaxBW :                       // When used SRTO_MAXBW
+                         m_llInputBW != 0 ? withOverhead(m_llInputBW) : // SRTO_INPUTBW + SRT_OHEADBW
+                             0; // When both MAXBW and INPUTBW are 0, request in-buffer sampling
 
             // Note: setting bw == 0 uses BW_INFINITE value in LiveCC
             m_CongCtl->updateBandwidth(m_llMaxBW, bw);
@@ -6664,9 +6786,11 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
                 m_pSndBuffer->resetInputRateSmpPeriod(disable_in_rate_calc);
             }
 
-            HLOGC(mglog.Debug, log << "updateCC/TEV_INIT: updating BW=" << m_llMaxBW
-                << (only_input == TEV_INIT_RESET ? " (UNCHANGED)"
-                        : only_input == TEV_INIT_OHEADBW ? " (only Overhead)": " (updated sampling rate)"));
+            HLOGC(mglog.Debug,
+                  log << "updateCC/TEV_INIT: updating BW=" << m_llMaxBW
+                      << (only_input == TEV_INIT_RESET
+                              ? " (UNCHANGED)"
+                              : only_input == TEV_INIT_OHEADBW ? " (only Overhead)" : " (updated sampling rate)"));
         }
     }
 
@@ -6689,7 +6813,7 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
              * Keep previously set maximum in that case (inputbw == 0).
              */
             if (inputbw != 0)
-                m_CongCtl->updateBandwidth(0, withOverhead(inputbw)); //Bytes/sec
+                m_CongCtl->updateBandwidth(0, withOverhead(inputbw)); // Bytes/sec
         }
     }
 
@@ -6706,18 +6830,18 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
         // NOTE: THESE things come from CCC class:
         // - m_dPktSndPeriod
         // - m_dCWndSize
-        m_ullInterval_tk = (uint64_t)(m_CongCtl->pktSndPeriod_us() * m_ullCPUFrequency);
+        m_ullInterval_tk    = (uint64_t)(m_CongCtl->pktSndPeriod_us() * m_ullCPUFrequency);
         m_dCongestionWindow = m_CongCtl->cgWindowSize();
 #if ENABLE_HEAVY_LOGGING
-        HLOGC(mglog.Debug, log << "updateCC: updated values from congctl: interval=" << m_ullInterval_tk
-            << "tk (" << m_CongCtl->pktSndPeriod_us() << "us) cgwindow="
-            << std::setprecision(3) << m_dCongestionWindow);
+        HLOGC(mglog.Debug,
+              log << "updateCC: updated values from congctl: interval=" << m_ullInterval_tk << "tk ("
+                  << m_CongCtl->pktSndPeriod_us() << "us) cgwindow=" << std::setprecision(3) << m_dCongestionWindow);
 #endif
     }
 
     HLOGC(mglog.Debug, log << "udpateCC: finished handling for EVENT:" << TransmissionEventStr(evt));
 
-#if 0//debug
+#if 0 // debug
     static int callcnt = 0;
     if (!(callcnt++ % 250)) cerr << "SndPeriod=" << (m_ullInterval_tk/m_ullCPUFrequency) << "\n");
 
@@ -6726,38 +6850,36 @@ void CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
 
 void CUDT::initSynch()
 {
-      pthread_mutex_init(&m_SendBlockLock, NULL);
-      pthread_cond_init(&m_SendBlockCond, NULL);
-      pthread_mutex_init(&m_RecvDataLock, NULL);
-      pthread_cond_init(&m_RecvDataCond, NULL);
-      pthread_mutex_init(&m_SendLock, NULL);
-      pthread_mutex_init(&m_RecvLock, NULL);
-      pthread_mutex_init(&m_RcvLossLock, NULL);
-      pthread_mutex_init(&m_RecvAckLock, NULL);
-      pthread_mutex_init(&m_RcvBufferLock, NULL);
-      pthread_mutex_init(&m_ConnectionLock, NULL);
-      pthread_mutex_init(&m_StatsLock, NULL);
+    pthread_mutex_init(&m_SendBlockLock, NULL);
+    pthread_cond_init(&m_SendBlockCond, NULL);
+    pthread_mutex_init(&m_RecvDataLock, NULL);
+    pthread_cond_init(&m_RecvDataCond, NULL);
+    pthread_mutex_init(&m_SendLock, NULL);
+    pthread_mutex_init(&m_RecvLock, NULL);
+    pthread_mutex_init(&m_RcvLossLock, NULL);
+    pthread_mutex_init(&m_RecvAckLock, NULL);
+    pthread_mutex_init(&m_RcvBufferLock, NULL);
+    pthread_mutex_init(&m_ConnectionLock, NULL);
+    pthread_mutex_init(&m_StatsLock, NULL);
 
-      memset(&m_RcvTsbPdThread, 0, sizeof m_RcvTsbPdThread);
-      pthread_cond_init(&m_RcvTsbPdCond, NULL);
-
+    memset(&m_RcvTsbPdThread, 0, sizeof m_RcvTsbPdThread);
+    pthread_cond_init(&m_RcvTsbPdCond, NULL);
 }
 
 void CUDT::destroySynch()
 {
-      pthread_mutex_destroy(&m_SendBlockLock);
-      pthread_cond_destroy(&m_SendBlockCond);
-      pthread_mutex_destroy(&m_RecvDataLock);
-      pthread_cond_destroy(&m_RecvDataCond);
-      pthread_mutex_destroy(&m_SendLock);
-      pthread_mutex_destroy(&m_RecvLock);
-      pthread_mutex_destroy(&m_RcvLossLock);
-      pthread_mutex_destroy(&m_RecvAckLock);
-      pthread_mutex_destroy(&m_RcvBufferLock);
-      pthread_mutex_destroy(&m_ConnectionLock);
-      pthread_mutex_destroy(&m_StatsLock);
-      pthread_cond_destroy(&m_RcvTsbPdCond);
-
+    pthread_mutex_destroy(&m_SendBlockLock);
+    pthread_cond_destroy(&m_SendBlockCond);
+    pthread_mutex_destroy(&m_RecvDataLock);
+    pthread_cond_destroy(&m_RecvDataCond);
+    pthread_mutex_destroy(&m_SendLock);
+    pthread_mutex_destroy(&m_RecvLock);
+    pthread_mutex_destroy(&m_RcvLossLock);
+    pthread_mutex_destroy(&m_RecvAckLock);
+    pthread_mutex_destroy(&m_RcvBufferLock);
+    pthread_mutex_destroy(&m_ConnectionLock);
+    pthread_mutex_destroy(&m_StatsLock);
+    pthread_cond_destroy(&m_RcvTsbPdCond);
 }
 
 void CUDT::releaseSynch()
@@ -6779,7 +6901,7 @@ void CUDT::releaseSynch()
     pthread_mutex_unlock(&m_RecvLock);
 
     pthread_mutex_lock(&m_RecvDataLock);
-    if (!pthread_equal(m_RcvTsbPdThread, pthread_t())) 
+    if (!pthread_equal(m_RcvTsbPdThread, pthread_t()))
     {
         pthread_join(m_RcvTsbPdThread, NULL);
         m_RcvTsbPdThread = pthread_t();
@@ -6793,351 +6915,345 @@ void CUDT::releaseSynch()
 #if ENABLE_HEAVY_LOGGING
 static void DebugAck(string hdr, int prev, int ack)
 {
-    if ( !prev )
+    if (!prev)
     {
         HLOGC(mglog.Debug, log << hdr << "ACK " << ack);
         return;
     }
 
-    prev = CSeqNo::incseq(prev);
+    prev     = CSeqNo::incseq(prev);
     int diff = CSeqNo::seqoff(prev, ack);
-    if ( diff < 0 )
+    if (diff < 0)
     {
         HLOGC(mglog.Debug, log << hdr << "ACK ERROR: " << prev << "-" << ack << "(diff " << diff << ")");
         return;
     }
 
     bool shorted = diff > 100; // sanity
-    if ( shorted )
+    if (shorted)
         ack = CSeqNo::incseq(prev, 100);
 
     ostringstream ackv;
     for (; prev != ack; prev = CSeqNo::incseq(prev))
         ackv << prev << " ";
-    if ( shorted )
+    if (shorted)
         ackv << "...";
-    HLOGC(mglog.Debug, log << hdr << "ACK (" << (diff+1) << "): " << ackv.str() << ack);
+    HLOGC(mglog.Debug, log << hdr << "ACK (" << (diff + 1) << "): " << ackv.str() << ack);
 }
 #else
 static inline void DebugAck(string, int, int) {}
 #endif
 
-void CUDT::sendCtrl(UDTMessageType pkttype, const void* lparam, void* rparam, int size)
+void CUDT::sendCtrl(UDTMessageType pkttype, const void *lparam, void *rparam, int size)
 {
-   CPacket ctrlpkt;
-   uint64_t currtime_tk;
-   CTimer::rdtsc(currtime_tk);
+    CPacket  ctrlpkt;
+    uint64_t currtime_tk;
+    CTimer::rdtsc(currtime_tk);
 
-   ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+    ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
 
-   int nbsent = 0;
-   int local_prevack = 0;
+    int nbsent        = 0;
+    int local_prevack = 0;
 
 #if ENABLE_HEAVY_LOGGING
-   struct SaveBack
-   {
-       int& target;
-       const int& source;
+    struct SaveBack
+    {
+        int &      target;
+        const int &source;
 
-       ~SaveBack()
-       {
-           target = source;
-       }
-   } l_saveback = { m_iDebugPrevLastAck, m_iRcvLastAck };
-   (void)l_saveback; //kill compiler warning: unused variable `l_saveback` [-Wunused-variable]
+        ~SaveBack() { target = source; }
+    } l_saveback = {m_iDebugPrevLastAck, m_iRcvLastAck};
+    (void)l_saveback; // kill compiler warning: unused variable `l_saveback` [-Wunused-variable]
 
-   local_prevack = m_iDebugPrevLastAck;
+    local_prevack = m_iDebugPrevLastAck;
 #endif
 
-   switch (pkttype)
-   {
-   case UMSG_ACK: //010 - Acknowledgement
-      {
-      int32_t ack;
+    switch (pkttype)
+    {
+    case UMSG_ACK: // 010 - Acknowledgement
+    {
+        int32_t ack;
 
-      // If there is no loss, the ACK is the current largest sequence number plus 1;
-      // Otherwise it is the smallest sequence number in the receiver loss list.
-      if (m_pRcvLossList->getLossLength() == 0)
-         ack = CSeqNo::incseq(m_iRcvCurrSeqNo);
-      else
-         ack = m_pRcvLossList->getFirstLostSeq();
+        // If there is no loss, the ACK is the current largest sequence number plus 1;
+        // Otherwise it is the smallest sequence number in the receiver loss list.
+        if (m_pRcvLossList->getLossLength() == 0)
+            ack = CSeqNo::incseq(m_iRcvCurrSeqNo);
+        else
+            ack = m_pRcvLossList->getFirstLostSeq();
 
-      if (m_iRcvLastAckAck == ack)
-         break;
+        if (m_iRcvLastAckAck == ack)
+            break;
 
-      // send out a lite ACK
-      // to save time on buffer processing and bandwidth/AS measurement, a lite ACK only feeds back an ACK number
-      if (size == SEND_LITE_ACK)
-      {
-         ctrlpkt.pack(pkttype, NULL, &ack, size);
-         ctrlpkt.m_iID = m_PeerID;
-         nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
-         DebugAck("sendCtrl(lite):" + CONID(), local_prevack, ack);
-         break;
-      }
+        // send out a lite ACK
+        // to save time on buffer processing and bandwidth/AS measurement, a lite ACK only feeds back an ACK number
+        if (size == SEND_LITE_ACK)
+        {
+            ctrlpkt.pack(pkttype, NULL, &ack, size);
+            ctrlpkt.m_iID = m_PeerID;
+            nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+            DebugAck("sendCtrl(lite):" + CONID(), local_prevack, ack);
+            break;
+        }
 
-      // There are new received packets to acknowledge, update related information.
-      /* tsbpd thread may also call ackData when skipping packet so protect code */
-      CGuard::enterCS(m_RcvBufferLock);
+        // There are new received packets to acknowledge, update related information.
+        /* tsbpd thread may also call ackData when skipping packet so protect code */
+        CGuard::enterCS(m_RcvBufferLock);
 
-      // IF ack > m_iRcvLastAck
-      if (CSeqNo::seqcmp(ack, m_iRcvLastAck) > 0)
-      {
-         int acksize = CSeqNo::seqoff(m_iRcvLastSkipAck, ack);
+        // IF ack > m_iRcvLastAck
+        if (CSeqNo::seqcmp(ack, m_iRcvLastAck) > 0)
+        {
+            int acksize = CSeqNo::seqoff(m_iRcvLastSkipAck, ack);
 
-         IF_HEAVY_LOGGING(int32_t oldack = m_iRcvLastSkipAck);
-         m_iRcvLastAck = ack;
-         m_iRcvLastSkipAck = ack;
+            IF_HEAVY_LOGGING(int32_t oldack = m_iRcvLastSkipAck);
+            m_iRcvLastAck     = ack;
+            m_iRcvLastSkipAck = ack;
 
-         // XXX Unknown as to whether it matters.
-         // This if (acksize) causes that ackData() won't be called.
-         // With size == 0 it wouldn't do anything except calling CTimer::triggerEvent().
-         // This, again, signals the condition, CTimer::m_EventCond.
-         // This releases CTimer::waitForEvent() call used in CUDTUnited::selectEx().
-         // Preventing to call this on zero size makes sense, if it prevents false alerts.
-         if (acksize > 0)
-             m_pRcvBuffer->ackData(acksize);
-         CGuard::leaveCS(m_RcvBufferLock);
+            // XXX Unknown as to whether it matters.
+            // This if (acksize) causes that ackData() won't be called.
+            // With size == 0 it wouldn't do anything except calling CTimer::triggerEvent().
+            // This, again, signals the condition, CTimer::m_EventCond.
+            // This releases CTimer::waitForEvent() call used in CUDTUnited::selectEx().
+            // Preventing to call this on zero size makes sense, if it prevents false alerts.
+            if (acksize > 0)
+                m_pRcvBuffer->ackData(acksize);
+            CGuard::leaveCS(m_RcvBufferLock);
 
-         // If TSBPD is enabled, then INSTEAD OF signaling m_RecvDataCond,
-         // signal m_RcvTsbPdCond. This will kick in the tsbpd thread, which
-         // will signal m_RecvDataCond when there's time to play for particular
-         // data packet.
-         HLOGC(dlog.Debug, log << "ACK: clip %" << oldack << "-%" << ack
-                 << ", REVOKED " << acksize << " from RCV buffer");
+            // If TSBPD is enabled, then INSTEAD OF signaling m_RecvDataCond,
+            // signal m_RcvTsbPdCond. This will kick in the tsbpd thread, which
+            // will signal m_RecvDataCond when there's time to play for particular
+            // data packet.
+            HLOGC(dlog.Debug,
+                  log << "ACK: clip %" << oldack << "-%" << ack << ", REVOKED " << acksize << " from RCV buffer");
 
-         if (m_bTsbPd)
-         {
-             /* Newly acknowledged data, signal TsbPD thread */
-             pthread_mutex_lock(&m_RecvLock);
-             if (m_bTsbPdAckWakeup)
-                pthread_cond_signal(&m_RcvTsbPdCond);
-             pthread_mutex_unlock(&m_RecvLock);
-         }
-         else
-         {
-             if (m_bSynRecving)
-             {
-                 // signal a waiting "recv" call if there is any data available
-                 pthread_mutex_lock(&m_RecvDataLock);
-                 pthread_cond_signal(&m_RecvDataCond);
-                 pthread_mutex_unlock(&m_RecvDataLock);
-             }
-             // acknowledge any waiting epolls to read
-             s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_IN, true);
-             CTimer::triggerEvent();
-         }
-         CGuard::enterCS(m_RcvBufferLock);
-      }
-      else if (ack == m_iRcvLastAck)
-      {
-         // If the ACK was just sent already AND elapsed time did not exceed RTT, 
-         if ((currtime_tk - m_ullLastAckTime_tk) < ((m_iRTT + 4 * m_iRTTVar) * m_ullCPUFrequency))
-         {
+            if (m_bTsbPd)
+            {
+                /* Newly acknowledged data, signal TsbPD thread */
+                pthread_mutex_lock(&m_RecvLock);
+                if (m_bTsbPdAckWakeup)
+                    pthread_cond_signal(&m_RcvTsbPdCond);
+                pthread_mutex_unlock(&m_RecvLock);
+            }
+            else
+            {
+                if (m_bSynRecving)
+                {
+                    // signal a waiting "recv" call if there is any data available
+                    pthread_mutex_lock(&m_RecvDataLock);
+                    pthread_cond_signal(&m_RecvDataCond);
+                    pthread_mutex_unlock(&m_RecvDataLock);
+                }
+                // acknowledge any waiting epolls to read
+                s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_IN, true);
+                CTimer::triggerEvent();
+            }
+            CGuard::enterCS(m_RcvBufferLock);
+        }
+        else if (ack == m_iRcvLastAck)
+        {
+            // If the ACK was just sent already AND elapsed time did not exceed RTT,
+            if ((currtime_tk - m_ullLastAckTime_tk) < ((m_iRTT + 4 * m_iRTTVar) * m_ullCPUFrequency))
+            {
+                CGuard::leaveCS(m_RcvBufferLock);
+                break;
+            }
+        }
+        else
+        {
+            // Not possible (m_iRcvCurrSeqNo+1 < m_iRcvLastAck ?)
             CGuard::leaveCS(m_RcvBufferLock);
             break;
-         }
-      }
-      else
-      {
-         // Not possible (m_iRcvCurrSeqNo+1 < m_iRcvLastAck ?)
-         CGuard::leaveCS(m_RcvBufferLock);
-         break;
-      }
+        }
 
-      // [[using assert( ack >= m_iRcvLastAck && is_periodic_ack ) ]]
+        // [[using assert( ack >= m_iRcvLastAck && is_periodic_ack ) ]]
 
-      // Send out the ACK only if has not been received by the sender before
-      if (CSeqNo::seqcmp(m_iRcvLastAck, m_iRcvLastAckAck) > 0)
-      {
-         // NOTE: The BSTATS feature turns on extra fields above size 6
-         // also known as ACKD_TOTAL_SIZE_VER100. 
-         int32_t data[ACKD_TOTAL_SIZE];
+        // Send out the ACK only if has not been received by the sender before
+        if (CSeqNo::seqcmp(m_iRcvLastAck, m_iRcvLastAckAck) > 0)
+        {
+            // NOTE: The BSTATS feature turns on extra fields above size 6
+            // also known as ACKD_TOTAL_SIZE_VER100.
+            int32_t data[ACKD_TOTAL_SIZE];
 
-         // Case you care, CAckNo::incack does exactly the same thing as
-         // CSeqNo::incseq. Logically the ACK number is a different thing
-         // than sequence number (it's a "journal" for ACK request-response,
-         // and starts from 0, unlike sequence, which starts from a random
-         // number), but still the numbers are from exactly the same domain.
-         m_iAckSeqNo = CAckNo::incack(m_iAckSeqNo);
-         data[ACKD_RCVLASTACK] = m_iRcvLastAck;
-         data[ACKD_RTT] = m_iRTT;
-         data[ACKD_RTTVAR] = m_iRTTVar;
-         data[ACKD_BUFFERLEFT] = m_pRcvBuffer->getAvailBufSize();
-         // a minimum flow window of 2 is used, even if buffer is full, to break potential deadlock
-         if (data[ACKD_BUFFERLEFT] < 2)
-            data[ACKD_BUFFERLEFT] = 2;
+            // Case you care, CAckNo::incack does exactly the same thing as
+            // CSeqNo::incseq. Logically the ACK number is a different thing
+            // than sequence number (it's a "journal" for ACK request-response,
+            // and starts from 0, unlike sequence, which starts from a random
+            // number), but still the numbers are from exactly the same domain.
+            m_iAckSeqNo           = CAckNo::incack(m_iAckSeqNo);
+            data[ACKD_RCVLASTACK] = m_iRcvLastAck;
+            data[ACKD_RTT]        = m_iRTT;
+            data[ACKD_RTTVAR]     = m_iRTTVar;
+            data[ACKD_BUFFERLEFT] = m_pRcvBuffer->getAvailBufSize();
+            // a minimum flow window of 2 is used, even if buffer is full, to break potential deadlock
+            if (data[ACKD_BUFFERLEFT] < 2)
+                data[ACKD_BUFFERLEFT] = 2;
 
-         // NOTE: m_CongCtl->ACKTimeout_us() should be taken into account.
-         if (currtime_tk - m_ullLastAckTime_tk > m_ullACKInt_tk)
-         {
-             int rcvRate;
-             int ctrlsz = ACKD_TOTAL_SIZE_UDTBASE * ACKD_FIELD_SIZE; // Minimum required size
+            // NOTE: m_CongCtl->ACKTimeout_us() should be taken into account.
+            if (currtime_tk - m_ullLastAckTime_tk > m_ullACKInt_tk)
+            {
+                int rcvRate;
+                int ctrlsz = ACKD_TOTAL_SIZE_UDTBASE * ACKD_FIELD_SIZE; // Minimum required size
 
-             data[ACKD_RCVSPEED] = m_RcvTimeWindow.getPktRcvSpeed(Ref(rcvRate));
-             data[ACKD_BANDWIDTH] = m_RcvTimeWindow.getBandwidth();
+                data[ACKD_RCVSPEED]  = m_RcvTimeWindow.getPktRcvSpeed(Ref(rcvRate));
+                data[ACKD_BANDWIDTH] = m_RcvTimeWindow.getBandwidth();
 
-             //>>Patch while incompatible (1.0.2) receiver floating around
-             if (m_lPeerSrtVersion == SrtVersion(1, 0, 2))
-             {
-                 data[ACKD_RCVRATE] = rcvRate; //bytes/sec
-                 data[ACKD_XMRATE] = data[ACKD_BANDWIDTH] * m_iMaxSRTPayloadSize; //bytes/sec
-                 ctrlsz = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER102;
-             }
-             else if (m_lPeerSrtVersion >= SrtVersion(1, 0, 3))
-             {
-                 // Normal, currently expected version.
-                 data[ACKD_RCVRATE] = rcvRate; //bytes/sec
-                 ctrlsz = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER101;
-             }
-             // ELSE: leave the buffer with ...UDTBASE size.
+                //>>Patch while incompatible (1.0.2) receiver floating around
+                if (m_lPeerSrtVersion == SrtVersion(1, 0, 2))
+                {
+                    data[ACKD_RCVRATE] = rcvRate;                                     // bytes/sec
+                    data[ACKD_XMRATE]  = data[ACKD_BANDWIDTH] * m_iMaxSRTPayloadSize; // bytes/sec
+                    ctrlsz             = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER102;
+                }
+                else if (m_lPeerSrtVersion >= SrtVersion(1, 0, 3))
+                {
+                    // Normal, currently expected version.
+                    data[ACKD_RCVRATE] = rcvRate; // bytes/sec
+                    ctrlsz             = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER101;
+                }
+                // ELSE: leave the buffer with ...UDTBASE size.
 
-             ctrlpkt.pack(pkttype, &m_iAckSeqNo, data, ctrlsz);
-             CTimer::rdtsc(m_ullLastAckTime_tk);
-         }
-         else
-         {
-             ctrlpkt.pack(pkttype, &m_iAckSeqNo, data, ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_SMALL);
-         }
+                ctrlpkt.pack(pkttype, &m_iAckSeqNo, data, ctrlsz);
+                CTimer::rdtsc(m_ullLastAckTime_tk);
+            }
+            else
+            {
+                ctrlpkt.pack(pkttype, &m_iAckSeqNo, data, ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_SMALL);
+            }
 
-         ctrlpkt.m_iID = m_PeerID;
-         ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-         nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
-         DebugAck("sendCtrl: " + CONID(), local_prevack, ack);
+            ctrlpkt.m_iID        = m_PeerID;
+            ctrlpkt.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+            nbsent               = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+            DebugAck("sendCtrl: " + CONID(), local_prevack, ack);
 
-         m_ACKWindow.store(m_iAckSeqNo, m_iRcvLastAck);
+            m_ACKWindow.store(m_iAckSeqNo, m_iRcvLastAck);
 
-         CGuard::enterCS(m_StatsLock);
-         ++ m_stats.sentACK;
-         ++ m_stats.sentACKTotal;
-         CGuard::leaveCS(m_StatsLock);
-      }
-      CGuard::leaveCS(m_RcvBufferLock);
-      break;
-      }
+            CGuard::enterCS(m_StatsLock);
+            ++m_stats.sentACK;
+            ++m_stats.sentACKTotal;
+            CGuard::leaveCS(m_StatsLock);
+        }
+        CGuard::leaveCS(m_RcvBufferLock);
+        break;
+    }
 
-   case UMSG_ACKACK: //110 - Acknowledgement of Acknowledgement
-      ctrlpkt.pack(pkttype, lparam);
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_ACKACK: // 110 - Acknowledgement of Acknowledgement
+        ctrlpkt.pack(pkttype, lparam);
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      break;
+        break;
 
-   case UMSG_LOSSREPORT: //011 - Loss Report
-      {
-          // Explicitly defined lost sequences 
-          if (rparam)
-          {
-              int32_t* lossdata = (int32_t*)rparam;
+    case UMSG_LOSSREPORT: // 011 - Loss Report
+    {
+        // Explicitly defined lost sequences
+        if (rparam)
+        {
+            int32_t *lossdata = (int32_t *)rparam;
 
-              size_t bytes = sizeof(*lossdata)*size;
-              ctrlpkt.pack(pkttype, NULL, lossdata, bytes);
+            size_t bytes = sizeof(*lossdata) * size;
+            ctrlpkt.pack(pkttype, NULL, lossdata, bytes);
 
-              ctrlpkt.m_iID = m_PeerID;
-              nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+            ctrlpkt.m_iID = m_PeerID;
+            nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-              CGuard::enterCS(m_StatsLock);
-              ++ m_stats.sentNAK;
-              ++ m_stats.sentNAKTotal;
-              CGuard::leaveCS(m_StatsLock);
-          }
-          // Call with no arguments - get loss list from internal data.
-          else if (m_pRcvLossList->getLossLength() > 0)
-          {
-              // this is periodically NAK report; make sure NAK cannot be sent back too often
+            CGuard::enterCS(m_StatsLock);
+            ++m_stats.sentNAK;
+            ++m_stats.sentNAKTotal;
+            CGuard::leaveCS(m_StatsLock);
+        }
+        // Call with no arguments - get loss list from internal data.
+        else if (m_pRcvLossList->getLossLength() > 0)
+        {
+            // this is periodically NAK report; make sure NAK cannot be sent back too often
 
-              // read loss list from the local receiver loss list
-              int32_t* data = new int32_t[m_iMaxSRTPayloadSize / 4];
-              int losslen;
-              m_pRcvLossList->getLossArray(data, losslen, m_iMaxSRTPayloadSize / 4);
+            // read loss list from the local receiver loss list
+            int32_t *data = new int32_t[m_iMaxSRTPayloadSize / 4];
+            int      losslen;
+            m_pRcvLossList->getLossArray(data, losslen, m_iMaxSRTPayloadSize / 4);
 
-              if (0 < losslen)
-              {
-                  ctrlpkt.pack(pkttype, NULL, data, losslen * 4);
-                  ctrlpkt.m_iID = m_PeerID;
-                  nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+            if (0 < losslen)
+            {
+                ctrlpkt.pack(pkttype, NULL, data, losslen * 4);
+                ctrlpkt.m_iID = m_PeerID;
+                nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-                  CGuard::enterCS(m_StatsLock);
-                  ++ m_stats.sentNAK;
-                  ++ m_stats.sentNAKTotal;
-                  CGuard::leaveCS(m_StatsLock);
-              }
+                CGuard::enterCS(m_StatsLock);
+                ++m_stats.sentNAK;
+                ++m_stats.sentNAKTotal;
+                CGuard::leaveCS(m_StatsLock);
+            }
 
-              delete [] data;
-          }
+            delete[] data;
+        }
 
-          // update next NAK time, which should wait enough time for the retansmission, but not too long
-          m_ullNAKInt_tk = (m_iRTT + 4 * m_iRTTVar) * m_ullCPUFrequency;
+        // update next NAK time, which should wait enough time for the retansmission, but not too long
+        m_ullNAKInt_tk = (m_iRTT + 4 * m_iRTTVar) * m_ullCPUFrequency;
 
-          // Fix the NAKreport period according to the congctl
-          m_ullNAKInt_tk = m_CongCtl->updateNAKInterval(
-                  m_ullNAKInt_tk,
-                  m_RcvTimeWindow.getPktRcvSpeed(),
-                  m_pRcvLossList->getLossLength()
-          );
+        // Fix the NAKreport period according to the congctl
+        m_ullNAKInt_tk = m_CongCtl->updateNAKInterval(
+            m_ullNAKInt_tk, m_RcvTimeWindow.getPktRcvSpeed(), m_pRcvLossList->getLossLength());
 
-          // This is necessary because a congctl need not wish to define
-          // its own minimum interval, in which case the default one is used.
-          if (m_ullNAKInt_tk < m_ullMinNakInt_tk)
-              m_ullNAKInt_tk = m_ullMinNakInt_tk;
+        // This is necessary because a congctl need not wish to define
+        // its own minimum interval, in which case the default one is used.
+        if (m_ullNAKInt_tk < m_ullMinNakInt_tk)
+            m_ullNAKInt_tk = m_ullMinNakInt_tk;
 
-          break;
-      }
+        break;
+    }
 
-   case UMSG_CGWARNING: //100 - Congestion Warning
-      ctrlpkt.pack(pkttype);
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_CGWARNING: // 100 - Congestion Warning
+        ctrlpkt.pack(pkttype);
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      CTimer::rdtsc(m_ullLastWarningTime);
+        CTimer::rdtsc(m_ullLastWarningTime);
 
-      break;
+        break;
 
-   case UMSG_KEEPALIVE: //001 - Keep-alive
-      ctrlpkt.pack(pkttype);
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_KEEPALIVE: // 001 - Keep-alive
+        ctrlpkt.pack(pkttype);
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      break;
+        break;
 
-   case UMSG_HANDSHAKE: //000 - Handshake
-      ctrlpkt.pack(pkttype, NULL, rparam, sizeof(CHandShake));
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_HANDSHAKE: // 000 - Handshake
+        ctrlpkt.pack(pkttype, NULL, rparam, sizeof(CHandShake));
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      break;
+        break;
 
-   case UMSG_SHUTDOWN: //101 - Shutdown
-      ctrlpkt.pack(pkttype);
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_SHUTDOWN: // 101 - Shutdown
+        ctrlpkt.pack(pkttype);
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      break;
+        break;
 
-   case UMSG_DROPREQ: //111 - Msg drop request
-      ctrlpkt.pack(pkttype, lparam, rparam, 8);
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_DROPREQ: // 111 - Msg drop request
+        ctrlpkt.pack(pkttype, lparam, rparam, 8);
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      break;
+        break;
 
-   case UMSG_PEERERROR: //1000 - acknowledge the peer side a special error
-      ctrlpkt.pack(pkttype, lparam);
-      ctrlpkt.m_iID = m_PeerID;
-      nbsent = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
+    case UMSG_PEERERROR: // 1000 - acknowledge the peer side a special error
+        ctrlpkt.pack(pkttype, lparam);
+        ctrlpkt.m_iID = m_PeerID;
+        nbsent        = m_pSndQueue->sendto(m_pPeerAddr, ctrlpkt);
 
-      break;
+        break;
 
-   case UMSG_EXT: //0x7FFF - Resevered for future use
-      break;
+    case UMSG_EXT: // 0x7FFF - Resevered for future use
+        break;
 
-   default:
-      break;
-   }
+    default:
+        break;
+    }
 
-   // Fix keepalive
-   if (nbsent)
-      m_ullLastSndTime_tk = currtime_tk;
+    // Fix keepalive
+    if (nbsent)
+        m_ullLastSndTime_tk = currtime_tk;
 }
 
 void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
@@ -7183,14 +7299,15 @@ void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
     CGuard::leaveCS(m_StatsLock);
 }
 
-void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
+void CUDT::processCtrlAck(const CPacket &ctrlpkt, const uint64_t currtime_tk)
 {
-    const int32_t* ackdata = (const int32_t*)ctrlpkt.m_pcData;
+    const int32_t *ackdata       = (const int32_t *)ctrlpkt.m_pcData;
     const int32_t  ackdata_seqno = ackdata[ACKD_RCVLASTACK];
 
     const bool isLiteAck = ctrlpkt.getLength() == (size_t)SEND_LITE_ACK;
-    HLOGC(mglog.Debug, log << CONID() << "ACK covers: " << m_iSndLastDataAck << " - " << ackdata_seqno
-        << " [ACK=" << m_iSndLastAck << "]" << (isLiteAck ? "[LITE]" : "[FULL]"));
+    HLOGC(mglog.Debug,
+          log << CONID() << "ACK covers: " << m_iSndLastDataAck << " - " << ackdata_seqno << " [ACK=" << m_iSndLastAck
+              << "]" << (isLiteAck ? "[LITE]" : "[FULL]"));
 
     updateSndLossListOnACK(ackdata_seqno);
 
@@ -7206,7 +7323,7 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
             // TODO: m_ullLastRspAckTime_tk should be protected with m_RecvAckLock
             // because the sendmsg2 may want to change it at the same time.
             m_ullLastRspAckTime_tk = currtime_tk;
-            m_iReXmitCount = 1; // Reset re-transmit count since last ACK
+            m_iReXmitCount         = 1; // Reset re-transmit count since last ACK
         }
 
         return;
@@ -7225,7 +7342,7 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
         if ((now - m_ullSndLastAck2Time > (uint64_t)COMM_SYN_INTERVAL_US) || (ack_seqno == m_iSndLastAck2))
         {
             sendCtrl(UMSG_ACKACK, &ack_seqno);
-            m_iSndLastAck2 = ack_seqno;
+            m_iSndLastAck2       = ack_seqno;
             m_ullSndLastAck2Time = now;
         }
     }
@@ -7242,9 +7359,10 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
     {
         CGuard::leaveCS(m_RecvAckLock);
         // this should not happen: attack or bug
-        LOGC(glog.Error, log << CONID() << "ATTACK/IPE: incoming ack seq " << ackdata_seqno << " exceeds current "
-            << m_iSndCurrSeqNo << " by " << (CSeqNo::seqoff(m_iSndCurrSeqNo, ackdata_seqno) - 1) << "!");
-        m_bBroken = true;
+        LOGC(glog.Error,
+             log << CONID() << "ATTACK/IPE: incoming ack seq " << ackdata_seqno << " exceeds current "
+                 << m_iSndCurrSeqNo << " by " << (CSeqNo::seqoff(m_iSndCurrSeqNo, ackdata_seqno) - 1) << "!");
+        m_bBroken        = true;
         m_iBrokenCounter = 0;
         return;
     }
@@ -7252,10 +7370,10 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
     if (CSeqNo::seqcmp(ackdata_seqno, m_iSndLastAck) >= 0)
     {
         // Update Flow Window Size, must update before and together with m_iSndLastAck
-        m_iFlowWindowSize = ackdata[ACKD_BUFFERLEFT];
-        m_iSndLastAck = ackdata_seqno;
-        m_ullLastRspAckTime_tk = currtime_tk;   // Should be protected with m_RecvAckLock
-        m_iReXmitCount = 1; // Reset re-transmit count since last ACK
+        m_iFlowWindowSize      = ackdata[ACKD_BUFFERLEFT];
+        m_iSndLastAck          = ackdata_seqno;
+        m_ullLastRspAckTime_tk = currtime_tk; // Should be protected with m_RecvAckLock
+        m_iReXmitCount         = 1;           // Reset re-transmit count since last ACK
     }
 
     /*
@@ -7281,16 +7399,16 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
     //
     CGuard::leaveCS(m_RecvAckLock);
 
-    size_t acksize = ctrlpkt.getLength(); // TEMPORARY VALUE FOR CHECKING
+    size_t acksize   = ctrlpkt.getLength(); // TEMPORARY VALUE FOR CHECKING
     bool   wrongsize = 0 != (acksize % ACKD_FIELD_SIZE);
-    acksize = acksize / ACKD_FIELD_SIZE; // ACTUAL VALUE
+    acksize          = acksize / ACKD_FIELD_SIZE; // ACTUAL VALUE
 
     if (wrongsize)
     {
         // Issue a log, but don't do anything but skipping the "odd" bytes from the payload.
         LOGC(mglog.Error,
-            log << CONID() << "Received UMSG_ACK payload is not evened up to 4-byte based field size - cutting to "
-            << acksize << " fields");
+             log << CONID() << "Received UMSG_ACK payload is not evened up to 4-byte based field size - cutting to "
+                 << acksize << " fields");
     }
 
     // Start with checking the base size.
@@ -7310,7 +7428,7 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
     const int rtt = ackdata[ACKD_RTT];
 
     m_iRTTVar = avg_iir<4>(m_iRTTVar, abs(rtt - m_iRTT));
-    m_iRTT = avg_iir<8>(m_iRTT, rtt);
+    m_iRTT    = avg_iir<8>(m_iRTT, rtt);
 
     /* Version-dependent fields:
      * Original UDT (total size: ACKD_TOTAL_SIZE_SMALL):
@@ -7330,20 +7448,20 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
     if (acksize > ACKD_TOTAL_SIZE_SMALL)
     {
         // This means that ACKD_RCVSPEED and ACKD_BANDWIDTH fields are available.
-        int pktps = ackdata[ACKD_RCVSPEED];
+        int pktps     = ackdata[ACKD_RCVSPEED];
         int bandwidth = ackdata[ACKD_BANDWIDTH];
         int bytesps;
 
         /* SRT v1.0.2 Bytes-based stats: bandwidth (pcData[ACKD_XMRATE]) and delivery rate (pcData[ACKD_RCVRATE]) in
          * bytes/sec instead of pkts/sec */
-         /* SRT v1.0.3 Bytes-based stats: only delivery rate (pcData[ACKD_RCVRATE]) in bytes/sec instead of pkts/sec */
+        /* SRT v1.0.3 Bytes-based stats: only delivery rate (pcData[ACKD_RCVRATE]) in bytes/sec instead of pkts/sec */
         if (acksize > ACKD_TOTAL_SIZE_UDTBASE)
             bytesps = ackdata[ACKD_RCVRATE];
         else
             bytesps = pktps * m_iMaxSRTPayloadSize;
 
-        m_iBandwidth = avg_iir<8>(m_iBandwidth, bandwidth);
-        m_iDeliveryRate = avg_iir<8>(m_iDeliveryRate, pktps);
+        m_iBandwidth        = avg_iir<8>(m_iBandwidth, bandwidth);
+        m_iDeliveryRate     = avg_iir<8>(m_iDeliveryRate, pktps);
         m_iByteDeliveryRate = avg_iir<8>(m_iByteDeliveryRate, bytesps);
         // XXX not sure if ACKD_XMRATE is of any use. This is simply
         // calculated as ACKD_BANDWIDTH * m_iMaxSRTPayloadSize.
@@ -7364,360 +7482,374 @@ void CUDT::processCtrlAck(const CPacket& ctrlpkt, const uint64_t currtime_tk)
     CGuard::leaveCS(m_StatsLock);
 }
 
-void CUDT::processCtrl(CPacket& ctrlpkt)
+void CUDT::processCtrl(CPacket &ctrlpkt)
 {
-   // Just heard from the peer, reset the expiration count.
-   m_iEXPCount = 1;
-   uint64_t currtime_tk;
-   CTimer::rdtsc(currtime_tk);
-   m_ullLastRspTime_tk = currtime_tk;
-   bool using_rexmit_flag = m_bPeerRexmitFlag;
+    // Just heard from the peer, reset the expiration count.
+    m_iEXPCount = 1;
+    uint64_t currtime_tk;
+    CTimer::rdtsc(currtime_tk);
+    m_ullLastRspTime_tk    = currtime_tk;
+    bool using_rexmit_flag = m_bPeerRexmitFlag;
 
-   HLOGC(mglog.Debug, log << CONID() << "incoming UMSG:" << ctrlpkt.getType() << " ("
-       << MessageTypeStr(ctrlpkt.getType(), ctrlpkt.getExtendedType()) << ") socket=%" << ctrlpkt.m_iID);
+    HLOGC(mglog.Debug,
+          log << CONID() << "incoming UMSG:" << ctrlpkt.getType() << " ("
+              << MessageTypeStr(ctrlpkt.getType(), ctrlpkt.getExtendedType()) << ") socket=%" << ctrlpkt.m_iID);
 
-   switch (ctrlpkt.getType())
-   {
-   case UMSG_ACK: //010 - Acknowledgement
-       processCtrlAck(ctrlpkt, currtime_tk);
-       break;
+    switch (ctrlpkt.getType())
+    {
+    case UMSG_ACK: // 010 - Acknowledgement
+        processCtrlAck(ctrlpkt, currtime_tk);
+        break;
 
-   case UMSG_ACKACK: //110 - Acknowledgement of Acknowledgement
-      {
-      int32_t ack = 0;
-      int rtt = -1;
+    case UMSG_ACKACK: // 110 - Acknowledgement of Acknowledgement
+    {
+        int32_t ack = 0;
+        int     rtt = -1;
 
-      // update RTT
-      rtt = m_ACKWindow.acknowledge(ctrlpkt.getAckSeqNo(), ack);
-      if (rtt <= 0)
-      {
-          LOGC(mglog.Error, log << "IPE: ACK node overwritten when acknowledging " <<
-              ctrlpkt.getAckSeqNo() << " (ack extracted: " << ack << ")");
-          break;
-      }
+        // update RTT
+        rtt = m_ACKWindow.acknowledge(ctrlpkt.getAckSeqNo(), ack);
+        if (rtt <= 0)
+        {
+            LOGC(mglog.Error,
+                 log << "IPE: ACK node overwritten when acknowledging " << ctrlpkt.getAckSeqNo()
+                     << " (ack extracted: " << ack << ")");
+            break;
+        }
 
-      //if increasing delay detected...
-      //   sendCtrl(UMSG_CGWARNING);
+        // if increasing delay detected...
+        //   sendCtrl(UMSG_CGWARNING);
 
-      // RTT EWMA
-      m_iRTTVar = (m_iRTTVar * 3 + abs(rtt - m_iRTT)) >> 2;
-      m_iRTT = (m_iRTT * 7 + rtt) >> 3;
+        // RTT EWMA
+        m_iRTTVar = (m_iRTTVar * 3 + abs(rtt - m_iRTT)) >> 2;
+        m_iRTT    = (m_iRTT * 7 + rtt) >> 3;
 
-      updateCC(TEV_ACKACK, ack);
+        updateCC(TEV_ACKACK, ack);
 
-      // This function will put a lock on m_RecvLock by itself, as needed.
-      // It must be done inside because this function reads the current time
-      // and if waiting for the lock has caused a delay, the time will be
-      // inaccurate. Additionally it won't lock if TSBPD mode is off, and
-      // won't update anything. Note that if you set TSBPD mode and use
-      // srt_recvfile (which doesn't make any sense), you'll have a deadlock.
-      m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(), m_RecvLock);
+        // This function will put a lock on m_RecvLock by itself, as needed.
+        // It must be done inside because this function reads the current time
+        // and if waiting for the lock has caused a delay, the time will be
+        // inaccurate. Additionally it won't lock if TSBPD mode is off, and
+        // won't update anything. Note that if you set TSBPD mode and use
+        // srt_recvfile (which doesn't make any sense), you'll have a deadlock.
+        m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(), m_RecvLock);
 
-      // update last ACK that has been received by the sender
-      if (CSeqNo::seqcmp(ack, m_iRcvLastAckAck) > 0)
-         m_iRcvLastAckAck = ack;
+        // update last ACK that has been received by the sender
+        if (CSeqNo::seqcmp(ack, m_iRcvLastAckAck) > 0)
+            m_iRcvLastAckAck = ack;
 
-      break;
-      }
+        break;
+    }
 
-   case UMSG_LOSSREPORT: //011 - Loss Report
-      {
-      int32_t* losslist = (int32_t *)(ctrlpkt.m_pcData);
-      size_t losslist_len = ctrlpkt.getLength() / 4;
+    case UMSG_LOSSREPORT: // 011 - Loss Report
+    {
+        int32_t *losslist     = (int32_t *)(ctrlpkt.m_pcData);
+        size_t   losslist_len = ctrlpkt.getLength() / 4;
 
-      bool secure = true;
+        bool secure = true;
 
-      // protect packet retransmission
-      CGuard::enterCS(m_RecvAckLock);
+        // protect packet retransmission
+        CGuard::enterCS(m_RecvAckLock);
 
-      // This variable is used in "normal" logs, so it may cause a warning
-      // when logging is forcefully off.
-      int32_t wrong_loss SRT_ATR_UNUSED = CSeqNo::m_iMaxSeqNo;
+        // This variable is used in "normal" logs, so it may cause a warning
+        // when logging is forcefully off.
+        int32_t wrong_loss SRT_ATR_UNUSED = CSeqNo::m_iMaxSeqNo;
 
-      // decode loss list message and insert loss into the sender loss list
-      for (int i = 0, n = (int)(ctrlpkt.getLength() / 4); i < n; ++ i)
-      {
-         if (IsSet(losslist[i], LOSSDATA_SEQNO_RANGE_FIRST))
-         {
-             // Then it's this is a <lo, hi> specification with HI in a consecutive cell.
-            int32_t losslist_lo = SEQNO_VALUE::unwrap(losslist[i]);
-            int32_t losslist_hi = losslist[i+1];
-            // <lo, hi> specification means that the consecutive cell has been already interpreted.
-            ++ i;
-
-            HLOGF(mglog.Debug, "received UMSG_LOSSREPORT: %d-%d (%d packets)...",
-                    losslist_lo, losslist_hi, CSeqNo::seqoff(losslist_lo, losslist_hi)+1);
-
-            if ((CSeqNo::seqcmp(losslist_lo, losslist_hi) > 0) || (CSeqNo::seqcmp(losslist_hi, m_iSndCurrSeqNo) > 0))
+        // decode loss list message and insert loss into the sender loss list
+        for (int i = 0, n = (int)(ctrlpkt.getLength() / 4); i < n; ++i)
+        {
+            if (IsSet(losslist[i], LOSSDATA_SEQNO_RANGE_FIRST))
             {
-               // seq_a must not be greater than seq_b; seq_b must not be greater than the most recent sent seq
-               secure = false;
-               wrong_loss = losslist_hi;
-               // XXX leaveCS: really necessary? 'break' will break the 'for' loop, not the 'switch' statement.
-               // and the leaveCS is done again next to the 'for' loop end.
-               CGuard::leaveCS(m_RecvAckLock);
-               break;
+                // Then it's this is a <lo, hi> specification with HI in a consecutive cell.
+                int32_t losslist_lo = SEQNO_VALUE::unwrap(losslist[i]);
+                int32_t losslist_hi = losslist[i + 1];
+                // <lo, hi> specification means that the consecutive cell has been already interpreted.
+                ++i;
+
+                HLOGF(mglog.Debug,
+                      "received UMSG_LOSSREPORT: %d-%d (%d packets)...",
+                      losslist_lo,
+                      losslist_hi,
+                      CSeqNo::seqoff(losslist_lo, losslist_hi) + 1);
+
+                if ((CSeqNo::seqcmp(losslist_lo, losslist_hi) > 0) ||
+                    (CSeqNo::seqcmp(losslist_hi, m_iSndCurrSeqNo) > 0))
+                {
+                    // seq_a must not be greater than seq_b; seq_b must not be greater than the most recent sent seq
+                    secure     = false;
+                    wrong_loss = losslist_hi;
+                    // XXX leaveCS: really necessary? 'break' will break the 'for' loop, not the 'switch' statement.
+                    // and the leaveCS is done again next to the 'for' loop end.
+                    CGuard::leaveCS(m_RecvAckLock);
+                    break;
+                }
+
+                int num = 0;
+                if (CSeqNo::seqcmp(losslist_lo, m_iSndLastAck) >= 0)
+                    num = m_pSndLossList->insert(losslist_lo, losslist_hi);
+                else if (CSeqNo::seqcmp(losslist_hi, m_iSndLastAck) >= 0)
+                {
+                    // This should be theoretically impossible because this would mean
+                    // that the received packet loss report informs about the loss that predates
+                    // the ACK sequence.
+                    // However, this can happen if the packet reordering has caused the earlier sent
+                    // LOSSREPORT will be delivered after later sent ACK. Whatever, ACK should be
+                    // more important, so simply drop the part that predates ACK.
+                    num = m_pSndLossList->insert(m_iSndLastAck, losslist_hi);
+                }
+
+                CGuard::enterCS(m_StatsLock);
+                m_stats.traceSndLoss += num;
+                m_stats.sndLossTotal += num;
+                CGuard::leaveCS(m_StatsLock);
+            }
+            else if (CSeqNo::seqcmp(losslist[i], m_iSndLastAck) >= 0)
+            {
+                HLOGF(mglog.Debug, "received UMSG_LOSSREPORT: %d (1 packet)...", losslist[i]);
+
+                if (CSeqNo::seqcmp(losslist[i], m_iSndCurrSeqNo) > 0)
+                {
+                    // seq_a must not be greater than the most recent sent seq
+                    secure     = false;
+                    wrong_loss = losslist[i];
+                    CGuard::leaveCS(m_RecvAckLock);
+                    break;
+                }
+
+                int num = m_pSndLossList->insert(losslist[i], losslist[i]);
+
+                CGuard::enterCS(m_StatsLock);
+                m_stats.traceSndLoss += num;
+                m_stats.sndLossTotal += num;
+                CGuard::leaveCS(m_StatsLock);
+            }
+        }
+        CGuard::leaveCS(m_RecvAckLock);
+
+        updateCC(TEV_LOSSREPORT, EventVariant(losslist, losslist_len));
+
+        if (!secure)
+        {
+            LOGC(mglog.Warn,
+                 log << "out-of-band LOSSREPORT received; BUG or ATTACK - last sent %" << m_iSndCurrSeqNo
+                     << " vs loss %" << wrong_loss);
+            // this should not happen: attack or bug
+            m_bBroken        = true;
+            m_iBrokenCounter = 0;
+            break;
+        }
+
+        // the lost packet (retransmission) should be sent out immediately
+        m_pSndQueue->m_pSndUList->update(this, CSndUList::DO_RESCHEDULE);
+
+        CGuard::enterCS(m_StatsLock);
+        ++m_stats.recvNAK;
+        ++m_stats.recvNAKTotal;
+        CGuard::leaveCS(m_StatsLock);
+
+        break;
+    }
+
+    case UMSG_CGWARNING: // 100 - Delay Warning
+        // One way packet delay is increasing, so decrease the sending rate
+        m_ullInterval_tk = (uint64_t)ceil(m_ullInterval_tk * 1.125);
+        m_iLastDecSeq    = m_iSndCurrSeqNo;
+        // XXX Note as interesting fact: this is only prepared for handling,
+        // but nothing in the code is sending this message. Probably predicted
+        // for a custom congctl. There's a predicted place to call it under
+        // UMSG_ACKACK handling, but it's commented out.
+
+        break;
+
+    case UMSG_KEEPALIVE: // 001 - Keep-alive
+        // The only purpose of keep-alive packet is to tell that the peer is still alive
+        // nothing needs to be done.
+
+        break;
+
+    case UMSG_HANDSHAKE: // 000 - Handshake
+    {
+        CHandShake req;
+        req.load_from(ctrlpkt.m_pcData, ctrlpkt.getLength());
+
+        HLOGC(mglog.Debug, log << "processCtrl: got HS: " << req.show());
+
+        if ((req.m_iReqType > URQ_INDUCTION_TYPES) // acually it catches URQ_INDUCTION and URQ_ERROR_* symbols...???
+            || (m_bRendezvous && (req.m_iReqType != URQ_AGREEMENT))) // rnd sends AGREEMENT in rsp to CONCLUSION
+        {
+            // The peer side has not received the handshake message, so it keeps querying
+            // resend the handshake packet
+
+            // This condition embraces cases when:
+            // - this is normal accept() and URQ_INDUCTION was received
+            // - this is rendezvous accept() and there's coming any kind of URQ except AGREEMENT (should be RENDEZVOUS
+            // or CONCLUSION)
+            // - this is any of URQ_ERROR_* - well...
+            CHandShake initdata;
+            initdata.m_iISN            = m_iISN;
+            initdata.m_iMSS            = m_iMSS;
+            initdata.m_iFlightFlagSize = m_iFlightFlagSize;
+
+            // For rendezvous we do URQ_WAVEAHAND/URQ_CONCLUSION --> URQ_AGREEMENT.
+            // For client-server we do URQ_INDUCTION --> URQ_CONCLUSION.
+            initdata.m_iReqType = (!m_bRendezvous) ? URQ_CONCLUSION : URQ_AGREEMENT;
+            initdata.m_iID      = m_SocketID;
+
+            uint32_t kmdata[SRTDATA_MAXSIZE];
+            size_t   kmdatasize = SRTDATA_MAXSIZE;
+            bool     have_hsreq = false;
+            if (req.m_iVersion > HS_VERSION_UDT4)
+            {
+                initdata.m_iVersion = HS_VERSION_SRT1; // if I remember correctly, this is induction/listener...
+                int hs_flags        = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
+                if (hs_flags != 0) // has SRT extensions
+                {
+                    HLOGC(mglog.Debug,
+                          log << "processCtrl/HS: got HS reqtype=" << RequestTypeStr(req.m_iReqType)
+                              << " WITH SRT ext");
+                    have_hsreq = interpretSrtHandshake(req, ctrlpkt, kmdata, &kmdatasize);
+                    if (!have_hsreq)
+                    {
+                        initdata.m_iVersion = 0;
+                        m_RejectReason      = SRT_REJ_ROGUE;
+                        initdata.m_iReqType = URQFailure(m_RejectReason);
+                    }
+                    else
+                    {
+                        // Extensions are added only in case of CONCLUSION (not AGREEMENT).
+                        // Actually what is expected here is that this may either process the
+                        // belated-repeated handshake from a caller (and then it's CONCLUSION,
+                        // and should be added with HSRSP/KMRSP), or it's a belated handshake
+                        // of Rendezvous when it has already considered itself connected.
+                        // Sanity check - according to the rules, there should be no such situation
+                        if (m_bRendezvous && m_SrtHsSide == HSD_RESPONDER)
+                        {
+                            LOGC(mglog.Error,
+                                 log << "processCtrl/HS: IPE???: RESPONDER should receive all its handshakes in "
+                                        "handshake phase.");
+                        }
+
+                        // The 'extension' flag will be set from this variable; set it to false
+                        // in case when the AGREEMENT response is to be sent.
+                        have_hsreq = initdata.m_iReqType == URQ_CONCLUSION;
+                        HLOGC(mglog.Debug,
+                              log << "processCtrl/HS: processing ok, reqtype=" << RequestTypeStr(initdata.m_iReqType)
+                                  << " kmdatasize=" << kmdatasize);
+                    }
+                }
+                else
+                {
+                    HLOGC(mglog.Debug, log << "processCtrl/HS: got HS reqtype=" << RequestTypeStr(req.m_iReqType));
+                }
+            }
+            else
+            {
+                initdata.m_iVersion = HS_VERSION_UDT4;
             }
 
-            int num = 0;
-            if (CSeqNo::seqcmp(losslist_lo, m_iSndLastAck) >= 0)
-               num = m_pSndLossList->insert(losslist_lo, losslist_hi);
-            else if (CSeqNo::seqcmp(losslist_hi, m_iSndLastAck) >= 0)
+            initdata.m_extension = have_hsreq;
+
+            HLOGC(mglog.Debug,
+                  log << CONID() << "processCtrl: responding HS reqtype=" << RequestTypeStr(initdata.m_iReqType)
+                      << (have_hsreq ? " WITH SRT HS response extensions" : ""));
+
+            // XXX here interpret SRT handshake extension
+            CPacket response;
+            response.setControl(UMSG_HANDSHAKE);
+            response.allocate(m_iMaxSRTPayloadSize);
+
+            // If createSrtHandshake failed, don't send anything. Actually it can only fail on IPE.
+            // There is also no possible IPE condition in case of HSv4 - for this version it will always return true.
+            if (createSrtHandshake(Ref(response), Ref(initdata), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
             {
-                // This should be theoretically impossible because this would mean
-                // that the received packet loss report informs about the loss that predates
-                // the ACK sequence.
-                // However, this can happen if the packet reordering has caused the earlier sent
-                // LOSSREPORT will be delivered after later sent ACK. Whatever, ACK should be
-                // more important, so simply drop the part that predates ACK.
-               num = m_pSndLossList->insert(m_iSndLastAck, losslist_hi);
+                response.m_iID        = m_PeerID;
+                response.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+                int nbsent            = m_pSndQueue->sendto(m_pPeerAddr, response);
+                if (nbsent)
+                {
+                    uint64_t currtime_tk;
+                    CTimer::rdtsc(currtime_tk);
+                    m_ullLastSndTime_tk = currtime_tk;
+                }
             }
+        }
+        else
+        {
+            HLOGC(mglog.Debug, log << "processCtrl: ... not INDUCTION, not ERROR, not rendezvous - IGNORED.");
+        }
 
-            CGuard::enterCS(m_StatsLock);
-            m_stats.traceSndLoss += num;
-            m_stats.sndLossTotal += num;
-            CGuard::leaveCS(m_StatsLock);
+        break;
+    }
 
-         }
-         else if (CSeqNo::seqcmp(losslist[i], m_iSndLastAck) >= 0)
-         {
-            HLOGF(mglog.Debug, "received UMSG_LOSSREPORT: %d (1 packet)...", losslist[i]);
+    case UMSG_SHUTDOWN: // 101 - Shutdown
+        m_bShutdown      = true;
+        m_bClosing       = true;
+        m_bBroken        = true;
+        m_iBrokenCounter = 60;
 
-            if (CSeqNo::seqcmp(losslist[i], m_iSndCurrSeqNo) > 0)
+        // Signal the sender and recver if they are waiting for data.
+        releaseSynch();
+        // Unblock any call so they learn the connection_broken error
+        s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_ERR, true);
+
+        CTimer::triggerEvent();
+
+        break;
+
+    case UMSG_DROPREQ: // 111 - Msg drop request
+        CGuard::enterCS(m_RecvLock);
+        m_pRcvBuffer->dropMsg(ctrlpkt.getMsgSeq(using_rexmit_flag), using_rexmit_flag);
+        CGuard::leaveCS(m_RecvLock);
+
+        dropFromLossLists(*(int32_t *)ctrlpkt.m_pcData, *(int32_t *)(ctrlpkt.m_pcData + 4));
+
+        // move forward with current recv seq no.
+        if ((CSeqNo::seqcmp(*(int32_t *)ctrlpkt.m_pcData, CSeqNo::incseq(m_iRcvCurrSeqNo)) <= 0) &&
+            (CSeqNo::seqcmp(*(int32_t *)(ctrlpkt.m_pcData + 4), m_iRcvCurrSeqNo) > 0))
+        {
+            m_iRcvCurrSeqNo = *(int32_t *)(ctrlpkt.m_pcData + 4);
+        }
+
+        break;
+
+    case UMSG_PEERERROR: // 1000 - An error has happened to the peer side
+        // int err_type = packet.getAddInfo();
+
+        // currently only this error is signalled from the peer side
+        // if recvfile() failes (e.g., due to disk fail), blcoked sendfile/send should return immediately
+        // giving the app a chance to fix the issue
+
+        m_bPeerHealth = false;
+
+        break;
+
+    case UMSG_EXT: // 0x7FFF - reserved and user defined messages
+        HLOGF(mglog.Debug, "CONTROL EXT MSG RECEIVED: %08X\n", ctrlpkt.getExtendedType());
+        {
+            // This has currently two roles in SRT:
+            // - HSv4 (legacy) handshake
+            // - refreshed KMX (initial KMX is done still in the HS process in HSv5)
+            bool understood = processSrtMsg(&ctrlpkt);
+            // CAREFUL HERE! This only means that this update comes from the UMSG_EXT
+            // message received, REGARDLESS OF WHAT IT IS. This version doesn't mean
+            // the handshake version, but the reason of calling this function.
+            //
+            // Fortunately, the only messages taken into account in this function
+            // are HSREQ and HSRSP, which should *never* be interchanged when both
+            // parties are HSv5.
+            if (understood)
             {
-               //seq_a must not be greater than the most recent sent seq
-               secure = false;
-               wrong_loss = losslist[i];
-               CGuard::leaveCS(m_RecvAckLock);
-               break;
+                updateAfterSrtHandshake(ctrlpkt.getExtendedType(), HS_VERSION_UDT4);
             }
+            else
+            {
+                updateCC(TEV_CUSTOM, &ctrlpkt);
+            }
+        }
+        break;
 
-            int num = m_pSndLossList->insert(losslist[i], losslist[i]);
-
-            CGuard::enterCS(m_StatsLock);
-            m_stats.traceSndLoss += num;
-            m_stats.sndLossTotal += num;
-            CGuard::leaveCS(m_StatsLock);
-         }
-      }
-      CGuard::leaveCS(m_RecvAckLock);
-
-      updateCC(TEV_LOSSREPORT, EventVariant(losslist, losslist_len));
-
-      if (!secure)
-      {
-         LOGC(mglog.Warn, log << "out-of-band LOSSREPORT received; BUG or ATTACK - last sent %" << m_iSndCurrSeqNo << " vs loss %" << wrong_loss);
-         //this should not happen: attack or bug
-         m_bBroken = true;
-         m_iBrokenCounter = 0;
-         break;
-      }
-
-      // the lost packet (retransmission) should be sent out immediately
-      m_pSndQueue->m_pSndUList->update(this, CSndUList::DO_RESCHEDULE);
-
-      CGuard::enterCS(m_StatsLock);
-      ++ m_stats.recvNAK;
-      ++ m_stats.recvNAKTotal;
-      CGuard::leaveCS(m_StatsLock);
-
-      break;
-      }
-
-   case UMSG_CGWARNING: //100 - Delay Warning
-      // One way packet delay is increasing, so decrease the sending rate
-      m_ullInterval_tk = (uint64_t)ceil(m_ullInterval_tk * 1.125);
-      m_iLastDecSeq = m_iSndCurrSeqNo;
-      // XXX Note as interesting fact: this is only prepared for handling,
-      // but nothing in the code is sending this message. Probably predicted
-      // for a custom congctl. There's a predicted place to call it under
-      // UMSG_ACKACK handling, but it's commented out.
-
-      break;
-
-   case UMSG_KEEPALIVE: //001 - Keep-alive
-      // The only purpose of keep-alive packet is to tell that the peer is still alive
-      // nothing needs to be done.
-
-      break;
-
-   case UMSG_HANDSHAKE: //000 - Handshake
-      {
-      CHandShake req;
-      req.load_from(ctrlpkt.m_pcData, ctrlpkt.getLength());
-
-      HLOGC(mglog.Debug, log << "processCtrl: got HS: " << req.show());
-
-      if ((req.m_iReqType > URQ_INDUCTION_TYPES) // acually it catches URQ_INDUCTION and URQ_ERROR_* symbols...???
-              || (m_bRendezvous && (req.m_iReqType != URQ_AGREEMENT))) // rnd sends AGREEMENT in rsp to CONCLUSION
-      {
-         // The peer side has not received the handshake message, so it keeps querying
-         // resend the handshake packet
-
-          // This condition embraces cases when:
-          // - this is normal accept() and URQ_INDUCTION was received
-          // - this is rendezvous accept() and there's coming any kind of URQ except AGREEMENT (should be RENDEZVOUS or CONCLUSION)
-          // - this is any of URQ_ERROR_* - well...
-         CHandShake initdata;
-         initdata.m_iISN = m_iISN;
-         initdata.m_iMSS = m_iMSS;
-         initdata.m_iFlightFlagSize = m_iFlightFlagSize;
-
-         // For rendezvous we do URQ_WAVEAHAND/URQ_CONCLUSION --> URQ_AGREEMENT.
-         // For client-server we do URQ_INDUCTION --> URQ_CONCLUSION.
-         initdata.m_iReqType = (!m_bRendezvous) ? URQ_CONCLUSION : URQ_AGREEMENT;
-         initdata.m_iID = m_SocketID;
-
-         uint32_t kmdata[SRTDATA_MAXSIZE];
-         size_t kmdatasize = SRTDATA_MAXSIZE;
-         bool have_hsreq = false;
-         if ( req.m_iVersion > HS_VERSION_UDT4 )
-         {
-             initdata.m_iVersion = HS_VERSION_SRT1; // if I remember correctly, this is induction/listener...
-             int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
-             if ( hs_flags != 0 ) // has SRT extensions
-             {
-                 HLOGC(mglog.Debug, log << "processCtrl/HS: got HS reqtype=" << RequestTypeStr(req.m_iReqType) << " WITH SRT ext");
-                 have_hsreq = interpretSrtHandshake(req, ctrlpkt, kmdata, &kmdatasize);
-                 if ( !have_hsreq )
-                 {
-                     initdata.m_iVersion = 0;
-                     m_RejectReason = SRT_REJ_ROGUE;
-                     initdata.m_iReqType = URQFailure(m_RejectReason);
-                 }
-                 else
-                 {
-                     // Extensions are added only in case of CONCLUSION (not AGREEMENT).
-                     // Actually what is expected here is that this may either process the
-                     // belated-repeated handshake from a caller (and then it's CONCLUSION,
-                     // and should be added with HSRSP/KMRSP), or it's a belated handshake
-                     // of Rendezvous when it has already considered itself connected.
-                     // Sanity check - according to the rules, there should be no such situation
-                     if (m_bRendezvous && m_SrtHsSide == HSD_RESPONDER)
-                     {
-                         LOGC(mglog.Error, log << "processCtrl/HS: IPE???: RESPONDER should receive all its handshakes in handshake phase.");
-                     }
-
-                     // The 'extension' flag will be set from this variable; set it to false
-                     // in case when the AGREEMENT response is to be sent.
-                     have_hsreq = initdata.m_iReqType == URQ_CONCLUSION;
-                     HLOGC(mglog.Debug, log << "processCtrl/HS: processing ok, reqtype="
-                             << RequestTypeStr(initdata.m_iReqType) << " kmdatasize=" << kmdatasize);
-                 }
-             }
-             else
-             {
-                 HLOGC(mglog.Debug, log << "processCtrl/HS: got HS reqtype=" << RequestTypeStr(req.m_iReqType));
-             }
-         }
-         else
-         {
-             initdata.m_iVersion = HS_VERSION_UDT4;
-         }
-
-         initdata.m_extension = have_hsreq;
-
-         HLOGC(mglog.Debug, log << CONID() << "processCtrl: responding HS reqtype=" << RequestTypeStr(initdata.m_iReqType) << (have_hsreq ? " WITH SRT HS response extensions" : ""));
-
-         // XXX here interpret SRT handshake extension
-         CPacket response;
-         response.setControl(UMSG_HANDSHAKE);
-         response.allocate(m_iMaxSRTPayloadSize);
-
-         // If createSrtHandshake failed, don't send anything. Actually it can only fail on IPE.
-         // There is also no possible IPE condition in case of HSv4 - for this version it will always return true.
-         if ( createSrtHandshake(Ref(response), Ref(initdata), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize) )
-         {
-             response.m_iID = m_PeerID;
-             response.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-             int nbsent = m_pSndQueue->sendto(m_pPeerAddr, response);
-             if (nbsent)
-             {
-                 uint64_t currtime_tk;
-                 CTimer::rdtsc(currtime_tk);
-                 m_ullLastSndTime_tk = currtime_tk;
-             }
-         }
-
-      }
-      else
-      {
-          HLOGC(mglog.Debug, log << "processCtrl: ... not INDUCTION, not ERROR, not rendezvous - IGNORED.");
-      }
-
-      break;
-      }
-
-   case UMSG_SHUTDOWN: //101 - Shutdown
-      m_bShutdown = true;
-      m_bClosing = true;
-      m_bBroken = true;
-      m_iBrokenCounter = 60;
-
-      // Signal the sender and recver if they are waiting for data.
-      releaseSynch();
-      // Unblock any call so they learn the connection_broken error
-      s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_ERR, true);
-
-      CTimer::triggerEvent();
-
-      break;
-
-   case UMSG_DROPREQ: //111 - Msg drop request
-      CGuard::enterCS(m_RecvLock);
-      m_pRcvBuffer->dropMsg(ctrlpkt.getMsgSeq(using_rexmit_flag), using_rexmit_flag);
-      CGuard::leaveCS(m_RecvLock);
-
-      dropFromLossLists(*(int32_t*)ctrlpkt.m_pcData, *(int32_t*)(ctrlpkt.m_pcData + 4));
-
-      // move forward with current recv seq no.
-      if ((CSeqNo::seqcmp(*(int32_t*)ctrlpkt.m_pcData, CSeqNo::incseq(m_iRcvCurrSeqNo)) <= 0)
-         && (CSeqNo::seqcmp(*(int32_t*)(ctrlpkt.m_pcData + 4), m_iRcvCurrSeqNo) > 0))
-      {
-         m_iRcvCurrSeqNo = *(int32_t*)(ctrlpkt.m_pcData + 4);
-      }
-
-      break;
-
-   case UMSG_PEERERROR: // 1000 - An error has happened to the peer side
-      //int err_type = packet.getAddInfo();
-
-      // currently only this error is signalled from the peer side
-      // if recvfile() failes (e.g., due to disk fail), blcoked sendfile/send should return immediately
-      // giving the app a chance to fix the issue
-
-      m_bPeerHealth = false;
-
-      break;
-
-   case UMSG_EXT: //0x7FFF - reserved and user defined messages
-      HLOGF(mglog.Debug, "CONTROL EXT MSG RECEIVED: %08X\n", ctrlpkt.getExtendedType());
-      {
-          // This has currently two roles in SRT:
-          // - HSv4 (legacy) handshake
-          // - refreshed KMX (initial KMX is done still in the HS process in HSv5)
-          bool understood = processSrtMsg(&ctrlpkt);
-          // CAREFUL HERE! This only means that this update comes from the UMSG_EXT
-          // message received, REGARDLESS OF WHAT IT IS. This version doesn't mean
-          // the handshake version, but the reason of calling this function.
-          //
-          // Fortunately, the only messages taken into account in this function
-          // are HSREQ and HSRSP, which should *never* be interchanged when both
-          // parties are HSv5.
-          if ( understood )
-          {
-              updateAfterSrtHandshake(ctrlpkt.getExtendedType(), HS_VERSION_UDT4);
-          }
-          else
-          {
-              updateCC(TEV_CUSTOM, &ctrlpkt);
-          }
-      }
-      break;
-
-   default:
-      break;
-   }
+    default:
+        break;
+    }
 }
 
 void CUDT::updateSrtRcvSettings()
@@ -7729,9 +7861,10 @@ void CUDT::updateSrtRcvSettings()
         m_pRcvBuffer->setRcvTsbPdMode(m_ullRcvPeerStartTime, m_iTsbPdDelay_ms * 1000);
         CGuard::leaveCS(m_RecvLock);
 
-        HLOGF(mglog.Debug,  "AFTER HS: Set Rcv TsbPd mode: delay=%u.%03u secs",
-                m_iTsbPdDelay_ms/1000,
-                m_iTsbPdDelay_ms%1000);
+        HLOGF(mglog.Debug,
+              "AFTER HS: Set Rcv TsbPd mode: delay=%u.%03u secs",
+              m_iTsbPdDelay_ms / 1000,
+              m_iTsbPdDelay_ms % 1000);
     }
     else
     {
@@ -7745,14 +7878,16 @@ void CUDT::updateSrtSndSettings()
     {
         /* We are TsbPd sender */
         // XXX Check what happened here.
-        //m_iPeerTsbPdDelay_ms = m_CongCtl->getSndPeerTsbPdDelay();// + ((m_iRTT + (4 * m_iRTTVar)) / 1000);
-        /* 
+        // m_iPeerTsbPdDelay_ms = m_CongCtl->getSndPeerTsbPdDelay();// + ((m_iRTT + (4 * m_iRTTVar)) / 1000);
+        /*
          * For sender to apply Too-Late Packet Drop
          * option (m_bTLPktDrop) must be enabled and receiving peer shall support it
          */
-        HLOGF(mglog.Debug,  "AFTER HS: Set Snd TsbPd mode %s: delay=%d.%03d secs",
-                m_bPeerTLPktDrop ? "with TLPktDrop" : "without TLPktDrop",
-                m_iPeerTsbPdDelay_ms/1000, m_iPeerTsbPdDelay_ms%1000);
+        HLOGF(mglog.Debug,
+              "AFTER HS: Set Snd TsbPd mode %s: delay=%d.%03d secs",
+              m_bPeerTLPktDrop ? "with TLPktDrop" : "without TLPktDrop",
+              m_iPeerTsbPdDelay_ms / 1000,
+              m_iPeerTsbPdDelay_ms % 1000);
     }
     else
     {
@@ -7782,12 +7917,12 @@ void CUDT::updateAfterSrtHandshake(int srt_cmd, int hsv)
     // This function will be called only ONCE in this
     // instance, through either HSREQ or HSRSP.
 
-    if ( hsv > HS_VERSION_UDT4 )
+    if (hsv > HS_VERSION_UDT4)
     {
         updateSrtRcvSettings();
         updateSrtSndSettings();
     }
-    else if ( srt_cmd == SRT_CMD_HSRSP )
+    else if (srt_cmd == SRT_CMD_HSRSP)
     {
         // HSv4 INITIATOR is sender
         updateSrtSndSettings();
@@ -7799,8 +7934,7 @@ void CUDT::updateAfterSrtHandshake(int srt_cmd, int hsv)
     }
 }
 
-
-int CUDT::packLostData(CPacket& packet, uint64_t& origintime)
+int CUDT::packLostData(CPacket &packet, uint64_t &origintime)
 {
     // protect m_iSndLastDataAck from updating by ACK processing
     CGuard ackguard(m_RecvAckLock);
@@ -7810,9 +7944,9 @@ int CUDT::packLostData(CPacket& packet, uint64_t& origintime)
         const int offset = CSeqNo::seqoff(m_iSndLastDataAck, packet.m_iSeqNo);
         if (offset < 0)
         {
-            LOGC(dlog.Error, log << "IPE: packLostData: LOST packet negative offset: seqoff(m_iSeqNo "
-                << packet.m_iSeqNo << ", m_iSndLastDataAck " << m_iSndLastDataAck
-                << ")=" << offset << ". Continue");
+            LOGC(dlog.Error,
+                 log << "IPE: packLostData: LOST packet negative offset: seqoff(m_iSeqNo " << packet.m_iSeqNo
+                     << ", m_iSndLastDataAck " << m_iSndLastDataAck << ")=" << offset << ". Continue");
             continue;
         }
 
@@ -7872,21 +8006,20 @@ int CUDT::packLostData(CPacket& packet, uint64_t& origintime)
     return 0;
 }
 
-
-int CUDT::packData(CPacket& packet, uint64_t& ts_tk)
+int CUDT::packData(CPacket &packet, uint64_t &ts_tk)
 {
-   int payload = 0;
-   bool probe = false;
-   uint64_t origintime = 0;
-   bool new_packet_packed = false;
-   bool filter_ctl_pkt = false;
+    int      payload           = 0;
+    bool     probe             = false;
+    uint64_t origintime        = 0;
+    bool     new_packet_packed = false;
+    bool     filter_ctl_pkt    = false;
 
-   int kflg = EK_NOENC;
+    int kflg = EK_NOENC;
 
-   uint64_t entertime_tk;
-   CTimer::rdtsc(entertime_tk);
+    uint64_t entertime_tk;
+    CTimer::rdtsc(entertime_tk);
 
-#if 0//debug: TimeDiff histogram
+#if 0 // debug: TimeDiff histogram
    static int lldiffhisto[23] = {0};
    static int llnodiff = 0;
    if (m_ullTargetTime_tk != 0)
@@ -7910,204 +8043,204 @@ int CUDT::packData(CPacket& packet, uint64_t& ts_tk)
         lldiffhisto[18],lldiffhisto[19],lldiffhisto[20],lldiffhisto[21],lldiffhisto[21],llnodiff);
    }
 #endif
-   if ((0 != m_ullTargetTime_tk) && (entertime_tk > m_ullTargetTime_tk))
-      m_ullTimeDiff_tk += entertime_tk - m_ullTargetTime_tk;
+    if ((0 != m_ullTargetTime_tk) && (entertime_tk > m_ullTargetTime_tk))
+        m_ullTimeDiff_tk += entertime_tk - m_ullTargetTime_tk;
 
-   string reason;
+    string reason;
 
-   payload = packLostData(packet, origintime);
-   if (payload > 0)
-   {
-       reason = "reXmit";
-   }
-   else if (m_PacketFilter && m_PacketFilter.packControlPacket(
-               Ref(packet), m_iSndCurrSeqNo,
-               m_pCryptoControl->getSndCryptoFlags()))
-   {
-       HLOGC(mglog.Debug, log << "filter: filter/CTL packet ready - packing instead of data.");
-       payload = packet.getLength();
-       reason = "filter";
-       filter_ctl_pkt = true; // Mark that this packet ALREADY HAS timestamp field and it should not be set
+    payload = packLostData(packet, origintime);
+    if (payload > 0)
+    {
+        reason = "reXmit";
+    }
+    else if (m_PacketFilter &&
+             m_PacketFilter.packControlPacket(Ref(packet), m_iSndCurrSeqNo, m_pCryptoControl->getSndCryptoFlags()))
+    {
+        HLOGC(mglog.Debug, log << "filter: filter/CTL packet ready - packing instead of data.");
+        payload        = packet.getLength();
+        reason         = "filter";
+        filter_ctl_pkt = true; // Mark that this packet ALREADY HAS timestamp field and it should not be set
 
-       // Stats
+        // Stats
 
-       {
-           CGuard lg(m_StatsLock);
-           ++m_stats.sndFilterExtra;
-           ++m_stats.sndFilterExtraTotal;
-       }
-   }
-   else
-   {
-      // If no loss, and no packetfilter control packet, pack a new packet.
+        {
+            CGuard lg(m_StatsLock);
+            ++m_stats.sndFilterExtra;
+            ++m_stats.sndFilterExtraTotal;
+        }
+    }
+    else
+    {
+        // If no loss, and no packetfilter control packet, pack a new packet.
 
-      // check congestion/flow window limit
-      int cwnd = std::min(int(m_iFlowWindowSize), int(m_dCongestionWindow));
-      int seqdiff = CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo));
-      if (cwnd >= seqdiff)
-      {
-         // XXX Here it's needed to set kflg to msgno_bitset in the block stored in the
-         // send buffer. This should be somehow avoided, the crypto flags should be set
-         // together with encrypting, and the packet should be sent as is, when rexmitting.
-         // It would be nice to research as to whether CSndBuffer::Block::m_iMsgNoBitset field
-         // isn't a useless redundant state copy. If it is, then taking the flags here can be removed.
-         kflg = m_pCryptoControl->getSndCryptoFlags();
-         payload = m_pSndBuffer->readData(&(packet.m_pcData), packet.m_iMsgNo, origintime, kflg);
-         if (payload)
-         {
-            m_iSndCurrSeqNo = CSeqNo::incseq(m_iSndCurrSeqNo);
-            //m_pCryptoControl->m_iSndCurrSeqNo = m_iSndCurrSeqNo;
+        // check congestion/flow window limit
+        int cwnd    = std::min(int(m_iFlowWindowSize), int(m_dCongestionWindow));
+        int seqdiff = CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo));
+        if (cwnd >= seqdiff)
+        {
+            // XXX Here it's needed to set kflg to msgno_bitset in the block stored in the
+            // send buffer. This should be somehow avoided, the crypto flags should be set
+            // together with encrypting, and the packet should be sent as is, when rexmitting.
+            // It would be nice to research as to whether CSndBuffer::Block::m_iMsgNoBitset field
+            // isn't a useless redundant state copy. If it is, then taking the flags here can be removed.
+            kflg    = m_pCryptoControl->getSndCryptoFlags();
+            payload = m_pSndBuffer->readData(&(packet.m_pcData), packet.m_iMsgNo, origintime, kflg);
+            if (payload)
+            {
+                m_iSndCurrSeqNo = CSeqNo::incseq(m_iSndCurrSeqNo);
+                // m_pCryptoControl->m_iSndCurrSeqNo = m_iSndCurrSeqNo;
 
-            packet.m_iSeqNo = m_iSndCurrSeqNo;
+                packet.m_iSeqNo = m_iSndCurrSeqNo;
 
-            // every 16 (0xF) packets, a packet pair is sent
-            if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 0)
-               probe = true;
+                // every 16 (0xF) packets, a packet pair is sent
+                if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 0)
+                    probe = true;
 
-            new_packet_packed = true;
-         }
-         else
-         {
+                new_packet_packed = true;
+            }
+            else
+            {
+                m_ullTargetTime_tk = 0;
+                m_ullTimeDiff_tk   = 0;
+                ts_tk              = 0;
+                return 0;
+            }
+        }
+        else
+        {
+            HLOGC(dlog.Debug,
+                  log << "packData: CONGESTED: cwnd=min(" << m_iFlowWindowSize << "," << m_dCongestionWindow
+                      << ")=" << cwnd << " seqlen=(" << m_iSndLastAck << "-" << m_iSndCurrSeqNo << ")=" << seqdiff);
             m_ullTargetTime_tk = 0;
-            m_ullTimeDiff_tk = 0;
-            ts_tk = 0;
+            m_ullTimeDiff_tk   = 0;
+            ts_tk              = 0;
             return 0;
-         }
-      }
-      else
-      {
-          HLOGC(dlog.Debug, log << "packData: CONGESTED: cwnd=min(" << m_iFlowWindowSize << "," << m_dCongestionWindow
-              << ")=" << cwnd << " seqlen=(" << m_iSndLastAck << "-" << m_iSndCurrSeqNo << ")=" << seqdiff);
-         m_ullTargetTime_tk = 0;
-         m_ullTimeDiff_tk = 0;
-         ts_tk = 0;
-         return 0;
-      }
+        }
 
-      reason = "normal";
-   }
+        reason = "normal";
+    }
 
-   // Normally packet.m_iTimeStamp field is set exactly here,
-   // usually as taken from m_StartTime and current time, unless live
-   // mode in which case it is based on 'origintime' as set during scheduling.
-   // In case when this is a filter control packet, the m_iTimeStamp field already
-   // contains the exactly needed value, and it's a timestamp clip, not a real
-   // timestamp.
-   if (!filter_ctl_pkt)
-   {
-       if (m_bPeerTsbPd)
-       {
-           /*
-            * When timestamp is carried over in this sending stream from a received stream,
-            * it may be older than the session start time causing a negative packet time
-            * that may block the receiver's Timestamp-based Packet Delivery.
-            * XXX Isn't it then better to not decrease it by m_StartTime? As long as it
-            * doesn't screw up the start time on the other side.
-            */
-           if (origintime >= m_stats.startTime)
-               packet.m_iTimeStamp = int(origintime - m_stats.startTime);
-           else
-               packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-       }
-       else
-       {
-           packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-       }
-   }
+    // Normally packet.m_iTimeStamp field is set exactly here,
+    // usually as taken from m_StartTime and current time, unless live
+    // mode in which case it is based on 'origintime' as set during scheduling.
+    // In case when this is a filter control packet, the m_iTimeStamp field already
+    // contains the exactly needed value, and it's a timestamp clip, not a real
+    // timestamp.
+    if (!filter_ctl_pkt)
+    {
+        if (m_bPeerTsbPd)
+        {
+            /*
+             * When timestamp is carried over in this sending stream from a received stream,
+             * it may be older than the session start time causing a negative packet time
+             * that may block the receiver's Timestamp-based Packet Delivery.
+             * XXX Isn't it then better to not decrease it by m_StartTime? As long as it
+             * doesn't screw up the start time on the other side.
+             */
+            if (origintime >= m_stats.startTime)
+                packet.m_iTimeStamp = int(origintime - m_stats.startTime);
+            else
+                packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+        }
+        else
+        {
+            packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+        }
+    }
 
-   packet.m_iID = m_PeerID;
-   packet.setLength(payload);
+    packet.m_iID = m_PeerID;
+    packet.setLength(payload);
 
-   /* Encrypt if 1st time this packet is sent and crypto is enabled */
-   if (kflg)
-   {
-       // XXX Encryption flags are already set on the packet before calling this.
-       // See readData() above.
-      if (m_pCryptoControl->encrypt(Ref(packet)))
-      {
-          // Encryption failed 
-          //>>Add stats for crypto failure
-          ts_tk = 0;
-          LOGC(dlog.Error, log << "ENCRYPT FAILED - packet won't be sent, size=" << payload);
-          return -1; //Encryption failed
-      }
-      payload = packet.getLength(); /* Cipher may change length */
-      reason += " (encrypted)";
-   }
+    /* Encrypt if 1st time this packet is sent and crypto is enabled */
+    if (kflg)
+    {
+        // XXX Encryption flags are already set on the packet before calling this.
+        // See readData() above.
+        if (m_pCryptoControl->encrypt(Ref(packet)))
+        {
+            // Encryption failed
+            //>>Add stats for crypto failure
+            ts_tk = 0;
+            LOGC(dlog.Error, log << "ENCRYPT FAILED - packet won't be sent, size=" << payload);
+            return -1; // Encryption failed
+        }
+        payload = packet.getLength(); /* Cipher may change length */
+        reason += " (encrypted)";
+    }
 
-   if (new_packet_packed && m_PacketFilter)
-   {
-       HLOGC(mglog.Debug, log << "filter: Feeding packet for source clip");
-       m_PacketFilter.feedSource(Ref(packet));
-   }
+    if (new_packet_packed && m_PacketFilter)
+    {
+        HLOGC(mglog.Debug, log << "filter: Feeding packet for source clip");
+        m_PacketFilter.feedSource(Ref(packet));
+    }
 
 #if ENABLE_HEAVY_LOGGING // Required because of referring to MessageFlagStr()
-   HLOGC(mglog.Debug, log << CONID() << "packData: " << reason << " packet seq=" << packet.m_iSeqNo
-       << " (ACK=" << m_iSndLastAck << " ACKDATA=" << m_iSndLastDataAck
-       << " MSG/FLAGS: " << packet.MessageFlagStr() << ")");
+    HLOGC(mglog.Debug,
+          log << CONID() << "packData: " << reason << " packet seq=" << packet.m_iSeqNo << " (ACK=" << m_iSndLastAck
+              << " ACKDATA=" << m_iSndLastDataAck << " MSG/FLAGS: " << packet.MessageFlagStr() << ")");
 #endif
 
-   // Fix keepalive
-   m_ullLastSndTime_tk = entertime_tk;
+    // Fix keepalive
+    m_ullLastSndTime_tk = entertime_tk;
 
-   considerLegacySrtHandshake(0);
+    considerLegacySrtHandshake(0);
 
-   // WARNING: TEV_SEND is the only event that is reported from
-   // the CSndQueue::worker thread. All others are reported from
-   // CRcvQueue::worker. If you connect to this signal, make sure
-   // that you are aware of prospective simultaneous access.
-   updateCC(TEV_SEND, &packet);
+    // WARNING: TEV_SEND is the only event that is reported from
+    // the CSndQueue::worker thread. All others are reported from
+    // CRcvQueue::worker. If you connect to this signal, make sure
+    // that you are aware of prospective simultaneous access.
+    updateCC(TEV_SEND, &packet);
 
-   // XXX This was a blocked code also originally in UDT. Probably not required.
-   // Left untouched for historical reasons.
-   // Might be possible that it was because of that this is send from
-   // different thread than the rest of the signals.
-   //m_pSndTimeWindow->onPktSent(packet.m_iTimeStamp);
+    // XXX This was a blocked code also originally in UDT. Probably not required.
+    // Left untouched for historical reasons.
+    // Might be possible that it was because of that this is send from
+    // different thread than the rest of the signals.
+    // m_pSndTimeWindow->onPktSent(packet.m_iTimeStamp);
 
-   CGuard::enterCS(m_StatsLock);
-   m_stats.traceBytesSent += payload;
-   m_stats.bytesSentTotal += payload;
-   ++ m_stats.traceSent;
-   ++ m_stats.sentTotal;
-   CGuard::leaveCS(m_StatsLock);
+    CGuard::enterCS(m_StatsLock);
+    m_stats.traceBytesSent += payload;
+    m_stats.bytesSentTotal += payload;
+    ++m_stats.traceSent;
+    ++m_stats.sentTotal;
+    CGuard::leaveCS(m_StatsLock);
 
-   if (probe)
-   {
-      // sends out probing packet pair
-      ts_tk = entertime_tk;
-      probe = false;
-   }
-   else
-   {
+    if (probe)
+    {
+        // sends out probing packet pair
+        ts_tk = entertime_tk;
+        probe = false;
+    }
+    else
+    {
 #if USE_BUSY_WAITING
-      ts_tk = entertime_tk + m_ullInterval_tk;
+        ts_tk = entertime_tk + m_ullInterval_tk;
 #else
-      if (m_ullTimeDiff_tk >= m_ullInterval_tk)
-      {
-         ts_tk = entertime_tk;
-         m_ullTimeDiff_tk -= m_ullInterval_tk;
-      }
-      else
-      {
-         ts_tk = entertime_tk + m_ullInterval_tk - m_ullTimeDiff_tk;
-         m_ullTimeDiff_tk = 0;
-      }
+        if (m_ullTimeDiff_tk >= m_ullInterval_tk)
+        {
+            ts_tk = entertime_tk;
+            m_ullTimeDiff_tk -= m_ullInterval_tk;
+        }
+        else
+        {
+            ts_tk = entertime_tk + m_ullInterval_tk - m_ullTimeDiff_tk;
+            m_ullTimeDiff_tk = 0;
+        }
 #endif
-   }
+    }
 
-   m_ullTargetTime_tk = ts_tk;
+    m_ullTargetTime_tk = ts_tk;
 
-   return payload;
+    return payload;
 }
 
-// This is a close request, but called from the 
+// This is a close request, but called from the
 void CUDT::processClose()
 {
     sendCtrl(UMSG_SHUTDOWN);
 
-    m_bShutdown = true;
-    m_bClosing = true;
-    m_bBroken = true;
+    m_bShutdown      = true;
+    m_bClosing       = true;
+    m_bBroken        = true;
     m_iBrokenCounter = 60;
 
     HLOGP(mglog.Debug, "processClose: sent message and set flags");
@@ -8126,12 +8259,11 @@ void CUDT::processClose()
 
     HLOGP(mglog.Debug, "processClose: triggering timer event to spread the bad news");
     CTimer::triggerEvent();
-
 }
 
-void CUDT::sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& loss_seqs)
+void CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
 {
-    typedef vector< pair<int32_t, int32_t> > loss_seqs_t;
+    typedef vector<pair<int32_t, int32_t> > loss_seqs_t;
 
     vector<int32_t> seqbuffer;
     seqbuffer.reserve(2 * loss_seqs.size()); // pessimistic
@@ -8146,8 +8278,11 @@ void CUDT::sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& loss
         {
             seqbuffer.push_back(i->first | LOSSDATA_SEQNO_RANGE_FIRST);
             seqbuffer.push_back(i->second);
-            HLOGF(mglog.Debug, "lost packets %d-%d (%d packets): sending LOSSREPORT",
-                    i->first, i->second, 1+CSeqNo::seqcmp(i->second, i->first));
+            HLOGF(mglog.Debug,
+                  "lost packets %d-%d (%d packets): sending LOSSREPORT",
+                  i->first,
+                  i->second,
+                  1 + CSeqNo::seqcmp(i->second, i->first));
         }
     }
 
@@ -8155,504 +8290,507 @@ void CUDT::sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& loss
     {
         sendCtrl(UMSG_LOSSREPORT, NULL, &seqbuffer[0], seqbuffer.size());
     }
-
 }
 
-int CUDT::processData(CUnit* in_unit)
+int CUDT::processData(CUnit *in_unit)
 {
-   CPacket& packet = in_unit->m_Packet;
+    CPacket &packet = in_unit->m_Packet;
 
-   // XXX This should be called (exclusively) here:
-   //m_pRcvBuffer->addLocalTsbPdDriftSample(packet.getMsgTimeStamp());
-   // Just heard from the peer, reset the expiration count.
-   m_iEXPCount = 1;
-   uint64_t currtime_tk;
-   CTimer::rdtsc(currtime_tk);
-   m_ullLastRspTime_tk = currtime_tk;
+    // XXX This should be called (exclusively) here:
+    // m_pRcvBuffer->addLocalTsbPdDriftSample(packet.getMsgTimeStamp());
+    // Just heard from the peer, reset the expiration count.
+    m_iEXPCount = 1;
+    uint64_t currtime_tk;
+    CTimer::rdtsc(currtime_tk);
+    m_ullLastRspTime_tk = currtime_tk;
 
-   // We are receiving data, start tsbpd thread if TsbPd is enabled
-   if (m_bTsbPd && pthread_equal(m_RcvTsbPdThread, pthread_t()))
-   {
-       HLOGP(mglog.Debug, "Spawning TSBPD thread");
-       int st = 0;
-       {
-           ThreadName tn("SRT:TsbPd");
-           st = pthread_create(&m_RcvTsbPdThread, NULL, CUDT::tsbpd, this);
-       }
-       if (st != 0)
-           return -1;
-   }
+    // We are receiving data, start tsbpd thread if TsbPd is enabled
+    if (m_bTsbPd && pthread_equal(m_RcvTsbPdThread, pthread_t()))
+    {
+        HLOGP(mglog.Debug, "Spawning TSBPD thread");
+        int st = 0;
+        {
+            ThreadName tn("SRT:TsbPd");
+            st = pthread_create(&m_RcvTsbPdThread, NULL, CUDT::tsbpd, this);
+        }
+        if (st != 0)
+            return -1;
+    }
 
-   const int pktrexmitflag = m_bPeerRexmitFlag ? (packet.getRexmitFlag() ? 1 : 0) : 2;
+    const int pktrexmitflag = m_bPeerRexmitFlag ? (packet.getRexmitFlag() ? 1 : 0) : 2;
 #if ENABLE_HEAVY_LOGGING
-   static const char* const rexmitstat [] = {"ORIGINAL", "REXMITTED", "RXS-UNKNOWN"};
-   string rexmit_reason;
+    static const char *const rexmitstat[] = {"ORIGINAL", "REXMITTED", "RXS-UNKNOWN"};
+    string                   rexmit_reason;
 #endif
 
-   if (pktrexmitflag == 1)
-   {
-       // This packet was retransmitted
-       CGuard::enterCS(m_StatsLock);
-       m_stats.traceRcvRetrans++;
-       CGuard::leaveCS(m_StatsLock);
+    if (pktrexmitflag == 1)
+    {
+        // This packet was retransmitted
+        CGuard::enterCS(m_StatsLock);
+        m_stats.traceRcvRetrans++;
+        CGuard::leaveCS(m_StatsLock);
 
 #if ENABLE_HEAVY_LOGGING
-       // Check if packet was retransmitted on request or on ack timeout
-       // Search the sequence in the loss record.
-       rexmit_reason = " by ";
-       if (!m_pRcvLossList->find(packet.m_iSeqNo, packet.m_iSeqNo))
-           rexmit_reason += "REQUEST";
-       else
-           rexmit_reason += "ACK-TMOUT";
+        // Check if packet was retransmitted on request or on ack timeout
+        // Search the sequence in the loss record.
+        rexmit_reason = " by ";
+        if (!m_pRcvLossList->find(packet.m_iSeqNo, packet.m_iSeqNo))
+            rexmit_reason += "REQUEST";
+        else
+            rexmit_reason += "ACK-TMOUT";
 #endif
-   }
+    }
 
-   HLOGC(dlog.Debug, log << CONID() << "processData: RECEIVED DATA: size=" << packet.getLength() << " seq=" << packet.getSeqNo());
+    HLOGC(dlog.Debug,
+          log << CONID() << "processData: RECEIVED DATA: size=" << packet.getLength() << " seq=" << packet.getSeqNo());
 
-   updateCC(TEV_RECEIVE, &packet);
-   ++ m_iPktCount;
+    updateCC(TEV_RECEIVE, &packet);
+    ++m_iPktCount;
 
-   const int pktsz = packet.getLength();
-   // Update time information
-   m_RcvTimeWindow.onPktArrival(pktsz);
+    const int pktsz = packet.getLength();
+    // Update time information
+    m_RcvTimeWindow.onPktArrival(pktsz);
 
-   // Check if it is a probing packet pair
-   if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 0)
-      m_RcvTimeWindow.probe1Arrival();
-   else if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 1)
-      m_RcvTimeWindow.probe2Arrival(pktsz);
+    // Check if it is a probing packet pair
+    if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 0)
+        m_RcvTimeWindow.probe1Arrival();
+    else if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 1)
+        m_RcvTimeWindow.probe2Arrival(pktsz);
 
-   CGuard::enterCS(m_StatsLock);
-   m_stats.traceBytesRecv += pktsz;
-   m_stats.bytesRecvTotal += pktsz;
-   ++ m_stats.traceRecv;
-   ++ m_stats.recvTotal;
-   CGuard::leaveCS(m_StatsLock);
+    CGuard::enterCS(m_StatsLock);
+    m_stats.traceBytesRecv += pktsz;
+    m_stats.bytesRecvTotal += pktsz;
+    ++m_stats.traceRecv;
+    ++m_stats.recvTotal;
+    CGuard::leaveCS(m_StatsLock);
 
-   typedef vector< pair<int32_t, int32_t> > loss_seqs_t;
-   loss_seqs_t filter_loss_seqs;
-   loss_seqs_t srt_loss_seqs;
-   vector<CUnit*> incoming;
-   bool was_sent_in_order = true;
-   bool reorder_prevent_lossreport = false;
+    typedef vector<pair<int32_t, int32_t> > loss_seqs_t;
+    loss_seqs_t                             filter_loss_seqs;
+    loss_seqs_t                             srt_loss_seqs;
+    vector<CUnit *>                         incoming;
+    bool                                    was_sent_in_order          = true;
+    bool                                    reorder_prevent_lossreport = false;
 
-   // If the peer doesn't understand REXMIT flag, send rexmit request
-   // always immediately.
-   int initial_loss_ttl = 0;
-   if ( m_bPeerRexmitFlag )
-       initial_loss_ttl = m_iReorderTolerance;
+    // If the peer doesn't understand REXMIT flag, send rexmit request
+    // always immediately.
+    int initial_loss_ttl = 0;
+    if (m_bPeerRexmitFlag)
+        initial_loss_ttl = m_iReorderTolerance;
 
+    // After introduction of packet filtering, the "recordable loss detection"
+    // does not exactly match the true loss detection. When a FEC filter is
+    // working, for example, then getting one group filled with all packet but
+    // the last one and the FEC control packet, in this special case this packet
+    // won't be notified at all as lost because it will be recovered by the
+    // filter immediately before anyone notices what happened (and the loss
+    // detection for the further functionality is checked only afterwards,
+    // and in this case the immediate recovery makes the loss to not be noticed
+    // at all).
+    //
+    // Because of that the check for losses must happen BEFORE passing the packet
+    // to the filter and before the filter could recover the packet before anyone
+    // notices :)
 
-   // After introduction of packet filtering, the "recordable loss detection"
-   // does not exactly match the true loss detection. When a FEC filter is
-   // working, for example, then getting one group filled with all packet but
-   // the last one and the FEC control packet, in this special case this packet
-   // won't be notified at all as lost because it will be recovered by the
-   // filter immediately before anyone notices what happened (and the loss
-   // detection for the further functionality is checked only afterwards,
-   // and in this case the immediate recovery makes the loss to not be noticed
-   // at all).
-   //
-   // Because of that the check for losses must happen BEFORE passing the packet
-   // to the filter and before the filter could recover the packet before anyone
-   // notices :)
+    if (packet.getMsgSeq() != 0) // disregard filter-control packets, their seq may mean nothing
+    {
+        int diff = CSeqNo::seqoff(m_iRcvCurrPhySeqNo, packet.m_iSeqNo);
+        if (diff > 1)
+        {
+            CGuard lg(m_StatsLock);
+            int    loss = diff - 1; // loss is all that is above diff == 1
+            m_stats.traceRcvLoss += loss;
+            m_stats.rcvLossTotal += loss;
+            uint64_t lossbytes = loss * m_pRcvBuffer->getRcvAvgPayloadSize();
+            m_stats.traceRcvBytesLoss += lossbytes;
+            m_stats.rcvBytesLossTotal += lossbytes;
+            HLOGC(mglog.Debug,
+                  log << "LOSS STATS: n=" << loss << " SEQ: [" << CSeqNo::incseq(m_iRcvCurrPhySeqNo) << " "
+                      << CSeqNo::decseq(packet.m_iSeqNo) << "]");
+        }
 
-   if (packet.getMsgSeq() != 0) // disregard filter-control packets, their seq may mean nothing
-   {
-       int diff = CSeqNo::seqoff(m_iRcvCurrPhySeqNo, packet.m_iSeqNo);
-       if (diff > 1)
-       {
-           CGuard lg(m_StatsLock);
-           int loss = diff - 1; // loss is all that is above diff == 1
-           m_stats.traceRcvLoss += loss;
-           m_stats.rcvLossTotal += loss;
-           uint64_t lossbytes = loss * m_pRcvBuffer->getRcvAvgPayloadSize();
-           m_stats.traceRcvBytesLoss += lossbytes;
-           m_stats.rcvBytesLossTotal += lossbytes;
-           HLOGC(mglog.Debug, log << "LOSS STATS: n=" << loss << " SEQ: ["
-                   << CSeqNo::incseq(m_iRcvCurrPhySeqNo) << " " << CSeqNo::decseq(packet.m_iSeqNo) << "]");
+        if (diff > 0)
+        {
+            // Record if it was further than latest
+            m_iRcvCurrPhySeqNo = packet.m_iSeqNo;
+        }
+    }
 
-       }
+    {
+        // Start of offset protected section
+        // Prevent TsbPd thread from modifying Ack position while adding data
+        // offset from RcvLastAck in RcvBuffer must remain valid between seqoff() and addData()
+        CGuard recvbuf_acklock(m_RcvBufferLock);
 
-       if (diff > 0)
-       {
-           // Record if it was further than latest
-           m_iRcvCurrPhySeqNo = packet.m_iSeqNo;
-       }
-   }
+        // vector<CUnit*> undec_units;
+        if (m_PacketFilter)
+        {
+            // Stuff this data into the filter
+            m_PacketFilter.receive(in_unit, Ref(incoming), Ref(filter_loss_seqs));
+            HLOGC(mglog.Debug,
+                  log << "(FILTER) fed data, received " << incoming.size() << " pkts, " << Printable(filter_loss_seqs)
+                      << " loss to report, "
+                      << (m_PktFilterRexmitLevel == SRT_ARQ_ALWAYS ? "FIND & REPORT LOSSES YOURSELF"
+                                                                   : "REPORT ONLY THOSE"));
+        }
+        else
+        {
+            // Stuff in just one packet that has come in.
+            incoming.push_back(in_unit);
+        }
 
-   {
-      // Start of offset protected section
-      // Prevent TsbPd thread from modifying Ack position while adding data
-      // offset from RcvLastAck in RcvBuffer must remain valid between seqoff() and addData()
-      CGuard recvbuf_acklock(m_RcvBufferLock);
+        bool excessive = true; // stays true unless it was successfully added
 
-      //vector<CUnit*> undec_units;
-      if (m_PacketFilter)
-      {
-          // Stuff this data into the filter
-          m_PacketFilter.receive(in_unit, Ref(incoming), Ref(filter_loss_seqs));
-          HLOGC(mglog.Debug, log << "(FILTER) fed data, received " << incoming.size() << " pkts, "
-                  << Printable(filter_loss_seqs) << " loss to report, "
-                  << (m_PktFilterRexmitLevel == SRT_ARQ_ALWAYS ? "FIND & REPORT LOSSES YOURSELF"
-                      : "REPORT ONLY THOSE"));
-      }
-      else
-      {
-          // Stuff in just one packet that has come in.
-          incoming.push_back(in_unit);
-      }
+        // Needed for possibly check for needsQuickACK.
+        bool incoming_belated = (CSeqNo::seqcmp(in_unit->m_Packet.m_iSeqNo, m_iRcvLastSkipAck) < 0);
 
-      bool excessive = true; // stays true unless it was successfully added
+        // Loop over all incoming packets that were filtered out.
+        // In case when there is no filter, there's just one packet in 'incoming',
+        // the one that came in the input of this function.
+        for (vector<CUnit *>::iterator i = incoming.begin(); i != incoming.end(); ++i)
+        {
+            CUnit *  u    = *i;
+            CPacket &rpkt = u->m_Packet;
 
-      // Needed for possibly check for needsQuickACK.
-      bool incoming_belated = ( CSeqNo::seqcmp(in_unit->m_Packet.m_iSeqNo, m_iRcvLastSkipAck) < 0 );
+            // m_iRcvLastSkipAck is the base sequence number for the receiver buffer.
+            // This is the offset in the buffer; if this is negative, it means that
+            // this sequence is already in the past and the buffer is not interested.
+            // Meaning, this packet will be rejected, even if it could potentially be
+            // one of missing packets in the transmission.
+            int32_t offset = CSeqNo::seqoff(m_iRcvLastSkipAck, rpkt.m_iSeqNo);
 
-      // Loop over all incoming packets that were filtered out.
-      // In case when there is no filter, there's just one packet in 'incoming',
-      // the one that came in the input of this function.
-      for (vector<CUnit*>::iterator i = incoming.begin(); i != incoming.end(); ++i)
-      {
-          CUnit* u = *i;
-          CPacket& rpkt = u->m_Packet;
+            IF_HEAVY_LOGGING(const char *exc_type = "EXPECTED");
 
-          // m_iRcvLastSkipAck is the base sequence number for the receiver buffer.
-          // This is the offset in the buffer; if this is negative, it means that
-          // this sequence is already in the past and the buffer is not interested.
-          // Meaning, this packet will be rejected, even if it could potentially be
-          // one of missing packets in the transmission.
-          int32_t offset = CSeqNo::seqoff(m_iRcvLastSkipAck, rpkt.m_iSeqNo);
+            if (offset < 0)
+            {
+                IF_HEAVY_LOGGING(exc_type = "BELATED");
+                uint64_t tsbpdtime = m_pRcvBuffer->getPktTsbPdTime(rpkt.getMsgTimeStamp());
+                uint64_t bltime =
+                    CountIIR(uint64_t(m_stats.traceBelatedTime) * 1000, CTimer::getTime() - tsbpdtime, 0.2);
 
-          IF_HEAVY_LOGGING(const char* exc_type = "EXPECTED");
+                CGuard::enterCS(m_StatsLock);
+                m_stats.traceBelatedTime = double(bltime) / 1000.0;
+                m_stats.traceRcvBelated++;
+                CGuard::leaveCS(m_StatsLock);
+                HLOGC(mglog.Debug,
+                      log << CONID() << "RECEIVED: seq=" << packet.m_iSeqNo << " offset=" << offset << " (BELATED/"
+                          << rexmitstat[pktrexmitflag] << rexmit_reason << ") FLAGS: " << packet.MessageFlagStr());
+                continue;
+            }
 
-          if (offset < 0)
-          {
-              IF_HEAVY_LOGGING(exc_type = "BELATED");
-              uint64_t tsbpdtime = m_pRcvBuffer->getPktTsbPdTime(rpkt.getMsgTimeStamp());
-              uint64_t bltime = CountIIR(
-                      uint64_t(m_stats.traceBelatedTime) * 1000,
-                      CTimer::getTime() - tsbpdtime, 0.2);
+            const int avail_bufsize = m_pRcvBuffer->getAvailBufSize();
+            if (offset >= avail_bufsize)
+            {
+                // This is already a sequence discrepancy. Probably there could be found
+                // some way to make it continue reception by overriding the sequence and
+                // make a kinda TLKPTDROP, but there has been found no reliable way to do this.
+                if (m_bTsbPd && m_bTLPktDrop && m_pRcvBuffer->empty())
+                {
+                    // Only in live mode. In File mode this shall not be possible
+                    // because the sender should stop sending in this situation.
+                    // In Live mode this means that there is a gap between the
+                    // lowest sequence in the empty buffer and the incoming sequence
+                    // that exceeds the buffer size. Receiving data in this situation
+                    // is no longer possible and this is a point of no return.
+                    LOGC(mglog.Error,
+                         log << CONID() << "SEQUENCE DISCREPANCY. BREAKING CONNECTION. offset=" << offset
+                             << " avail=" << avail_bufsize << " ack.seq=" << m_iRcvLastSkipAck
+                             << " pkt.seq=" << rpkt.m_iSeqNo << " rcv-remain=" << m_pRcvBuffer->debugGetSize());
 
-              CGuard::enterCS(m_StatsLock);
-              m_stats.traceBelatedTime = double(bltime) / 1000.0;
-              m_stats.traceRcvBelated++;
-              CGuard::leaveCS(m_StatsLock);
-              HLOGC(mglog.Debug, log << CONID() << "RECEIVED: seq=" << packet.m_iSeqNo
-                      << " offset=" << offset << " (BELATED/" << rexmitstat[pktrexmitflag] << rexmit_reason
-                      << ") FLAGS: " << packet.MessageFlagStr());
-              continue;
-          }
+                    // This is a scoped lock with AckLock, but for the moment
+                    // when processClose() is called this lock must be taken out,
+                    // otherwise this will cause a deadlock. We don't need this
+                    // lock anymore, and at 'return' it will be unlocked anyway.
+                    recvbuf_acklock.forceUnlock();
+                    processClose();
+                    return -1;
+                }
+                else
+                {
+                    LOGC(mglog.Error,
+                         log << CONID() << "No room to store incoming packet: offset=" << offset
+                             << " avail=" << avail_bufsize << " ack.seq=" << m_iRcvLastSkipAck
+                             << " pkt.seq=" << rpkt.m_iSeqNo << " rcv-remain=" << m_pRcvBuffer->debugGetSize());
+                    return -1;
+                }
+            }
 
-          const int avail_bufsize = m_pRcvBuffer->getAvailBufSize();
-          if (offset >= avail_bufsize)
-          {
-              // This is already a sequence discrepancy. Probably there could be found
-              // some way to make it continue reception by overriding the sequence and
-              // make a kinda TLKPTDROP, but there has been found no reliable way to do this.
-              if (m_bTsbPd && m_bTLPktDrop && m_pRcvBuffer->empty())
-              {
-                  // Only in live mode. In File mode this shall not be possible
-                  // because the sender should stop sending in this situation.
-                  // In Live mode this means that there is a gap between the
-                  // lowest sequence in the empty buffer and the incoming sequence
-                  // that exceeds the buffer size. Receiving data in this situation
-                  // is no longer possible and this is a point of no return.
-                  LOGC(mglog.Error, log << CONID() << "SEQUENCE DISCREPANCY. BREAKING CONNECTION. offset="
-                          << offset << " avail=" << avail_bufsize
-                          << " ack.seq=" << m_iRcvLastSkipAck << " pkt.seq=" << rpkt.m_iSeqNo
-                          << " rcv-remain=" << m_pRcvBuffer->debugGetSize()
-                      );
+            bool adding_successful = true;
+            if (m_pRcvBuffer->addData(*i, offset) < 0)
+            {
+                // addData returns -1 if at the m_iLastAckPos+offset position there already is a packet.
+                // So this packet is "redundant".
+                IF_HEAVY_LOGGING(exc_type = "UNACKED");
+                adding_successful = false;
+            }
+            else
+            {
+                IF_HEAVY_LOGGING(exc_type = "ACCEPTED");
+                excessive = false;
+                if (u->m_Packet.getMsgCryptoFlags())
+                {
+                    EncryptionStatus rc = m_pCryptoControl ? m_pCryptoControl->decrypt(Ref(u->m_Packet)) : ENCS_NOTSUP;
+                    if (rc != ENCS_CLEAR)
+                    {
+                        // Could not decrypt
+                        // Keep packet in received buffer
+                        // Crypto flags are still set
+                        // It will be acknowledged
+                        {
+                            CGuard lg(m_StatsLock);
+                            m_stats.traceRcvUndecrypt += 1;
+                            m_stats.traceRcvBytesUndecrypt += pktsz;
+                            m_stats.m_rcvUndecryptTotal += 1;
+                            m_stats.m_rcvBytesUndecryptTotal += pktsz;
+                        }
 
-                  // This is a scoped lock with AckLock, but for the moment
-                  // when processClose() is called this lock must be taken out,
-                  // otherwise this will cause a deadlock. We don't need this
-                  // lock anymore, and at 'return' it will be unlocked anyway.
-                  recvbuf_acklock.forceUnlock();
-                  processClose();
-                  return -1;
-              }
-              else
-              {
-                  LOGC(mglog.Error, log << CONID() << "No room to store incoming packet: offset="
-                          << offset << " avail=" << avail_bufsize
-                          << " ack.seq=" << m_iRcvLastSkipAck << " pkt.seq=" << rpkt.m_iSeqNo
-                          << " rcv-remain=" << m_pRcvBuffer->debugGetSize()
-                      );
-                  return -1;
-              }
+                        // Log message degraded to debug because it may happen very often
+                        HLOGC(dlog.Debug, log << CONID() << "ERROR: packet not decrypted, dropping data.");
+                        adding_successful = false;
+                        IF_HEAVY_LOGGING(exc_type = "UNDECRYPTED");
+                    }
+                }
+            }
 
-          }
+            HLOGC(mglog.Debug,
+                  log << CONID() << "RECEIVED: seq=" << rpkt.m_iSeqNo << " offset=" << offset << " (" << exc_type << "/"
+                      << rexmitstat[pktrexmitflag] << rexmit_reason << ") FLAGS: " << packet.MessageFlagStr());
 
-          bool adding_successful = true;
-          if (m_pRcvBuffer->addData(*i, offset) < 0)
-          {
-              // addData returns -1 if at the m_iLastAckPos+offset position there already is a packet.
-              // So this packet is "redundant".
-              IF_HEAVY_LOGGING(exc_type = "UNACKED");
-              adding_successful = false;
-          }
-          else
-          {
-              IF_HEAVY_LOGGING(exc_type = "ACCEPTED");
-              excessive = false;
-              if (u->m_Packet.getMsgCryptoFlags())
-              {
-                  EncryptionStatus rc = m_pCryptoControl ? m_pCryptoControl->decrypt(Ref(u->m_Packet)) : ENCS_NOTSUP;
-                  if ( rc != ENCS_CLEAR )
-                  {
-                      // Could not decrypt
-                      // Keep packet in received buffer
-                      // Crypto flags are still set
-                      // It will be acknowledged
-                      {
-                          CGuard lg(m_StatsLock);
-                          m_stats.traceRcvUndecrypt += 1;
-                          m_stats.traceRcvBytesUndecrypt += pktsz;
-                          m_stats.m_rcvUndecryptTotal += 1;
-                          m_stats.m_rcvBytesUndecryptTotal += pktsz;
-                      }
+            // Decryption should have made the crypto flags EK_NOENC.
+            // Otherwise it's an error.
+            if (adding_successful)
+            {
+                HLOGC(dlog.Debug,
+                      log << "CONTIGUITY CHECK: sequence distance: " << CSeqNo::seqoff(m_iRcvCurrSeqNo, rpkt.m_iSeqNo));
+                if (CSeqNo::seqcmp(rpkt.m_iSeqNo, CSeqNo::incseq(m_iRcvCurrSeqNo)) > 0) // Loss detection.
+                {
+                    int32_t seqlo = CSeqNo::incseq(m_iRcvCurrSeqNo);
+                    int32_t seqhi = CSeqNo::decseq(rpkt.m_iSeqNo);
 
-                      // Log message degraded to debug because it may happen very often
-                      HLOGC(dlog.Debug, log << CONID() << "ERROR: packet not decrypted, dropping data.");
-                      adding_successful = false;
-                      IF_HEAVY_LOGGING(exc_type = "UNDECRYPTED");
-                  }
-              }
-          }
+                    srt_loss_seqs.push_back(make_pair(seqlo, seqhi));
 
-          HLOGC(mglog.Debug, log << CONID() << "RECEIVED: seq=" << rpkt.m_iSeqNo << " offset=" << offset
-                  << " (" << exc_type << "/" << rexmitstat[pktrexmitflag] << rexmit_reason << ") FLAGS: "
-                  << packet.MessageFlagStr());
+                    if (initial_loss_ttl)
+                    {
+                        // pack loss list for (possibly belated) NAK
+                        // The LOSSREPORT will be sent in a while.
 
-          // Decryption should have made the crypto flags EK_NOENC.
-          // Otherwise it's an error.
-          if (adding_successful)
-          {
-              HLOGC(dlog.Debug, log << "CONTIGUITY CHECK: sequence distance: "
-                      << CSeqNo::seqoff(m_iRcvCurrSeqNo, rpkt.m_iSeqNo));
-              if (CSeqNo::seqcmp(rpkt.m_iSeqNo, CSeqNo::incseq(m_iRcvCurrSeqNo)) > 0)   // Loss detection.
-              {
-                  int32_t seqlo = CSeqNo::incseq(m_iRcvCurrSeqNo);
-                  int32_t seqhi = CSeqNo::decseq(rpkt.m_iSeqNo);
+                        for (loss_seqs_t::iterator i = srt_loss_seqs.begin(); i != srt_loss_seqs.end(); ++i)
+                        {
+                            m_FreshLoss.push_back(CRcvFreshLoss(i->first, i->second, initial_loss_ttl));
+                        }
+                        HLOGC(mglog.Debug,
+                              log << "FreshLoss: added sequences: " << Printable(srt_loss_seqs)
+                                  << " tolerance: " << initial_loss_ttl);
+                        reorder_prevent_lossreport = true;
+                    }
+                }
+            }
 
-                  srt_loss_seqs.push_back(make_pair(seqlo, seqhi));
+            // Update the current largest sequence number that has been received.
+            // Or it is a retransmitted packet, remove it from receiver loss list.
+            if (CSeqNo::seqcmp(rpkt.m_iSeqNo, m_iRcvCurrSeqNo) > 0)
+            {
+                m_iRcvCurrSeqNo = rpkt.m_iSeqNo; // Latest possible received
+            }
+            else
+            {
+                unlose(rpkt); // was BELATED or RETRANSMITTED
+                was_sent_in_order &= 0 != pktrexmitflag;
+            }
+        }
 
-                  if ( initial_loss_ttl )
-                  {
-                      // pack loss list for (possibly belated) NAK
-                      // The LOSSREPORT will be sent in a while.
+        // This is moved earlier after introducing filter because it shouldn't
+        // be executed in case when the packet was rejected by the receiver buffer.
+        // However now the 'excessive' condition may be true also in case when
+        // a truly non-excessive packet has been received, just it has been temporarily
+        // stored for better times by the filter module. This way 'excessive' is also true,
+        // although the old condition that a packet with a newer sequence number has arrived
+        // or arrived out of order may still be satisfied.
+        if (!incoming_belated && was_sent_in_order)
+        {
+            // Basing on some special case in the packet, it might be required
+            // to enforce sending ACK immediately (earlier than normally after
+            // a given period).
+            if (m_CongCtl->needsQuickACK(packet))
+            {
+                CTimer::rdtsc(m_ullNextACKTime_tk);
+            }
+        }
 
-                      for (loss_seqs_t::iterator i = srt_loss_seqs.begin(); i != srt_loss_seqs.end(); ++i)
-                      {
-                          m_FreshLoss.push_back(CRcvFreshLoss(i->first, i->second, initial_loss_ttl));
-                      }
-                      HLOGC(mglog.Debug, log << "FreshLoss: added sequences: " << Printable(srt_loss_seqs) << " tolerance: " << initial_loss_ttl);
-                      reorder_prevent_lossreport = true;
-                  }
-              }
-          }
+        if (excessive)
+        {
+            return -1;
+        }
 
-          // Update the current largest sequence number that has been received.
-          // Or it is a retransmitted packet, remove it from receiver loss list.
-          if (CSeqNo::seqcmp(rpkt.m_iSeqNo, m_iRcvCurrSeqNo) > 0)
-          {
-              m_iRcvCurrSeqNo = rpkt.m_iSeqNo; // Latest possible received
-          }
-          else
-          {
-              unlose(rpkt); // was BELATED or RETRANSMITTED
-              was_sent_in_order &= 0!=  pktrexmitflag;
-          }
-      }
+    } // End of recvbuf_acklock
 
-      // This is moved earlier after introducing filter because it shouldn't
-      // be executed in case when the packet was rejected by the receiver buffer.
-      // However now the 'excessive' condition may be true also in case when
-      // a truly non-excessive packet has been received, just it has been temporarily
-      // stored for better times by the filter module. This way 'excessive' is also true,
-      // although the old condition that a packet with a newer sequence number has arrived
-      // or arrived out of order may still be satisfied.
-      if (!incoming_belated && was_sent_in_order)
-      {
-          // Basing on some special case in the packet, it might be required
-          // to enforce sending ACK immediately (earlier than normally after
-          // a given period).
-          if (m_CongCtl->needsQuickACK(packet))
-          {
-              CTimer::rdtsc(m_ullNextACKTime_tk);
-          }
-      }
+    if (m_bClosing)
+    {
+        // RcvQueue worker thread can call processData while closing (or close while processData)
+        // This race condition exists in the UDT design but the protection against TsbPd thread
+        // (with AckLock) and decryption enlarged the probability window.
+        // Application can crash deep in decrypt stack since crypto context is deleted in close.
+        // RcvQueue worker thread will not necessarily be deleted with this connection as it can be
+        // used by others (socket multiplexer).
+        return -1;
+    }
 
-      if ( excessive )
-      {
-          return -1;
-      }
+    if (incoming.empty())
+    {
+        // Treat as excessive. This is when a filter cumulates packets
+        // until the loss is rebuilt, or eats up a filter control packet
+        return -1;
+    }
 
+    if (!srt_loss_seqs.empty())
+    {
+        // A loss is detected
+        {
+            // TODO: Can unlock rcvloss after m_pRcvLossList->insert(...)?
+            // And probably protect m_FreshLoss as well.
 
-   }  // End of recvbuf_acklock
+            HLOGC(mglog.Debug, log << "processData: LOSS DETECTED, %: " << Printable(srt_loss_seqs) << " - RECORDING.");
+            // if record_loss == false, nothing will be contained here
+            // Insert lost sequence numbers to the receiver loss list
+            CGuard lg(m_RcvLossLock);
+            for (loss_seqs_t::iterator i = srt_loss_seqs.begin(); i != srt_loss_seqs.end(); ++i)
+            {
+                // If loss found, insert them to the receiver loss list
+                m_pRcvLossList->insert(i->first, i->second);
+            }
+        }
 
-   if (m_bClosing)
-   {
-      // RcvQueue worker thread can call processData while closing (or close while processData)
-      // This race condition exists in the UDT design but the protection against TsbPd thread
-      // (with AckLock) and decryption enlarged the probability window.
-      // Application can crash deep in decrypt stack since crypto context is deleted in close.
-      // RcvQueue worker thread will not necessarily be deleted with this connection as it can be
-      // used by others (socket multiplexer).
-      return -1;
-   }
+        const bool report_recorded_loss = !m_PacketFilter || m_PktFilterRexmitLevel == SRT_ARQ_ALWAYS;
+        if (!reorder_prevent_lossreport && report_recorded_loss)
+        {
+            HLOGC(mglog.Debug, log << "WILL REPORT LOSSES (SRT): " << Printable(srt_loss_seqs));
+            sendLossReport(srt_loss_seqs);
+        }
 
-   if (incoming.empty())
-   {
-       // Treat as excessive. This is when a filter cumulates packets
-       // until the loss is rebuilt, or eats up a filter control packet
-       return -1;
-   }
+        if (m_bTsbPd)
+        {
+            pthread_mutex_lock(&m_RecvLock);
+            pthread_cond_signal(&m_RcvTsbPdCond);
+            pthread_mutex_unlock(&m_RecvLock);
+        }
+    }
 
-   if (!srt_loss_seqs.empty())
-   {
-       // A loss is detected
-       {
-           // TODO: Can unlock rcvloss after m_pRcvLossList->insert(...)?
-           // And probably protect m_FreshLoss as well.
+    // Separately report loss records of those reported by a filter.
+    // ALWAYS report whatever has been reported back by a filter. Note that
+    // the filter never reports anything when rexmit fallback level is ALWAYS or NEVER.
+    // With ALWAYS only those are reported that were recorded here by SRT.
+    // With NEVER, nothing is to be reported.
+    if (!filter_loss_seqs.empty())
+    {
+        HLOGC(mglog.Debug, log << "WILL REPORT LOSSES (filter): " << Printable(filter_loss_seqs));
+        sendLossReport(filter_loss_seqs);
 
-           HLOGC(mglog.Debug, log << "processData: LOSS DETECTED, %: " << Printable(srt_loss_seqs)
-                   << " - RECORDING.");
-           // if record_loss == false, nothing will be contained here
-           // Insert lost sequence numbers to the receiver loss list
-           CGuard lg(m_RcvLossLock);
-           for (loss_seqs_t::iterator i = srt_loss_seqs.begin(); i != srt_loss_seqs.end(); ++i)
-           {
-               // If loss found, insert them to the receiver loss list
-               m_pRcvLossList->insert(i->first, i->second);
-           }
-       }
+        if (m_bTsbPd)
+        {
+            pthread_mutex_lock(&m_RecvLock);
+            pthread_cond_signal(&m_RcvTsbPdCond);
+            pthread_mutex_unlock(&m_RecvLock);
+        }
+    }
 
-       const bool report_recorded_loss = !m_PacketFilter || m_PktFilterRexmitLevel == SRT_ARQ_ALWAYS;
-       if (!reorder_prevent_lossreport && report_recorded_loss)
-       {
-           HLOGC(mglog.Debug, log << "WILL REPORT LOSSES (SRT): " << Printable(srt_loss_seqs));
-           sendLossReport(srt_loss_seqs);
-       }
+    // Now review the list of FreshLoss to see if there's any "old enough" to send UMSG_LOSSREPORT to it.
 
-       if (m_bTsbPd)
-       {
-           pthread_mutex_lock(&m_RecvLock);
-           pthread_cond_signal(&m_RcvTsbPdCond);
-           pthread_mutex_unlock(&m_RecvLock);
-       }
-   }
+    // PERFORMANCE CONSIDERATIONS:
+    // This list is quite inefficient as a data type and finding the candidate to send UMSG_LOSSREPORT
+    // is linear time. On the other hand, there are some special cases that are important for performance:
+    // - only the first (plus some following) could have had TTL drown to 0
+    // - the only (little likely) possibility that the next-to-first record has TTL=0 is when there was
+    //   a loss range split (due to unlose() of one sequence)
+    // - first found record with TTL>0 means end of "ready to LOSSREPORT" records
+    // So:
+    // All you have to do is:
+    //  - start with first element and continue with next elements, as long as they have TTL=0
+    //    If so, send the loss report and remove this element.
+    //  - Since the first element that has TTL>0, iterate until the end of container and decrease TTL.
+    //
+    // This will be efficient becase the loop to increment one field (without any condition check)
+    // can be quite well optimized.
 
-   // Separately report loss records of those reported by a filter.
-   // ALWAYS report whatever has been reported back by a filter. Note that
-   // the filter never reports anything when rexmit fallback level is ALWAYS or NEVER.
-   // With ALWAYS only those are reported that were recorded here by SRT.
-   // With NEVER, nothing is to be reported.
-   if (!filter_loss_seqs.empty())
-   {
-       HLOGC(mglog.Debug, log << "WILL REPORT LOSSES (filter): " << Printable(filter_loss_seqs));
-       sendLossReport(filter_loss_seqs);
+    vector<int32_t> lossdata;
+    {
+        CGuard lg(m_RcvLossLock);
 
-       if (m_bTsbPd)
-       {
-           pthread_mutex_lock(&m_RecvLock);
-           pthread_cond_signal(&m_RcvTsbPdCond);
-           pthread_mutex_unlock(&m_RecvLock);
-       }
-   }
+        // XXX There was a mysterious crash around m_FreshLoss. When the initial_loss_ttl is 0
+        // (that is, "belated loss report" feature is off), don't even touch m_FreshLoss.
+        if (initial_loss_ttl && !m_FreshLoss.empty())
+        {
+            deque<CRcvFreshLoss>::iterator i = m_FreshLoss.begin();
 
-   // Now review the list of FreshLoss to see if there's any "old enough" to send UMSG_LOSSREPORT to it.
+            // Phase 1: take while TTL <= 0.
+            // There can be more than one record with the same TTL, if it has happened before
+            // that there was an 'unlost' (@c unlose) sequence that has split one detected loss
+            // into two records.
+            for (; i != m_FreshLoss.end() && i->ttl <= 0; ++i)
+            {
+                HLOGF(mglog.Debug,
+                      "Packet seq %d-%d (%d packets) considered lost - sending LOSSREPORT",
+                      i->seq[0],
+                      i->seq[1],
+                      CSeqNo::seqoff(i->seq[0], i->seq[1]) + 1);
+                addLossRecord(lossdata, i->seq[0], i->seq[1]);
+            }
 
-   // PERFORMANCE CONSIDERATIONS:
-   // This list is quite inefficient as a data type and finding the candidate to send UMSG_LOSSREPORT
-   // is linear time. On the other hand, there are some special cases that are important for performance:
-   // - only the first (plus some following) could have had TTL drown to 0
-   // - the only (little likely) possibility that the next-to-first record has TTL=0 is when there was
-   //   a loss range split (due to unlose() of one sequence)
-   // - first found record with TTL>0 means end of "ready to LOSSREPORT" records
-   // So:
-   // All you have to do is:
-   //  - start with first element and continue with next elements, as long as they have TTL=0
-   //    If so, send the loss report and remove this element.
-   //  - Since the first element that has TTL>0, iterate until the end of container and decrease TTL.
-   //
-   // This will be efficient becase the loop to increment one field (without any condition check)
-   // can be quite well optimized.
+            // Remove elements that have been processed and prepared for lossreport.
+            if (i != m_FreshLoss.begin())
+            {
+                m_FreshLoss.erase(m_FreshLoss.begin(), i);
+                i = m_FreshLoss.begin();
+            }
 
-   vector<int32_t> lossdata;
-   {
-       CGuard lg(m_RcvLossLock);
+            if (m_FreshLoss.empty())
+            {
+                HLOGP(mglog.Debug, "NO MORE FRESH LOSS RECORDS.");
+            }
+            else
+            {
+                HLOGF(mglog.Debug,
+                      "STILL %" PRIzu " FRESH LOSS RECORDS, FIRST: %d-%d (%d) TTL: %d",
+                      m_FreshLoss.size(),
+                      i->seq[0],
+                      i->seq[1],
+                      1 + CSeqNo::seqoff(i->seq[0], i->seq[1]),
+                      i->ttl);
+            }
 
-       // XXX There was a mysterious crash around m_FreshLoss. When the initial_loss_ttl is 0
-       // (that is, "belated loss report" feature is off), don't even touch m_FreshLoss.
-       if (initial_loss_ttl && !m_FreshLoss.empty())
-       {
-           deque<CRcvFreshLoss>::iterator i = m_FreshLoss.begin();
+            // Phase 2: rest of the records should have TTL decreased.
+            for (; i != m_FreshLoss.end(); ++i)
+                --i->ttl;
+        }
+    }
+    if (!lossdata.empty())
+    {
+        sendCtrl(UMSG_LOSSREPORT, NULL, &lossdata[0], lossdata.size());
+    }
 
-           // Phase 1: take while TTL <= 0.
-           // There can be more than one record with the same TTL, if it has happened before
-           // that there was an 'unlost' (@c unlose) sequence that has split one detected loss
-           // into two records.
-           for ( ; i != m_FreshLoss.end() && i->ttl <= 0; ++i)
-           {
-               HLOGF(mglog.Debug, "Packet seq %d-%d (%d packets) considered lost - sending LOSSREPORT",
-                                      i->seq[0], i->seq[1], CSeqNo::seqoff(i->seq[0], i->seq[1])+1);
-               addLossRecord(lossdata, i->seq[0], i->seq[1]);
-           }
+    // was_sent_in_order means either of:
+    // - packet was sent in order (first if branch above)
+    // - packet was sent as old, but was a retransmitted packet
 
-           // Remove elements that have been processed and prepared for lossreport.
-           if (i != m_FreshLoss.begin())
-           {
-               m_FreshLoss.erase(m_FreshLoss.begin(), i);
-               i = m_FreshLoss.begin();
-           }
+    if (m_bPeerRexmitFlag && was_sent_in_order)
+    {
+        ++m_iConsecOrderedDelivery;
+        if (m_iConsecOrderedDelivery >= 50)
+        {
+            m_iConsecOrderedDelivery = 0;
+            if (m_iReorderTolerance > 0)
+            {
+                m_iReorderTolerance--;
+                CGuard::enterCS(m_StatsLock);
+                m_stats.traceReorderDistance--;
+                CGuard::leaveCS(m_StatsLock);
+                HLOGF(mglog.Debug,
+                      "ORDERED DELIVERY of 50 packets in a row - decreasing tolerance to %d",
+                      m_iReorderTolerance);
+            }
+        }
+    }
 
-           if (m_FreshLoss.empty())
-           {
-               HLOGP(mglog.Debug, "NO MORE FRESH LOSS RECORDS.");
-           }
-           else
-           {
-               HLOGF(mglog.Debug, "STILL %" PRIzu " FRESH LOSS RECORDS, FIRST: %d-%d (%d) TTL: %d", m_FreshLoss.size(),
-                       i->seq[0], i->seq[1], 1+CSeqNo::seqoff(i->seq[0], i->seq[1]),
-                       i->ttl);
-           }
-
-           // Phase 2: rest of the records should have TTL decreased.
-           for ( ; i != m_FreshLoss.end(); ++i)
-               --i->ttl;
-       }
-   }
-   if (!lossdata.empty())
-   {
-       sendCtrl(UMSG_LOSSREPORT, NULL, &lossdata[0], lossdata.size());
-   }
-
-
-   // was_sent_in_order means either of:
-   // - packet was sent in order (first if branch above)
-   // - packet was sent as old, but was a retransmitted packet
-
-   if (m_bPeerRexmitFlag && was_sent_in_order)
-   {
-       ++m_iConsecOrderedDelivery;
-       if (m_iConsecOrderedDelivery >= 50)
-       {
-           m_iConsecOrderedDelivery = 0;
-           if (m_iReorderTolerance > 0)
-           {
-               m_iReorderTolerance--;
-               CGuard::enterCS(m_StatsLock);
-               m_stats.traceReorderDistance--;
-               CGuard::leaveCS(m_StatsLock);
-               HLOGF(mglog.Debug,  "ORDERED DELIVERY of 50 packets in a row - decreasing tolerance to %d", m_iReorderTolerance);
-           }
-       }
-   }
-
-   return 0;
+    return 0;
 }
-
 
 /// This function is called when a packet has arrived, which was behind the current
 /// received sequence - that is, belated or retransmitted. Try to remove the packet
@@ -8669,16 +8807,16 @@ int CUDT::processData(CUnit* in_unit)
 /// do not include the lacking packet.
 /// The tolerance is not increased infinitely - it's bordered by m_iMaxReorderTolerance.
 /// This value can be set in options - SRT_LOSSMAXTTL.
-void CUDT::unlose(const CPacket& packet)
+void CUDT::unlose(const CPacket &packet)
 {
-    CGuard lg(m_RcvLossLock);
+    CGuard  lg(m_RcvLossLock);
     int32_t sequence = packet.m_iSeqNo;
     m_pRcvLossList->remove(sequence);
 
     // Rest of this code concerns only the "belated lossreport" feature.
 
     bool has_increased_tolerance = false;
-    bool was_reordered = false;
+    bool was_reordered           = false;
 
     if (m_bPeerRexmitFlag)
     {
@@ -8699,10 +8837,14 @@ void CUDT::unlose(const CPacket& packet)
             if (seqdiff > m_iReorderTolerance)
             {
                 const int new_tolerance = min(seqdiff, m_iMaxReorderTolerance);
-                HLOGF(mglog.Debug, "Belated by %d seqs - Reorder tolerance %s %d", seqdiff,
-                        (new_tolerance == m_iReorderTolerance) ? "REMAINS with" : "increased to", new_tolerance);
+                HLOGF(mglog.Debug,
+                      "Belated by %d seqs - Reorder tolerance %s %d",
+                      seqdiff,
+                      (new_tolerance == m_iReorderTolerance) ? "REMAINS with" : "increased to",
+                      new_tolerance);
                 m_iReorderTolerance = new_tolerance;
-                has_increased_tolerance = true; // Yes, even if reorder tolerance is already at maximum - this prevents decreasing tolerance.
+                has_increased_tolerance =
+                    true; // Yes, even if reorder tolerance is already at maximum - this prevents decreasing tolerance.
             }
         }
         else
@@ -8726,8 +8868,8 @@ void CUDT::unlose(const CPacket& packet)
     if (m_bPeerRexmitFlag == 0 || m_iReorderTolerance == 0)
         return;
 
-    size_t i = 0;
-    int had_ttl = 0;
+    size_t i       = 0;
+    int    had_ttl = 0;
     for (i = 0; i < m_FreshLoss.size(); ++i)
     {
         had_ttl = m_FreshLoss[i].ttl;
@@ -8747,29 +8889,30 @@ void CUDT::unlose(const CPacket& packet)
 
         case CRcvFreshLoss::SPLIT:
             // Oh, this will be more complicated. This means that it was in between.
-        {
-            // So create a new element that will hold the upper part of the range,
-            // and this one modify to be the lower part of the range.
+            {
+                // So create a new element that will hold the upper part of the range,
+                // and this one modify to be the lower part of the range.
 
-            // Keep the current end-of-sequence value for the second element
-            int32_t next_end = m_FreshLoss[i].seq[1];
+                // Keep the current end-of-sequence value for the second element
+                int32_t next_end = m_FreshLoss[i].seq[1];
 
-            // seq-1 set to the end of this element
-            m_FreshLoss[i].seq[1] = CSeqNo::decseq(sequence);
-            // seq+1 set to the begin of the next element
-            int32_t next_begin = CSeqNo::incseq(sequence);
+                // seq-1 set to the end of this element
+                m_FreshLoss[i].seq[1] = CSeqNo::decseq(sequence);
+                // seq+1 set to the begin of the next element
+                int32_t next_begin = CSeqNo::incseq(sequence);
 
-            // Use position of the NEXT element because insertion happens BEFORE pointed element.
-            // Use the same TTL (will stay the same in the other one).
-            m_FreshLoss.insert(m_FreshLoss.begin() + i + 1, CRcvFreshLoss(next_begin, next_end, m_FreshLoss[i].ttl));
-        }
-        goto breakbreak;
+                // Use position of the NEXT element because insertion happens BEFORE pointed element.
+                // Use the same TTL (will stay the same in the other one).
+                m_FreshLoss.insert(m_FreshLoss.begin() + i + 1,
+                                   CRcvFreshLoss(next_begin, next_end, m_FreshLoss[i].ttl));
+            }
+            goto breakbreak;
         }
     }
 
     // Could have made the "return" instruction instead of goto, but maybe there will be something
     // to add in future, so keeping that.
-breakbreak: ;
+breakbreak:;
 
     if (i != m_FreshLoss.size())
     {
@@ -8788,24 +8931,25 @@ breakbreak: ;
             ++m_iConsecEarlyDelivery; // otherwise, and if it arrived quite earlier, increase counter
             HLOGF(mglog.Debug, "... arrived at TTL %d case %d", had_ttl, m_iConsecEarlyDelivery);
 
-            // After 10 consecutive 
-            if ( m_iConsecEarlyDelivery >= 10 )
+            // After 10 consecutive
+            if (m_iConsecEarlyDelivery >= 10)
             {
                 m_iConsecEarlyDelivery = 0;
-                if ( m_iReorderTolerance > 0 )
+                if (m_iReorderTolerance > 0)
                 {
                     m_iReorderTolerance--;
                     CGuard::enterCS(m_StatsLock);
                     m_stats.traceReorderDistance--;
                     CGuard::leaveCS(m_StatsLock);
-                    HLOGF(mglog.Debug, "... reached %d times - decreasing tolerance to %d", m_iConsecEarlyDelivery, m_iReorderTolerance);
+                    HLOGF(mglog.Debug,
+                          "... reached %d times - decreasing tolerance to %d",
+                          m_iConsecEarlyDelivery,
+                          m_iReorderTolerance);
                 }
             }
-
         }
         // If hasn't increased tolerance, but the packet appeared at TTL less than 2, do nothing.
     }
-
 }
 
 void CUDT::dropFromLossLists(int32_t from, int32_t to)
@@ -8819,7 +8963,7 @@ void CUDT::dropFromLossLists(int32_t from, int32_t to)
         return;
 
     // All code below concerns only "belated lossreport" feature.
-    
+
     // It's highly unlikely that this is waiting to send a belated UMSG_LOSSREPORT,
     // so treat it rather as a sanity check.
 
@@ -8830,58 +8974,62 @@ void CUDT::dropFromLossLists(int32_t from, int32_t to)
     for (size_t i = 0; i < m_FreshLoss.size(); ++i)
     {
         CRcvFreshLoss::Emod result = m_FreshLoss[i].revoke(from, to);
-        switch ( result )
+        switch (result)
         {
         case CRcvFreshLoss::DELETE:
-            delete_index = i+1; // PAST THE END
-            continue; // There may be further ranges that are included in this one, so check on.
+            delete_index = i + 1; // PAST THE END
+            continue;             // There may be further ranges that are included in this one, so check on.
 
         case CRcvFreshLoss::NONE:
         case CRcvFreshLoss::STRIPPED:
             break; // THIS BREAKS ONLY 'switch', not 'for'!
 
-        case CRcvFreshLoss::SPLIT: ; // This function never returns it. It's only a compiler shut-up.
+        case CRcvFreshLoss::SPLIT:; // This function never returns it. It's only a compiler shut-up.
         }
 
         break; // Now this breaks also FOR.
     }
 
-    m_FreshLoss.erase(m_FreshLoss.begin(), m_FreshLoss.begin() + delete_index); // with delete_index == 0 will do nothing
+    m_FreshLoss.erase(m_FreshLoss.begin(),
+                      m_FreshLoss.begin() + delete_index); // with delete_index == 0 will do nothing
 }
 
 // This function, as the name states, should bake a new cookie.
-int32_t CUDT::bake(const sockaddr* addr, int32_t current_cookie, int correction)
+int32_t CUDT::bake(const sockaddr *addr, int32_t current_cookie, int correction)
 {
     static unsigned int distractor = 0;
-    unsigned int rollover = distractor+10;
+    unsigned int        rollover   = distractor + 10;
 
-    for(;;)
+    for (;;)
     {
         // SYN cookie
         char clienthost[NI_MAXHOST];
         char clientport[NI_MAXSERV];
         getnameinfo(addr,
-                (m_iIPversion == AF_INET) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6),
-                clienthost, sizeof(clienthost), clientport, sizeof(clientport),
-                NI_NUMERICHOST|NI_NUMERICSERV);
-        int64_t timestamp = ((CTimer::getTime() - m_stats.startTime) / 60000000) + distractor - correction; // secret changes every one minute
+                    (m_iIPversion == AF_INET) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6),
+                    clienthost,
+                    sizeof(clienthost),
+                    clientport,
+                    sizeof(clientport),
+                    NI_NUMERICHOST | NI_NUMERICSERV);
+        int64_t timestamp = ((CTimer::getTime() - m_stats.startTime) / 60000000) + distractor -
+                            correction; // secret changes every one minute
         stringstream cookiestr;
         cookiestr << clienthost << ":" << clientport << ":" << timestamp;
-        union
-        {
+        union {
             unsigned char cookie[16];
-            int32_t cookie_val;
+            int32_t       cookie_val;
         };
         CMD5::compute(cookiestr.str().c_str(), cookie);
 
-        if ( cookie_val != current_cookie )
+        if (cookie_val != current_cookie)
             return cookie_val;
 
         ++distractor;
 
         // This is just to make the loop formally breakable,
         // but this is virtually impossible to happen.
-        if ( distractor == rollover )
+        if (distractor == rollover)
             return cookie_val;
     }
 }
@@ -8904,257 +9052,266 @@ int32_t CUDT::bake(const sockaddr* addr, int32_t current_cookie, int correction)
 //
 // XXX Make this function return EConnectStatus enum type (extend if needed),
 // and this will be directly passed to the caller.
-SRT_REJECT_REASON CUDT::processConnectRequest(const sockaddr* addr, CPacket& packet)
+SRT_REJECT_REASON CUDT::processConnectRequest(const sockaddr *addr, CPacket &packet)
 {
     // XXX ASSUMPTIONS:
     // [[using assert(packet.m_iID == 0)]]
 
-   HLOGC(mglog.Debug, log << "processConnectRequest: received a connection request");
+    HLOGC(mglog.Debug, log << "processConnectRequest: received a connection request");
 
-   if (m_bClosing)
-   {
-       m_RejectReason = SRT_REJ_CLOSE;
-       HLOGC(mglog.Debug, log << "processConnectRequest: ... NOT. Rejecting because closing.");
-       return m_RejectReason;
-   }
+    if (m_bClosing)
+    {
+        m_RejectReason = SRT_REJ_CLOSE;
+        HLOGC(mglog.Debug, log << "processConnectRequest: ... NOT. Rejecting because closing.");
+        return m_RejectReason;
+    }
 
-   /*
-   * Closing a listening socket only set bBroken
-   * If a connect packet is received while closing it gets through
-   * processing and crashes later.
-   */
-   if (m_bBroken)
-   {
-      m_RejectReason = SRT_REJ_CLOSE;
-      HLOGC(mglog.Debug, log << "processConnectRequest: ... NOT. Rejecting because broken.");
-      return m_RejectReason;
-   }
-   size_t exp_len = CHandShake::m_iContentSize; // When CHandShake::m_iContentSize is used in log, the file fails to link!
+    /*
+     * Closing a listening socket only set bBroken
+     * If a connect packet is received while closing it gets through
+     * processing and crashes later.
+     */
+    if (m_bBroken)
+    {
+        m_RejectReason = SRT_REJ_CLOSE;
+        HLOGC(mglog.Debug, log << "processConnectRequest: ... NOT. Rejecting because broken.");
+        return m_RejectReason;
+    }
+    size_t exp_len =
+        CHandShake::m_iContentSize; // When CHandShake::m_iContentSize is used in log, the file fails to link!
 
-   // NOTE!!! Old version of SRT code checks if the size of the HS packet
-   // is EQUAL to the above CHandShake::m_iContentSize.
+    // NOTE!!! Old version of SRT code checks if the size of the HS packet
+    // is EQUAL to the above CHandShake::m_iContentSize.
 
-   // Changed to < exp_len because we actually need that the packet
-   // be at least of a size for handshake, although it may contain
-   // more data, depending on what's inside.
-   if (packet.getLength() < exp_len)
-   {
-      m_RejectReason = SRT_REJ_ROGUE;
-      HLOGC(mglog.Debug, log << "processConnectRequest: ... NOT. Wrong size: " << packet.getLength() << " (expected: " << exp_len << ")");
-      return m_RejectReason;
-   }
+    // Changed to < exp_len because we actually need that the packet
+    // be at least of a size for handshake, although it may contain
+    // more data, depending on what's inside.
+    if (packet.getLength() < exp_len)
+    {
+        m_RejectReason = SRT_REJ_ROGUE;
+        HLOGC(mglog.Debug,
+              log << "processConnectRequest: ... NOT. Wrong size: " << packet.getLength() << " (expected: " << exp_len
+                  << ")");
+        return m_RejectReason;
+    }
 
-   // Dunno why the original UDT4 code only MUCH LATER was checking if the packet was UMSG_HANDSHAKE.
-   // It doesn't seem to make sense to deserialize it into the handshake structure if we are not
-   // sure that the packet contains the handshake at all!
-   if ( !packet.isControl(UMSG_HANDSHAKE) )
-   {
-       m_RejectReason = SRT_REJ_ROGUE;
-       LOGC(mglog.Error, log << "processConnectRequest: the packet received as handshake is not a handshake message");
-       return m_RejectReason;
-   }
+    // Dunno why the original UDT4 code only MUCH LATER was checking if the packet was UMSG_HANDSHAKE.
+    // It doesn't seem to make sense to deserialize it into the handshake structure if we are not
+    // sure that the packet contains the handshake at all!
+    if (!packet.isControl(UMSG_HANDSHAKE))
+    {
+        m_RejectReason = SRT_REJ_ROGUE;
+        LOGC(mglog.Error, log << "processConnectRequest: the packet received as handshake is not a handshake message");
+        return m_RejectReason;
+    }
 
-   CHandShake hs;
-   hs.load_from(packet.m_pcData, packet.getLength());
+    CHandShake hs;
+    hs.load_from(packet.m_pcData, packet.getLength());
 
-   // XXX MOST LIKELY this hs should be now copied into m_ConnRes field, which holds
-   // the handshake structure sent from the peer (no matter the role or mode).
-   // This should simplify the createSrtHandshake() function which can this time
-   // simply write the crafted handshake structure into m_ConnReq, which needs no
-   // participation of the local handshake and passing it as a parameter through
-   // newConnection() -> acceptAndRespond() -> createSrtHandshake(). This is also
-   // required as a source of the peer's information used in processing in other
-   // structures.
+    // XXX MOST LIKELY this hs should be now copied into m_ConnRes field, which holds
+    // the handshake structure sent from the peer (no matter the role or mode).
+    // This should simplify the createSrtHandshake() function which can this time
+    // simply write the crafted handshake structure into m_ConnReq, which needs no
+    // participation of the local handshake and passing it as a parameter through
+    // newConnection() -> acceptAndRespond() -> createSrtHandshake(). This is also
+    // required as a source of the peer's information used in processing in other
+    // structures.
 
-   int32_t cookie_val = bake(addr);
+    int32_t cookie_val = bake(addr);
 
-   HLOGC(mglog.Debug, log << "processConnectRequest: new cookie: " << hex << cookie_val);
+    HLOGC(mglog.Debug, log << "processConnectRequest: new cookie: " << hex << cookie_val);
 
-   // REQUEST:INDUCTION.
-   // Set a cookie, a target ID, and send back the same as
-   // RESPONSE:INDUCTION.
-   if (hs.m_iReqType == URQ_INDUCTION)
-   {
-       HLOGC(mglog.Debug, log << "processConnectRequest: received type=induction, sending back with cookie+socket");
+    // REQUEST:INDUCTION.
+    // Set a cookie, a target ID, and send back the same as
+    // RESPONSE:INDUCTION.
+    if (hs.m_iReqType == URQ_INDUCTION)
+    {
+        HLOGC(mglog.Debug, log << "processConnectRequest: received type=induction, sending back with cookie+socket");
 
-       // XXX That looks weird - the calculated md5 sum out of the given host/port/timestamp
-       // is 16 bytes long, but CHandShake::m_iCookie has 4 bytes. This then effectively copies
-       // only the first 4 bytes. Moreover, it's dangerous on some platforms because the char
-       // array need not be aligned to int32_t - changed to union in a hope that using int32_t
-       // inside a union will enforce whole union to be aligned to int32_t.
-      hs.m_iCookie = cookie_val;
-      packet.m_iID = hs.m_iID;
+        // XXX That looks weird - the calculated md5 sum out of the given host/port/timestamp
+        // is 16 bytes long, but CHandShake::m_iCookie has 4 bytes. This then effectively copies
+        // only the first 4 bytes. Moreover, it's dangerous on some platforms because the char
+        // array need not be aligned to int32_t - changed to union in a hope that using int32_t
+        // inside a union will enforce whole union to be aligned to int32_t.
+        hs.m_iCookie = cookie_val;
+        packet.m_iID = hs.m_iID;
 
-      // Ok, now's the time. The listener sets here the version 5 handshake,
-      // even though the request was 4. This is because the old client would
-      // simply return THE SAME version, not even looking into it, giving the
-      // listener false impression as if it supported version 5.
-      //
-      // If the caller was really HSv4, it will simply ignore the version 5 in INDUCTION;
-      // it will respond with CONCLUSION, but with its own set version, which is version 4.
-      //
-      // If the caller was really HSv5, it will RECOGNIZE this version 5 in INDUCTION, so
-      // it will respond with version 5 when sending CONCLUSION.
+        // Ok, now's the time. The listener sets here the version 5 handshake,
+        // even though the request was 4. This is because the old client would
+        // simply return THE SAME version, not even looking into it, giving the
+        // listener false impression as if it supported version 5.
+        //
+        // If the caller was really HSv4, it will simply ignore the version 5 in INDUCTION;
+        // it will respond with CONCLUSION, but with its own set version, which is version 4.
+        //
+        // If the caller was really HSv5, it will RECOGNIZE this version 5 in INDUCTION, so
+        // it will respond with version 5 when sending CONCLUSION.
 
-      hs.m_iVersion = HS_VERSION_SRT1;
+        hs.m_iVersion = HS_VERSION_SRT1;
 
-      // Additionally, set this field to a MAGIC value. This field isn't used during INDUCTION
-      // by HSv4 client, HSv5 client can use it to additionally verify that this is a HSv5 listener.
-      // In this field we also advertise the PBKEYLEN value. When 0, it's considered not advertised.
-      hs.m_iType = SrtHSRequest::wrapFlags(true /*put SRT_MAGIC_CODE in HSFLAGS*/, m_iSndCryptoKeyLen);
-      bool whether SRT_ATR_UNUSED = m_iSndCryptoKeyLen != 0;
-      HLOGC(mglog.Debug, log << "processConnectRequest: " << (whether ? "" : "NOT ") << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
+        // Additionally, set this field to a MAGIC value. This field isn't used during INDUCTION
+        // by HSv4 client, HSv5 client can use it to additionally verify that this is a HSv5 listener.
+        // In this field we also advertise the PBKEYLEN value. When 0, it's considered not advertised.
+        hs.m_iType = SrtHSRequest::wrapFlags(true /*put SRT_MAGIC_CODE in HSFLAGS*/, m_iSndCryptoKeyLen);
+        bool whether SRT_ATR_UNUSED = m_iSndCryptoKeyLen != 0;
+        HLOGC(mglog.Debug,
+              log << "processConnectRequest: " << (whether ? "" : "NOT ")
+                  << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
 
-      size_t size = packet.getLength();
-      hs.store_to(packet.m_pcData, Ref(size));
-      packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-      m_pSndQueue->sendto(addr, packet);
-      return SRT_REJ_UNKNOWN; // EXCEPTION: this is a "no-error" code.
-   }
+        size_t size = packet.getLength();
+        hs.store_to(packet.m_pcData, Ref(size));
+        packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+        m_pSndQueue->sendto(addr, packet);
+        return SRT_REJ_UNKNOWN; // EXCEPTION: this is a "no-error" code.
+    }
 
-   // Otherwise this should be REQUEST:CONCLUSION.
-   // Should then come with the correct cookie that was
-   // set in the above INDUCTION, in the HS_VERSION_SRT1
-   // should also contain extra data.
+    // Otherwise this should be REQUEST:CONCLUSION.
+    // Should then come with the correct cookie that was
+    // set in the above INDUCTION, in the HS_VERSION_SRT1
+    // should also contain extra data.
 
-   HLOGC(mglog.Debug, log << "processConnectRequest: received type=" << RequestTypeStr(hs.m_iReqType) << " - checking cookie...");
-   if (hs.m_iCookie != cookie_val)
-   {
-       cookie_val = bake(addr, cookie_val, -1); // SHOULD generate an earlier, distracted cookie
+    HLOGC(mglog.Debug,
+          log << "processConnectRequest: received type=" << RequestTypeStr(hs.m_iReqType) << " - checking cookie...");
+    if (hs.m_iCookie != cookie_val)
+    {
+        cookie_val = bake(addr, cookie_val, -1); // SHOULD generate an earlier, distracted cookie
 
-       if (hs.m_iCookie != cookie_val)
-       {
-           m_RejectReason = SRT_REJ_RDVCOOKIE;
-           HLOGC(mglog.Debug, log << "processConnectRequest: ...wrong cookie " << hex << cookie_val << ". Ignoring.");
-           return m_RejectReason;
-       }
+        if (hs.m_iCookie != cookie_val)
+        {
+            m_RejectReason = SRT_REJ_RDVCOOKIE;
+            HLOGC(mglog.Debug, log << "processConnectRequest: ...wrong cookie " << hex << cookie_val << ". Ignoring.");
+            return m_RejectReason;
+        }
 
-       HLOGC(mglog.Debug, log << "processConnectRequest: ... correct (FIXED) cookie. Proceeding.");
-   }
-   else
-   {
-       HLOGC(mglog.Debug, log << "processConnectRequest: ... correct (ORIGINAL) cookie. Proceeding.");
-   }
+        HLOGC(mglog.Debug, log << "processConnectRequest: ... correct (FIXED) cookie. Proceeding.");
+    }
+    else
+    {
+        HLOGC(mglog.Debug, log << "processConnectRequest: ... correct (ORIGINAL) cookie. Proceeding.");
+    }
 
-   int32_t id = hs.m_iID;
+    int32_t id = hs.m_iID;
 
-   // HANDSHAKE: The old client sees the version that does not match HS_VERSION_UDT4 (5).
-   // In this case it will respond with URQ_ERROR_REJECT. Rest of the data are the same
-   // as in the handshake request. When this message is received, the connector side should
-   // switch itself to the version number HS_VERSION_UDT4 and continue the old way (that is,
-   // continue sending URQ_INDUCTION, but this time with HS_VERSION_UDT4).
+    // HANDSHAKE: The old client sees the version that does not match HS_VERSION_UDT4 (5).
+    // In this case it will respond with URQ_ERROR_REJECT. Rest of the data are the same
+    // as in the handshake request. When this message is received, the connector side should
+    // switch itself to the version number HS_VERSION_UDT4 and continue the old way (that is,
+    // continue sending URQ_INDUCTION, but this time with HS_VERSION_UDT4).
 
-   bool accepted_hs = true;
+    bool accepted_hs = true;
 
-   if (hs.m_iVersion == HS_VERSION_SRT1)
-   {
-       // No further check required.
-       // The m_iType contains handshake extension flags.
-   }
-   else if (hs.m_iVersion == HS_VERSION_UDT4)
-   {
-       // In UDT, and so in older SRT version, the hs.m_iType field should contain
-       // the socket type, although SRT only allowed this field to be UDT_DGRAM.
-       // Older SRT version contained that value in a field, but now that this can
-       // only contain UDT_DGRAM the field itself has been abandoned.
-       // For the sake of any old client that reports version 4 handshake, interpret
-       // this hs.m_iType field as a socket type and check if it's UDT_DGRAM.
+    if (hs.m_iVersion == HS_VERSION_SRT1)
+    {
+        // No further check required.
+        // The m_iType contains handshake extension flags.
+    }
+    else if (hs.m_iVersion == HS_VERSION_UDT4)
+    {
+        // In UDT, and so in older SRT version, the hs.m_iType field should contain
+        // the socket type, although SRT only allowed this field to be UDT_DGRAM.
+        // Older SRT version contained that value in a field, but now that this can
+        // only contain UDT_DGRAM the field itself has been abandoned.
+        // For the sake of any old client that reports version 4 handshake, interpret
+        // this hs.m_iType field as a socket type and check if it's UDT_DGRAM.
 
-       // Note that in HSv5 hs.m_iType contains extension flags.
-       if (hs.m_iType != UDT_DGRAM)
-       {
-           m_RejectReason = SRT_REJ_ROGUE;
-           accepted_hs = false;
-       }
-   }
-   else
-   {
-       // Unsupported version
-       // (NOTE: This includes "version=0" which is a rejection flag).
-       m_RejectReason = SRT_REJ_VERSION;
-       accepted_hs = false;
-   }
+        // Note that in HSv5 hs.m_iType contains extension flags.
+        if (hs.m_iType != UDT_DGRAM)
+        {
+            m_RejectReason = SRT_REJ_ROGUE;
+            accepted_hs    = false;
+        }
+    }
+    else
+    {
+        // Unsupported version
+        // (NOTE: This includes "version=0" which is a rejection flag).
+        m_RejectReason = SRT_REJ_VERSION;
+        accepted_hs    = false;
+    }
 
-   if (!accepted_hs)
-   {
-       HLOGC(mglog.Debug, log << "processConnectRequest: version/type mismatch. Sending REJECT code:" << m_RejectReason
-               << " MSG: " << srt_rejectreason_str(m_RejectReason));
-       // mismatch, reject the request
-       hs.m_iReqType = URQFailure(m_RejectReason);
-       size_t size = CHandShake::m_iContentSize;
-       hs.store_to(packet.m_pcData, Ref(size));
-       packet.m_iID = id;
-       packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-       m_pSndQueue->sendto(addr, packet);
-   }
-   else
-   {
-       SRT_REJECT_REASON error = SRT_REJ_UNKNOWN;
-       int result = s_UDTUnited.newConnection(m_SocketID, addr, &hs, packet, Ref(error));
+    if (!accepted_hs)
+    {
+        HLOGC(mglog.Debug,
+              log << "processConnectRequest: version/type mismatch. Sending REJECT code:" << m_RejectReason
+                  << " MSG: " << srt_rejectreason_str(m_RejectReason));
+        // mismatch, reject the request
+        hs.m_iReqType = URQFailure(m_RejectReason);
+        size_t size   = CHandShake::m_iContentSize;
+        hs.store_to(packet.m_pcData, Ref(size));
+        packet.m_iID        = id;
+        packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+        m_pSndQueue->sendto(addr, packet);
+    }
+    else
+    {
+        SRT_REJECT_REASON error  = SRT_REJ_UNKNOWN;
+        int               result = s_UDTUnited.newConnection(m_SocketID, addr, &hs, packet, Ref(error));
 
-       // This is listener - m_RejectReason need not be set
-       // because listener has no functionality of giving the app
-       // insight into rejected callers.
+        // This is listener - m_RejectReason need not be set
+        // because listener has no functionality of giving the app
+        // insight into rejected callers.
 
-       // --->
-       //        (global.) CUDTUnited::updateListenerMux
-       //        (new Socket.) CUDT::acceptAndRespond
-       if (result == -1)
-       {
-           hs.m_iReqType = URQFailure(error);
-           LOGF(mglog.Error, "UU:newConnection: rsp(REJECT): %d - %s", hs.m_iReqType, srt_rejectreason_str(error));
-       }
+        // --->
+        //        (global.) CUDTUnited::updateListenerMux
+        //        (new Socket.) CUDT::acceptAndRespond
+        if (result == -1)
+        {
+            hs.m_iReqType = URQFailure(error);
+            LOGF(mglog.Error, "UU:newConnection: rsp(REJECT): %d - %s", hs.m_iReqType, srt_rejectreason_str(error));
+        }
 
-       // CONFUSION WARNING!
-       //
-       // The newConnection() will call acceptAndRespond() if the processing
-       // was successful - IN WHICH CASE THIS PROCEDURE SHOULD DO NOTHING.
-       // Ok, almost nothing - see update_events below.
-       //
-       // If newConnection() failed, acceptAndRespond() will not be called.
-       // Ok, more precisely, the thing that acceptAndRespond() is expected to do
-       // will not be done (this includes sending any response to the peer).
-       //
-       // Now read CAREFULLY. The newConnection() will return:
-       //
-       // - -1: The connection processing failed due to errors like:
-       //       - memory alloation error
-       //       - listen backlog exceeded
-       //       - any error propagated from CUDT::open and CUDT::acceptAndRespond
-       // - 0: The connection already exists
-       // - 1: Connection accepted.
-       //
-       // So, update_events is called only if the connection is established.
-       // Both 0 (repeated) and -1 (error) require that a response be sent.
-       // The CPacket object that has arrived as a connection request is here
-       // reused for the connection rejection response (see URQ_ERROR_REJECT set
-       // as m_iReqType).
+        // CONFUSION WARNING!
+        //
+        // The newConnection() will call acceptAndRespond() if the processing
+        // was successful - IN WHICH CASE THIS PROCEDURE SHOULD DO NOTHING.
+        // Ok, almost nothing - see update_events below.
+        //
+        // If newConnection() failed, acceptAndRespond() will not be called.
+        // Ok, more precisely, the thing that acceptAndRespond() is expected to do
+        // will not be done (this includes sending any response to the peer).
+        //
+        // Now read CAREFULLY. The newConnection() will return:
+        //
+        // - -1: The connection processing failed due to errors like:
+        //       - memory alloation error
+        //       - listen backlog exceeded
+        //       - any error propagated from CUDT::open and CUDT::acceptAndRespond
+        // - 0: The connection already exists
+        // - 1: Connection accepted.
+        //
+        // So, update_events is called only if the connection is established.
+        // Both 0 (repeated) and -1 (error) require that a response be sent.
+        // The CPacket object that has arrived as a connection request is here
+        // reused for the connection rejection response (see URQ_ERROR_REJECT set
+        // as m_iReqType).
 
-       // send back a response if connection failed or connection already existed
-       // new connection response should be sent in acceptAndRespond()
-       if (result != 1)
-       {
-           HLOGC(mglog.Debug, log << CONID() << "processConnectRequest: sending ABNORMAL handshake info req=" << RequestTypeStr(hs.m_iReqType));
-           size_t size = CHandShake::m_iContentSize;
-           hs.store_to(packet.m_pcData, Ref(size));
-           packet.m_iID = id;
-           packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
-           m_pSndQueue->sendto(addr, packet);
-       }
-       else
-       {
-           // a new connection has been created, enable epoll for write
-           s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_OUT, true);
-       }
-   }
-   LOGC(mglog.Note, log << "listen ret: " << hs.m_iReqType << " - " << RequestTypeStr(hs.m_iReqType));
+        // send back a response if connection failed or connection already existed
+        // new connection response should be sent in acceptAndRespond()
+        if (result != 1)
+        {
+            HLOGC(mglog.Debug,
+                  log << CONID() << "processConnectRequest: sending ABNORMAL handshake info req="
+                      << RequestTypeStr(hs.m_iReqType));
+            size_t size = CHandShake::m_iContentSize;
+            hs.store_to(packet.m_pcData, Ref(size));
+            packet.m_iID        = id;
+            packet.m_iTimeStamp = int(CTimer::getTime() - m_stats.startTime);
+            m_pSndQueue->sendto(addr, packet);
+        }
+        else
+        {
+            // a new connection has been created, enable epoll for write
+            s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_OUT, true);
+        }
+    }
+    LOGC(mglog.Note, log << "listen ret: " << hs.m_iReqType << " - " << RequestTypeStr(hs.m_iReqType));
 
-   return RejectReasonForURQ(hs.m_iReqType);
+    return RejectReasonForURQ(hs.m_iReqType);
 }
 
-void CUDT::addLossRecord(std::vector<int32_t>& lr, int32_t lo, int32_t hi)
+void CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
 {
-    if ( lo == hi )
+    if (lo == hi)
         lr.push_back(lo);
     else
     {
@@ -9165,22 +9322,21 @@ void CUDT::addLossRecord(std::vector<int32_t>& lr, int32_t lo, int32_t hi)
 
 void CUDT::checkACKTimer(uint64_t currtime_tk)
 {
-    if (currtime_tk > m_ullNextACKTime_tk  // ACK time has come
-            // OR the number of sent packets since last ACK has reached
-            // the congctl-defined value of ACK Interval
-            // (note that none of the builtin congctls defines ACK Interval)
-            || (m_CongCtl->ACKMaxPackets() > 0 && m_iPktCount >= m_CongCtl->ACKMaxPackets()))
+    if (currtime_tk > m_ullNextACKTime_tk // ACK time has come
+                                          // OR the number of sent packets since last ACK has reached
+                                          // the congctl-defined value of ACK Interval
+                                          // (note that none of the builtin congctls defines ACK Interval)
+        || (m_CongCtl->ACKMaxPackets() > 0 && m_iPktCount >= m_CongCtl->ACKMaxPackets()))
     {
         // ACK timer expired or ACK interval is reached
         sendCtrl(UMSG_ACK);
         CTimer::rdtsc(currtime_tk);
 
-        const int ack_interval_tk = m_CongCtl->ACKTimeout_us() > 0
-            ? m_CongCtl->ACKTimeout_us() * m_ullCPUFrequency
-            : m_ullACKInt_tk;
+        const int ack_interval_tk =
+            m_CongCtl->ACKTimeout_us() > 0 ? m_CongCtl->ACKTimeout_us() * m_ullCPUFrequency : m_ullACKInt_tk;
         m_ullNextACKTime_tk = currtime_tk + ack_interval_tk;
 
-        m_iPktCount = 0;
+        m_iPktCount      = 0;
         m_iLightACKCount = 1;
     }
     // Or the transfer rate is so high that the number of packets
@@ -9191,12 +9347,11 @@ void CUDT::checkACKTimer(uint64_t currtime_tk)
     // normally according to the timely rules.
     else if (m_iPktCount >= SELF_CLOCK_INTERVAL * m_iLightACKCount)
     {
-        //send a "light" ACK
+        // send a "light" ACK
         sendCtrl(UMSG_ACK, NULL, NULL, SEND_LITE_ACK);
         ++m_iLightACKCount;
     }
 }
-
 
 void CUDT::checkNAKTimer(uint64_t currtime_tk)
 {
@@ -9215,11 +9370,11 @@ void CUDT::checkNAKTimer(uint64_t currtime_tk)
         return;
 
     /*
-    * m_bRcvNakReport enables NAK reports for SRT.
-    * Retransmission based on timeout is bandwidth consuming,
-    * not knowing what to retransmit when the only NAK sent by receiver is lost,
-    * all packets past last ACK are retransmitted (rexmitMethod() == SRM_FASTREXMIT).
-    */
+     * m_bRcvNakReport enables NAK reports for SRT.
+     * Retransmission based on timeout is bandwidth consuming,
+     * not knowing what to retransmit when the only NAK sent by receiver is lost,
+     * all packets past last ACK are retransmitted (rexmitMethod() == SRM_FASTREXMIT).
+     */
     if ((currtime_tk > m_ullNextNAKTime_tk) && (m_pRcvLossList->getLossLength() > 0))
     {
         // NAK timer expired, and there is loss to be reported.
@@ -9255,17 +9410,18 @@ bool CUDT::checkExpTimer(uint64_t currtime_tk)
     const int PEER_IDLE_TMO_US = m_iOPT_PeerIdleTimeout * 1000;
     // Haven't received any information from the peer, is it dead?!
     // timeout: at least 16 expirations and must be greater than 5 seconds
-    if ((m_iEXPCount > COMM_RESPONSE_MAX_EXP)
-        && (currtime_tk - m_ullLastRspTime_tk > PEER_IDLE_TMO_US * m_ullCPUFrequency))
+    if ((m_iEXPCount > COMM_RESPONSE_MAX_EXP) &&
+        (currtime_tk - m_ullLastRspTime_tk > PEER_IDLE_TMO_US * m_ullCPUFrequency))
     {
         //
         // Connection is broken.
         // UDT does not signal any information about this instead of to stop quietly.
         // Application will detect this when it calls any UDT methods next time.
         //
-        HLOGC(mglog.Debug, log << "CONNECTION EXPIRED after " << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "ms");
-        m_bClosing = true;
-        m_bBroken  = true;
+        HLOGC(mglog.Debug,
+              log << "CONNECTION EXPIRED after " << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "ms");
+        m_bClosing       = true;
+        m_bBroken        = true;
         m_iBrokenCounter = 30;
 
         // update snd U list to remove this socket
@@ -9281,8 +9437,9 @@ bool CUDT::checkExpTimer(uint64_t currtime_tk)
         return true;
     }
 
-    HLOGC(mglog.Debug, log << "EXP TIMER: count=" << m_iEXPCount << "/" << (+COMM_RESPONSE_MAX_EXP)
-        << " elapsed=" << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "/" << (+PEER_IDLE_TMO_US) << "us");
+    HLOGC(mglog.Debug,
+          log << "EXP TIMER: count=" << m_iEXPCount << "/" << (+COMM_RESPONSE_MAX_EXP) << " elapsed="
+              << ((currtime_tk - m_ullLastRspTime_tk) / m_ullCPUFrequency) << "/" << (+PEER_IDLE_TMO_US) << "us");
 
     ++m_iEXPCount;
 
@@ -9352,10 +9509,10 @@ void CUDT::checkRexmitTimer(uint64_t currtime_tk)
     if (retransmit)
     {
         // Sender: Insert all the packets sent after last received acknowledgement into the sender loss list.
-        CGuard acklock(m_RecvAckLock);  // Protect packet retransmission
+        CGuard acklock(m_RecvAckLock); // Protect packet retransmission
         // Resend all unacknowledged packets on timeout, but only if there is no packet in the loss list
         const int32_t csn = m_iSndCurrSeqNo;
-        const int num = m_pSndLossList->insert(m_iSndLastAck, csn);
+        const int     num = m_pSndLossList->insert(m_iSndLastAck, csn);
         if (num > 0)
         {
             CGuard::enterCS(m_StatsLock);
@@ -9363,9 +9520,10 @@ void CUDT::checkRexmitTimer(uint64_t currtime_tk)
             m_stats.sndLossTotal += num;
             CGuard::leaveCS(m_StatsLock);
 
-            HLOGC(mglog.Debug, log << CONID() << "ENFORCED " << (is_laterexmit ? "LATEREXMIT" : "FASTREXMIT")
-                << " by ACK-TMOUT (scheduling): " << CSeqNo::incseq(m_iSndLastAck) << "-" << csn
-                << " (" << CSeqNo::seqoff(m_iSndLastAck, csn) << " packets)");
+            HLOGC(mglog.Debug,
+                  log << CONID() << "ENFORCED " << (is_laterexmit ? "LATEREXMIT" : "FASTREXMIT")
+                      << " by ACK-TMOUT (scheduling): " << CSeqNo::incseq(m_iSndLastAck) << "-" << csn << " ("
+                      << CSeqNo::seqoff(m_iSndLastAck, csn) << " packets)");
         }
     }
 
@@ -9383,8 +9541,8 @@ void CUDT::checkTimers()
 {
     // update CC parameters
     updateCC(TEV_CHECKTIMER, TEV_CHT_INIT);
-    //uint64_t minint = (uint64_t)(m_ullCPUFrequency * m_pSndTimeWindow->getMinPktSndInt() * 0.9);
-    //if (m_ullInterval_tk < minint)
+    // uint64_t minint = (uint64_t)(m_ullCPUFrequency * m_pSndTimeWindow->getMinPktSndInt() * 0.9);
+    // if (m_ullInterval_tk < minint)
     //   m_ullInterval_tk = minint;
     // NOTE: This commented-out ^^^ code was commented out in original UDT. Leaving for historical reasons
 
@@ -9421,37 +9579,37 @@ void CUDT::checkTimers()
 
 void CUDT::addEPoll(const int eid)
 {
-   CGuard::enterCS(s_UDTUnited.m_EPoll.m_EPollLock);
-   m_sPollID.insert(eid);
-   CGuard::leaveCS(s_UDTUnited.m_EPoll.m_EPollLock);
+    CGuard::enterCS(s_UDTUnited.m_EPoll.m_EPollLock);
+    m_sPollID.insert(eid);
+    CGuard::leaveCS(s_UDTUnited.m_EPoll.m_EPollLock);
 
-   if (!stillConnected())
-       return;
+    if (!stillConnected())
+        return;
 
-   CGuard::enterCS(m_RecvLock);
-   if (m_pRcvBuffer->isRcvDataReady())
-   {
-      s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_IN, true);
-   }
-   CGuard::leaveCS(m_RecvLock);
+    CGuard::enterCS(m_RecvLock);
+    if (m_pRcvBuffer->isRcvDataReady())
+    {
+        s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_IN, true);
+    }
+    CGuard::leaveCS(m_RecvLock);
 
-   if (m_iSndBufSize > m_pSndBuffer->getCurrBufSize())
-   {
-      s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_OUT, true);
-   }
+    if (m_iSndBufSize > m_pSndBuffer->getCurrBufSize())
+    {
+        s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_OUT, true);
+    }
 }
 
 void CUDT::removeEPoll(const int eid)
 {
-   // clear IO events notifications;
-   // since this happens after the epoll ID has been removed, they cannot be set again
-   set<int> remove;
-   remove.insert(eid);
-   s_UDTUnited.m_EPoll.update_events(m_SocketID, remove, UDT_EPOLL_IN | UDT_EPOLL_OUT, false);
+    // clear IO events notifications;
+    // since this happens after the epoll ID has been removed, they cannot be set again
+    set<int> remove;
+    remove.insert(eid);
+    s_UDTUnited.m_EPoll.update_events(m_SocketID, remove, UDT_EPOLL_IN | UDT_EPOLL_OUT, false);
 
-   CGuard::enterCS(s_UDTUnited.m_EPoll.m_EPollLock);
-   m_sPollID.erase(eid);
-   CGuard::leaveCS(s_UDTUnited.m_EPoll.m_EPollLock);
+    CGuard::enterCS(s_UDTUnited.m_EPoll.m_EPollLock);
+    m_sPollID.erase(eid);
+    CGuard::leaveCS(s_UDTUnited.m_EPoll.m_EPollLock);
 }
 
 void CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
@@ -9472,20 +9630,19 @@ void CUDT::DisconnectSignal(ETransmissionEvent evt)
 
 void CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
 {
-    for (std::vector<EventSlot>::iterator i = m_Slots[tev].begin();
-            i != m_Slots[tev].end(); ++i)
+    for (std::vector<EventSlot>::iterator i = m_Slots[tev].begin(); i != m_Slots[tev].end(); ++i)
     {
         i->emit(tev, var);
     }
 }
 
-int CUDT::getsndbuffer(SRTSOCKET u, size_t* blocks, size_t* bytes)
+int CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
 {
-    CUDTSocket* s = s_UDTUnited.locate(u);
+    CUDTSocket *s = s_UDTUnited.locate(u);
     if (!s || !s->m_pUDT)
         return -1;
 
-    CSndBuffer* b = s->m_pUDT->m_pSndBuffer;
+    CSndBuffer *b = s->m_pUDT->m_pSndBuffer;
 
     if (!b)
         return -1;
@@ -9504,20 +9661,20 @@ int CUDT::getsndbuffer(SRTSOCKET u, size_t* blocks, size_t* bytes)
 
 SRT_REJECT_REASON CUDT::rejectReason(SRTSOCKET u)
 {
-    CUDTSocket* s = s_UDTUnited.locate(u);
+    CUDTSocket *s = s_UDTUnited.locate(u);
     if (!s || !s->m_pUDT)
         return SRT_REJ_UNKNOWN;
 
     return s->m_pUDT->m_RejectReason;
 }
 
-bool CUDT::runAcceptHook(CUDT* acore, const sockaddr* peer, const CHandShake* hs, const CPacket& hspkt)
+bool CUDT::runAcceptHook(CUDT *acore, const sockaddr *peer, const CHandShake *hs, const CPacket &hspkt)
 {
     // Prepare the information for the hook.
 
     // We need streamid.
-    char target[MAX_SID_LENGTH+1];
-    memset(target, 0, MAX_SID_LENGTH+1);
+    char target[MAX_SID_LENGTH + 1];
+    memset(target, 0, MAX_SID_LENGTH + 1);
 
     // Just for a case, check the length.
     // This wasn't done before, and we could risk memory crash.
@@ -9529,31 +9686,32 @@ bool CUDT::runAcceptHook(CUDT* acore, const sockaddr* peer, const CHandShake* hs
     // This tests if there are any extensions.
     if (hspkt.getLength() > CHandShake::m_iContentSize + 4 && IsSet(ext_flags, CHandShake::HS_EXT_CONFIG))
     {
-        uint32_t* begin = reinterpret_cast<uint32_t*>(hspkt.m_pcData + CHandShake::m_iContentSize);
-        size_t size = hspkt.getLength() - CHandShake::m_iContentSize; // Due to previous cond check we grant it's >0
-        uint32_t* next = 0;
-        size_t length = size / sizeof(uint32_t);
-        size_t blocklen = 0;
+        uint32_t *begin = reinterpret_cast<uint32_t *>(hspkt.m_pcData + CHandShake::m_iContentSize);
+        size_t    size  = hspkt.getLength() - CHandShake::m_iContentSize; // Due to previous cond check we grant it's >0
+        uint32_t *next  = 0;
+        size_t    length   = size / sizeof(uint32_t);
+        size_t    blocklen = 0;
 
         for (;;) // ONE SHOT, but continuable loop
         {
             int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
 
-            const size_t bytelen = blocklen*sizeof(uint32_t);
+            const size_t bytelen = blocklen * sizeof(uint32_t);
 
             if (cmd == SRT_CMD_SID)
             {
                 if (!bytelen || bytelen > MAX_SID_LENGTH)
                 {
-                    LOGC(mglog.Error, log << "interpretSrtHandshake: STREAMID length " << bytelen
-                           << " is 0 or > " << +MAX_SID_LENGTH << " - PROTOCOL ERROR, REJECTING");
+                    LOGC(mglog.Error,
+                         log << "interpretSrtHandshake: STREAMID length " << bytelen << " is 0 or > " << +MAX_SID_LENGTH
+                             << " - PROTOCOL ERROR, REJECTING");
                     return false;
                 }
                 // See comment at CUDT::interpretSrtHandshake().
-                memcpy(target, begin+1, bytelen);
+                memcpy(target, begin + 1, bytelen);
 
                 // Un-swap on big endian machines
-                ItoHLA((uint32_t*)target, (uint32_t*)target, blocklen);
+                ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
 
                 // Nothing more expected from connection block.
                 break;
@@ -9590,4 +9748,3 @@ bool CUDT::runAcceptHook(CUDT* acore, const sockaddr* peer, const CHandShake* hs
 
     return true;
 }
-

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -484,8 +484,7 @@ m_pChannel(NULL),
 m_pTimer(NULL),
 m_WindowLock(),
 m_WindowCond(),
-m_bClosing(false),
-m_ExitCond()
+m_bClosing(false)
 {
     pthread_cond_init(&m_WindowCond, NULL);
     pthread_mutex_init(&m_WindowLock, NULL);
@@ -554,69 +553,13 @@ void* CSndQueue::worker(void* param)
 
     while (!self->m_bClosing)
     {
-        uint64_t ts = self->m_pSndUList->getNextProcTime();
+        uint64_t next_time = self->m_pSndUList->getNextProcTime();
 
 #if   defined(SRT_DEBUG_SNDQ_HIGHRATE)
         self->m_WorkerStats.lIteration++;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
-        if (ts > 0)
-        {
-            // wait until next processing time of the first socket on the list
-            uint64_t currtime;
-            CTimer::rdtsc(currtime);
-
-#if      defined(SRT_DEBUG_SNDQ_HIGHRATE)
-            if (self->m_ullDbgTime <= currtime) {
-                fprintf(stdout, "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",  
-                        self->m_WorkerStats.lIteration,
-                        self->m_WorkerStats.lSleepTo,
-                        self->m_WorkerStats.lNotReadyPop,
-                        self->m_WorkerStats.lSendTo,
-                        self->m_WorkerStats.lNotReadyTs,  
-                        self->m_WorkerStats.lCondWait);
-                memset(&self->m_WorkerStats, 0, sizeof(self->m_WorkerStats));
-                self->m_ullDbgTime = currtime + self->m_ullDbgPeriod;
-            }
-#endif   /* SRT_DEBUG_SNDQ_HIGHRATE */
-
-            THREAD_PAUSED();
-            if (currtime < ts) 
-            {
-                self->m_pTimer->sleepto(ts);
-
-#if         defined(HAI_DEBUG_SNDQ_HIGHRATE)
-                self->m_WorkerStats.lSleepTo++;
-#endif      /* SRT_DEBUG_SNDQ_HIGHRATE */
-            }
-            THREAD_RESUMED();
-
-            // it is time to send the next pkt
-            sockaddr* addr;
-            CPacket pkt;
-            if (self->m_pSndUList->pop(addr, pkt) < 0) 
-            {
-                continue;
-
-#if         defined(SRT_DEBUG_SNDQ_HIGHRATE)
-                self->m_WorkerStats.lNotReadyPop++;
-#endif      /* SRT_DEBUG_SNDQ_HIGHRATE */
-            }
-            if ( pkt.isControl() )
-            {
-                HLOGC(mglog.Debug, log << self->CONID() << "chn:SENDING: " << MessageTypeStr(pkt.getType(), pkt.getExtendedType()));
-            }
-            else
-            {
-                HLOGC(dlog.Debug, log << self->CONID() << "chn:SENDING SIZE " << pkt.getLength() << " SEQ: " << pkt.getSeqNo());
-            }
-            self->m_pChannel->sendto(addr, pkt);
-
-#if      defined(SRT_DEBUG_SNDQ_HIGHRATE)
-            self->m_WorkerStats.lSendTo++;
-#endif   /* SRT_DEBUG_SNDQ_HIGHRATE */
-        }
-        else
+        if (next_time <= 0)
         {
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
             self->m_WorkerStats.lNotReadyTs++;
@@ -634,7 +577,67 @@ void* CSndQueue::worker(void* param)
             }
             THREAD_RESUMED();
             pthread_mutex_unlock(&self->m_WindowLock);
+
+            continue;
         }
+
+        // wait until next processing time of the first socket on the list
+        uint64_t currtime;
+        CTimer::rdtsc(currtime);
+
+#if      defined(SRT_DEBUG_SNDQ_HIGHRATE)
+        if (self->m_ullDbgTime <= currtime)
+        {
+            fprintf(stdout,
+                "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",
+                self->m_WorkerStats.lIteration,
+                self->m_WorkerStats.lSleepTo,
+                self->m_WorkerStats.lNotReadyPop,
+                self->m_WorkerStats.lSendTo,
+                self->m_WorkerStats.lNotReadyTs,
+                self->m_WorkerStats.lCondWait);
+            memset(&self->m_WorkerStats, 0, sizeof(self->m_WorkerStats));
+            self->m_ullDbgTime = currtime + self->m_ullDbgPeriod;
+        }
+#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+
+        THREAD_PAUSED();
+        if (currtime < next_time)
+        {
+            self->m_pTimer->sleepto(next_time);
+
+#if         defined(HAI_DEBUG_SNDQ_HIGHRATE)
+            self->m_WorkerStats.lSleepTo++;
+#endif      /* SRT_DEBUG_SNDQ_HIGHRATE */
+        }
+        THREAD_RESUMED();
+
+        // it is time to send the next pkt
+        sockaddr* addr;
+        CPacket pkt;
+        if (self->m_pSndUList->pop(addr, pkt) < 0)
+        {
+            continue;
+
+#if         defined(SRT_DEBUG_SNDQ_HIGHRATE)
+            self->m_WorkerStats.lNotReadyPop++;
+#endif      /* SRT_DEBUG_SNDQ_HIGHRATE */
+        }
+        if (pkt.isControl())
+        {
+            HLOGC(mglog.Debug,
+                 log << self->CONID() << "chn:SENDING: " << MessageTypeStr(pkt.getType(), pkt.getExtendedType()));
+        }
+        else
+        {
+            HLOGC(dlog.Debug,
+                log << self->CONID() << "chn:SENDING SIZE " << pkt.getLength() << " SEQ: " << pkt.getSeqNo());
+        }
+        self->m_pChannel->sendto(addr, pkt);
+
+#if      defined(SRT_DEBUG_SNDQ_HIGHRATE)
+        self->m_WorkerStats.lSendTo++;
+#endif   /* SRT_DEBUG_SNDQ_HIGHRATE */
     }
 
     THREAD_EXIT();
@@ -1054,7 +1057,6 @@ CRcvQueue::CRcvQueue():
     m_pTimer(NULL),
     m_iPayloadSize(),
     m_bClosing(false),
-    m_ExitCond(),
     m_LSLock(),
     m_pListener(NULL),
     m_pRendezvousQueue(NULL),

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -51,8 +51,8 @@ modified by
 *****************************************************************************/
 
 #ifdef _WIN32
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #endif
 #include <cstring>
 
@@ -66,177 +66,177 @@ modified by
 using namespace std;
 using namespace srt_logging;
 
-CUnitQueue::CUnitQueue():
-m_pQEntry(NULL),
-m_pCurrQueue(NULL),
-m_pLastQueue(NULL),
-m_iSize(0),
-m_iCount(0),
-m_iMSS(),
-m_iIPversion()
+CUnitQueue::CUnitQueue()
+    : m_pQEntry(NULL)
+    , m_pCurrQueue(NULL)
+    , m_pLastQueue(NULL)
+    , m_iSize(0)
+    , m_iCount(0)
+    , m_iMSS()
+    , m_iIPversion()
 {
 }
 
 CUnitQueue::~CUnitQueue()
 {
-   CQEntry* p = m_pQEntry;
+    CQEntry *p = m_pQEntry;
 
-   while (p != NULL)
-   {
-      delete [] p->m_pUnit;
-      delete [] p->m_pBuffer;
+    while (p != NULL)
+    {
+        delete[] p->m_pUnit;
+        delete[] p->m_pBuffer;
 
-      CQEntry* q = p;
-      if (p == m_pLastQueue)
-         p = NULL;
-      else
-         p = p->m_pNext;
-      delete q;
-   }
+        CQEntry *q = p;
+        if (p == m_pLastQueue)
+            p = NULL;
+        else
+            p = p->m_pNext;
+        delete q;
+    }
 }
 
 int CUnitQueue::init(int size, int mss, int version)
 {
-   CQEntry* tempq = NULL;
-   CUnit* tempu = NULL;
-   char* tempb = NULL;
+    CQEntry *tempq = NULL;
+    CUnit *  tempu = NULL;
+    char *   tempb = NULL;
 
-   try
-   {
-      tempq = new CQEntry;
-      tempu = new CUnit [size];
-      tempb = new char [size * mss];
-   }
-   catch (...)
-   {
-      delete tempq;
-      delete [] tempu;
-      delete [] tempb;
+    try
+    {
+        tempq = new CQEntry;
+        tempu = new CUnit[size];
+        tempb = new char[size * mss];
+    }
+    catch (...)
+    {
+        delete tempq;
+        delete[] tempu;
+        delete[] tempb;
 
-      return -1;
-   }
+        return -1;
+    }
 
-   for (int i = 0; i < size; ++ i)
-   {
-      tempu[i].m_iFlag = CUnit::FREE;
-      tempu[i].m_Packet.m_pcData = tempb + i * mss;
-   }
-   tempq->m_pUnit = tempu;
-   tempq->m_pBuffer = tempb;
-   tempq->m_iSize = size;
+    for (int i = 0; i < size; ++i)
+    {
+        tempu[i].m_iFlag           = CUnit::FREE;
+        tempu[i].m_Packet.m_pcData = tempb + i * mss;
+    }
+    tempq->m_pUnit   = tempu;
+    tempq->m_pBuffer = tempb;
+    tempq->m_iSize   = size;
 
-   m_pQEntry = m_pCurrQueue = m_pLastQueue = tempq;
-   m_pQEntry->m_pNext = m_pQEntry;
+    m_pQEntry = m_pCurrQueue = m_pLastQueue = tempq;
+    m_pQEntry->m_pNext                      = m_pQEntry;
 
-   m_pAvailUnit = m_pCurrQueue->m_pUnit;
+    m_pAvailUnit = m_pCurrQueue->m_pUnit;
 
-   m_iSize = size;
-   m_iMSS = mss;
-   m_iIPversion = version;
+    m_iSize      = size;
+    m_iMSS       = mss;
+    m_iIPversion = version;
 
-   return 0;
+    return 0;
 }
 
 int CUnitQueue::increase()
 {
-   // adjust/correct m_iCount
-   int real_count = 0;
-   CQEntry* p = m_pQEntry;
-   while (p != NULL)
-   {
-      CUnit* u = p->m_pUnit;
-      for (CUnit* end = u + p->m_iSize; u != end; ++ u)
-         if (u->m_iFlag != CUnit::FREE)
-            ++ real_count;
+    // adjust/correct m_iCount
+    int      real_count = 0;
+    CQEntry *p          = m_pQEntry;
+    while (p != NULL)
+    {
+        CUnit *u = p->m_pUnit;
+        for (CUnit *end = u + p->m_iSize; u != end; ++u)
+            if (u->m_iFlag != CUnit::FREE)
+                ++real_count;
 
-      if (p == m_pLastQueue)
-         p = NULL;
-      else
-         p = p->m_pNext;
-   }
-   m_iCount = real_count;
-   if (double(m_iCount) / m_iSize < 0.9)
-      return -1;
+        if (p == m_pLastQueue)
+            p = NULL;
+        else
+            p = p->m_pNext;
+    }
+    m_iCount = real_count;
+    if (double(m_iCount) / m_iSize < 0.9)
+        return -1;
 
-   CQEntry* tempq = NULL;
-   CUnit* tempu = NULL;
-   char* tempb = NULL;
+    CQEntry *tempq = NULL;
+    CUnit *  tempu = NULL;
+    char *   tempb = NULL;
 
-   // all queues have the same size
-   int size = m_pQEntry->m_iSize;
+    // all queues have the same size
+    int size = m_pQEntry->m_iSize;
 
-   try
-   {
-      tempq = new CQEntry;
-      tempu = new CUnit [size];
-      tempb = new char [size * m_iMSS];
-   }
-   catch (...)
-   {
-      delete tempq;
-      delete [] tempu;
-      delete [] tempb;
+    try
+    {
+        tempq = new CQEntry;
+        tempu = new CUnit[size];
+        tempb = new char[size * m_iMSS];
+    }
+    catch (...)
+    {
+        delete tempq;
+        delete[] tempu;
+        delete[] tempb;
 
-      return -1;
-   }
+        return -1;
+    }
 
-   for (int i = 0; i < size; ++ i)
-   {
-      tempu[i].m_iFlag = CUnit::FREE;
-      tempu[i].m_Packet.m_pcData = tempb + i * m_iMSS;
-   }
-   tempq->m_pUnit = tempu;
-   tempq->m_pBuffer = tempb;
-   tempq->m_iSize = size;
+    for (int i = 0; i < size; ++i)
+    {
+        tempu[i].m_iFlag           = CUnit::FREE;
+        tempu[i].m_Packet.m_pcData = tempb + i * m_iMSS;
+    }
+    tempq->m_pUnit   = tempu;
+    tempq->m_pBuffer = tempb;
+    tempq->m_iSize   = size;
 
-   m_pLastQueue->m_pNext = tempq;
-   m_pLastQueue = tempq;
-   m_pLastQueue->m_pNext = m_pQEntry;
+    m_pLastQueue->m_pNext = tempq;
+    m_pLastQueue          = tempq;
+    m_pLastQueue->m_pNext = m_pQEntry;
 
-   m_iSize += size;
+    m_iSize += size;
 
-   return 0;
+    return 0;
 }
 
 int CUnitQueue::shrink()
 {
-   // currently queue cannot be shrunk.
-   return -1;
+    // currently queue cannot be shrunk.
+    return -1;
 }
 
-CUnit* CUnitQueue::getNextAvailUnit()
+CUnit *CUnitQueue::getNextAvailUnit()
 {
-   if (m_iCount * 10 > m_iSize * 9)
-      increase();
+    if (m_iCount * 10 > m_iSize * 9)
+        increase();
 
-   if (m_iCount >= m_iSize)
-      return NULL;
+    if (m_iCount >= m_iSize)
+        return NULL;
 
-   CQEntry* entrance = m_pCurrQueue;
+    CQEntry *entrance = m_pCurrQueue;
 
-   do
-   {
-      for (CUnit* sentinel = m_pCurrQueue->m_pUnit + m_pCurrQueue->m_iSize - 1; m_pAvailUnit != sentinel; ++ m_pAvailUnit)
-         if (m_pAvailUnit->m_iFlag == CUnit::FREE)
+    do
+    {
+        for (CUnit *sentinel = m_pCurrQueue->m_pUnit + m_pCurrQueue->m_iSize - 1; m_pAvailUnit != sentinel;
+             ++m_pAvailUnit)
+            if (m_pAvailUnit->m_iFlag == CUnit::FREE)
+                return m_pAvailUnit;
+
+        if (m_pCurrQueue->m_pUnit->m_iFlag == CUnit::FREE)
+        {
+            m_pAvailUnit = m_pCurrQueue->m_pUnit;
             return m_pAvailUnit;
+        }
 
-      if (m_pCurrQueue->m_pUnit->m_iFlag == CUnit::FREE)
-      {
-         m_pAvailUnit = m_pCurrQueue->m_pUnit;
-         return m_pAvailUnit;
-      }
+        m_pCurrQueue = m_pCurrQueue->m_pNext;
+        m_pAvailUnit = m_pCurrQueue->m_pUnit;
+    } while (m_pCurrQueue != entrance);
 
-      m_pCurrQueue = m_pCurrQueue->m_pNext;
-      m_pAvailUnit = m_pCurrQueue->m_pUnit;
-   } while (m_pCurrQueue != entrance);
+    increase();
 
-   increase();
-
-   return NULL;
+    return NULL;
 }
 
-
-void CUnitQueue::makeUnitFree(CUnit * unit)
+void CUnitQueue::makeUnitFree(CUnit *unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_iFlag != CUnit::FREE);
@@ -244,8 +244,7 @@ void CUnitQueue::makeUnitFree(CUnit * unit)
     --m_iCount;
 }
 
-
-void CUnitQueue::makeUnitGood(CUnit * unit)
+void CUnitQueue::makeUnitGood(CUnit *unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_iFlag == CUnit::FREE);
@@ -253,139 +252,128 @@ void CUnitQueue::makeUnitGood(CUnit * unit)
     ++m_iCount;
 }
 
-
-CSndUList::CSndUList():
-    m_pHeap(NULL),
-    m_iArrayLength(512),
-    m_iLastEntry(-1),
-    m_ListLock(),
-    m_pWindowLock(NULL),
-    m_pWindowCond(NULL),
-    m_pTimer(NULL)
+CSndUList::CSndUList()
+    : m_pHeap(NULL)
+    , m_iArrayLength(512)
+    , m_iLastEntry(-1)
+    , m_ListLock()
+    , m_pWindowLock(NULL)
+    , m_pWindowCond(NULL)
+    , m_pTimer(NULL)
 {
-    m_pHeap = new CSNode*[m_iArrayLength];
+    m_pHeap = new CSNode *[m_iArrayLength];
     pthread_mutex_init(&m_ListLock, NULL);
 }
 
 CSndUList::~CSndUList()
 {
-    delete [] m_pHeap;
+    delete[] m_pHeap;
     pthread_mutex_destroy(&m_ListLock);
 }
 
-
-void CSndUList::update(const CUDT* u, EReschedule reschedule)
+void CSndUList::update(const CUDT *u, EReschedule reschedule)
 {
-   CGuard listguard(m_ListLock);
+    CGuard listguard(m_ListLock);
 
-   CSNode* n = u->m_pSNode;
+    CSNode *n = u->m_pSNode;
 
-   if (n->m_iHeapLoc >= 0)
-   {
-      if (!reschedule) // EReschedule to bool conversion, predicted.
-         return;
+    if (n->m_iHeapLoc >= 0)
+    {
+        if (!reschedule) // EReschedule to bool conversion, predicted.
+            return;
 
-      if (n->m_iHeapLoc == 0)
-      {
-         n->m_llTimeStamp_tk = 1;
-         m_pTimer->interrupt();
-         return;
-      }
+        if (n->m_iHeapLoc == 0)
+        {
+            n->m_llTimeStamp_tk = 1;
+            m_pTimer->interrupt();
+            return;
+        }
 
-      remove_(u);
-      insert_norealloc_(1, u);
-      return;
-   }
+        remove_(u);
+        insert_norealloc_(1, u);
+        return;
+    }
 
-   insert_(1, u);
+    insert_(1, u);
 }
 
-int CSndUList::pop(sockaddr*& addr, CPacket& pkt)
+int CSndUList::pop(sockaddr *&addr, CPacket &pkt)
 {
-   CGuard listguard(m_ListLock);
+    CGuard listguard(m_ListLock);
 
-   if (-1 == m_iLastEntry)
-      return -1;
+    if (-1 == m_iLastEntry)
+        return -1;
 
-   // no pop until the next schedulled time
-   uint64_t ts;
-   CTimer::rdtsc(ts);
-   if (ts < m_pHeap[0]->m_llTimeStamp_tk)
-      return -1;
+    // no pop until the next schedulled time
+    uint64_t ts;
+    CTimer::rdtsc(ts);
+    if (ts < m_pHeap[0]->m_llTimeStamp_tk)
+        return -1;
 
-   CUDT* u = m_pHeap[0]->m_pUDT;
-   remove_(u);
+    CUDT *u = m_pHeap[0]->m_pUDT;
+    remove_(u);
 
-#define UST(field) ( (u->m_b##field) ? "+" : "-" ) << #field << " "
+#define UST(field) ((u->m_b##field) ? "+" : "-") << #field << " "
 
-   HLOGC(mglog.Debug, log << "SND:pop: requesting packet from @" << u->socketID()
-           << " STATUS: "
-           << UST(Listening)
-           << UST(Connecting)
-           << UST(Connected)
-           << UST(Closing)
-           << UST(Shutdown)
-           << UST(Broken)
-           << UST(PeerHealth)
-           << UST(Opened)
-        );
+    HLOGC(mglog.Debug,
+          log << "SND:pop: requesting packet from @" << u->socketID() << " STATUS: " << UST(Listening)
+              << UST(Connecting) << UST(Connected) << UST(Closing) << UST(Shutdown) << UST(Broken) << UST(PeerHealth)
+              << UST(Opened));
 #undef UST
 
-   if (!u->m_bConnected || u->m_bBroken)
-      return -1;
+    if (!u->m_bConnected || u->m_bBroken)
+        return -1;
 
-   // pack a packet from the socket
-   if (u->packData(pkt, ts) <= 0)
-      return -1;
+    // pack a packet from the socket
+    if (u->packData(pkt, ts) <= 0)
+        return -1;
 
-   addr = u->m_pPeerAddr;
+    addr = u->m_pPeerAddr;
 
-   // insert a new entry, ts is the next processing time
-   if (ts > 0)
-      insert_norealloc_(ts, u);
+    // insert a new entry, ts is the next processing time
+    if (ts > 0)
+        insert_norealloc_(ts, u);
 
-   return 1;
+    return 1;
 }
 
-void CSndUList::remove(const CUDT* u)
+void CSndUList::remove(const CUDT *u)
 {
-   CGuard listguard(m_ListLock);
+    CGuard listguard(m_ListLock);
 
-   remove_(u);
+    remove_(u);
 }
 
 uint64_t CSndUList::getNextProcTime()
 {
-   CGuard listguard(m_ListLock);
+    CGuard listguard(m_ListLock);
 
-   if (-1 == m_iLastEntry)
-      return 0;
+    if (-1 == m_iLastEntry)
+        return 0;
 
-   return m_pHeap[0]->m_llTimeStamp_tk;
+    return m_pHeap[0]->m_llTimeStamp_tk;
 }
-
 
 void CSndUList::realloc_()
 {
-   CSNode** temp = NULL;
+    CSNode **temp = NULL;
 
-   try
-   {
-       temp = new CSNode *[2 * m_iArrayLength];
-   }
-   catch (...)
-   {
-       throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
+    try
+    {
+        temp = new CSNode *[2 * m_iArrayLength];
+    }
+    catch (...)
+    {
+        throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
 
-   memcpy(temp, m_pHeap, sizeof(CSNode*) * m_iArrayLength);
-   m_iArrayLength *= 2;
-   delete[] m_pHeap;
-   m_pHeap = temp;
+    memcpy(temp, m_pHeap, sizeof(CSNode *) * m_iArrayLength);
+    m_iArrayLength *= 2;
+    delete[] m_pHeap;
+    m_pHeap = temp;
 }
 
-
-void CSndUList::insert_(int64_t ts, const CUDT* u)
+void CSndUList::insert_(int64_t ts, const CUDT *u)
 {
     // increase the heap array size if necessary
     if (m_iLastEntry == m_iArrayLength - 1)
@@ -394,97 +382,96 @@ void CSndUList::insert_(int64_t ts, const CUDT* u)
     insert_norealloc_(ts, u);
 }
 
-
-void CSndUList::insert_norealloc_(int64_t ts, const CUDT* u)
+void CSndUList::insert_norealloc_(int64_t ts, const CUDT *u)
 {
-   CSNode* n = u->m_pSNode;
+    CSNode *n = u->m_pSNode;
 
-   // do not insert repeated node
-   if (n->m_iHeapLoc >= 0)
-      return;
+    // do not insert repeated node
+    if (n->m_iHeapLoc >= 0)
+        return;
 
-   SRT_ASSERT(m_iLastEntry < m_iArrayLength);
+    SRT_ASSERT(m_iLastEntry < m_iArrayLength);
 
-   m_iLastEntry ++;
-   m_pHeap[m_iLastEntry] = n;
-   n->m_llTimeStamp_tk = ts;
+    m_iLastEntry++;
+    m_pHeap[m_iLastEntry] = n;
+    n->m_llTimeStamp_tk   = ts;
 
-   int q = m_iLastEntry;
-   int p = q;
-   while (p != 0)
-   {
-      p = (q - 1) >> 1;
-      if (m_pHeap[p]->m_llTimeStamp_tk <= m_pHeap[q]->m_llTimeStamp_tk)
-          break;
+    int q = m_iLastEntry;
+    int p = q;
+    while (p != 0)
+    {
+        p = (q - 1) >> 1;
+        if (m_pHeap[p]->m_llTimeStamp_tk <= m_pHeap[q]->m_llTimeStamp_tk)
+            break;
 
-      swap(m_pHeap[p], m_pHeap[q]);
-      m_pHeap[q]->m_iHeapLoc = q;
-      q = p;
-   }
+        swap(m_pHeap[p], m_pHeap[q]);
+        m_pHeap[q]->m_iHeapLoc = q;
+        q                      = p;
+    }
 
-   n->m_iHeapLoc = q;
+    n->m_iHeapLoc = q;
 
-   // an earlier event has been inserted, wake up sending worker
-   if (n->m_iHeapLoc == 0)
-      m_pTimer->interrupt();
+    // an earlier event has been inserted, wake up sending worker
+    if (n->m_iHeapLoc == 0)
+        m_pTimer->interrupt();
 
-   // first entry, activate the sending queue
-   if (0 == m_iLastEntry)
-   {
-       pthread_mutex_lock(m_pWindowLock);
-       pthread_cond_signal(m_pWindowCond);
-       pthread_mutex_unlock(m_pWindowLock);
-   }
+    // first entry, activate the sending queue
+    if (0 == m_iLastEntry)
+    {
+        pthread_mutex_lock(m_pWindowLock);
+        pthread_cond_signal(m_pWindowCond);
+        pthread_mutex_unlock(m_pWindowLock);
+    }
 }
 
-void CSndUList::remove_(const CUDT* u)
+void CSndUList::remove_(const CUDT *u)
 {
-   CSNode* n = u->m_pSNode;
+    CSNode *n = u->m_pSNode;
 
-   if (n->m_iHeapLoc >= 0)
-   {
-      // remove the node from heap
-      m_pHeap[n->m_iHeapLoc] = m_pHeap[m_iLastEntry];
-      m_iLastEntry --;
-      m_pHeap[n->m_iHeapLoc]->m_iHeapLoc = n->m_iHeapLoc;
+    if (n->m_iHeapLoc >= 0)
+    {
+        // remove the node from heap
+        m_pHeap[n->m_iHeapLoc] = m_pHeap[m_iLastEntry];
+        m_iLastEntry--;
+        m_pHeap[n->m_iHeapLoc]->m_iHeapLoc = n->m_iHeapLoc;
 
-      int q = n->m_iHeapLoc;
-      int p = q * 2 + 1;
-      while (p <= m_iLastEntry)
-      {
-         if ((p + 1 <= m_iLastEntry) && (m_pHeap[p]->m_llTimeStamp_tk > m_pHeap[p + 1]->m_llTimeStamp_tk))
-            p ++;
+        int q = n->m_iHeapLoc;
+        int p = q * 2 + 1;
+        while (p <= m_iLastEntry)
+        {
+            if ((p + 1 <= m_iLastEntry) && (m_pHeap[p]->m_llTimeStamp_tk > m_pHeap[p + 1]->m_llTimeStamp_tk))
+                p++;
 
-         if (m_pHeap[q]->m_llTimeStamp_tk > m_pHeap[p]->m_llTimeStamp_tk)
-         {
-            swap(m_pHeap[p], m_pHeap[q]);
-            m_pHeap[p]->m_iHeapLoc = p;
-            m_pHeap[q]->m_iHeapLoc = q;
+            if (m_pHeap[q]->m_llTimeStamp_tk > m_pHeap[p]->m_llTimeStamp_tk)
+            {
+                swap(m_pHeap[p], m_pHeap[q]);
+                m_pHeap[p]->m_iHeapLoc = p;
+                m_pHeap[q]->m_iHeapLoc = q;
 
-            q = p;
-            p = q * 2 + 1;
-         }
-         else
-            break;
-      }
+                q = p;
+                p = q * 2 + 1;
+            }
+            else
+                break;
+        }
 
-      n->m_iHeapLoc = -1;
-   }
+        n->m_iHeapLoc = -1;
+    }
 
-   // the only event has been deleted, wake up immediately
-   if (0 == m_iLastEntry)
-      m_pTimer->interrupt();
+    // the only event has been deleted, wake up immediately
+    if (0 == m_iLastEntry)
+        m_pTimer->interrupt();
 }
 
 //
-CSndQueue::CSndQueue():
-m_WorkerThread(),
-m_pSndUList(NULL),
-m_pChannel(NULL),
-m_pTimer(NULL),
-m_WindowLock(),
-m_WindowCond(),
-m_bClosing(false)
+CSndQueue::CSndQueue()
+    : m_WorkerThread()
+    , m_pSndUList(NULL)
+    , m_pChannel(NULL)
+    , m_pTimer(NULL)
+    , m_WindowLock()
+    , m_WindowCond()
+    , m_bClosing(false)
 {
     pthread_cond_init(&m_WindowCond, NULL);
     pthread_mutex_init(&m_WindowLock, NULL);
@@ -492,56 +479,50 @@ m_bClosing(false)
 
 CSndQueue::~CSndQueue()
 {
-   m_bClosing = true;
+    m_bClosing = true;
 
-   if(m_pTimer != NULL)
-   {
+    if (m_pTimer != NULL)
+    {
         m_pTimer->interrupt();
-   }
+    }
 
-   pthread_mutex_lock(&m_WindowLock);
-   pthread_cond_signal(&m_WindowCond);
-   pthread_mutex_unlock(&m_WindowLock);
-   if (!pthread_equal(m_WorkerThread, pthread_t()))
-       pthread_join(m_WorkerThread, NULL);
-   pthread_cond_destroy(&m_WindowCond);
-   pthread_mutex_destroy(&m_WindowLock);
+    pthread_mutex_lock(&m_WindowLock);
+    pthread_cond_signal(&m_WindowCond);
+    pthread_mutex_unlock(&m_WindowLock);
+    if (!pthread_equal(m_WorkerThread, pthread_t()))
+        pthread_join(m_WorkerThread, NULL);
+    pthread_cond_destroy(&m_WindowCond);
+    pthread_mutex_destroy(&m_WindowLock);
 
-   delete m_pSndUList;
+    delete m_pSndUList;
 }
 
-void CSndQueue::init(CChannel* c, CTimer* t)
+void CSndQueue::init(CChannel *c, CTimer *t)
 {
-   m_pChannel = c;
-   m_pTimer = t;
-   m_pSndUList = new CSndUList;
-   m_pSndUList->m_pWindowLock = &m_WindowLock;
-   m_pSndUList->m_pWindowCond = &m_WindowCond;
-   m_pSndUList->m_pTimer = m_pTimer;
+    m_pChannel                 = c;
+    m_pTimer                   = t;
+    m_pSndUList                = new CSndUList;
+    m_pSndUList->m_pWindowLock = &m_WindowLock;
+    m_pSndUList->m_pWindowCond = &m_WindowCond;
+    m_pSndUList->m_pTimer      = m_pTimer;
 
-   ThreadName tn("SRT:SndQ:worker");
-   if (0 != pthread_create(&m_WorkerThread, NULL, CSndQueue::worker, this))
-   {
-       m_WorkerThread = pthread_t();
-       throw CUDTException(MJ_SYSTEMRES, MN_THREAD);
-   }
+    ThreadName tn("SRT:SndQ:worker");
+    if (0 != pthread_create(&m_WorkerThread, NULL, CSndQueue::worker, this))
+    {
+        m_WorkerThread = pthread_t();
+        throw CUDTException(MJ_SYSTEMRES, MN_THREAD);
+    }
 }
 
 #ifdef SRT_ENABLE_IPOPTS
-int CSndQueue::getIpTTL() const
-{
-   return m_pChannel ? m_pChannel->getIpTTL() : -1;
-}
+int CSndQueue::getIpTTL() const { return m_pChannel ? m_pChannel->getIpTTL() : -1; }
 
-int CSndQueue::getIpToS() const
-{
-   return m_pChannel ? m_pChannel->getIpToS() : -1;
-}
+int CSndQueue::getIpToS() const { return m_pChannel ? m_pChannel->getIpToS() : -1; }
 #endif
 
-void* CSndQueue::worker(void* param)
+void *CSndQueue::worker(void *param)
 {
-    CSndQueue* self = (CSndQueue*)param;
+    CSndQueue *self = (CSndQueue *)param;
 
     THREAD_STATE_INIT("SRT:SndQ:worker");
 
@@ -555,7 +536,7 @@ void* CSndQueue::worker(void* param)
     {
         uint64_t next_time = self->m_pSndUList->getNextProcTime();
 
-#if   defined(SRT_DEBUG_SNDQ_HIGHRATE)
+#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
         self->m_WorkerStats.lIteration++;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
@@ -563,17 +544,18 @@ void* CSndQueue::worker(void* param)
         {
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
             self->m_WorkerStats.lNotReadyTs++;
-#endif   /* SRT_DEBUG_SNDQ_HIGHRATE */
+#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
             // wait here if there is no sockets with data to be sent
             THREAD_PAUSED();
             pthread_mutex_lock(&self->m_WindowLock);
-            if (!self->m_bClosing && (self->m_pSndUList->m_iLastEntry < 0)) {
+            if (!self->m_bClosing && (self->m_pSndUList->m_iLastEntry < 0))
+            {
                 pthread_cond_wait(&self->m_WindowCond, &self->m_WindowLock);
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
                 self->m_WorkerStats.lCondWait++;
-#endif         /* SRT_DEBUG_SNDQ_HIGHRATE */
+#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
             }
             THREAD_RESUMED();
             pthread_mutex_unlock(&self->m_WindowLock);
@@ -585,17 +567,17 @@ void* CSndQueue::worker(void* param)
         uint64_t currtime;
         CTimer::rdtsc(currtime);
 
-#if      defined(SRT_DEBUG_SNDQ_HIGHRATE)
+#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
         if (self->m_ullDbgTime <= currtime)
         {
             fprintf(stdout,
-                "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",
-                self->m_WorkerStats.lIteration,
-                self->m_WorkerStats.lSleepTo,
-                self->m_WorkerStats.lNotReadyPop,
-                self->m_WorkerStats.lSendTo,
-                self->m_WorkerStats.lNotReadyTs,
-                self->m_WorkerStats.lCondWait);
+                    "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",
+                    self->m_WorkerStats.lIteration,
+                    self->m_WorkerStats.lSleepTo,
+                    self->m_WorkerStats.lNotReadyPop,
+                    self->m_WorkerStats.lSendTo,
+                    self->m_WorkerStats.lNotReadyTs,
+                    self->m_WorkerStats.lCondWait);
             memset(&self->m_WorkerStats, 0, sizeof(self->m_WorkerStats));
             self->m_ullDbgTime = currtime + self->m_ullDbgPeriod;
         }
@@ -606,318 +588,316 @@ void* CSndQueue::worker(void* param)
         {
             self->m_pTimer->sleepto(next_time);
 
-#if         defined(HAI_DEBUG_SNDQ_HIGHRATE)
+#if defined(HAI_DEBUG_SNDQ_HIGHRATE)
             self->m_WorkerStats.lSleepTo++;
-#endif      /* SRT_DEBUG_SNDQ_HIGHRATE */
+#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
         }
         THREAD_RESUMED();
 
         // it is time to send the next pkt
-        sockaddr* addr;
-        CPacket pkt;
+        sockaddr *addr;
+        CPacket   pkt;
         if (self->m_pSndUList->pop(addr, pkt) < 0)
         {
             continue;
 
-#if         defined(SRT_DEBUG_SNDQ_HIGHRATE)
+#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
             self->m_WorkerStats.lNotReadyPop++;
-#endif      /* SRT_DEBUG_SNDQ_HIGHRATE */
+#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
         }
         if (pkt.isControl())
         {
             HLOGC(mglog.Debug,
-                 log << self->CONID() << "chn:SENDING: " << MessageTypeStr(pkt.getType(), pkt.getExtendedType()));
+                  log << self->CONID() << "chn:SENDING: " << MessageTypeStr(pkt.getType(), pkt.getExtendedType()));
         }
         else
         {
             HLOGC(dlog.Debug,
-                log << self->CONID() << "chn:SENDING SIZE " << pkt.getLength() << " SEQ: " << pkt.getSeqNo());
+                  log << self->CONID() << "chn:SENDING SIZE " << pkt.getLength() << " SEQ: " << pkt.getSeqNo());
         }
         self->m_pChannel->sendto(addr, pkt);
 
-#if      defined(SRT_DEBUG_SNDQ_HIGHRATE)
+#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
         self->m_WorkerStats.lSendTo++;
-#endif   /* SRT_DEBUG_SNDQ_HIGHRATE */
+#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
     }
 
     THREAD_EXIT();
     return NULL;
 }
 
-int CSndQueue::sendto(const sockaddr* addr, CPacket& packet)
+int CSndQueue::sendto(const sockaddr *addr, CPacket &packet)
 {
-   // send out the packet immediately (high priority), this is a control packet
-   m_pChannel->sendto(addr, packet);
-   return (int) packet.getLength();
-}
-
-
-//
-CRcvUList::CRcvUList():
-m_pUList(NULL),
-m_pLast(NULL)
-{
-}
-
-CRcvUList::~CRcvUList()
-{
-}
-
-void CRcvUList::insert(const CUDT* u)
-{
-   CRNode* n = u->m_pRNode;
-   CTimer::rdtsc(n->m_llTimeStamp_tk);
-
-   if (NULL == m_pUList)
-   {
-      // empty list, insert as the single node
-      n->m_pPrev = n->m_pNext = NULL;
-      m_pLast = m_pUList = n;
-
-      return;
-   }
-
-   // always insert at the end for RcvUList
-   n->m_pPrev = m_pLast;
-   n->m_pNext = NULL;
-   m_pLast->m_pNext = n;
-   m_pLast = n;
-}
-
-void CRcvUList::remove(const CUDT* u)
-{
-   CRNode* n = u->m_pRNode;
-
-   if (!n->m_bOnList)
-      return;
-
-   if (NULL == n->m_pPrev)
-   {
-      // n is the first node
-      m_pUList = n->m_pNext;
-      if (NULL == m_pUList)
-         m_pLast = NULL;
-      else
-         m_pUList->m_pPrev = NULL;
-   }
-   else
-   {
-      n->m_pPrev->m_pNext = n->m_pNext;
-      if (NULL == n->m_pNext)
-      {
-         // n is the last node
-         m_pLast = n->m_pPrev;
-      }
-      else
-         n->m_pNext->m_pPrev = n->m_pPrev;
-   }
-
-   n->m_pNext = n->m_pPrev = NULL;
-}
-
-void CRcvUList::update(const CUDT* u)
-{
-   CRNode* n = u->m_pRNode;
-
-   if (!n->m_bOnList)
-      return;
-
-   CTimer::rdtsc(n->m_llTimeStamp_tk);
-
-   // if n is the last node, do not need to change
-   if (NULL == n->m_pNext)
-      return;
-
-   if (NULL == n->m_pPrev)
-   {
-      m_pUList = n->m_pNext;
-      m_pUList->m_pPrev = NULL;
-   }
-   else
-   {
-      n->m_pPrev->m_pNext = n->m_pNext;
-      n->m_pNext->m_pPrev = n->m_pPrev;
-   }
-
-   n->m_pPrev = m_pLast;
-   n->m_pNext = NULL;
-   m_pLast->m_pNext = n;
-   m_pLast = n;
+    // send out the packet immediately (high priority), this is a control packet
+    m_pChannel->sendto(addr, packet);
+    return (int)packet.getLength();
 }
 
 //
-CHash::CHash():
-m_pBucket(NULL),
-m_iHashSize(0)
+CRcvUList::CRcvUList()
+    : m_pUList(NULL)
+    , m_pLast(NULL)
+{
+}
+
+CRcvUList::~CRcvUList() {}
+
+void CRcvUList::insert(const CUDT *u)
+{
+    CRNode *n = u->m_pRNode;
+    CTimer::rdtsc(n->m_llTimeStamp_tk);
+
+    if (NULL == m_pUList)
+    {
+        // empty list, insert as the single node
+        n->m_pPrev = n->m_pNext = NULL;
+        m_pLast = m_pUList = n;
+
+        return;
+    }
+
+    // always insert at the end for RcvUList
+    n->m_pPrev       = m_pLast;
+    n->m_pNext       = NULL;
+    m_pLast->m_pNext = n;
+    m_pLast          = n;
+}
+
+void CRcvUList::remove(const CUDT *u)
+{
+    CRNode *n = u->m_pRNode;
+
+    if (!n->m_bOnList)
+        return;
+
+    if (NULL == n->m_pPrev)
+    {
+        // n is the first node
+        m_pUList = n->m_pNext;
+        if (NULL == m_pUList)
+            m_pLast = NULL;
+        else
+            m_pUList->m_pPrev = NULL;
+    }
+    else
+    {
+        n->m_pPrev->m_pNext = n->m_pNext;
+        if (NULL == n->m_pNext)
+        {
+            // n is the last node
+            m_pLast = n->m_pPrev;
+        }
+        else
+            n->m_pNext->m_pPrev = n->m_pPrev;
+    }
+
+    n->m_pNext = n->m_pPrev = NULL;
+}
+
+void CRcvUList::update(const CUDT *u)
+{
+    CRNode *n = u->m_pRNode;
+
+    if (!n->m_bOnList)
+        return;
+
+    CTimer::rdtsc(n->m_llTimeStamp_tk);
+
+    // if n is the last node, do not need to change
+    if (NULL == n->m_pNext)
+        return;
+
+    if (NULL == n->m_pPrev)
+    {
+        m_pUList          = n->m_pNext;
+        m_pUList->m_pPrev = NULL;
+    }
+    else
+    {
+        n->m_pPrev->m_pNext = n->m_pNext;
+        n->m_pNext->m_pPrev = n->m_pPrev;
+    }
+
+    n->m_pPrev       = m_pLast;
+    n->m_pNext       = NULL;
+    m_pLast->m_pNext = n;
+    m_pLast          = n;
+}
+
+//
+CHash::CHash()
+    : m_pBucket(NULL)
+    , m_iHashSize(0)
 {
 }
 
 CHash::~CHash()
 {
-   for (int i = 0; i < m_iHashSize; ++ i)
-   {
-      CBucket* b = m_pBucket[i];
-      while (NULL != b)
-      {
-         CBucket* n = b->m_pNext;
-         delete b;
-         b = n;
-      }
-   }
+    for (int i = 0; i < m_iHashSize; ++i)
+    {
+        CBucket *b = m_pBucket[i];
+        while (NULL != b)
+        {
+            CBucket *n = b->m_pNext;
+            delete b;
+            b = n;
+        }
+    }
 
-   delete [] m_pBucket;
+    delete[] m_pBucket;
 }
 
 void CHash::init(int size)
 {
-   m_pBucket = new CBucket* [size];
+    m_pBucket = new CBucket *[size];
 
-   for (int i = 0; i < size; ++ i)
-      m_pBucket[i] = NULL;
+    for (int i = 0; i < size; ++i)
+        m_pBucket[i] = NULL;
 
-   m_iHashSize = size;
+    m_iHashSize = size;
 }
 
-CUDT* CHash::lookup(int32_t id)
+CUDT *CHash::lookup(int32_t id)
 {
-   // simple hash function (% hash table size); suitable for socket descriptors
-   CBucket* b = m_pBucket[id % m_iHashSize];
+    // simple hash function (% hash table size); suitable for socket descriptors
+    CBucket *b = m_pBucket[id % m_iHashSize];
 
-   while (NULL != b)
-   {
-      if (id == b->m_iID)
-         return b->m_pUDT;
-      b = b->m_pNext;
-   }
+    while (NULL != b)
+    {
+        if (id == b->m_iID)
+            return b->m_pUDT;
+        b = b->m_pNext;
+    }
 
-   return NULL;
+    return NULL;
 }
 
-void CHash::insert(int32_t id, CUDT* u)
+void CHash::insert(int32_t id, CUDT *u)
 {
-   CBucket* b = m_pBucket[id % m_iHashSize];
+    CBucket *b = m_pBucket[id % m_iHashSize];
 
-   CBucket* n = new CBucket;
-   n->m_iID = id;
-   n->m_pUDT = u;
-   n->m_pNext = b;
+    CBucket *n = new CBucket;
+    n->m_iID   = id;
+    n->m_pUDT  = u;
+    n->m_pNext = b;
 
-   m_pBucket[id % m_iHashSize] = n;
+    m_pBucket[id % m_iHashSize] = n;
 }
 
 void CHash::remove(int32_t id)
 {
-   CBucket* b = m_pBucket[id % m_iHashSize];
-   CBucket* p = NULL;
+    CBucket *b = m_pBucket[id % m_iHashSize];
+    CBucket *p = NULL;
 
-   while (NULL != b)
-   {
-      if (id == b->m_iID)
-      {
-         if (NULL == p)
-            m_pBucket[id % m_iHashSize] = b->m_pNext;
-         else
-            p->m_pNext = b->m_pNext;
+    while (NULL != b)
+    {
+        if (id == b->m_iID)
+        {
+            if (NULL == p)
+                m_pBucket[id % m_iHashSize] = b->m_pNext;
+            else
+                p->m_pNext = b->m_pNext;
 
-         delete b;
+            delete b;
 
-         return;
-      }
+            return;
+        }
 
-      p = b;
-      b = b->m_pNext;
-   }
+        p = b;
+        b = b->m_pNext;
+    }
 }
 
-
 //
-CRendezvousQueue::CRendezvousQueue():
-m_lRendezvousID(),
-m_RIDVectorLock()
+CRendezvousQueue::CRendezvousQueue()
+    : m_lRendezvousID()
+    , m_RIDVectorLock()
 {
     pthread_mutex_init(&m_RIDVectorLock, NULL);
 }
 
 CRendezvousQueue::~CRendezvousQueue()
 {
-   pthread_mutex_destroy(&m_RIDVectorLock);
+    pthread_mutex_destroy(&m_RIDVectorLock);
 
-   for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++ i)
-   {
-      if (AF_INET == i->m_iIPversion)
-         delete (sockaddr_in*)i->m_pPeerAddr;
-      else
-         delete (sockaddr_in6*)i->m_pPeerAddr;
-   }
+    for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
+    {
+        if (AF_INET == i->m_iIPversion)
+            delete (sockaddr_in *)i->m_pPeerAddr;
+        else
+            delete (sockaddr_in6 *)i->m_pPeerAddr;
+    }
 
-   m_lRendezvousID.clear();
+    m_lRendezvousID.clear();
 }
 
-void CRendezvousQueue::insert(const SRTSOCKET& id, CUDT* u, int ipv, const sockaddr* addr, uint64_t ttl)
+void CRendezvousQueue::insert(const SRTSOCKET &id, CUDT *u, int ipv, const sockaddr *addr, uint64_t ttl)
 {
-   CGuard vg(m_RIDVectorLock);
+    CGuard vg(m_RIDVectorLock);
 
-   CRL r;
-   r.m_iID = id;
-   r.m_pUDT = u;
-   r.m_iIPversion = ipv;
-   r.m_pPeerAddr = (AF_INET == ipv) ? (sockaddr*)new sockaddr_in : (sockaddr*)new sockaddr_in6;
-   memcpy(r.m_pPeerAddr, addr, (AF_INET == ipv) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
-   r.m_ullTTL = ttl;
+    CRL r;
+    r.m_iID        = id;
+    r.m_pUDT       = u;
+    r.m_iIPversion = ipv;
+    r.m_pPeerAddr  = (AF_INET == ipv) ? (sockaddr *)new sockaddr_in : (sockaddr *)new sockaddr_in6;
+    memcpy(r.m_pPeerAddr, addr, (AF_INET == ipv) ? sizeof(sockaddr_in) : sizeof(sockaddr_in6));
+    r.m_ullTTL = ttl;
 
-   m_lRendezvousID.push_back(r);
+    m_lRendezvousID.push_back(r);
 }
 
-void CRendezvousQueue::remove(const SRTSOCKET& id, bool should_lock)
+void CRendezvousQueue::remove(const SRTSOCKET &id, bool should_lock)
 {
-   CGuard vg(m_RIDVectorLock, should_lock);
+    CGuard vg(m_RIDVectorLock, should_lock);
 
-   for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++ i)
-   {
-      if (i->m_iID == id)
-      {
-         if (AF_INET == i->m_iIPversion)
-            delete (sockaddr_in*)i->m_pPeerAddr;
-         else
-            delete (sockaddr_in6*)i->m_pPeerAddr;
+    for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
+    {
+        if (i->m_iID == id)
+        {
+            if (AF_INET == i->m_iIPversion)
+                delete (sockaddr_in *)i->m_pPeerAddr;
+            else
+                delete (sockaddr_in6 *)i->m_pPeerAddr;
 
-         m_lRendezvousID.erase(i);
+            m_lRendezvousID.erase(i);
 
-         return;
-      }
-   }
+            return;
+        }
+    }
 }
 
-CUDT* CRendezvousQueue::retrieve(const sockaddr* addr, ref_t<SRTSOCKET> r_id)
+CUDT *CRendezvousQueue::retrieve(const sockaddr *addr, ref_t<SRTSOCKET> r_id)
 {
-   CGuard vg(m_RIDVectorLock);
-   SRTSOCKET& id = *r_id;
+    CGuard     vg(m_RIDVectorLock);
+    SRTSOCKET &id = *r_id;
 
-   // TODO: optimize search
-   for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++ i)
-   {
-      if (CIPAddress::ipcmp(addr, i->m_pPeerAddr, i->m_iIPversion) && ((id == 0) || (id == i->m_iID)))
-      {
-         id = i->m_iID;
-         return i->m_pUDT;
-      }
-   }
+    // TODO: optimize search
+    for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
+    {
+        if (CIPAddress::ipcmp(addr, i->m_pPeerAddr, i->m_iIPversion) && ((id == 0) || (id == i->m_iID)))
+        {
+            id = i->m_iID;
+            return i->m_pUDT;
+        }
+    }
 
-   return NULL;
+    return NULL;
 }
 
-void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket& response)
+void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket &response)
 {
     CGuard vg(m_RIDVectorLock);
 
     if (m_lRendezvousID.empty())
         return;
 
-    HLOGC(mglog.Debug, log << "updateConnStatus: updating after getting pkt id=" << response.m_iID << " status: " << ConnectStatusStr(cst));
+    HLOGC(mglog.Debug,
+          log << "updateConnStatus: updating after getting pkt id=" << response.m_iID
+              << " status: " << ConnectStatusStr(cst));
 
 #if ENABLE_HEAVY_LOGGING
-    int debug_nupd = 0;
-    int debug_nrun = 0;
+    int debug_nupd  = 0;
+    int debug_nrun  = 0;
     int debug_nfail = 0;
 #endif
 
@@ -943,11 +923,12 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
         {
             // If no packet has been received from the peer,
             // avoid sending too many requests, at most 1 request per 250ms
-            const uint64_t then = i->m_pUDT->m_llLastReqTime;
-            const uint64_t now = CTimer::getTime();
-            const bool nowstime = (now - then) > 250000;
-            HLOGC(mglog.Debug, log << "RID:%" << i->m_iID << " then=" << then << " now=" << now << " passed=" << (now - then)
-                << "<=> 250000 -- now's " << (nowstime ? "" : "NOT ") << "the time");
+            const uint64_t then     = i->m_pUDT->m_llLastReqTime;
+            const uint64_t now      = CTimer::getTime();
+            const bool     nowstime = (now - then) > 250000;
+            HLOGC(mglog.Debug,
+                  log << "RID:%" << i->m_iID << " then=" << then << " now=" << now << " passed=" << (now - then)
+                      << "<=> 250000 -- now's " << (nowstime ? "" : "NOT ") << "the time");
 
             if (!nowstime)
                 continue;
@@ -971,21 +952,21 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
         // done when "it's not the time"?
         if (CTimer::getTime() >= i->m_ullTTL)
         {
-            HLOGC(mglog.Debug, log << "RendezvousQueue: EXPIRED ("
-                << (i->m_ullTTL ? "enforced on FAILURE" : "passed TTL")
-                << ". removing from queue");
+            HLOGC(mglog.Debug,
+                  log << "RendezvousQueue: EXPIRED (" << (i->m_ullTTL ? "enforced on FAILURE" : "passed TTL")
+                      << ". removing from queue");
             // connection timer expired, acknowledge app via epoll
             i->m_pUDT->m_bConnecting = false;
             CUDT::s_UDTUnited.m_EPoll.update_events(i->m_iID, i->m_pUDT->m_sPollID, UDT_EPOLL_ERR, true);
             /*
-                * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
-                * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
-                * and may crash here on next pass.
-                */
+             * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
+             * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
+             * and may crash here on next pass.
+             */
             if (AF_INET == i->m_iIPversion)
-                delete (sockaddr_in*)i->m_pPeerAddr;
+                delete (sockaddr_in *)i->m_pPeerAddr;
             else
-                delete (sockaddr_in6*)i->m_pPeerAddr;
+                delete (sockaddr_in6 *)i->m_pPeerAddr;
 
             // i_next was preincremented, but this is guaranteed to point to
             // the element next to erased one.
@@ -1042,29 +1023,28 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
     }
 
     HLOGC(mglog.Debug,
-        log << "updateConnStatus: " << debug_nupd << "/" << debug_nrun << " sockets updated ("
-        << (debug_nrun - debug_nupd) << " useless). REMOVED " << debug_nfail << " sockets."
-    );
+          log << "updateConnStatus: " << debug_nupd << "/" << debug_nrun << " sockets updated ("
+              << (debug_nrun - debug_nupd) << " useless). REMOVED " << debug_nfail << " sockets.");
 }
 
 //
-CRcvQueue::CRcvQueue():
-    m_WorkerThread(),
-    m_UnitQueue(),
-    m_pRcvUList(NULL),
-    m_pHash(NULL),
-    m_pChannel(NULL),
-    m_pTimer(NULL),
-    m_iPayloadSize(),
-    m_bClosing(false),
-    m_LSLock(),
-    m_pListener(NULL),
-    m_pRendezvousQueue(NULL),
-    m_vNewEntry(),
-    m_IDLock(),
-    m_mBuffer(),
-    m_PassLock(),
-    m_PassCond()
+CRcvQueue::CRcvQueue()
+    : m_WorkerThread()
+    , m_UnitQueue()
+    , m_pRcvUList(NULL)
+    , m_pHash(NULL)
+    , m_pChannel(NULL)
+    , m_pTimer(NULL)
+    , m_iPayloadSize()
+    , m_bClosing(false)
+    , m_LSLock()
+    , m_pListener(NULL)
+    , m_pRendezvousQueue(NULL)
+    , m_vNewEntry()
+    , m_IDLock()
+    , m_mBuffer()
+    , m_PassLock()
+    , m_PassCond()
 {
     pthread_mutex_init(&m_PassLock, NULL);
     pthread_cond_init(&m_PassCond, NULL);
@@ -1087,19 +1067,19 @@ CRcvQueue::~CRcvQueue()
     delete m_pRendezvousQueue;
 
     // remove all queued messages
-    for (map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.begin(); i != m_mBuffer.end(); ++ i)
+    for (map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.begin(); i != m_mBuffer.end(); ++i)
     {
         while (!i->second.empty())
         {
-            CPacket* pkt = i->second.front();
-            delete [] pkt->m_pcData;
+            CPacket *pkt = i->second.front();
+            delete[] pkt->m_pcData;
             delete pkt;
             i->second.pop();
         }
     }
 }
 
-void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel* cc, CTimer* t)
+void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel *cc, CTimer *t)
 {
     m_iPayloadSize = payload;
 
@@ -1109,9 +1089,9 @@ void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel* c
     m_pHash->init(hsize);
 
     m_pChannel = cc;
-    m_pTimer = t;
+    m_pTimer   = t;
 
-    m_pRcvUList = new CRcvUList;
+    m_pRcvUList        = new CRcvUList;
     m_pRendezvousQueue = new CRendezvousQueue;
 
     ThreadName tn("SRT:RcvQ:worker");
@@ -1122,130 +1102,136 @@ void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel* c
     }
 }
 
-void* CRcvQueue::worker(void* param)
+void *CRcvQueue::worker(void *param)
 {
-   CRcvQueue* self = (CRcvQueue*)param;
-   sockaddr_any sa (self->m_UnitQueue.getIPversion());
-   int32_t id = 0;
+    CRcvQueue *  self = (CRcvQueue *)param;
+    sockaddr_any sa(self->m_UnitQueue.getIPversion());
+    int32_t      id = 0;
 
-   THREAD_STATE_INIT("SRT:RcvQ:worker");
+    THREAD_STATE_INIT("SRT:RcvQ:worker");
 
-   CUnit* unit = 0;
-   EConnectStatus cst = CONN_AGAIN;
-   while (!self->m_bClosing)
-   {
-       bool have_received = false;
-       EReadStatus rst = self->worker_RetrieveUnit(Ref(id), Ref(unit), &sa);
-       if (rst == RST_OK)
-       {
-           if (id < 0)
-           {
-               // User error on peer. May log something, but generally can only ignore it.
-               // XXX Think maybe about sending some "connection rejection response".
-               HLOGC(mglog.Debug, log << self->CONID() << "RECEIVED negative socket id '" << id << "', rejecting (POSSIBLE ATTACK)");
-               continue;
-           }
+    CUnit *        unit = 0;
+    EConnectStatus cst  = CONN_AGAIN;
+    while (!self->m_bClosing)
+    {
+        bool        have_received = false;
+        EReadStatus rst           = self->worker_RetrieveUnit(Ref(id), Ref(unit), &sa);
+        if (rst == RST_OK)
+        {
+            if (id < 0)
+            {
+                // User error on peer. May log something, but generally can only ignore it.
+                // XXX Think maybe about sending some "connection rejection response".
+                HLOGC(mglog.Debug,
+                      log << self->CONID() << "RECEIVED negative socket id '" << id
+                          << "', rejecting (POSSIBLE ATTACK)");
+                continue;
+            }
 
-           // NOTE: cst state is being changed here.
-           // This state should be maintained through any next failed calls to worker_RetrieveUnit.
-           // Any error switches this to rejection, just for a case.
+            // NOTE: cst state is being changed here.
+            // This state should be maintained through any next failed calls to worker_RetrieveUnit.
+            // Any error switches this to rejection, just for a case.
 
-           // Note to rendezvous connection. This can accept:
-           // - ID == 0 - take the first waiting rendezvous socket
-           // - ID > 0  - find the rendezvous socket that has this ID.
-           if (id == 0)
-           {
-               // ID 0 is for connection request, which should be passed to the listening socket or rendezvous sockets
-               cst = self->worker_ProcessConnectionRequest(unit, &sa);
-           }
-           else
-           {
-               // Otherwise ID is expected to be associated with:
-               // - an enqueued rendezvous socket
-               // - a socket connected to a peer
-               cst = self->worker_ProcessAddressedPacket(id, unit, &sa);
-               // CAN RETURN CONN_REJECT, but m_RejectReason is already set
-           }
-           HLOGC(mglog.Debug, log << self->CONID() << "worker: result for the unit: " << ConnectStatusStr(cst));
-           if (cst == CONN_AGAIN)
-           {
-               HLOGC(mglog.Debug, log << self->CONID() << "worker: packet not dispatched, continuing reading.");
-               continue;
-           }
-           have_received = true;
-       }
-       else if (rst == RST_ERROR)
-       {
-           // According to the description by CChannel::recvfrom, this can be either of:
-           // - IPE: all errors except EBADF
-           // - socket was closed in the meantime by another thread: EBADF
-           // If EBADF, then it's expected that the "closing" state is also set.
-           // Check that just to report possible errors, but interrupt the loop anyway.
-           if (self->m_bClosing)
-           {
-               HLOGC(mglog.Debug, log << self->CONID() << "CChannel reported error, but Queue is closing - INTERRUPTING worker.");
-           }
-           else
-           {
-               LOGC(mglog.Fatal, log << self->CONID() << "CChannel reported ERROR DURING TRANSMISSION - IPE. INTERRUPTING worker anyway.");
-           }
-           cst = CONN_REJECT;
-           break;
-       }
-       // OTHERWISE: this is an "AGAIN" situation. No data was read, but the process should continue.
+            // Note to rendezvous connection. This can accept:
+            // - ID == 0 - take the first waiting rendezvous socket
+            // - ID > 0  - find the rendezvous socket that has this ID.
+            if (id == 0)
+            {
+                // ID 0 is for connection request, which should be passed to the listening socket or rendezvous sockets
+                cst = self->worker_ProcessConnectionRequest(unit, &sa);
+            }
+            else
+            {
+                // Otherwise ID is expected to be associated with:
+                // - an enqueued rendezvous socket
+                // - a socket connected to a peer
+                cst = self->worker_ProcessAddressedPacket(id, unit, &sa);
+                // CAN RETURN CONN_REJECT, but m_RejectReason is already set
+            }
+            HLOGC(mglog.Debug, log << self->CONID() << "worker: result for the unit: " << ConnectStatusStr(cst));
+            if (cst == CONN_AGAIN)
+            {
+                HLOGC(mglog.Debug, log << self->CONID() << "worker: packet not dispatched, continuing reading.");
+                continue;
+            }
+            have_received = true;
+        }
+        else if (rst == RST_ERROR)
+        {
+            // According to the description by CChannel::recvfrom, this can be either of:
+            // - IPE: all errors except EBADF
+            // - socket was closed in the meantime by another thread: EBADF
+            // If EBADF, then it's expected that the "closing" state is also set.
+            // Check that just to report possible errors, but interrupt the loop anyway.
+            if (self->m_bClosing)
+            {
+                HLOGC(mglog.Debug,
+                      log << self->CONID() << "CChannel reported error, but Queue is closing - INTERRUPTING worker.");
+            }
+            else
+            {
+                LOGC(mglog.Fatal,
+                     log << self->CONID()
+                         << "CChannel reported ERROR DURING TRANSMISSION - IPE. INTERRUPTING worker anyway.");
+            }
+            cst = CONN_REJECT;
+            break;
+        }
+        // OTHERWISE: this is an "AGAIN" situation. No data was read, but the process should continue.
 
+        // take care of the timing event for all UDT sockets
+        uint64_t currtime_tk;
+        CTimer::rdtsc(currtime_tk);
 
-       // take care of the timing event for all UDT sockets
-       uint64_t currtime_tk;
-       CTimer::rdtsc(currtime_tk);
+        CRNode * ul       = self->m_pRcvUList->m_pUList;
+        uint64_t ctime_tk = currtime_tk - 100000 * CTimer::getCPUFrequency();
+        while ((NULL != ul) && (ul->m_llTimeStamp_tk < ctime_tk))
+        {
+            CUDT *u = ul->m_pUDT;
 
-       CRNode* ul = self->m_pRcvUList->m_pUList;
-       uint64_t ctime_tk = currtime_tk - 100000 * CTimer::getCPUFrequency();
-       while ((NULL != ul) && (ul->m_llTimeStamp_tk < ctime_tk))
-       {
-           CUDT* u = ul->m_pUDT;
+            if (u->m_bConnected && !u->m_bBroken && !u->m_bClosing)
+            {
+                u->checkTimers();
+                self->m_pRcvUList->update(u);
+            }
+            else
+            {
+                HLOGC(mglog.Debug,
+                      log << CUDTUnited::CONID(u->m_SocketID) << " SOCKET broken, REMOVING FROM RCV QUEUE/MAP.");
+                // the socket must be removed from Hash table first, then RcvUList
+                self->m_pHash->remove(u->m_SocketID);
+                self->m_pRcvUList->remove(u);
+                u->m_pRNode->m_bOnList = false;
+            }
 
-           if (u->m_bConnected && !u->m_bBroken && !u->m_bClosing)
-           {
-               u->checkTimers();
-               self->m_pRcvUList->update(u);
-           }
-           else
-           {
-               HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << " SOCKET broken, REMOVING FROM RCV QUEUE/MAP.");
-               // the socket must be removed from Hash table first, then RcvUList
-               self->m_pHash->remove(u->m_SocketID);
-               self->m_pRcvUList->remove(u);
-               u->m_pRNode->m_bOnList = false;
-           }
+            ul = self->m_pRcvUList->m_pUList;
+        }
 
-           ul = self->m_pRcvUList->m_pUList;
-       }
+        if (have_received)
+        {
+            HLOGC(mglog.Debug,
+                  log << "worker: RECEIVED PACKET --> updateConnStatus. cst=" << ConnectStatusStr(cst) << " id=" << id
+                      << " pkt-payload-size=" << unit->m_Packet.getLength());
+        }
 
-       if ( have_received )
-       {
-           HLOGC(mglog.Debug, log << "worker: RECEIVED PACKET --> updateConnStatus. cst=" << ConnectStatusStr(cst)
-                   << " id=" << id << " pkt-payload-size=" << unit->m_Packet.getLength());
-       }
+        // Check connection requests status for all sockets in the RendezvousQueue.
+        // Pass the connection status from the last call of:
+        // worker_ProcessAddressedPacket --->
+        // worker_TryAsyncRend_OrStore --->
+        // CUDT::processAsyncConnectResponse --->
+        // CUDT::processConnectResponse
+        self->m_pRendezvousQueue->updateConnStatus(rst, cst, unit->m_Packet);
 
-       // Check connection requests status for all sockets in the RendezvousQueue.
-       // Pass the connection status from the last call of:
-       // worker_ProcessAddressedPacket --->
-       // worker_TryAsyncRend_OrStore --->
-       // CUDT::processAsyncConnectResponse --->
-       // CUDT::processConnectResponse 
-       self->m_pRendezvousQueue->updateConnStatus(rst, cst, unit->m_Packet);
+        // XXX updateConnStatus may have removed the connector from the list,
+        // however there's still m_mBuffer in CRcvQueue for that socket to care about.
+    }
 
-       // XXX updateConnStatus may have removed the connector from the list,
-       // however there's still m_mBuffer in CRcvQueue for that socket to care about.
-   }
-
-   THREAD_EXIT();
-   return NULL;
+    THREAD_EXIT();
+    return NULL;
 }
 
 #if ENABLE_LOGGING
-static string PacketInfo(const CPacket& pkt)
+static string PacketInfo(const CPacket &pkt)
 {
     ostringstream os;
     os << "TARGET=" << pkt.m_iID << " ";
@@ -1268,7 +1254,7 @@ static string PacketInfo(const CPacket& pkt)
 }
 #endif
 
-EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_unit, sockaddr* addr)
+EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit *> r_unit, sockaddr *addr)
 {
 #if !USE_BUSY_WAITING
     // This might be not really necessary, and probably
@@ -1279,10 +1265,12 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_
     // check waiting list, if new socket, insert it to the list
     while (ifNewEntry())
     {
-        CUDT* ne = getNewEntry();
+        CUDT *ne = getNewEntry();
         if (ne)
         {
-            HLOGC(mglog.Debug, log << CUDTUnited::CONID(ne->m_SocketID) << " SOCKET pending for connection - ADDING TO RCV QUEUE/MAP");
+            HLOGC(mglog.Debug,
+                  log << CUDTUnited::CONID(ne->m_SocketID)
+                      << " SOCKET pending for connection - ADDING TO RCV QUEUE/MAP");
             m_pRcvUList->insert(ne);
             m_pHash->insert(ne->m_SocketID, ne);
         }
@@ -1301,7 +1289,7 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_
 #if ENABLE_LOGGING
         LOGC(mglog.Error, log << CONID() << "LOCAL STORAGE DEPLETED. Dropping 1 packet: " << PacketInfo(temp));
 #endif
-        delete [] temp.m_pcData;
+        delete[] temp.m_pcData;
 
         // Be transparent for RST_ERROR, but ignore the correct
         // data read and fake that the packet was dropped.
@@ -1318,25 +1306,30 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_
     if (rst == RST_OK)
     {
         *r_id = r_unit->m_Packet.m_iID;
-        HLOGC(mglog.Debug, log << "INCOMING PACKET: BOUND=" << SockaddrToString(m_pChannel->bindAddress()) << " " << PacketInfo(r_unit->m_Packet));
+        HLOGC(mglog.Debug,
+              log << "INCOMING PACKET: BOUND=" << SockaddrToString(m_pChannel->bindAddress()) << " "
+                  << PacketInfo(r_unit->m_Packet));
     }
     return rst;
 }
 
-EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr* addr)
+EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit *unit, const sockaddr *addr)
 {
-    HLOGC(mglog.Debug, log << "Got sockID=0 from " << SockaddrToString(addr) << " - trying to resolve it as a connection request...");
+    HLOGC(mglog.Debug,
+          log << "Got sockID=0 from " << SockaddrToString(addr)
+              << " - trying to resolve it as a connection request...");
     // Introduced protection because it may potentially happen
     // that another thread could have closed the socket at
     // the same time and inject a bug between checking the
     // pointer for NULL and using it.
-    SRT_REJECT_REASON listener_ret = SRT_REJ_UNKNOWN;
-    bool have_listener = false;
+    SRT_REJECT_REASON listener_ret  = SRT_REJ_UNKNOWN;
+    bool              have_listener = false;
     {
         CGuard cg(m_LSLock);
         if (m_pListener)
         {
-            LOGC(mglog.Note, log << "PASSING request from: " << SockaddrToString(addr) << " to agent:" << m_pListener->socketID());
+            LOGC(mglog.Note,
+                 log << "PASSING request from: " << SockaddrToString(addr) << " to agent:" << m_pListener->socketID());
             listener_ret = m_pListener->processConnectRequest(addr, unit->m_Packet);
 
             // This function does return a code, but it's hard to say as to whether
@@ -1353,10 +1346,11 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     // ready to accept connection requests, but they are not being redirected to the listener
     // socket, as this is not a listener socket at all. This goes then HERE.
 
-    if ( have_listener ) // That is, the above block with m_pListener->processConnectRequest was executed
+    if (have_listener) // That is, the above block with m_pListener->processConnectRequest was executed
     {
-        LOGC(mglog.Note, log << CONID() << "Listener managed the connection request from: " << SockaddrToString(addr)
-            << " result:" << RequestTypeStr(UDTRequestType(listener_ret)));
+        LOGC(mglog.Note,
+             log << CONID() << "Listener managed the connection request from: " << SockaddrToString(addr)
+                 << " result:" << RequestTypeStr(UDTRequestType(listener_ret)));
         return listener_ret == SRT_REJ_UNKNOWN ? CONN_CONTINUE : CONN_REJECT;
     }
 
@@ -1364,10 +1358,10 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     return worker_TryAsyncRend_OrStore(0, unit, addr); // 0 id because the packet came in with that very ID.
 }
 
-EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr* addr)
+EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit *unit, const sockaddr *addr)
 {
-    CUDT* u = m_pHash->lookup(id);
-    if ( !u )
+    CUDT *u = m_pHash->lookup(id);
+    if (!u)
     {
         // Pass this to either async rendezvous connection,
         // or store the packet in the queue.
@@ -1379,8 +1373,9 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
     // addressed to an associated socket.
     if (!CIPAddress::ipcmp(addr, u->m_pPeerAddr, u->m_iIPversion))
     {
-        HLOGC(mglog.Debug, log << CONID() << "Packet for SID=" << id << " asoc with " << SockaddrToString(u->m_pPeerAddr)
-            << " received from " << SockaddrToString(addr) << " (CONSIDERED ATTACK ATTEMPT)");
+        HLOGC(mglog.Debug,
+              log << CONID() << "Packet for SID=" << id << " asoc with " << SockaddrToString(u->m_pPeerAddr)
+                  << " received from " << SockaddrToString(addr) << " (CONSIDERED ATTACK ATTEMPT)");
         // This came not from the address that is the peer associated
         // with the socket. Ignore it.
         return CONN_AGAIN;
@@ -1411,18 +1406,18 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
 // for a socket that does not expect to receive a normal connection
 // request. This can be then:
 // - a normal packet of whatever kind, just to be processed by the message loop
-// - a rendezvous connection 
+// - a rendezvous connection
 // This function then tries to manage the packet as a rendezvous connection
 // request in ASYNC mode; when this is not applicable, it stores the packet
 // in the "receiving queue" so that it will be picked up in the "main" thread.
-EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr* addr)
+EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit *unit, const sockaddr *addr)
 {
     // This 'retrieve' requires that 'id' be either one of those
     // stored in the rendezvous queue (see CRcvQueue::registerConnector)
     // or simply 0, but then at least the address must match one of these.
     // If the id was 0, it will be set to the actual socket ID of the returned CUDT.
-    CUDT* u = m_pRendezvousQueue->retrieve(addr, Ref(id));
-    if ( !u )
+    CUDT *u = m_pRendezvousQueue->retrieve(addr, Ref(id));
+    if (!u)
     {
         // this socket is then completely unknown to the system.
         // Note that this situation may also happen at a very unfortunate
@@ -1436,15 +1431,17 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
         // not belonging to the connection and not registered as rendezvous) as "possible
         // attach" and ignore it. This also should better protect the rendezvous socket
         // against a rogue connector.
-        if ( id == 0 )
+        if (id == 0)
         {
-            HLOGC(mglog.Debug, log << CONID() << "AsyncOrRND: no sockets expect connection from "
-                << SockaddrToString(addr) << " - POSSIBLE ATTACK, ignore packet");
+            HLOGC(mglog.Debug,
+                  log << CONID() << "AsyncOrRND: no sockets expect connection from " << SockaddrToString(addr)
+                      << " - POSSIBLE ATTACK, ignore packet");
         }
         else
         {
-            HLOGC(mglog.Debug, log << CONID() << "AsyncOrRND: no sockets expect socket " << id << " from "
-                << SockaddrToString(addr) << " - POSSIBLE ATTACK, ignore packet");
+            HLOGC(mglog.Debug,
+                  log << CONID() << "AsyncOrRND: no sockets expect socket " << id << " from " << SockaddrToString(addr)
+                      << " - POSSIBLE ATTACK, ignore packet");
         }
         return CONN_AGAIN; // This means that the packet should be ignored.
     }
@@ -1490,7 +1487,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
             // that we KNOW (by the cst == CONN_ACCEPT result) that the socket should be inserted
             // into the pending anteroom.
 
-            CUDT* ne = getNewEntry(); // This function actuall removes the entry and returns it.
+            CUDT *ne = getNewEntry(); // This function actuall removes the entry and returns it.
             // This **should** now always return a non-null value, but check it first
             // because if this accidentally isn't true, the call to worker_ProcessAddressedPacket will
             // result in redirecting it to here and so on until the call stack overflow. In case of
@@ -1500,7 +1497,9 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
             // differently throughout the functions).
             if (ne)
             {
-                HLOGC(mglog.Debug, log << CUDTUnited::CONID(ne->m_SocketID) << " SOCKET pending for connection - ADDING TO RCV QUEUE/MAP");
+                HLOGC(mglog.Debug,
+                      log << CUDTUnited::CONID(ne->m_SocketID)
+                          << " SOCKET pending for connection - ADDING TO RCV QUEUE/MAP");
                 m_pRcvUList->insert(ne);
                 m_pHash->insert(ne->m_SocketID, ne);
 
@@ -1511,25 +1510,29 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
                 // data packet that should have expected the connection to be already established. Therefore
                 // redirect it once again into worker_ProcessAddressedPacket here.
 
-                HLOGC(mglog.Debug, log << "AsyncOrRND: packet SWITCHED TO CONNECTED with ID=" << id
-                        << " -- passing to worker_ProcessAddressedPacket");
+                HLOGC(mglog.Debug,
+                      log << "AsyncOrRND: packet SWITCHED TO CONNECTED with ID=" << id
+                          << " -- passing to worker_ProcessAddressedPacket");
 
                 // Theoretically we should check if m_pHash->lookup(ne->m_SocketID) returns 'ne', but this
                 // has been just added to m_pHash, so the check would be extremely paranoid here.
                 cst = worker_ProcessAddressedPacket(id, unit, addr);
                 if (cst == CONN_REJECT)
                     return cst;
-                return CONN_ACCEPT; // this function usually will return CONN_CONTINUE, which doesn't represent current situation.
+                return CONN_ACCEPT; // this function usually will return CONN_CONTINUE, which doesn't represent current
+                                    // situation.
             }
             else
             {
-                LOGC(mglog.Error, log << "IPE: AsyncOrRND: packet SWITCHED TO CONNECTED, but ID=" << id
-                        << " is still not present in the socket ID dispatch hash - DISREGARDING");
+                LOGC(mglog.Error,
+                     log << "IPE: AsyncOrRND: packet SWITCHED TO CONNECTED, but ID=" << id
+                         << " is still not present in the socket ID dispatch hash - DISREGARDING");
             }
         }
         return cst;
     }
-    HLOGC(mglog.Debug, log << "AsyncOrRND: packet RESOLVED TO ID=" << id << " -- continuing through CENTRAL PACKET QUEUE");
+    HLOGC(mglog.Debug,
+          log << "AsyncOrRND: packet RESOLVED TO ID=" << id << " -- continuing through CENTRAL PACKET QUEUE");
     // This is where also the packets for rendezvous connection will be landing,
     // in case of a synchronous connection.
     storePkt(id, unit->m_Packet.clone());
@@ -1537,98 +1540,99 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
     return CONN_CONTINUE;
 }
 
-
 int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
 {
-   CGuard bufferlock(m_PassLock);
-   CPacket& packet = *r_packet;
+    CGuard   bufferlock(m_PassLock);
+    CPacket &packet = *r_packet;
 
-   map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
+    map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
 
-   if (i == m_mBuffer.end())
-   {
-      CTimer::condTimedWaitUS(&m_PassCond, &m_PassLock, 1000000);
+    if (i == m_mBuffer.end())
+    {
+        CTimer::condTimedWaitUS(&m_PassCond, &m_PassLock, 1000000);
 
-      i = m_mBuffer.find(id);
-      if (i == m_mBuffer.end())
-      {
-         packet.setLength(-1);
-         return -1;
-      }
-   }
+        i = m_mBuffer.find(id);
+        if (i == m_mBuffer.end())
+        {
+            packet.setLength(-1);
+            return -1;
+        }
+    }
 
-   // retrieve the earliest packet
-   CPacket* newpkt = i->second.front();
+    // retrieve the earliest packet
+    CPacket *newpkt = i->second.front();
 
-   if (packet.getLength() < newpkt->getLength())
-   {
-      packet.setLength(-1);
-      return -1;
-   }
+    if (packet.getLength() < newpkt->getLength())
+    {
+        packet.setLength(-1);
+        return -1;
+    }
 
-   // copy packet content
-   // XXX Check if this wouldn't be better done by providing
-   // copy constructor for DynamicStruct.
-   // XXX Another thing: this looks wasteful. This expects an already
-   // allocated memory on the packet, this thing gets the packet,
-   // copies it into the passed packet and then the source packet
-   // gets deleted. Why not simply return the originally stored packet,
-   // without copying, allocation and deallocation?
-   memcpy(packet.m_nHeader, newpkt->m_nHeader, CPacket::HDR_SIZE);
-   memcpy(packet.m_pcData, newpkt->m_pcData, newpkt->getLength());
-   packet.setLength(newpkt->getLength());
+    // copy packet content
+    // XXX Check if this wouldn't be better done by providing
+    // copy constructor for DynamicStruct.
+    // XXX Another thing: this looks wasteful. This expects an already
+    // allocated memory on the packet, this thing gets the packet,
+    // copies it into the passed packet and then the source packet
+    // gets deleted. Why not simply return the originally stored packet,
+    // without copying, allocation and deallocation?
+    memcpy(packet.m_nHeader, newpkt->m_nHeader, CPacket::HDR_SIZE);
+    memcpy(packet.m_pcData, newpkt->m_pcData, newpkt->getLength());
+    packet.setLength(newpkt->getLength());
 
-   delete [] newpkt->m_pcData;
-   delete newpkt;
+    delete[] newpkt->m_pcData;
+    delete newpkt;
 
-   // remove this message from queue,
-   // if no more messages left for this socket, release its data structure
-   i->second.pop();
-   if (i->second.empty())
-      m_mBuffer.erase(i);
+    // remove this message from queue,
+    // if no more messages left for this socket, release its data structure
+    i->second.pop();
+    if (i->second.empty())
+        m_mBuffer.erase(i);
 
-   return (int) packet.getLength();
+    return (int)packet.getLength();
 }
 
-int CRcvQueue::setListener(CUDT* u)
+int CRcvQueue::setListener(CUDT *u)
 {
-   CGuard lslock(m_LSLock);
+    CGuard lslock(m_LSLock);
 
-   if (NULL != m_pListener)
-      return -1;
+    if (NULL != m_pListener)
+        return -1;
 
-   m_pListener = u;
-   return 0;
+    m_pListener = u;
+    return 0;
 }
 
-void CRcvQueue::removeListener(const CUDT* u)
+void CRcvQueue::removeListener(const CUDT *u)
 {
-   CGuard lslock(m_LSLock);
+    CGuard lslock(m_LSLock);
 
-   if (u == m_pListener)
-      m_pListener = NULL;
+    if (u == m_pListener)
+        m_pListener = NULL;
 }
 
-void CRcvQueue::registerConnector(const SRTSOCKET& id, CUDT* u, int ipv, const sockaddr* addr, uint64_t ttl)
+void CRcvQueue::registerConnector(const SRTSOCKET &id, CUDT *u, int ipv, const sockaddr *addr, uint64_t ttl)
 {
-   HLOGC(mglog.Debug, log << "registerConnector: adding %" << id << " addr=" << SockaddrToString(addr) << " TTL=" << ttl);
-   m_pRendezvousQueue->insert(id, u, ipv, addr, ttl);
+    HLOGC(mglog.Debug,
+          log << "registerConnector: adding %" << id << " addr=" << SockaddrToString(addr) << " TTL=" << ttl);
+    m_pRendezvousQueue->insert(id, u, ipv, addr, ttl);
 }
 
-void CRcvQueue::removeConnector(const SRTSOCKET& id, bool should_lock)
+void CRcvQueue::removeConnector(const SRTSOCKET &id, bool should_lock)
 {
     HLOGC(mglog.Debug, log << "removeConnector: removing %" << id);
     m_pRendezvousQueue->remove(id, should_lock);
 
     CGuard bufferlock(m_PassLock);
 
-    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
+    map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
     if (i != m_mBuffer.end())
     {
-        HLOGC(mglog.Debug, log << "removeConnector: ... and its packet queue with " << i->second.size() << " packets collected");
+        HLOGC(mglog.Debug,
+              log << "removeConnector: ... and its packet queue with " << i->second.size() << " packets collected");
         while (!i->second.empty())
         {
-            delete [] i->second.front()->m_pcData;
+            delete[] i->second.front()->m_pcData;
             delete i->second.front();
             i->second.pop();
         }
@@ -1636,48 +1640,45 @@ void CRcvQueue::removeConnector(const SRTSOCKET& id, bool should_lock)
     }
 }
 
-void CRcvQueue::setNewEntry(CUDT* u)
+void CRcvQueue::setNewEntry(CUDT *u)
 {
-   HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
-   CGuard listguard(m_IDLock);
-   m_vNewEntry.push_back(u);
+    HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
+    CGuard listguard(m_IDLock);
+    m_vNewEntry.push_back(u);
 }
 
-bool CRcvQueue::ifNewEntry()
+bool CRcvQueue::ifNewEntry() { return !(m_vNewEntry.empty()); }
+
+CUDT *CRcvQueue::getNewEntry()
 {
-   return !(m_vNewEntry.empty());
+    CGuard listguard(m_IDLock);
+
+    if (m_vNewEntry.empty())
+        return NULL;
+
+    CUDT *u = (CUDT *)*(m_vNewEntry.begin());
+    m_vNewEntry.erase(m_vNewEntry.begin());
+
+    return u;
 }
 
-CUDT* CRcvQueue::getNewEntry()
+void CRcvQueue::storePkt(int32_t id, CPacket *pkt)
 {
-   CGuard listguard(m_IDLock);
+    CGuard bufferlock(m_PassLock);
 
-   if (m_vNewEntry.empty())
-      return NULL;
+    map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
 
-   CUDT* u = (CUDT*)*(m_vNewEntry.begin());
-   m_vNewEntry.erase(m_vNewEntry.begin());
+    if (i == m_mBuffer.end())
+    {
+        m_mBuffer[id].push(pkt);
+        pthread_cond_signal(&m_PassCond);
+    }
+    else
+    {
+        // avoid storing too many packets, in case of malfunction or attack
+        if (i->second.size() > 16)
+            return;
 
-   return u;
-}
-
-void CRcvQueue::storePkt(int32_t id, CPacket* pkt)
-{
-   CGuard bufferlock(m_PassLock);
-
-   map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
-
-   if (i == m_mBuffer.end())
-   {
-      m_mBuffer[id].push(pkt);
-      pthread_cond_signal(&m_PassCond);
-   }
-   else
-   {
-      //avoid storing too many packets, in case of malfunction or attack
-      if (i->second.size() > 16)
-         return;
-
-      i->second.push(pkt);
-   }
+        i->second.push(pkt);
+    }
 }

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -168,7 +168,7 @@ public:
 
       /// Update the timestamp of the UDT instance on the list.
       /// @param [in] u pointer to the UDT instance
-      /// @param [in] resechedule if the timestampe shoudl be rescheduled
+      /// @param [in] reschedule if the timestamp should be rescheduled
 
    void update(const CUDT* u, EReschedule reschedule);
 
@@ -415,7 +415,6 @@ private:
    pthread_cond_t m_WindowCond;
 
    volatile bool m_bClosing;		// closing the worker
-   pthread_cond_t m_ExitCond;
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)//>>debug high freq worker
    uint64_t m_ullDbgPeriod;
@@ -494,7 +493,6 @@ private:
    int m_iPayloadSize;                  // packet payload size
 
    volatile bool m_bClosing;            // closing the worker
-   pthread_cond_t m_ExitCond;
 
 private:
    int setListener(CUDT* u);


### PR DESCRIPTION
* [core] Refactored `CSndQueue::worker(...)`. Deleted unused `m_ExitCond` from `CSndQueue` and `CRcvQueue`
* [core] Refactored `CRcvBuffer::isRcvDataReady(...)`
* [core] Renamed timestamp to timestamp_us in `CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp_us)`
* [core] Renamed `CUDTSocket::m_TimeStamp` to `m_ClosureTimeStamp`
* [apps] Merged collapsible "if" statements 
* [core] Applied clang-format on "srtcore/queue.cpp"
* [core] Applied clang-format on "srtcore/core.cpp"