### PR TITLE
[core] htonl and ntohl moved to CPacket

### DIFF
--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -327,6 +327,42 @@ void CPacket::pack(UDTMessageType pkttype, const void* lparam, void* rparam, int
    }
 }
 
+void CPacket::toNL()
+{
+    // XXX USE HtoNLA!
+    if (isControl())
+    {
+        for (ptrdiff_t i = 0, n = getLength() / 4; i < n; ++i)
+            *((uint32_t*)m_pcData + i) = htonl(*((uint32_t*)m_pcData + i));
+    }
+
+    // convert packet header into network order
+    uint32_t* p = m_nHeader;
+    for (int j = 0; j < 4; ++j)
+    {
+        *p = htonl(*p);
+        ++p;
+    }
+}
+
+void CPacket::toHL()
+{
+    // convert back into local host order
+    uint32_t* p = m_nHeader;
+    for (int k = 0; k < 4; ++k)
+    {
+        *p = ntohl(*p);
+        ++p;
+    }
+
+    if (isControl())
+    {
+        for (ptrdiff_t l = 0, n = getLength() / 4; l < n; ++l)
+            *((uint32_t*) m_pcData + l) = ntohl(*((uint32_t*) m_pcData + l));
+    }
+}
+
+
 IOVector* CPacket::getPacketVector()
 {
    return m_PacketVector;

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -64,59 +64,59 @@ modified by
 // to the native structure for use in WSARecvFrom() and recvmsg(...) functions 
 class IOVector
 #ifdef _WIN32
-	: public WSABUF
+    : public WSABUF
 #else
-	: public iovec
+    : public iovec
 #endif
 {
 public:
 
-	inline void set(void  *buffer, size_t length)
-	{
+    inline void set(void  *buffer, size_t length)
+    {
 #ifdef _WIN32
-		len = (ULONG)length;
-		buf = (CHAR*)buffer;
+        len = (ULONG)length;
+        buf = (CHAR*)buffer;
 #else
-		iov_base = (void*)buffer;
-		iov_len = length;
+        iov_base = (void*)buffer;
+        iov_len = length;
 #endif
-	}
+    }
 
-	inline char*& dataRef()
-	{
+    inline char*& dataRef()
+    {
 #ifdef _WIN32
-		return buf;
+        return buf;
 #else
-		return (char*&) iov_base;
+        return (char*&) iov_base;
 #endif
-	}
+    }
 
-	inline char* data()
-	{
+    inline char* data()
+    {
 #ifdef _WIN32
-		return buf;
+        return buf;
 #else
-		return (char*)iov_base;
+        return (char*)iov_base;
 #endif
-	}
+    }
 
-	inline size_t size() const
-	{
+    inline size_t size() const
+    {
 #ifdef _WIN32
-		return (size_t) len;
+        return (size_t) len;
 #else
-		return iov_len;
+        return iov_len;
 #endif
-	}
+    }
 
-	inline void setLength(size_t length)
-	{
+    inline void setLength(size_t length)
+    {
 #ifdef _WIN32
-		len = length;
+        len = length;
 #else
-		iov_len = length;
+        iov_len = length;
 #endif
-	}
+    }
 };
 
 
@@ -355,6 +355,10 @@ public:
 
        PV_SIZE = 2
    };
+
+public:
+    void toNL();
+    void toHL();
 
 protected:
    // Length in bytes


### PR DESCRIPTION
- [x] Moved byte reordering of the packet into the CPacket public functions for consistency.
- [x] Replaced tabs with spaces