### PR TITLE
Added SonarCloud integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,26 @@ addons:
         - cmake
         - libssl-dev
         - build-essential
+    sonarcloud:
+        organization: "haivision"
+        token:
+            secure: "wJZC0kyyjuf4SZyonZ6p/5Ga9asEqSnKWF9NpRbu6S6ceERO7vbebuSJF5qX3A6ivPuw0TTk5WASOdnvIyfA28FU/D0MWRdH8K7T3w77wdE9EgAEYTUXzdrbzJY18+9pxjljHwWXWALPSGf3MClg4irWrdk1e6uHK+68R39+ZvBGBFpWeeZy/+at9+xwhtAGKBlSHe8zc+3wPxuYdvviLVJ25qbpNmnzkUR0X89G+UBl90raCPSN32EHFdImHZ5DxfEQQJgZFRjzQUY4EW/iYwaMel7jufAq0ClgV4psKujl9Lz8cPqx3WgqRfJyiIthOMTsac7G4zAw8LK2CI0VsssBp0JalLXaumi6vG7o6c3rIwKckzSKccq3pHa7h45praIVVn9s3nq+Q/JGA11FMkKQxdQtmwgFsLhbi6ZxabgsUi5KtWoWY2z6MgpJuROuAjNxZi9XJzUoJs7zSTUtRRW7V8Q2lRiOnknYh25N6TCA5bpyy1EZmRdJErm071YNI9P01gbFz5137FWJFiJzro9TGF0KoHSGiCIdUt3WlMzwr/i/wFLxFBQOZQ2rjTXvhs4hxONxMZV3gzxA1NdLaf9i5Mh6jxVMV+ujaRSV7JmPGzxqiAlpT9cJUhTCYuar9diLLeDrpe7RawEZR8V1xVDQ7yT8ruDNQ78VbSn/sC0="
     homebrew:
         packages:
         - openssl
 
 matrix:
     include:
-        - env: BUILD_TYPE=Debug
+        - os: linux
+          env:
+          - BUILD_TYPE=Debug
+          - BUILD_OPTS=-DENABLE_CODE_COVERAGE=ON
+          - RUN_SONARCUBE=1
         - env:
           - BUILD_TYPE=Debug
           - BUILD_OPTS=-DENABLE_LOGGING=OFF
-        - env: BUILD_TYPE=Release
+        - os: linux
+          env: BUILD_TYPE=Release
         - os: osx
           osx_image: xcode10.2
           env: BUILD_TYPE=Debug
@@ -54,5 +63,17 @@ script:
         export PKG_CONFIG_PATH=$(brew --prefix openssl)"/lib/pkgconfig";
         cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
       fi
-    - make
+    - echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG"
+    - echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
+    - if [[ "$TRAVIS_REPO_SLUG" != "Haivision/srt" || "$TRAVIS_PULL_REQUEST" -gt 0 ]]; then
+        export RUN_SONARCUBE=0;
+      fi
+    - echo "RUN_SONARCUBE=$RUN_SONARCUBE"
+    - if (( "$RUN_SONARCUBE" )); then
+        build-wrapper-linux-x86-64 --out-dir bw-output make;
+      else
+        make;
+      fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then ctest --extra-verbose; fi
+    - if (( "$RUN_SONARCUBE" )); then source ./scripts/collect-gcov.sh; fi
+    - if (( "$RUN_SONARCUBE" )); then sonar-scanner -D"sonar.cfamily.gcov.reportPath=."; fi

--- a/scripts/collect-gcov.sh
+++ b/scripts/collect-gcov.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+shopt -s globstar
+gcov_data_dir="."
+for x in ./**/*.o; do
+  echo "x: $x"
+  gcov "$gcov_data_dir/$x"
+done

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,36 @@
+# must be unique in a given SonarQube instance
+sonar.projectKey=srt
+sonar.organization=haivision
+
+# --- optional properties ---
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=srt
+#sonar.projectVersion=1.0
+ 
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+ 
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+# =====================================================
+#   Meta-data for the project
+# =====================================================
+
+sonar.links.homepage=https://github.com/Haivision/srt
+sonar.links.ci=https://travis-ci.org/Haivision/srt
+sonar.links.scm=https://github.com/Haivision/srt
+sonar.links.issue=https://github.com/Haivision/srt/issues
+
+
+# =====================================================
+#   Properties that will be shared amongst all modules
+# =====================================================
+
+# SQ standard properties
+sonar.sources=.
+
+# Properties specific to the C/C++ analyzer:
+sonar.cfamily.build-wrapper-output=bw-output
+sonar.cfamily.gcov.reportsPath=.


### PR DESCRIPTION
This PR adds integration with SonarCloud for static code checks and test coverage.
SonarCloud project URL: [https://sonarcloud.io/dashboard?id=srt](https://sonarcloud.io/dashboard?id=srt)

Condition `TRAVIS_REPO_SLUG == "Haivisio/srt"` should disable this checks if built in forks.
Potentially can use some environment variable like `RUN_SONARCUBE` to disable SonarQube check from Travis project config, without changing the yaml file.

### TODO

- [x] Disable sonarcloud build for pull requests (env var `TRAVIS_PULL_REQUEST`).

### Update

Turned out SonarCloud analysis in Travis is only supported for internal pull requests.
[Documentation](https://docs.travis-ci.com/user/sonarcloud/#analysis-of-internal-pull-requests)
[Travis Issue](https://github.com/travis-ci/travis-ci/issues/8379)

SonarCloud for GitHub Actions ([link](https://github.com/SonarSource/sonarcloud-github-action)) is not recomended for C++ projects. The recommendation is to use Travis, and this PR does.