### PR TITLE
Improvements and fixes in sockaddr_any

### DIFF
--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -35,6 +35,13 @@ struct sockaddr_any
     };
     socklen_t len;
 
+    void reset()
+    {
+        // sin6 is the largest field
+        memset(&sin6, 0, sizeof sin6);
+        len = 0;
+    }
+
     // Default domain is unspecified, and
     // in this case the size is 0.
     // Note that AF_* (and alias PF_*) types have
@@ -44,11 +51,7 @@ struct sockaddr_any
     explicit sockaddr_any(int domain = AF_UNSPEC)
     {
         // Default domain is "unspecified", 0
-        // The intermediate variable required to clear out warning
-        // by specifying that "I know what I'm doing" by memset-clearing
-        // a nontrivial object.
-        void* object_begin = this;
-        memset(object_begin, 0, sizeof *this);
+        reset();
 
         // Overriding family as required in the parameters
         // and the size then accordingly.
@@ -111,12 +114,7 @@ struct sockaddr_any
         }
         else
         {
-            // Error fallback: no other families than IP are regarded.
-            void* object_begin = this;
-
-            // This embraces setting sockaddr::sa_family = AF_UNSPEC
-            // and sockaddr_any::len = 0.
-            memset(object_begin, 0, sizeof *this);
+            reset();
         }
     }
 

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -140,33 +140,33 @@ struct sockaddr_any
     {
         switch (family)
         {
-        case AF_INET: return socklen_t(sizeof (sockaddr_in));
-        case AF_INET6: return socklen_t(sizeof (sockaddr_in6));
+        case AF_INET:
+            return socklen_t(sizeof (sockaddr_in));
 
-        default: return 0; // fallback
+        case AF_INET6:
+            return socklen_t(sizeof (sockaddr_in6));
+
+        default:
+            return 0; // fallback
         }
     }
 
     bool empty() const
     {
-        switch (sa.sa_family)
+        bool isempty = true;  // unspec-family address is always empty
+
+        if (sa.sa_family == AF_INET)
         {
-        case AF_INET:
-            return sin.sin_port == 0 && sin.sin_addr.s_addr == 0;
-
-        case AF_INET6:
-            if (sin6.sin6_port != 0)
-                return false;
-
-            // This length expression should result in 4, as
-            // the size of sin6_addr is 16.
-            for (size_t i = 0; i < (sizeof sin6.sin6_addr)/sizeof(int32_t); ++i)
-                if (((int32_t*)&sin6.sin6_addr)[i] != 0)
-                    return false;
-            return true;
+            isempty = (sin.sin_port == 0
+                    && sin.sin_addr.s_addr == 0);
         }
-
-        return true; // unspec-family address is always empty
+        else if (sa.sa_family == AF_INET6)
+        {
+            isempty = (sin6.sin6_port == 0
+                    && memcmp(&sin6.sin6_addr, &in6addr_any, sizeof in6addr_any) == 0);
+        }
+        // otherwise isempty stays with default false
+        return isempty;
     }
 
     socklen_t size() const

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -35,25 +35,145 @@ struct sockaddr_any
     };
     socklen_t len;
 
-    sockaddr_any(int domain = AF_INET)
+    // Default domain is unspecified, and
+    // in this case the size is 0.
+    // Note that AF_* (and alias PF_*) types have
+    // many various values, of which only
+    // AF_INET and AF_INET6 are handled here.
+    // Others make the same effect as unspecified.
+    explicit sockaddr_any(int domain = AF_UNSPEC)
     {
+        // Default domain is "unspecified"
         memset(this, 0, sizeof *this);
         sa.sa_family = domain;
         len = size();
     }
 
-    socklen_t size() const
+    sockaddr_any(const sockaddr_storage& stor)
     {
-        switch (sa.sa_family)
-        {
-        case AF_INET: return socklen_t(sizeof sin);
-        case AF_INET6: return socklen_t(sizeof sin6);
+        // Here the length isn't passed, so just rely on family.
+        set((const sockaddr*)&stor);
+    }
 
-        default: return 0; // fallback, impossible
+    sockaddr_any(const sockaddr* source, socklen_t namelen = 0)
+    {
+        if (namelen == 0)
+            set(source);
+        else
+            set(source, namelen);
+    }
+
+    void set(const sockaddr* source)
+    {
+        // Less safe version, simply trust the caller that the
+        // memory at 'source' is also large enough to contain
+        // all data required for particular family.
+        if (source->sa_family == AF_INET)
+        {
+            memcpy(&sin, source, sizeof sin);
+            len = sizeof sin;
+        }
+        else if (source->sa_family == AF_INET6)
+        {
+            memcpy(&sin6, source, sizeof sin6);
+            len = sizeof sin6;
+        }
+        else
+        {
+            // Error fallback: no other families than IP are regarded.
+            sa.sa_family = AF_UNSPEC;
+            len = 0;
         }
     }
 
+    void set(const sockaddr* source, socklen_t namelen)
+    {
+        // It's not safe to copy it directly, so check.
+        if (source->sa_family == AF_INET && namelen >= sizeof sin)
+        {
+            memcpy(&sin, source, sizeof sin);
+            len = sizeof sin;
+        }
+        else if (source->sa_family == AF_INET6 && namelen >= sizeof sin6)
+        {
+            // Note: this isn't too safe, may crash for stupid values
+            // of source->sa_family or any other data
+            // in the source structure, so make sure it's correct first.
+            memcpy(&sin6, source, sizeof sin6);
+            len = sizeof sin6;
+        }
+        else
+        {
+            // Clear as a sign or error
+            memset(&sa, 0, sizeof *this);
+            // Error fallback: no other families than IP are regarded.
+            sa.sa_family = AF_UNSPEC;
+            len = 0;
+        }
+    }
+
+    sockaddr_any(const in_addr& i4_adr, uint16_t port)
+    {
+        // Some cases require separately IPv4 address passed as in_addr,
+        // so port is given separately.
+        sa.sa_family = AF_INET;
+        sin.sin_addr = i4_adr;
+        sin.sin_port = htons(port);
+        len = sizeof sin;
+    }
+
+    sockaddr_any(const in6_addr& i6_adr, uint16_t port)
+    {
+        sa.sa_family = AF_INET6;
+        sin6.sin6_addr = i6_adr;
+        sin6.sin6_port = htons(port);
+        len = sizeof sin6;
+    }
+
+    static socklen_t size(int family)
+    {
+        switch (family)
+        {
+        case AF_INET: return socklen_t(sizeof (sockaddr_in));
+        case AF_INET6: return socklen_t(sizeof (sockaddr_in6));
+
+        default: return 0; // fallback
+        }
+    }
+
+    bool empty() const
+    {
+        switch (sa.sa_family)
+        {
+        case AF_INET:
+            return sin.sin_port == 0 && sin.sin_addr.s_addr == 0;
+
+        case AF_INET6:
+            if (sin6.sin6_port != 0)
+                return false;
+
+            // This length expression should result in 4, as
+            // the size of sin6_addr is 16.
+            for (size_t i = 0; i < (sizeof sin6.sin6_addr)/sizeof(int32_t); ++i)
+                if (((int32_t*)&sin6.sin6_addr)[i] != 0)
+                    return false;
+            return true;
+        }
+
+        return true; // unspec-family address is always empty
+    }
+
+    socklen_t size() const
+    {
+        return size(sa.sa_family);
+    }
+
     int family() const { return sa.sa_family; }
+    void family(int val)
+    {
+        sa.sa_family = val;
+        len = size();
+    }
 
     // port is in exactly the same location in both sin and sin6
     // and has the same size. This is actually yet another common
@@ -71,10 +191,12 @@ struct sockaddr_any
     }
 
     sockaddr* get() { return &sa; }
-    sockaddr* operator&() { return &sa; }
-
     const sockaddr* get() const { return &sa; }
+    sockaddr* operator&() { return &sa; }
     const sockaddr* operator&() const { return &sa; }
+
+    operator sockaddr&() { return sa; }
+    operator const sockaddr&() const { return sa; }
 
     template <int> struct TypeMap;
 
@@ -85,7 +207,26 @@ struct sockaddr_any
     {
         bool operator()(const sockaddr_any& c1, const sockaddr_any& c2)
         {
-            return memcmp(&c1, &c2, sizeof(c1)) == 0;
+            if (c1.family() != c2.family())
+                return false;
+
+            // Cannot use memcmp due to having in some systems
+            // another field like sockaddr_in::sin_len. This exists
+            // in some BSD-derived systems, but is not required by POSIX.
+            // Therefore sockaddr_any class cannot operate with it,
+            // as in this situation it would be safest to state that
+            // particular implementations may have additional fields
+            // of different purpose beside those required by POSIX.
+            //
+            // The only reliable way to compare two underlying sockaddr
+            // object is then to compare the port value and the address
+            // value.
+            //
+            // Fortunately the port is 16-bit and located at the same
+            // offset in both sockaddr_in and sockaddr_in6.
+
+            return c1.sin.sin_port == c2.sin.sin_port
+                && c1.equal_address(c2);
         }
     };
 
@@ -120,6 +261,21 @@ struct sockaddr_any
             return memcmp(&c1, &c2, sizeof(c1)) < 0;
         }
     };
+
+    // Tests if the current address is the "any" wildcard.
+    bool isany() const
+    {
+        if (sa.sa_family == AF_INET)
+            return sin.sin_addr.s_addr == INADDR_ANY;
+        return memcmp(&sin6.sin6_addr, &in6addr_any, sizeof in6addr_any) == 0;
+    }
+
+    bool operator==(const sockaddr_any& other) const
+    {
+        return Equal()(*this, other);
+    }
+
+    bool operator!=(const sockaddr_any& other) const { return !(*this == other); }
 };
 
 template<> struct sockaddr_any::TypeMap<AF_INET> { typedef sockaddr_in type; };

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -32,7 +32,6 @@ struct sockaddr_any
         sockaddr_in sin;
         sockaddr_in6 sin6;
         sockaddr sa;
-        sockaddr_storage storage; // largest part
     };
     socklen_t len;
 

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -273,7 +273,11 @@ struct sockaddr_any
     {
         if (sa.sa_family == AF_INET)
             return sin.sin_addr.s_addr == INADDR_ANY;
-        return memcmp(&sin6.sin6_addr, &in6addr_any, sizeof in6addr_any) == 0;
+
+        if (sa.sa_family == AF_INET)
+            return memcmp(&sin6.sin6_addr, &in6addr_any, sizeof in6addr_any) == 0;
+
+        return false;
     }
 
     bool operator==(const sockaddr_any& other) const


### PR DESCRIPTION
Added construction from sockaddr and in_addr.
Added family override.
Fixed address comparison for Mac.