### PR TITLE
CSndLossList::getLostSeq() renamed to popLostSeq()

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7855,7 +7855,7 @@ int CUDT::packLostData(CPacket &packet, uint64_t &origintime)
     // protect m_iSndLastDataAck from updating by ACK processing
     CGuard ackguard(m_RecvAckLock);
 
-    while ((packet.m_iSeqNo = m_pSndLossList->getLostSeq()) >= 0)
+    while ((packet.m_iSeqNo = m_pSndLossList->popLostSeq()) >= 0)
     {
         const int offset = CSeqNo::seqoff(m_iSndLastDataAck, packet.m_iSeqNo);
         if (offset < 0)

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -213,40 +213,38 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
          return 0;
    }
 
-   // coalesce with next node. E.g., [3, 7], ..., [6, 9] becomes [3, 9] 
+   // coalesce with next node. E.g., [3, 7], ..., [6, 9] becomes [3, 9]
    while ((-1 != m_caSeq[loc].next) && (-1 != m_caSeq[loc].data2))
    {
-      int i = m_caSeq[loc].next;
+      const int i = m_caSeq[loc].next;
 
-      if (CSeqNo::seqcmp(m_caSeq[i].data1, CSeqNo::incseq(m_caSeq[loc].data2)) <= 0)
+      if (CSeqNo::seqcmp(m_caSeq[i].data1, CSeqNo::incseq(m_caSeq[loc].data2)) > 0)
+         break;
+
+      // coalesce if there is overlap
+      if (-1 != m_caSeq[i].data2)
       {
-         // coalesce if there is overlap
-         if (-1 != m_caSeq[i].data2)
+         if (CSeqNo::seqcmp(m_caSeq[i].data2, m_caSeq[loc].data2) > 0)
          {
-            if (CSeqNo::seqcmp(m_caSeq[i].data2, m_caSeq[loc].data2) > 0)
-            {
-               if (CSeqNo::seqcmp(m_caSeq[loc].data2, m_caSeq[i].data1) >= 0)
-                  m_iLength -= CSeqNo::seqlen(m_caSeq[i].data1, m_caSeq[loc].data2);
+            if (CSeqNo::seqcmp(m_caSeq[loc].data2, m_caSeq[i].data1) >= 0)
+               m_iLength -= CSeqNo::seqlen(m_caSeq[i].data1, m_caSeq[loc].data2);
 
-               m_caSeq[loc].data2 = m_caSeq[i].data2;
-            }
-            else
-               m_iLength -= CSeqNo::seqlen(m_caSeq[i].data1, m_caSeq[i].data2);
+            m_caSeq[loc].data2 = m_caSeq[i].data2;
          }
          else
-         {
-            if (m_caSeq[i].data1 == CSeqNo::incseq(m_caSeq[loc].data2))
-               m_caSeq[loc].data2 = m_caSeq[i].data1;
-            else
-               m_iLength --;
-         }
-
-         m_caSeq[i].data1 = -1;
-         m_caSeq[i].data2 = -1;
-         m_caSeq[loc].next = m_caSeq[i].next;
+            m_iLength -= CSeqNo::seqlen(m_caSeq[i].data1, m_caSeq[i].data2);
       }
       else
-         break;
+      {
+         if (m_caSeq[i].data1 == CSeqNo::incseq(m_caSeq[loc].data2))
+            m_caSeq[loc].data2 = m_caSeq[i].data1;
+         else
+            m_iLength--;
+      }
+
+      m_caSeq[i].data1  = -1;
+      m_caSeq[i].data2  = -1;
+      m_caSeq[loc].next = m_caSeq[i].next;
    }
 
    return m_iLength - origlen;

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -364,18 +364,15 @@ void CSndLossList::remove(int32_t seqno)
    }
 }
 
-int CSndLossList::getLossLength()
+int CSndLossList::getLossLength() const
 {
    CGuard listguard(m_ListLock);
 
    return m_iLength;
 }
 
-int32_t CSndLossList::getLostSeq()
+int32_t CSndLossList::popLostSeq()
 {
-   if (0 == m_iLength)
-     return -1;
-
    CGuard listguard(m_ListLock);
 
    if (0 == m_iLength)

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -79,12 +79,12 @@ public:
       /// Read the loss length.
       /// @return The length of the list.
 
-   int getLossLength();
+   int getLossLength() const;
 
       /// Read the first (smallest) loss seq. no. in the list and remove it.
       /// @return The seq. no. or -1 if the list is empty.
 
-   int32_t getLostSeq();
+   int32_t popLostSeq();
 
 private:
    struct Seq
@@ -99,7 +99,7 @@ private:
    int m_iSize;                         // size of the static array
    int m_iLastInsertPos;                // position of last insert node
 
-   pthread_mutex_t m_ListLock;          // used to synchronize list operation
+   mutable pthread_mutex_t m_ListLock; // used to synchronize list operation
 
 private:
    CSndLossList(const CSndLossList&);


### PR DESCRIPTION
- Renamed `CSndLossList::getLostSeq()` to `popLostSeq()`
- Minor refactor of CSndLossList::insert()
- Extra check for length in `CSndLossList::popLostSeq()`

Suggested review method: by commit.