### PR TITLE
Added fixes for assignment copy compliance

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -410,14 +410,6 @@ m_iMinor(minor)
       m_iErrno = err;
 }
 
-CUDTException::CUDTException(const CUDTException& e):
-m_iMajor(e.m_iMajor),
-m_iMinor(e.m_iMinor),
-m_iErrno(e.m_iErrno),
-m_strMsg()
-{
-}
-
 CUDTException::~CUDTException()
 {
 }

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -79,6 +79,7 @@ public:
     // 1. The congctl is individual, so don't copy it. Set NULL.
     // 2. The selected name is copied so that it's configured correctly.
     SrtCongestion(const SrtCongestion& source): congctl(), selector(source.selector) {}
+    void operator=(const SrtCongestion& source) { congctl = 0; selector = source.selector; }
 
     // This function will be called by the parent CUDT
     // in appropriate time. It should select appropriate

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -247,7 +247,6 @@ class UDT_API CUDTException
 public:
 
    CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
-   CUDTException(const CUDTException& e);
 
    ~CUDTException();
 

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1272,10 +1272,10 @@ public:
         if (adapter != "")
         {
             sockaddr_in maddr = CreateAddrInet(adapter, 0);
-            in_addr addr = maddr.sin_addr.s_addr;
+            in_addr addr = maddr.sin_addr;
 
             int res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char*>(&addr), sizeof(addr));
-            if ( res == status_error )
+            if (res == -1)
             {
                 Error(SysError(), "setsockopt/IP_MULTICAST_IF: " + adapter);
             }


### PR DESCRIPTION
Fixes #1019, #1018 
(part of the fixes are provided additionally on #1006)

Changes:

1. Added copy-assignment operator for `SrtCongestion`.

There was a hidden problem there, as the copying was predicted to copy just the name, but the pointer to the managed object was set to 0. This copy constructor wasn't used, however, when copying was made through the `CUDT` copy constructor, which was using simple assignment inside, and this one was using a generated assignment operator, which was copying the pointer value as well. **Fortunately** nothing wrong happened, as the newly spawned socket for accept was then processed by `CUDT::acceptAndRespond` which was calling inside `CUDT::setupCC` that was calling `configure` on this object, which was overwriting the pointer value anyway, just relying on the name, no matter what was in that pointer before (and it was expected to be NULL there).

In this fix, the provided assignment operator does the same as the constructor, so the pointer value isn't effectively copied. Important thing is that the object claims to own the pointer and it deletes it when it's not NULL at the end.

2. Removed copy constructor for CUDTException.

The copy constructor was intentionally copying all fields, so it was actually duplicating the potentially autogenerated copy constructor. There are also some extra fields there of unknown purpose (their function and existence might need to be revised later), but from the logical point of view they should be copied as well, so a generated copy constructor is still better.

As there's no copy constructor, copy-assignment operator can also stay generated.

3. Assignment to `in_addr` type from `in_addr_t`. This should be a typo that should have been caught by the compiler as type mismatch - only gcc 9 has found it. It wasn't causing any trouble as the effective copying starts at the same address, still it was an error from the language standard point of view.