### PR TITLE
[core] Improved periodic NAK report timing

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9307,18 +9307,16 @@ void CUDT::checkNAKTimer(uint64_t currtime_tk)
      */
     const int loss_len = m_pRcvLossList->getLossLength();
     SRT_ASSERT(loss_len >= 0);
-    if (loss_len <= 0)
+
+    if (loss_len > 0)
     {
-        // If there are no losses so far, update the next NACK time,
-        // so that a loss report is not sent too erly right after a new loss happens.
-        m_ullNextNAKTime_tk = currtime_tk + m_ullNAKInt_tk;
-    }
-    else if (currtime_tk > m_ullNextNAKTime_tk)
-    {
-        // NAK timer expired, and there is loss to be reported.
+        if (currtime_tk <= m_ullNextNAKTime_tk)
+            return; // wait for next NAK time
+
         sendCtrl(UMSG_LOSSREPORT);
-        m_ullNextNAKTime_tk = currtime_tk + m_ullNAKInt_tk;
     }
+
+    m_ullNextNAKTime_tk = currtime_tk + m_ullNAKInt_tk;
 }
 
 bool CUDT::checkExpTimer(uint64_t currtime_tk)


### PR DESCRIPTION
### Periodic NAK Reports

Periodic NAK report is a mechanism for the receiver to periodically resend reports on the current loss list. Roughly, NAK interval equals to `max(300ms; RTT / 2)`. More precise description is [here](https://github.com/Haivision/srt/issues/701#issuecomment-508121973).

### Problem Statement 

Periodic NAK report timing **has several minor issues**. They are mainly described in #701.

Those issues can be split into two groups:
1. Periodic NAK report is triggered too early after a LOSS report for this very range of packets was already sent.
2. Newly detected loss is added to the general receiver's loss list, and sent too soon with all the previous packets detected as lost.

### Suggested Fix

`CUDT::checkNAKTimer()` is called with every incoming packet. Previously it was only checking if it is time to send NAK report. But if the receiver's loss list is empty, nothing happens.
This means a newly detected loss, observed after more than 300 ms from previous LOSS, will trigger sending immediate loss report, and almost immediate periodic NAK report with the same sequence range.

In this PR the `m_ullNextNAKTime_tk` is updated in case the receiver's loss list is empty. This fixes group 1 problems.
