### PR TITLE
Added binding a socket used for multicast to the adapter address, if adapter was specified

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -1053,15 +1053,6 @@ protected:
                 Error(errno, "adding to multicast membership failed");
             }
 
-            if (adapter != "")
-            {
-                res = ::bind(m_sock, (sockaddr*)&maddr, sizeof maddr);
-                if ( res == status_error )
-                {
-                    Error(errno, "binding to user-specified adapter: " + adapter);
-                }
-            }
-
             attr.erase("multicast");
             attr.erase("adapter");
         }
@@ -1171,6 +1162,18 @@ public:
     UdpTarget(string host, int port, const map<string,string>& attr )
     {
         Setup(host, port, attr);
+        if (adapter != "")
+        {
+            sockaddr_in maddr = CreateAddrInet(adapter, 0);
+            in_addr addr = maddr.sin_addr;
+
+            int res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char*>(&addr), sizeof(addr));
+            if (res == -1)
+            {
+                Error(SysError(), "setsockopt/IP_MULTICAST_IF: " + adapter);
+            }
+        }
+
     }
 
     int Write(const char* data, size_t len, ostream &SRT_ATR_UNUSED = cout) override

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -1050,8 +1050,18 @@ protected:
 
             if ( res == status_error )
             {
-                throw runtime_error("adding to multicast membership failed");
+                Error(errno, "adding to multicast membership failed");
             }
+
+            if (adapter != "")
+            {
+                res = ::bind(m_sock, (sockaddr*)&maddr, sizeof maddr);
+                if ( res == status_error )
+                {
+                    Error(errno, "binding to user-specified adapter: " + adapter);
+                }
+            }
+
             attr.erase("multicast");
             attr.erase("adapter");
         }

--- a/docs/stransmit.md
+++ b/docs/stransmit.md
@@ -65,7 +65,7 @@ If you're having trouble, make sure this works, then add complexity one step at 
 General medium specification
 ----------------------------
 
-The media are specified as the standard URI format:
+The mediums are specified as the standard URI format:
 
 ```
     SCHEME://HOST:PORT?PARAM1=VALUE&PARAM2=VALUE...
@@ -84,7 +84,8 @@ can be handled by other applications from this project).
 Medium: FILE (including standard process pipes)
 -----------------------------------------------
 
-**NB!** File mode, except `file://con`, is not supported in *srt-file-transmit* tool!
+**NB!** File mode, except `file://con`, is not supported in the
+*srt-file-transmit* tool!
 
 The general syntax is: `file:///global/path/to/the/file`. No
 parameters in the URL are extracted. There's one (non-standard!)
@@ -107,8 +108,8 @@ UDP can only be used in listening mode for reading, and in calling mode
 for writing. The multicast specification is also possible. The specification
 and meaning of the fields in the URI depend on the mode.
 
-The **PORT** part is always mandatory and it designates the port number
-for either the target host or to be bound to read from.
+The **PORT** part is always mandatory and it designates either the port number
+for the target host or the port number to be bound to read from.
 
 For sending to unicast:
 
@@ -185,10 +186,10 @@ SRT can be connected using one of three connection modes:
   the peer, which must be **listener**, and this way it initiates the
 connection.
 
-- **listener**: the "agent" waits for being contacted by any peer **caller**
-  (note that a listener can accept multiple callers, but *srt-live-transmit*
-does not use this possibility - after the first connected one, it no longer
-accepts new connections).
+- **listener**: the "agent" waits to be contacted by any peer **caller**.
+Note that a listener can accept multiple callers, but *srt-live-transmit*
+does not use this ability; after the first connection, it no longer
+accepts new connections.
 
 - **rendezvous**: A one-to-one only connection where both parties are
   equivalent and both connect to one another simultaneously. Whoever happened

--- a/docs/stransmit.md
+++ b/docs/stransmit.md
@@ -116,7 +116,7 @@ For sending to unicast:
     udp://TARGET:PORT?parameters...
 ```
 
-* The **HOST** part is mandatory and designates the target host
+* The **HOST** part (here: TARGET) is mandatory and designates the target host
 
 * The **iptos** parameter designates the Type-Of-Service (TOS) field for
 outgoing packets via `IP_TOS` socket option.
@@ -131,8 +131,8 @@ For receiving from unicast:
 ```
 
 
-* The **HOST** part designates the local interface to bind.
-It's optional and defaults to 0.0.0.0 (`INADDR_ANY`).
+* The **HOST** part (here: LOCALADDR) designates the local interface to bind.
+It's optional (can be empty) and defaults to 0.0.0.0 (`INADDR_ANY`).
 
 
 For multicast the scheme is:
@@ -141,9 +141,9 @@ For multicast the scheme is:
     udp://GROUPADDR:PORT?parameters...
 ```
 
-* The **HOST** part is mandatory always and designates the target
-multicast group. The `@` character is handled in this case, but it's not
-necessary, as the IGMP addresses are recognized by their mask
+* The **HOST** part (here: GROUPADDR) is mandatory always and designates the
+target multicast group. The `@` character is handled in this case, but it's not
+necessary, as the IGMP addresses are recognized by their mask.
 
 
 For sending to a multicast group:
@@ -165,8 +165,10 @@ For receiving from a multicast group:
 the given multicast group can be reached (it's used to bind the socket)
 
 * The **source** parameter enforces the use of `IP_ADD_SOURCE_MEMBERSHIP`
-instead of `IP_ADD_MEMBERSHIP`
+instead of `IP_ADD_MEMBERSHIP` and the value is set to `imr_sourceaddr` field.
 
+Explanations for the symbols and terms used above can be found in POSIX
+manual pages, like `ip(7)` and on Microsoft docs pages under `IPPROTO_IP`.
 
 
 Medium: SRT

--- a/docs/stransmit.md
+++ b/docs/stransmit.md
@@ -1,5 +1,5 @@
 SRT Live Transmit
----------
+-----------------
 
 The *srt-live-transmit* tool is a universal data transport tool, which's
 intention is to transport data between SRT and other medium.
@@ -62,10 +62,29 @@ and you should see bars and tone right away.
 If you're having trouble, make sure this works, then add complexity one step at a time (multicast, push vs listen, etc)
 
 
+General medium specification
+----------------------------
+
+The media are specified as the standard URI format:
+
+```
+    SCHEME://HOST:PORT?PARAM1=VALUE&PARAM2=VALUE...
+```
+
+This application handles the following schemes:
+
+* `file` - for file or standard input and output
+* `udp` - UDP output (unicast and multicast)
+* `srt` - SRT connection
+
+(Note that this application doesn't support file as a medium, but this
+can be handled by other applications from this project).
+
+
 Medium: FILE (including standard process pipes)
 -----------------------------------------------
 
-**NB!** File mode, except `file://con` is supported in *srt-file-transmit* tool!
+**NB!** File mode, except `file://con`, is not supported in *srt-file-transmit* tool!
 
 The general syntax is: `file:///global/path/to/the/file`. No
 parameters in the URL are extracted. There's one (non-standard!)
@@ -80,29 +99,75 @@ Be careful with options being specified together with having standard
 output as output URI - some of them are not allowed as the extra output
 controlled by options might interfere with the data output.
 
+
 Medium: UDP
 -----------
 
 UDP can only be used in listening mode for reading, and in calling mode
-for writing. Therefore, when UDP is your \<input-uri\>, you usually
-specify the local port, e.g.:
+for writing. The multicast specification is also possible. The specification
+and meaning of the fields in the URI depend on the mode.
 
-    udp://:5555
+The **PORT** part is always mandatory and it designates the port number
+for either the target host or to be bound to read from.
 
-UDP handles two parameters: **iptos** and **ttl**.
-**iptos** will set the value of Type-Of-Service (TOS) field for outgoing packets via IP_TOS socket option.
-**ttl** parameter will set time-to-live value for outgoing packets via IP_TTL or IP_MULTICAST_TTL socket options.
-See IP protocol documentation for details.
+For sending to unicast:
 
-For a single host IP address (unicast):
-* **reading**: The *host* part or **adapter** parameter can specify the adapter. The *port* part is mandatory.
-* **writing**: Both *host* and *port* are mandatory. The **adapter** parameter is of no use.
+```
+    udp://TARGET:PORT?parameters...
+```
 
-If you use multicast IP address:
-* For reading, need extra `@` character before the *host* part so that the application subscribes to the multicast group before reading
-* The *host* part designates the multicast group (also as a resolvable name)
-* The *port* designates the port in the multicast group
-* The **adapter** parameter can be used to specify the adapter through which the given multicast group can be reached
+* The **HOST** part is mandatory and designates the target host
+
+* The **iptos** parameter designates the Type-Of-Service (TOS) field for
+outgoing packets via `IP_TOS` socket option.
+
+* The **ttl** parameter will set time-to-live value for outgoing packets via
+`IP_TTL` socket options.
+
+For receiving from unicast:
+
+```
+    udp://LOCALADDR:PORT?parameters...
+```
+
+
+* The **HOST** part designates the local interface to bind.
+It's optional and defaults to 0.0.0.0 (`INADDR_ANY`).
+
+
+For multicast the scheme is:
+
+```
+    udp://GROUPADDR:PORT?parameters...
+```
+
+* The **HOST** part is mandatory always and designates the target
+multicast group. The `@` character is handled in this case, but it's not
+necessary, as the IGMP addresses are recognized by their mask
+
+
+For sending to a multicast group:
+
+* The **iptos** parameter designates the Type-Of-Service (TOS) field for
+outgoing packets via `IP_TOS` socket option.
+
+* The **ttl** parameter will set time-to-live value for outgoing packets via
+`IP_MULTICAST_TTL` socket options.
+
+* The **adapter** parameter can be used to specify the adapter to be set
+through `IP_MULTICAST_IF` option to override the default device used for
+sending
+
+
+For receiving from a multicast group:
+
+* The **adapter** parameter can be used to specify the adapter through which
+the given multicast group can be reached (it's used to bind the socket)
+
+* The **source** parameter enforces the use of `IP_ADD_SOURCE_MEMBERSHIP`
+instead of `IP_ADD_MEMBERSHIP`
+
+
 
 Medium: SRT
 -----------
@@ -110,25 +175,37 @@ Medium: SRT
 Most important about SRT is that it can be either input or output and in
 both these cases it can work in listener, caller and rendezvous mode. SRT
 also handles several parameters special way, in addition to standard SRT
-options that can be set through the parameters:
-
-    srt://HOST:PORT?PARAM1=VALUE&PARAM2=VALUE...
+options that can be set through the parameters.
 
 SRT can be connected using one of three connection modes:
 
-- **caller**: the "agent" (this application) sends the connection request to the peer, which must be **listener**, and this way it initiates the connection.
-- **listener**: the "agent" waits for being contacted by any peer **caller** (note that a listener can accept multiple callers, but *srt-live-transmit* does not use this possibility - after the first connected one, it no longer accepts new connections).
-- **rendezvous**: A one-to-one only connection where both parties are equivalent and both connect to one another simultaneously. Whoever happened to start first (or succeeded to punch through the firewall) is meant to have initiated the connection.
+- **caller**: the "agent" (this application) sends the connection request to
+  the peer, which must be **listener**, and this way it initiates the
+connection.
 
-This mode can be specified explicitly using the **mode** parameter. When it's not specified, then it is "deduced" the following way:
+- **listener**: the "agent" waits for being contacted by any peer **caller**
+  (note that a listener can accept multiple callers, but *srt-live-transmit*
+does not use this possibility - after the first connected one, it no longer
+accepts new connections).
+
+- **rendezvous**: A one-to-one only connection where both parties are
+  equivalent and both connect to one another simultaneously. Whoever happened
+to start first (or succeeded to punch through the firewall) is meant to have
+initiated the connection.
+
+This mode can be specified explicitly using the **mode** parameter. When it's
+not specified, then it is "deduced" the following way:
 
 - `srt://:1234` - the *port* is specified (1234), but *host* is empty. This assumes **listener** mode.
 - `srt://remote.host.com:1234` - both *host* ***and*** *port* are specified. This assumes **caller** mode.
 
 When the `mode` parameter is specified explicitly, then the interpretation of the `host` part is the following:
 
-* For caller, it's always the destination host address. If this is empty, it is resolved to `0.0.0.0`, which usually should mean connecting to the local host
-* For listener, it defines the IP address of the local device on which the socket should listen, e.g.:
+* For caller, it's always the destination host address. If this is empty, it is
+resolved to `0.0.0.0`, which usually should mean connecting to the local host
+
+* For listener, it defines the IP address of the local device on which the
+socket should listen, e.g.:
 
 ```
 srt://10.10.10.100:5001?mode=listener

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1089,8 +1089,14 @@ protected:
 
         if (is_multicast)
         {
-            adapter = attr.count("adapter") ? attr.at("adapter") : string();
+            ip_mreq_source mreq_ssm;
+            ip_mreq mreq;
             sockaddr_in maddr;
+            int opt_name;
+            void* mreq_arg_ptr;
+            socklen_t mreq_arg_size;
+
+            adapter = attr.count("adapter") ? attr.at("adapter") : string();
             if ( adapter == "" )
             {
                 Verb() << "Multicast: home address: INADDR_ANY:" << port;
@@ -1104,14 +1110,30 @@ protected:
                 maddr = CreateAddrInet(adapter, port);
             }
 
-            ip_mreq mreq;
-            mreq.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
-            mreq.imr_interface.s_addr = maddr.sin_addr.s_addr;
+            if (attr.count("source"))
+            {
+                /* this is an ssm.  we need to use the right struct and opt */
+                opt_name = IP_ADD_SOURCE_MEMBERSHIP;
+                mreq_ssm.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
+                mreq_ssm.imr_interface.s_addr = maddr.sin_addr.s_addr;
+                inet_pton(AF_INET, attr.at("source").c_str(), &mreq_ssm.imr_sourceaddr);
+                mreq_arg_size = sizeof(mreq_ssm);
+                mreq_arg_ptr = &mreq_ssm;
+            }
+            else
+            {
+                opt_name = IP_ADD_MEMBERSHIP;
+                mreq.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
+                mreq.imr_interface.s_addr = maddr.sin_addr.s_addr;
+                mreq_arg_size = sizeof(mreq);
+                mreq_arg_ptr = &mreq;
+            }
+
 #ifdef _WIN32
-            const char* mreq_arg = (const char*)&mreq;
+            const char* mreq_arg = (const char*)mreq_arg_ptr;
             const auto status_error = SOCKET_ERROR;
 #else
-            const void* mreq_arg = &mreq;
+            const void* mreq_arg = mreq_arg_ptr;
             const auto status_error = -1;
 #endif
 
@@ -1131,20 +1153,11 @@ protected:
 #else
             Verb() << "Multicast(POSIX): will bind to IGMP address: " << host;
 #endif
-            int res = setsockopt(m_sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, mreq_arg, sizeof(mreq));
+            int res = setsockopt(m_sock, IPPROTO_IP, opt_name, mreq_arg, mreq_arg_size);
 
             if ( res == status_error )
             {
-                throw runtime_error("adding to multicast membership failed");
-            }
-
-            if (adapter != "")
-            {
-                res = ::bind(m_sock, (sockaddr*)&maddr, sizeof maddr);
-                if ( res == status_error )
-                {
-                    Error(errno, "binding to user-specified adapter: " + adapter);
-                }
+                Error(errno, "adding to multicast membership failed");
             }
 
             attr.erase("multicast");
@@ -1256,6 +1269,18 @@ public:
     UdpTarget(string host, int port, const map<string,string>& attr )
     {
         Setup(host, port, attr);
+        if (adapter != "")
+        {
+            sockaddr_in maddr = CreateAddrInet(adapter, 0);
+            in_addr addr = maddr.sin_addr.s_addr;
+
+            int res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char*>(&addr), sizeof(addr));
+            if ( res == status_error )
+            {
+                Error(SysError(), "setsockopt/IP_MULTICAST_IF: " + adapter);
+            }
+        }
+
     }
 
     void Write(const bytevector& data) override

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1137,6 +1137,16 @@ protected:
             {
                 throw runtime_error("adding to multicast membership failed");
             }
+
+            if (adapter != "")
+            {
+                res = ::bind(m_sock, (sockaddr*)&maddr, sizeof maddr);
+                if ( res == status_error )
+                {
+                    Error(errno, "binding to user-specified adapter: " + adapter);
+                }
+            }
+
             attr.erase("multicast");
             attr.erase("adapter");
         }


### PR DESCRIPTION
Fixes #956.

This changes also the existing behavior, as now if you specify the `adapter` parameter for `udp` URI, the socket used for sending will be also bound to this address. Please review if this change is acceptable.