### PR TITLE
[build] Removed version.h direct include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,11 +597,9 @@ if (ENABLE_SHARED)
 	if (MICROSOFT)
 		MafReadDir(srtcore filelist.maf
 			SOURCES_WIN32_SHARED SOURCES_srt_shared_win32
-			PRIVATE_HEADERS_WIN32_SHARED HEADERS_srt_shared_win32
 		)
 		
 		message(STATUS "WINDOWS detected: Adding sources to SRT shared project: ${SOURCES_srt_shared_win32}")
-		message(STATUS "WINDOWS detected: Adding private headers to SRT shared project: ${HEADERS_srt_shared_win32}")
 	endif()
 endif()
 

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -55,7 +55,3 @@ window.h
 
 SOURCES WIN32 SHARED
 srt_shared.rc
-
-PRIVATE HEADERS WIN32 SHARED
-../version.h
-


### PR DESCRIPTION
Fixing version.h reference in filelist.maf. Wrongfully added in #639.
@lewk2 please review if the build is still ok.