### PR TITLE
Fixed some problems reported by gcc 8

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2001,7 +2001,7 @@ SRTSOCKET CUDT::socket(int af, int, int)
       s_UDTUnited.setError(new CUDTException(e));
       return INVALID_SOCK;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
@@ -2027,7 +2027,7 @@ int CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2053,7 +2053,7 @@ int CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2078,7 +2078,7 @@ int CUDT::listen(SRTSOCKET u, int backlog)
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2124,7 +2124,7 @@ int CUDT::connect(
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2255,7 +2255,7 @@ int CUDT::send(SRTSOCKET u, const char* buf, int len, int)
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2304,7 +2304,7 @@ int CUDT::sendmsg(
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2331,7 +2331,7 @@ int CUDT::sendmsg2(
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2399,7 +2399,7 @@ int64_t CUDT::sendfile(
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2457,7 +2457,7 @@ int CUDT::select(
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;
@@ -2493,7 +2493,7 @@ int CUDT::selectEx(
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;
    }
-   catch (bad_alloc)
+   catch (bad_alloc&)
    {
       s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return ERROR;


### PR DESCRIPTION
This is the first portion. More problems are reported on `dev-pktinfo` branch. This at least solves some warnings as reported by gcc 8. Note that this compiler compiles in C++14 mode by default.