### PR TITLE
Short Functions: freeUnitAt, shift. Minor log improvements and refax.

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1734,7 +1734,7 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 }
 
 #if ENABLE_HEAVY_LOGGING
-int CRcvBuffer::readMsgHeavyLogging(int p)
+void CRcvBuffer::readMsgHeavyLogging(int p)
 {
     static uint64_t prev_now;
     static uint64_t prev_srctime;

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -345,6 +345,10 @@ public:
 
    int readMsg(char* data, int len);
 
+#if ENABLE_HEAVY_LOGGING
+   void readMsgHeavyLogging(int p);
+#endif
+
       /// read a message.
       /// @param [out] data buffer to write the message into.
       /// @param [in] len size of the buffer.
@@ -362,9 +366,9 @@ public:
 
    bool isRcvDataReady(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpktseq);
 #ifdef SRT_DEBUG_TSBPD_OUTJITTER
-   void debugJitter(uint64_t);
+   void debugTraceJitter(uint64_t);
 #else
-   void debugJitter(uint64_t) {}
+   void debugTraceJitter(uint64_t) {}
 #endif   /* SRT_DEBUG_TSBPD_OUTJITTER */
 
    bool isRcvDataReady();
@@ -411,9 +415,9 @@ public:
    void skipData(int len);
 
 #if ENABLE_HEAVY_LOGGING
-   void reportBufferStats(); // Heavy logging Debug only
+   void reportBufferStats() const; // Heavy logging Debug only
 #endif
-   bool empty()
+   bool empty() const
    {
        // This will not always return the intended value,
        // that is, it may return false when the buffer really is
@@ -423,8 +427,8 @@ public:
        // is going to be broken - so this behavior is acceptable.
        return m_iStartPos == m_iLastAckPos;
    }
-   bool full() { return m_iStartPos == (m_iLastAckPos+1)%m_iSize; }
-   int capacity() { return m_iSize; }
+   bool full() const { return m_iStartPos == (m_iLastAckPos+1)%m_iSize; }
+   int capacity() const { return m_iSize; }
 
 
 private:

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -491,14 +491,14 @@ private:
    }
 
    // Simplified versions with ++ and --; avoid using division instruction
-   int shift_forward(int basepos) const
+   int shiftFwd(int basepos) const
    {
        if (++basepos == m_iSize)
            return 0;
        return basepos;
    }
 
-   int shift_backward(int basepos) const
+   int shiftBack(int basepos) const
    {
        if (basepos == 0)
            return m_iSize-1;

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -60,6 +60,19 @@ modified by
 #include "utilities.h"
 #include <fstream>
 
+// The notation used for "circular numbers" in comments:
+// The "cicrular numbers" are numbers that when increased up to the
+// maximum become zero, and similarly, when the zero value is decreased,
+// it turns into the maximum value minus one. This wrapping works the
+// same for adding and subtracting. Circular numbers cannot be multiplied.
+
+// Operations done on these numbers are marked with additional % character:
+// a %> b : a is later than b
+// a ++% (++%a) : shift a by 1 forward
+// a +% b : shift a by b
+// a == b : equality is same as for just numbers
+
+
 class CSndBuffer
 {
 public:
@@ -240,11 +253,11 @@ public:
     // Currently just "unimplemented".
     std::string CONID() const { return ""; }
 
-
+   static const int DEFAULT_SIZE = 65536;
       /// Construct the buffer.
       /// @param [in] queue  CUnitQueue that actually holds the units (packets)
       /// @param [in] bufsize_pkts in units (packets)
-   CRcvBuffer(CUnitQueue* queue, int bufsize_pkts = 65536);
+   CRcvBuffer(CUnitQueue* queue, int bufsize_pkts = DEFAULT_SIZE);
    ~CRcvBuffer();
 
 
@@ -348,6 +361,12 @@ public:
       /// both cases).
 
    bool isRcvDataReady(ref_t<uint64_t> tsbpdtime, ref_t<int32_t> curpktseq);
+#ifdef SRT_DEBUG_TSBPD_OUTJITTER
+   void debugJitter(uint64_t);
+#else
+   void debugJitter(uint64_t) {}
+#endif   /* SRT_DEBUG_TSBPD_OUTJITTER */
+
    bool isRcvDataReady();
    bool isRcvDataAvailable()
    {
@@ -394,8 +413,33 @@ public:
 #if ENABLE_HEAVY_LOGGING
    void reportBufferStats(); // Heavy logging Debug only
 #endif
+   bool empty()
+   {
+       // This will not always return the intended value,
+       // that is, it may return false when the buffer really is
+       // empty - but it will return true then in one of next calls.
+       // This function will be always called again at some point
+       // if it returned false, and on true the connection
+       // is going to be broken - so this behavior is acceptable.
+       return m_iStartPos == m_iLastAckPos;
+   }
+   bool full() { return m_iStartPos == (m_iLastAckPos+1)%m_iSize; }
+   int capacity() { return m_iSize; }
+
 
 private:
+   /// This gives up unit at index p. The unit is given back to the
+   /// free unit storage for further assignment for the new incoming
+   /// data.
+   size_t freeUnitAt(size_t p)
+   {
+       CUnit* u = m_pUnit[p];
+       m_pUnit[p] = NULL;
+       size_t rmbytes = u->m_Packet.getLength();
+       m_pUnitQueue->makeUnitFree(u);
+       return rmbytes;
+   }
+
       /// Adjust receive queue to 1st ready to play message (tsbpdtime < now).
       // Parameters (of the 1st packet queue, ready to play or not):
       /// @param [out] tsbpdtime localtime-based (uSec) packet time stamp including buffering delay of 1st packet or 0 if none
@@ -420,8 +464,8 @@ public:
 public:
    uint64_t getPktTsbPdTime(uint32_t timestamp);
    int debugGetSize() const;
-   bool empty() const;
-
+   uint64_t debugGetDeliveryTime(int offset);
+   
    // Required by PacketFilter facility to use as a storage
    // for provided packets
    CUnitQueue* getUnitQueue()
@@ -441,17 +485,42 @@ private:
 private:
    bool scanMsg(ref_t<int> start, ref_t<int> end, ref_t<bool> passack);
 
+   int shift(int basepos, int shift) const
+   {
+       return (basepos + shift) % m_iSize;
+   }
+
+   // Simplified versions with ++ and --; avoid using division instruction
+   int shift_forward(int basepos) const
+   {
+       if (++basepos == m_iSize)
+           return 0;
+       return basepos;
+   }
+
+   int shift_backward(int basepos) const
+   {
+       if (basepos == 0)
+           return m_iSize-1;
+       return --basepos;
+   }
+
 private:
-   CUnit** m_pUnit;                     // pointer to the protocol buffer (array of CUnit* items)
-   const int m_iSize;                   // size of the array of CUnit* items
+   CUnit** m_pUnit;                     // Array of pointed units collected in the buffer
+   const int m_iSize;                   // Size of the internal array of CUnit* items
    CUnitQueue* m_pUnitQueue;            // the shared unit queue
 
-   int m_iStartPos;                     // the head position for I/O (inclusive)
-   int m_iLastAckPos;                   // the last ACKed position (exclusive)
+   int m_iStartPos;                     // HEAD: first packet available for reading
+   int m_iLastAckPos;                   // the last ACKed position (exclusive), follows the last readable
                                         // EMPTY: m_iStartPos = m_iLastAckPos   FULL: m_iStartPos = m_iLastAckPos + 1
-   int m_iMaxPos;                       // the furthest data position
+   int m_iMaxPos;                       // delta between acked-TAIL and reception-TAIL
+
 
    int m_iNotch;                        // the starting read point of the first unit
+                                        // (this is required for stream reading mode; it's
+                                        // the position in the first unit in the list
+                                        // up to which data are already retrieved;
+                                        // in message reading mode it's unused and always 0)
 
    pthread_mutex_t m_BytesCountLock;    // used to protect counters operations
    int m_iBytesCount;                   // Number of payload bytes in the buffer

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -60,19 +60,6 @@ modified by
 #include "utilities.h"
 #include <fstream>
 
-// The notation used for "circular numbers" in comments:
-// The "cicrular numbers" are numbers that when increased up to the
-// maximum become zero, and similarly, when the zero value is decreased,
-// it turns into the maximum value minus one. This wrapping works the
-// same for adding and subtracting. Circular numbers cannot be multiplied.
-
-// Operations done on these numbers are marked with additional % character:
-// a %> b : a is later than b
-// a ++% (++%a) : shift a by 1 forward
-// a +% b : shift a by b
-// a == b : equality is same as for just numbers
-
-
 class CSndBuffer
 {
 public:


### PR DESCRIPTION
Changes:
* added two simplification functions:
   - freeUnitAt: should be used always when a unit is going to be removed from the buffer (and freed for later use)
   - `shift` group ( + `_forward` and `_backward`): shortcut for advancing and demoting a rolling number that is an index to a circular buffer
* Some improvements in comments
* Improvements in debug logs
* Refax of the debugging stuff (`debugJitter` taken out the function to improve readability)