### PR TITLE
Made order in includes

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -50,13 +50,14 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include <exception>
 #include <stdexcept>
 #include <typeinfo>
 #include <iterator>
 
 #include <cstring>
-#include "platform_sys.h"
 #include "api.h"
 #include "core.h"
 #include "logging.h"

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -50,6 +50,8 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include <cstring>
 #include <cmath>
 #include "buffer.h"

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -38,10 +38,8 @@ written by
    Yunhong Gu, last updated 05/05/2009
 *****************************************************************************/
 
-#ifdef _WIN32
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
-#endif
+
+#include "platform_sys.h"
 
 #include <cstring>
 #include "cache.h"

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -50,24 +50,7 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifndef _WIN32
-   #if __APPLE__
-      #include "TargetConditionals.h"
-   #endif
-   #include <sys/socket.h>
-   #include <sys/ioctl.h>
-   #include <netdb.h>
-   #include <arpa/inet.h>
-   #include <unistd.h>
-   #include <fcntl.h>
-   #include <cstring>
-   #include <cstdio>
-   #include <cerrno>
-#else
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
-   #include <mswsock.h>
-#endif
+#include "platform_sys.h"
 
 #include <iostream>
 #include <iomanip> // Logging 
@@ -382,7 +365,7 @@ void CChannel::setIpToS(int tos)
 
 int CChannel::ioctlQuery(int SRT_ATR_UNUSED type) const
 {
-#ifdef unix
+#if defined(unix) || defined(__APPLE__)
     int value = 0;
     int res = ::ioctl(m_iSocket, type, &value);
     if ( res != -1 )
@@ -393,7 +376,7 @@ int CChannel::ioctlQuery(int SRT_ATR_UNUSED type) const
 
 int CChannel::sockoptQuery(int SRT_ATR_UNUSED level, int SRT_ATR_UNUSED option) const
 {
-#ifdef unix
+#if defined(unix) || defined(__APPLE__)
     int value = 0;
     socklen_t len = sizeof (int);
     int res = ::getsockopt(m_iSocket, level, option, &value, &len);

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -53,7 +53,7 @@ modified by
 #ifndef __UDT_CHANNEL_H__
 #define __UDT_CHANNEL_H__
 
-
+#include "platform_sys.h"
 #include "udt.h"
 #include "packet.h"
 #include "netinet_any.h"

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -50,25 +50,8 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-
-#ifndef _WIN32
-   #include <cstring>
-   #include <cerrno>
-   #include <unistd.h>
-   #if __APPLE__
-      #include "TargetConditionals.h"
-   #endif
-   #if defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
-      #include <mach/mach_time.h>
-   #endif
-#else
-   #include <winsock2.h>
-   #include <ws2tcpip.h>
-   #include <win/wintime.h>
-#ifndef __MINGW__
-   #include <intrin.h>
-#endif
-#endif
+#define SRT_IMPORT_TIME 1
+#include "platform_sys.h"
 
 #include <string>
 #include <sstream>

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -12,7 +12,7 @@
 // This is a controversial thing, so temporarily blocking
 //#define SRT_ENABLE_SYSTEMBUFFER_TRACE
 
-
+#include "platform_sys.h"
 
 
 #ifdef SRT_ENABLE_SYSTEMBUFFER_TRACE

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -50,17 +50,8 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#include <netdb.h>
-#include <arpa/inet.h>
-#include <cerrno>
-#include <cstring>
-#include <cstdlib>
-#else
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
+#include "platform_sys.h"
+
 #include <cmath>
 #include <sstream>
 #include "srt.h"

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -13,6 +13,8 @@ written by
    Haivision Systems Inc.
  *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include <cstring>
 #include <string>
 #include <sstream>

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -50,22 +50,9 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifdef LINUX
-   #include <sys/epoll.h>
-   #include <unistd.h>
-#endif
-#if __APPLE__
-   #include "TargetConditionals.h"
-#endif
-#if defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
-   #include <sys/types.h>
-   #include <sys/event.h>
-   #include <sys/time.h>
-   #include <unistd.h>
-#endif
-#if defined(__ANDROID__) || defined(ANDROID)
-   #include <sys/select.h>
-#endif
+#define SRT_IMPORT_EVENT
+#include "platform_sys.h"
+
 #include <algorithm>
 #include <cerrno>
 #include <cstring>

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -43,6 +43,8 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include <cstring>
 #include <string>
 #include <sstream>

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -50,6 +50,8 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include "list.h"
 #include "packet.h"
 

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -159,6 +159,7 @@ modified by
 //      For any single loss or consectutive loss less than 2 packets, use
 //      the original sequence numbers in the field.
 
+#include "platform_sys.h"
 
 #include <cstring>
 #include "packet.h"

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -56,6 +56,7 @@ modified by
 #include "udt.h"
 #include "common.h"
 #include "utilities.h"
+#include "netinet_any.h"
 #include "packetfilter_api.h"
 
 //////////////////////////////////////////////////////////////////////////////

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -10,25 +10,89 @@
 #ifndef INC__PLATFORM_SYS_H
 #define INC__PLATFORM_SYS_H
 
+// INFORMATION
+//
+// This file collects all required platform-specific declarations
+// required to provide everything that the SRT library needs from system.
+//
+// There's also semi-modular system implemented using SRT_IMPORT_* macros.
+// To require a module to be imported, #define SRT_IMPORT_* where * is
+// the module name. Currently handled module macros:
+//
+// SRT_IMPORT_TIME   (mach time on Mac, portability gettimeofday on WIN32)
+// SRT_IMPORT_EVENT  (includes kevent on Mac)
+
+
 #ifdef _WIN32
+   #define _CRT_SECURE_NO_WARNINGS 1 // silences windows complaints for sscanf
    #include <winsock2.h>
    #include <ws2tcpip.h>
    #include <ws2ipdef.h>
    #include <windows.h>
+
+#ifndef __MINGW__
+   #include <intrin.h>
+#endif
+
+   #ifdef SRT_IMPORT_TIME
+   #include <win/wintime.h>
+   #endif
+
    #include <stdint.h>
    #include <inttypes.h>
    #if defined(_MSC_VER)
       #pragma warning(disable:4251)
    #endif
 #else
+
+#if __APPLE__
+// XXX Check if this condition doesn't require checking of
+// also other macros, like TARGET_OS_IOS etc.
+
+#include "TargetConditionals.h"
+#define __APPLE_USE_RFC_3542 /* IPV6_PKTINFO */
+
+
+#ifdef SRT_IMPORT_TIME
+      #include <mach/mach_time.h>
+#endif
+
+#ifdef SRT_IMPORT_EVENT
+   #include <sys/types.h>
+   #include <sys/event.h>
+   #include <sys/time.h>
+   #include <unistd.h>
+#endif
+
+#endif
+
+#ifdef LINUX
+
+#ifdef SRT_IMPORT_EVENT
+   #include <sys/epoll.h>
+   #include <unistd.h>
+#endif
+
+#endif
+
+#if defined(__ANDROID__) || defined(ANDROID)
+
+#ifdef SRT_IMPORT_EVENT
+   #include <sys/select.h>
+#endif
+
+#endif
+
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <sys/time.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
-#include <netdb.h>
+#include <fcntl.h>
+
 #endif
 
 #endif

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -50,10 +50,8 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-#ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
+#include "platform_sys.h"
+
 #include <cstring>
 
 #include "common.h"

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -13,11 +13,10 @@ written by
    Haivision Systems Inc.
  *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include <iterator>
 #include <fstream>
-#if __APPLE__
-   #include "TargetConditionals.h"
-#endif
 #include "srt.h"
 #include "common.h"
 #include "core.h"

--- a/srtcore/srt_compat.h
+++ b/srtcore/srt_compat.h
@@ -78,6 +78,7 @@ SRT_API const char * SysStrError(int errnum, char * buf, size_t buflen);
 
 
 #include <string>
+#include <cstring>
 inline std::string SysStrError(int errnum)
 {
     char buf[1024];

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -50,6 +50,8 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
+#include "platform_sys.h"
+
 #include <cmath>
 #include <cstring>
 #include "common.h"


### PR DESCRIPTION
Changes:

1. Removed all platform-related includes from everywhere - replaced by `#include "platform_sys.h"`
2. The platform include file is armed with all possible platform-related include files.