### PR TITLE
Fixed deprecated option declarations to work in C mode

### DIFF
--- a/examples/recvlive.cpp
+++ b/examples/recvlive.cpp
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
    // use this function to initialize the UDT library
    srt_startup();
 
-   srt_setloglevel(logging::LogLevel::debug);
+   srt_setloglevel(srt_logging::LogLevel::debug);
 
    addrinfo hints;
    addrinfo* res;

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -78,7 +78,7 @@ written by
 #define SRT_ATR_NODISCARD [[nodiscard]]
 
 // GNUG is GNU C++; this syntax is also supported by Clang
-#elif defined( __GNUG__)
+#elif defined( __GNUC__)
 #define SRT_ATR_UNUSED __attribute__((unused))
 #define SRT_ATR_DEPRECATED __attribute__((deprecated))
 #define SRT_ATR_NODISCARD __attribute__((warn_unused_result))
@@ -185,6 +185,22 @@ typedef enum SRT_SOCKOPT {
    SRTO_PACKETFILTER = 60          // Add and configure a packet filter
 } SRT_SOCKOPT;
 
+#ifdef __cplusplus
+
+    // In C++, declare the value of THE SAME enum type, but as a static constant
+    #define SRT_DECLARE_DEPRECATED_OPT(name, value) \
+        const SRT_SOCKOPT name SRT_ATR_DEPRECATED = (SRT_SOCKOPT)value;
+
+#else
+
+    // In C, declare them as a separate enum, as it's not an error in C to mix enum types
+    typedef enum SRT_SOCKOPT_DEPRECATED
+    {
+    #define SRT_DECLARE_DEPRECATED_OPT(name, value) \
+        name SRT_ATR_DEPRECATED = value,
+
+#endif
+
 // DEPRECATED OPTIONS:
 
 // SRTO_TWOWAYDATA: not to be used. SRT connection is always bidirectional if
@@ -194,36 +210,47 @@ typedef enum SRT_SOCKOPT {
 // differences between bidirectional support (especially concerning encryption)
 // with HSv4 and HSv5 (that is, HSv4 was decided to remain unidirectional only,
 // even though partial support is already provided in this version).
-static const SRT_SOCKOPT SRTO_TWOWAYDATA SRT_ATR_DEPRECATED = (SRT_SOCKOPT)37;
+
+SRT_DECLARE_DEPRECATED_OPT(SRT_TWOWAYDATA, 37)
 
 // This has been deprecated a long time ago, treat this as never implemented.
 // The value is also already reused for another option.
-static const SRT_SOCKOPT SRTO_TSBPDMAXLAG SRT_ATR_DEPRECATED = (SRT_SOCKOPT)32;
+SRT_DECLARE_DEPRECATED_OPT(SRTO_TSBPDMAXLAG, 32)
 
 // This option is a derivative from UDT; the mechanism that uses it is now
 // settable by SRTO_CONGESTION, or more generally by SRTO_TRANSTYPE. The freed
 // number has been reused for a read-only option SRTO_ISN. This option should
 // have never been used anywhere, just for safety this is temporarily declared
 // as deprecated.
-static const SRT_SOCKOPT SRTO_CC SRT_ATR_DEPRECATED = (SRT_SOCKOPT)3;
+SRT_DECLARE_DEPRECATED_OPT(SRTO_CC, 3)
 
 // These two flags were derived from UDT, but they were never used.
 // Probably it didn't make sense anyway. The maximum size of the message
 // in File/Message mode is defined by SRTO_SNDBUF, and the MSGTTL is
 // a parameter used in `srt_sendmsg` and `srt_sendmsg2`.
-static const SRT_SOCKOPT SRTO_MAXMSG SRT_ATR_DEPRECATED = (SRT_SOCKOPT)10;
-static const SRT_SOCKOPT SRTO_MSGTTL SRT_ATR_DEPRECATED = (SRT_SOCKOPT)11;
+SRT_DECLARE_DEPRECATED_OPT(SRTO_MAXMSG, 10)
+SRT_DECLARE_DEPRECATED_OPT(SRTO_MSGTTL, 11)
 
 // These flags come from an older experimental implementation of bidirectional
 // encryption support, which were used two different SEKs, KEKs and passphrases
 // per direction. The current implementation uses just one in both directions,
 // so SRTO_PBKEYLEN should be used for both cases.
-static const SRT_SOCKOPT SRTO_SNDPBKEYLEN SRT_ATR_DEPRECATED = (SRT_SOCKOPT)38;
-static const SRT_SOCKOPT SRTO_RCVPBKEYLEN SRT_ATR_DEPRECATED = (SRT_SOCKOPT)39;
+SRT_DECLARE_DEPRECATED_OPT(SRTO_SNDPBKEYLEN, 38)
+SRT_DECLARE_DEPRECATED_OPT(SRTO_RCVPBKEYLEN, 39)
 
 // Keeping old name for compatibility (deprecated)
-static const SRT_SOCKOPT SRTO_SMOOTHER SRT_ATR_DEPRECATED = SRTO_CONGESTION;
-static const SRT_SOCKOPT SRTO_STRICTENC SRT_ATR_DEPRECATED = SRTO_ENFORCEDENCRYPTION;
+SRT_DECLARE_DEPRECATED_OPT(SRTO_SMOOTHER, 47)
+SRT_DECLARE_DEPRECATED_OPT(SRTO_STRICTENC, 53)
+
+#ifdef __cplusplus
+// That's it. In C++ no postfix needed
+#else
+
+// Dummy last option, as every entry ends with a comma
+    SRTO_DEPRECATED_END = 0
+
+} SRT_SOCKOPT_DEPRECATED;
+#endif
 
 typedef enum SRT_TRANSTYPE
 {


### PR DESCRIPTION
Fixes #986 

Changes:

1. Deprecated options use different solutions in C and C++:
- C++: usual static const of the same type as other options
- C: a separate enum type for these options, with deprecation marker

2. Fixed: public attributes available now for both C and C++ for GNU-compatible compilers

3. Fixed build break in an example: `srt_logging` namespace should be used