### PR TITLE
Added UDT::devel_setfakeloss testing utility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,9 @@ if (ENABLE_MONOTONIC_CLOCK AND LINUX)
 	set (WITH_EXTRALIBS "${WITH_EXTRALIBS} ${NEED_CLOCK_GETTIME}")
 endif()
 
+if (ENABLE_DEVEL_API)
+	add_definitions(-DENABLE_DEVEL_API=1)
+endif()
 
 # This options is necessary on some systems; on a cross-ARM compiler it
 # has been detected, for example, that -lrt is necessary for some applications

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2826,6 +2826,23 @@ SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
    }
 }
 
+#if ENABLE_DEVEL_API
+void CUDT::setfakeloss(SRTSOCKET s, const std::string& conf)
+{
+    CUDTSocket* us = s_UDTUnited.locate(s);
+    if (!us)
+        return;
+
+    CUDT* u = us->m_pUDT;
+    if (!u)
+        return;
+
+    if (u->m_pSndQueue)
+        u->m_pSndQueue->setfakeloss(conf);
+}
+
+#endif
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -3256,5 +3273,12 @@ SRT_REJECT_REASON getrejectreason(SRTSOCKET u)
 {
     return CUDT::rejectReason(u);
 }
+
+#if ENABLE_DEVEL_API
+void devel_setfakeloss(UDTSOCKET u, const std::string& config)
+{
+    CUDT::setfakeloss(u, config);
+}
+#endif
 
 }  // namespace UDT

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -946,7 +946,8 @@ bool CRcvBuffer::getRcvFirstMsg(ref_t<uint64_t> r_tsbpdtime, ref_t<bool> r_passa
     }
     else if (*r_tsbpdtime != 0)
     {
-        HLOGC(dlog.Debug, log << "getRcvFirstMsg: no packets found");
+        HLOGC(dlog.Debug, log << "getRcvFirstMsg: no READY packets found (first playtime:"
+                << FormatTime(*r_tsbpdtime) << ")");
         return false;
     }
 

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -165,6 +165,26 @@ public:
    const sockaddr* bindAddress() { return &m_BindAddr; }
    const sockaddr_any& bindAddressAny() { return m_BindAddr; }
 
+#if ENABLE_DEVEL_API
+   void setfakeloss(const std::string& conf);
+   bool checkFakeLoss(int32_t seq) const;
+
+    struct FakeLossConfig
+    {
+        int config_length;
+        int config_interval;
+        FakeLossConfig(const std::string& f);
+
+        // Fakeloss state
+        int dcounter;
+        int flwcounter;
+    };
+
+private:
+    mutable UniquePtr<FakeLossConfig> m_fakeloss;
+
+#endif
+
 private:
    void setUDPSockOpt();
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -217,6 +217,10 @@ public: //API
         return SRT_ERROR;
     }
 
+#if ENABLE_DEVEL_API
+    static void setfakeloss(SRTSOCKET s, const std::string& conf);
+#endif
+
 public: // internal API
     static const SRTSOCKET INVALID_SOCK = -1;         // invalid socket descriptor
     static const int ERROR = -1;                      // socket api error returned value

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -401,6 +401,10 @@ public:
        m_bClosing = true;
    }
 
+#if ENABLE_DEVEL_API
+   void setfakeloss(const std::string& conf) { m_pChannel->setfakeloss(conf); }
+#endif
+
 private:
    static void* worker(void* param);
    pthread_t m_WorkerThread;

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -397,6 +397,10 @@ UDT_API void setlogflags(int flags);
 UDT_API bool setstreamid(UDTSOCKET u, const std::string& sid);
 UDT_API std::string getstreamid(UDTSOCKET u);
 
+#if ENABLE_DEVEL_API
+UDT_API void devel_setfakeloss(UDTSOCKET u, const std::string& config);
+#endif
+
 }  // namespace UDT
 
 // This is a log configuration used inside SRT.

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -31,6 +31,8 @@
 #include "srt_compat.h"
 #include "verbose.hpp"
 
+#include "udt.h"
+
 using namespace std;
 
 
@@ -329,6 +331,13 @@ void SrtCommon::InitParameters(string host, map<string,string> par)
         }
     }
 
+    if (par.count("fakeloss"))
+    {
+        m_fakeloss = par["fakeloss"];
+        par.erase("fakeloss");
+        Verb() << "Will do FAKE LOSS: " << m_fakeloss;
+    }
+
     // Assign the others here.
     m_options = par;
 }
@@ -518,6 +527,16 @@ int SrtCommon::ConfigurePost(SRTSOCKET sock)
     vector<string> failures;
 
     SrtConfigurePost(sock, m_options, &failures);
+
+    if (m_fakeloss != "")
+    {
+#if ENABLE_DEVEL_API
+        UDT::devel_setfakeloss(sock, m_fakeloss);
+#else
+        Verb() << "ERROR: fakeloss not enabled at compile time";
+        return -1;
+#endif
+    }
 
 
     if (!failures.empty())

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -50,6 +50,7 @@ protected:
     int m_outgoing_port = 0;
     string m_mode;
     string m_adapter;
+    string m_fakeloss;
     map<string, string> m_options; // All other options, as provided in the URI
     SRTSOCKET m_sock = SRT_INVALID_SOCK;
     SRTSOCKET m_bindsock = SRT_INVALID_SOCK;


### PR DESCRIPTION
This can be used from both `UDT::devel_setfakeloss` function and the `srt-test-live` application using the `fakeloss` attribute for SRT URI.

Syntax: `fakeloss=LENGTH+INTERVAL` where:

LENGTH: The number of consecutively dropped DATA packets
INTERVAL: how many packets are expected to be delivered normally between the loss events.

The real interval between packet loss events is a sum of these two plus a small random value from the range 8-24.