### PR TITLE
[core] Catch exception from connect_complete.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -930,21 +930,6 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
    return 0;
 }
 
-void CUDTUnited::connect_complete(const SRTSOCKET u)
-{
-   CUDTSocket* s = locate(u);
-   if (!s)
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
-
-   // copy address information of local node
-   // the local port must be correctly assigned BEFORE CUDT::startConnect(),
-   // otherwise if startConnect() fails, the multiplexer cannot be located
-   // by garbage collection and will cause leak
-   s->m_pUDT->m_pSndQueue->m_pChannel->getSockAddr(s->m_pSelfAddr);
-   CIPAddress::pton(s->m_pSelfAddr, s->m_pUDT->m_piSelfIP, s->m_iIPversion);
-
-   s->m_Status = SRTS_CONNECTED;
-}
 
 int CUDTUnited::close(const SRTSOCKET u)
 {

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -227,7 +227,6 @@ private:
    static void TLSDestroy(void* e) {if (NULL != e) delete (CUDTException*)e;}
 
 private:
-   void connect_complete(const SRTSOCKET u);
    CUDTSocket* locate(const SRTSOCKET u);
    CUDTSocket* locate(const sockaddr* peer, const SRTSOCKET id, int32_t isn);
    void updateMux(CUDTSocket* s, const sockaddr* addr = NULL, const UDPSOCKET* = NULL);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4321,7 +4321,18 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
     m_pRcvQueue->removeConnector(m_SocketID, synchro);
 
     // acknowledge the management module.
-    s_UDTUnited.connect_complete(m_SocketID);
+    try {
+        s_UDTUnited.connect_complete(m_SocketID);
+    }
+    catch (const CUDTException & e)
+    {
+        if (eout)
+        {
+            *eout = CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+        }
+
+        return CONN_REJECT;
+    }
 
     // acknowledde any waiting epolls to write
     s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, UDT_EPOLL_OUT, true);


### PR DESCRIPTION
`CUDTUnited::connect_complete(...)` can throw an exception. It has to be handled. Refer too issue #971.
Alternative fix in #972 produces more changes, that can impact normal operation mode (without exception).

Further improvement of the socket closure while handshake is being processed should  be performed.
This PR only fixes obviously uncaught exception.