### PR TITLE
Added lacking IF_HEAVY_LOGGING for logging off. Removed duplicated def

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1048,12 +1048,7 @@ bool CRcvBuffer::getRcvReadyMsg(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpkt
 {
     *tsbpdtime = 0;
 
-#if ENABLE_HEAVY_LOGGING
-    const char* reason = "NOT RECEIVED";
-#define IF_HEAVY_LOGGING(instr) instr
-#else 
-#define IF_HEAVY_LOGGING(instr) (void)0
-#endif 
+    IF_HEAVY_LOGGING(const char* reason = "NOT RECEIVED");
 
     for (int i = m_iStartPos, n = m_iLastAckPos; i != n; i = (i + 1) % m_iSize)
     {

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -92,6 +92,8 @@ written by
 #define HLOGF(...)
 #define HLOGP(...)
 
+#define IF_HEAVY_LOGGING(instr) (void)0
+
 #endif
 
 namespace srt_logging


### PR DESCRIPTION
Lacking definition of `IF_HEAVY_LOGGING` for a case with `--disable-logging` caused treating it as a potential function call and caused compile error at use time.