### PR TITLE
[core] Use busy wait only to refine below 1 ms.

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -443,15 +443,15 @@ public:
 
 public:
 
-      /// Sleep for "interval" CCs.
-      /// @param [in] interval CCs to sleep.
+      /// Sleep for "interval_tk" CCs.
+      /// @param [in] interval_tk CCs to sleep.
 
-   void sleep(uint64_t interval);
+   void sleep(uint64_t interval_tk);
 
-      /// Seelp until CC "nexttime".
-      /// @param [in] nexttime next time the caller is waken up.
+      /// Seelp until CC "nexttime_tk".
+      /// @param [in] nexttime_tk next time the caller is waken up.
 
-   void sleepto(uint64_t nexttime);
+   void sleepto(uint64_t nexttime_tk);
 
       /// Stop the sleep() or sleepto() methods.
 
@@ -508,7 +508,7 @@ private:
    uint64_t getTimeInMicroSec();
 
 private:
-   uint64_t m_ullSchedTime;             // next schedulled time
+   uint64_t m_ullSchedTime_tk;             // next schedulled time
 
    pthread_cond_t m_TickCond;
    pthread_mutex_t m_TickLock;


### PR DESCRIPTION
Use high accuracy busy waiting to wait only the remaining 1 ms (10 ms on Windows) of the waiting time.
Reduces idle CPU from around 20% to almost zero on Windows machines at low bitrates.

The solution is taken from #673, proposed by @oviano.