### PR TITLE
[core] Fixed checkTimers interval (100ms -> 10 ms)

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1183,8 +1183,8 @@ void *CRcvQueue::worker(void *param)
         uint64_t currtime_tk;
         CTimer::rdtsc(currtime_tk);
 
-        CRNode * ul       = self->m_pRcvUList->m_pUList;
-        uint64_t ctime_tk = currtime_tk - 100000 * CTimer::getCPUFrequency();
+        CRNode * ul             = self->m_pRcvUList->m_pUList;
+        const uint64_t ctime_tk = currtime_tk - CUDT::COMM_SYN_INTERVAL_US * CTimer::getCPUFrequency();
         while ((NULL != ul) && (ul->m_llTimeStamp_tk < ctime_tk))
         {
             CUDT *u = ul->m_pUDT;


### PR DESCRIPTION
There are two triggers to check timers on a receiving socket.
The first one is to check timers on every packet received. It is done in `CRcvQueue::worker_ProcessAddressedPacket(…)`.

The second place to check the timers is by a timeout in `CRcvQueue::worker(…)`.
The condition was to check the timers if the time of the last check for that socket was at least 100 ms in the past.
However, the timer needs to be checked every 10 ms, in accordance to the communication synchronization interval.

### Impact of the bug

Having a 100 ms check does not impact live transmission mode, because the receiver has a constant stream of incoming packets, that trigger timers check.

On the contrary, in file mode the sender first sends 16 packets and waits for an ACK packet from the receiver. And the waiting time might be 100 ms, that slows down the start of the transmission.