### PR TITLE
[core] WSASend overlapped

### DIFF
--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -176,6 +176,9 @@ private:
 private:
 
    UDPSOCKET m_iSocket;                 // socket descriptor
+#ifdef _WIN32
+   mutable WSAOVERLAPPED m_SendOverlapped;
+#endif
    int m_iIpTTL;
    int m_iIpToS;
 #ifdef SRT_ENABLE_BINDTODEVICE


### PR DESCRIPTION
Added check of the `WSASend` result, as reported in #973.
Given that `::send(...)` wan not observed to fail on Linux, adding a common `::select(...)` call for both Windows and Linux might decrease the performance.
This PR uses Windows OverlappedIO API to wait for `WSASend` to suceed.
50 ms waiting time was chosen empiricaly. 10 ms produce more failures on sending.