### PR TITLE
Fixes for CUDTException class. Derived from exception, moved out of the API.

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -361,11 +361,11 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
 {
     m_bindsock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     if ( m_bindsock == SRT_ERROR )
-        Error(UDT::getlasterror(), "srt_socket");
+        Error("srt_socket");
 
     int stat = ConfigurePre(m_bindsock);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "ConfigurePre");
+        Error("ConfigurePre");
 
     sockaddr_in sa = CreateAddrInet(host, port);
     sockaddr* psa = (sockaddr*)&sa;
@@ -375,7 +375,7 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
     if ( stat == SRT_ERROR )
     {
         srt_close(m_bindsock);
-        Error(UDT::getlasterror(), "srt_bind");
+        Error("srt_bind");
     }
 
     Verb() << " listen...";
@@ -384,7 +384,7 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
     if ( stat == SRT_ERROR )
     {
         srt_close(m_bindsock);
-        Error(UDT::getlasterror(), "srt_listen");
+        Error("srt_listen");
     }
 }
 
@@ -414,7 +414,7 @@ bool SrtCommon::AcceptNewClient()
     {
         srt_close(m_bindsock);
         m_bindsock = SRT_INVALID_SOCK;
-        Error(UDT::getlasterror(), "srt_accept");
+        Error("srt_accept");
     }
 
     // we do one client connection at a time,
@@ -428,7 +428,7 @@ bool SrtCommon::AcceptNewClient()
     // are DERIVED by sock. ConfigurePost is done exclusively on sock.
     int stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "ConfigurePost");
+        Error("ConfigurePost");
 
     return true;
 }
@@ -543,7 +543,7 @@ void SrtCommon::SetupAdapter(const string& host, int port)
     sockaddr* psa = (sockaddr*)&localsa;
     int stat = srt_bind(m_sock, psa, sizeof localsa);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "srt_bind");
+        Error("srt_bind");
 }
 
 void SrtCommon::OpenClient(string host, int port)
@@ -562,11 +562,11 @@ void SrtCommon::PrepareClient()
 {
     m_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     if ( m_sock == SRT_ERROR )
-        Error(UDT::getlasterror(), "srt_socket");
+        Error("srt_socket");
 
     int stat = ConfigurePre(m_sock);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "ConfigurePre");
+        Error("ConfigurePre");
 }
 
 
@@ -582,21 +582,21 @@ void SrtCommon::ConnectClient(string host, int port)
     if ( stat == SRT_ERROR )
     {
         srt_close(m_sock);
-        Error(UDT::getlasterror(), "UDT::connect");
+        Error("srt_connect");
     }
 
     stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "ConfigurePost");
+        Error("ConfigurePost");
 }
 
-void SrtCommon::Error(UDT::ERRORINFO& udtError, string src)
+void SrtCommon::Error(string src)
 {
-    int udtResult = udtError.getErrorCode();
-    string message = udtError.getErrorMessage();
-    Verb() << "\nERROR #" << udtResult << ": " << message;
+    int errnov = 0;
+    int result = srt_getlasterror(&errnov);
+    string message = srt_getlasterror_str();
+    Verb() << "\nERROR #" << result << "." << errnov << ": " << message;
 
-    udtError.clear();
     throw TransmissionError("error: " + src + ": " + message);
 }
 
@@ -604,14 +604,14 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
 {
     m_sock = srt_socket(AF_INET, SOCK_DGRAM, 0);
     if ( m_sock == SRT_ERROR )
-        Error(UDT::getlasterror(), "srt_socket");
+        Error("srt_socket");
 
     bool yes = true;
     srt_setsockopt(m_sock, 0, SRTO_RENDEZVOUS, &yes, sizeof yes);
 
     int stat = ConfigurePre(m_sock);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "ConfigurePre");
+        Error("ConfigurePre");
 
     sockaddr_in localsa = CreateAddrInet(adapter, port);
     sockaddr* plsa = (sockaddr*)&localsa;
@@ -622,7 +622,7 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
     if ( stat == SRT_ERROR )
     {
         srt_close(m_sock);
-        Error(UDT::getlasterror(), "srt_bind");
+        Error("srt_bind");
     }
 
     sockaddr_in sa = CreateAddrInet(host, port);
@@ -633,12 +633,12 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
     if ( stat == SRT_ERROR )
     {
         srt_close(m_sock);
-        Error(UDT::getlasterror(), "srt_connect");
+        Error("srt_connect");
     }
 
     stat = ConfigurePost(m_sock);
     if ( stat == SRT_ERROR )
-        Error(UDT::getlasterror(), "ConfigurePost");
+        Error("ConfigurePost");
 }
 
 void SrtCommon::Close()
@@ -813,7 +813,7 @@ void SrtModel::Establish(ref_t<std::string> name)
             int namelen = s.size();
             if ( srt_getsockname(Socket(), &s, &namelen) == SRT_ERROR )
             {
-                Error(UDT::getlasterror(), "srt_getsockname");
+                Error("srt_getsockname");
             }
 
             m_outgoing_port = s.hport();

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -60,7 +60,7 @@ public:
 
 protected:
 
-    void Error(UDT::ERRORINFO& udtError, string src);
+    void Error(string src);
     void Init(string host, int port, map<string,string> par, bool dir_output);
 
     virtual int ConfigurePost(SRTSOCKET sock);

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -63,6 +63,7 @@ modified by
 #include "logging.h"
 #include "threadname.h"
 #include "srt.h"
+#include "udt.h"
 
 #ifdef _WIN32
    #include <win/wintime.h>

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -410,7 +410,7 @@ m_iMinor(minor)
       m_iErrno = err;
 }
 
-const char* CUDTException::getErrorMessage() const ATR_NOEXCEPT
+const char* CUDTException::getErrorMessage() const ATR_NOTHROW
 {
    // translate "Major:Minor" code into text message.
 

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -410,11 +410,7 @@ m_iMinor(minor)
       m_iErrno = err;
 }
 
-CUDTException::~CUDTException()
-{
-}
-
-const char* CUDTException::getErrorMessage()
+const char* CUDTException::getErrorMessage() const ATR_NOEXCEPT
 {
    // translate "Major:Minor" code into text message.
 

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -410,14 +410,6 @@ m_iMinor(minor)
       m_iErrno = err;
 }
 
-CUDTException::CUDTException(const CUDTException& e):
-m_iMajor(e.m_iMajor),
-m_iMinor(e.m_iMinor),
-m_iErrno(e.m_iErrno),
-m_strMsg()
-{
-}
-
 CUDTException::~CUDTException()
 {
 }

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -92,10 +92,9 @@ public:
       /// Get the description of the exception.
       /// @return Text message for the exception description.
 
-   const char* getErrorMessage() const noexcept;
+   const char* getErrorMessage() const ATR_NOEXCEPT;
 
-   //virtual const char* what() const ATR_NOEXCEPT ATR_OVERRIDE
-   virtual const char* what() const noexcept override
+   virtual const char* what() const ATR_NOEXCEPT ATR_OVERRIDE
    {
        return getErrorMessage();
    }

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -87,40 +87,37 @@ class UDT_API CUDTException: public std::exception
 {
 public:
 
-   CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
-   virtual ~CUDTException() ATR_NOTHROW {}
+    CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
+    virtual ~CUDTException() ATR_NOTHROW {}
 
-      /// Get the description of the exception.
-      /// @return Text message for the exception description.
+    /// Get the description of the exception.
+    /// @return Text message for the exception description.
+    const char* getErrorMessage() const ATR_NOTHROW;
 
-   const char* getErrorMessage() const ATR_NOTHROW;
+    virtual const char* what() const ATR_NOTHROW ATR_OVERRIDE
+    {
+        return getErrorMessage();
+    }
 
-   virtual const char* what() const ATR_NOTHROW ATR_OVERRIDE
-   {
-       return getErrorMessage();
-   }
+    /// Get the system errno for the exception.
+    /// @return errno.
+    int getErrorCode() const;
 
-      /// Get the system errno for the exception.
-      /// @return errno.
+    /// Get the system network errno for the exception.
+    /// @return errno.
+    int getErrno() const;
 
-   int getErrorCode() const;
-
-      /// Get the system network errno for the exception.
-      /// @return errno.
-
-   int getErrno() const;
-      /// Clear the error code.
-
-   void clear();
+    /// Clear the error code.
+    void clear();
 
 private:
-   CodeMajor m_iMajor;        // major exception categories
-   CodeMinor m_iMinor;		// for specific error reasons
-   int m_iErrno;		// errno returned by the system if there is any
-   mutable std::string m_strMsg; // text error message (cache)
+    CodeMajor m_iMajor;        // major exception categories
+    CodeMinor m_iMinor;		// for specific error reasons
+    int m_iErrno;		// errno returned by the system if there is any
+    mutable std::string m_strMsg; // text error message (cache)
 
-   std::string m_strAPI;	// the name of UDT function that returns the error
-   std::string m_strDebug;	// debug information, set to the original place that causes the error
+    std::string m_strAPI;	// the name of UDT function that returns the error
+    std::string m_strDebug;	// debug information, set to the original place that causes the error
 
 public: // Legacy Error Code
 

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -75,6 +75,98 @@ modified by
 #define SRT_ASSERT(cond)
 #endif
 
+#include <exception>
+
+// Class CUDTException exposed for C++ API.
+// This is actually useless, unless you'd use a DIRECT C++ API,
+// however there's no such API so far. The current C++ API for UDT/SRT
+// is predicted to NEVER LET ANY EXCEPTION out of implementation,
+// so it's useless to catch this exception anyway.
+
+class UDT_API CUDTException: public std::exception
+{
+public:
+
+   CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
+
+      /// Get the description of the exception.
+      /// @return Text message for the exception description.
+
+   const char* getErrorMessage() const noexcept;
+
+   //virtual const char* what() const ATR_NOEXCEPT ATR_OVERRIDE
+   virtual const char* what() const noexcept override
+   {
+       return getErrorMessage();
+   }
+
+      /// Get the system errno for the exception.
+      /// @return errno.
+
+   int getErrorCode() const;
+
+      /// Get the system network errno for the exception.
+      /// @return errno.
+
+   int getErrno() const;
+      /// Clear the error code.
+
+   void clear();
+
+private:
+   CodeMajor m_iMajor;        // major exception categories
+   CodeMinor m_iMinor;		// for specific error reasons
+   int m_iErrno;		// errno returned by the system if there is any
+   mutable std::string m_strMsg; // text error message (cache)
+
+   std::string m_strAPI;	// the name of UDT function that returns the error
+   std::string m_strDebug;	// debug information, set to the original place that causes the error
+
+public: // Legacy Error Code
+
+    static const int EUNKNOWN = SRT_EUNKNOWN;
+    static const int SUCCESS = SRT_SUCCESS;
+    static const int ECONNSETUP = SRT_ECONNSETUP;
+    static const int ENOSERVER = SRT_ENOSERVER;
+    static const int ECONNREJ = SRT_ECONNREJ;
+    static const int ESOCKFAIL = SRT_ESOCKFAIL;
+    static const int ESECFAIL = SRT_ESECFAIL;
+    static const int ECONNFAIL = SRT_ECONNFAIL;
+    static const int ECONNLOST = SRT_ECONNLOST;
+    static const int ENOCONN = SRT_ENOCONN;
+    static const int ERESOURCE = SRT_ERESOURCE;
+    static const int ETHREAD = SRT_ETHREAD;
+    static const int ENOBUF = SRT_ENOBUF;
+    static const int EFILE = SRT_EFILE;
+    static const int EINVRDOFF = SRT_EINVRDOFF;
+    static const int ERDPERM = SRT_ERDPERM;
+    static const int EINVWROFF = SRT_EINVWROFF;
+    static const int EWRPERM = SRT_EWRPERM;
+    static const int EINVOP = SRT_EINVOP;
+    static const int EBOUNDSOCK = SRT_EBOUNDSOCK;
+    static const int ECONNSOCK = SRT_ECONNSOCK;
+    static const int EINVPARAM = SRT_EINVPARAM;
+    static const int EINVSOCK = SRT_EINVSOCK;
+    static const int EUNBOUNDSOCK = SRT_EUNBOUNDSOCK;
+    static const int ESTREAMILL = SRT_EINVALMSGAPI;
+    static const int EDGRAMILL = SRT_EINVALBUFFERAPI;
+    static const int ENOLISTEN = SRT_ENOLISTEN;
+    static const int ERDVNOSERV = SRT_ERDVNOSERV;
+    static const int ERDVUNBOUND = SRT_ERDVUNBOUND;
+    static const int EINVALMSGAPI = SRT_EINVALMSGAPI;
+    static const int EINVALBUFFERAPI = SRT_EINVALBUFFERAPI;
+    static const int EDUPLISTEN = SRT_EDUPLISTEN;
+    static const int ELARGEMSG = SRT_ELARGEMSG;
+    static const int EINVPOLLID = SRT_EINVPOLLID;
+    static const int EASYNCFAIL = SRT_EASYNCFAIL;
+    static const int EASYNCSND = SRT_EASYNCSND;
+    static const int EASYNCRCV = SRT_EASYNCRCV;
+    static const int ETIMEOUT = SRT_ETIMEOUT;
+    static const int ECONGEST = SRT_ECONGEST;
+    static const int EPEERERR = SRT_EPEERERR;
+};
+
+
 
 enum UDTSockType
 {

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -88,13 +88,14 @@ class UDT_API CUDTException: public std::exception
 public:
 
    CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
+   virtual ~CUDTException() ATR_NOTHROW {}
 
       /// Get the description of the exception.
       /// @return Text message for the exception description.
 
-   const char* getErrorMessage() const ATR_NOEXCEPT;
+   const char* getErrorMessage() const ATR_NOTHROW;
 
-   virtual const char* what() const ATR_NOEXCEPT ATR_OVERRIDE
+   virtual const char* what() const ATR_NOTHROW ATR_OVERRIDE
    {
        return getErrorMessage();
    }

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -79,6 +79,7 @@ public:
     // 1. The congctl is individual, so don't copy it. Set NULL.
     // 2. The selected name is copied so that it's configured correctly.
     SrtCongestion(const SrtCongestion& source): congctl(), selector(source.selector) {}
+    void operator=(const SrtCongestion& source) { congctl = 0; selector = source.selector; }
 
     // This function will be called by the parent CUDT
     // in appropriate time. It should select appropriate

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -247,7 +247,6 @@ class UDT_API CUDTException
 public:
 
    CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
-   CUDTException(const CUDTException& e);
 
    ~CUDTException();
 

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -236,98 +236,14 @@ typedef SRTSOCKET UDTSOCKET; //legacy alias
 
 #ifdef __cplusplus
 
-// Class CUDTException exposed for C++ API.
-// This is actually useless, unless you'd use a DIRECT C++ API,
-// however there's no such API so far. The current C++ API for UDT/SRT
-// is predicted to NEVER LET ANY EXCEPTION out of implementation,
-// so it's useless to catch this exception anyway.
-
-class UDT_API CUDTException
-{
-public:
-
-   CUDTException(CodeMajor major = MJ_SUCCESS, CodeMinor minor = MN_NONE, int err = -1);
-
-   ~CUDTException();
-
-      /// Get the description of the exception.
-      /// @return Text message for the exception description.
-
-   const char* getErrorMessage();
-
-      /// Get the system errno for the exception.
-      /// @return errno.
-
-   int getErrorCode() const;
-
-      /// Get the system network errno for the exception.
-      /// @return errno.
-
-   int getErrno() const;
-      /// Clear the error code.
-
-   void clear();
-
-private:
-   CodeMajor m_iMajor;        // major exception categories
-   CodeMinor m_iMinor;		// for specific error reasons
-   int m_iErrno;		// errno returned by the system if there is any
-   std::string m_strMsg;	// text error message
-
-   std::string m_strAPI;	// the name of UDT function that returns the error
-   std::string m_strDebug;	// debug information, set to the original place that causes the error
-
-public: // Legacy Error Code
-
-    static const int EUNKNOWN = SRT_EUNKNOWN;
-    static const int SUCCESS = SRT_SUCCESS;
-    static const int ECONNSETUP = SRT_ECONNSETUP;
-    static const int ENOSERVER = SRT_ENOSERVER;
-    static const int ECONNREJ = SRT_ECONNREJ;
-    static const int ESOCKFAIL = SRT_ESOCKFAIL;
-    static const int ESECFAIL = SRT_ESECFAIL;
-    static const int ECONNFAIL = SRT_ECONNFAIL;
-    static const int ECONNLOST = SRT_ECONNLOST;
-    static const int ENOCONN = SRT_ENOCONN;
-    static const int ERESOURCE = SRT_ERESOURCE;
-    static const int ETHREAD = SRT_ETHREAD;
-    static const int ENOBUF = SRT_ENOBUF;
-    static const int EFILE = SRT_EFILE;
-    static const int EINVRDOFF = SRT_EINVRDOFF;
-    static const int ERDPERM = SRT_ERDPERM;
-    static const int EINVWROFF = SRT_EINVWROFF;
-    static const int EWRPERM = SRT_EWRPERM;
-    static const int EINVOP = SRT_EINVOP;
-    static const int EBOUNDSOCK = SRT_EBOUNDSOCK;
-    static const int ECONNSOCK = SRT_ECONNSOCK;
-    static const int EINVPARAM = SRT_EINVPARAM;
-    static const int EINVSOCK = SRT_EINVSOCK;
-    static const int EUNBOUNDSOCK = SRT_EUNBOUNDSOCK;
-    static const int ESTREAMILL = SRT_EINVALMSGAPI;
-    static const int EDGRAMILL = SRT_EINVALBUFFERAPI;
-    static const int ENOLISTEN = SRT_ENOLISTEN;
-    static const int ERDVNOSERV = SRT_ERDVNOSERV;
-    static const int ERDVUNBOUND = SRT_ERDVUNBOUND;
-    static const int EINVALMSGAPI = SRT_EINVALMSGAPI;
-    static const int EINVALBUFFERAPI = SRT_EINVALBUFFERAPI;
-    static const int EDUPLISTEN = SRT_EDUPLISTEN;
-    static const int ELARGEMSG = SRT_ELARGEMSG;
-    static const int EINVPOLLID = SRT_EINVPOLLID;
-    static const int EASYNCFAIL = SRT_EASYNCFAIL;
-    static const int EASYNCSND = SRT_EASYNCSND;
-    static const int EASYNCRCV = SRT_EASYNCRCV;
-    static const int ETIMEOUT = SRT_ETIMEOUT;
-    static const int ECONGEST = SRT_ECONGEST;
-    static const int EPEERERR = SRT_EPEERERR;
-};
+class CUDTException;
 
 namespace UDT
 {
 
 typedef CUDTException ERRORINFO;
-//typedef UDT_SOCKOPT SOCKOPT;
 typedef CPerfMon TRACEINFO;
-typedef CBytePerfMon TRACEBSTATS;
+typedef class CBytePerfMon TRACEBSTATS;
 typedef ud_set UDSET;
 
 UDT_API extern const SRTSOCKET INVALID_SOCK;

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -16,6 +16,16 @@ written by
 #ifndef INC__SRT_UTILITIES_H
 #define INC__SRT_UTILITIES_H
 
+// ATTRIBUTES:
+//
+// ATR_UNUSED: declare an entity ALLOWED to be unused (prevents warnings)
+// ATR_DEPRECATED: declare an entity deprecated (compiler should warn when used)
+// ATR_NOEXCEPT: The true `noexcept` from C++11, or nothing if compiling in pre-C++11 mode
+// ATR_NOTHROW: In C++11: `noexcept`. In pre-C++11: `throw()`. Required for GNU libstdc++.
+// ATR_CONSTEXPR: In C++11: `constexpr`. Otherwise empty.
+// ATR_OVERRIDE: In C++11: `override`. Otherwise empty.
+// ATR_FINAL: In C++11: `final`. Otherwise empty.
+
 
 #ifdef __GNUG__
 #define ATR_UNUSED __attribute__((unused))
@@ -32,12 +42,14 @@ written by
 // however it's only the "most required C++11 support".
 #if defined(__GXX_EXPERIMENTAL_CXX0X__) && __GNUC__ == 4 && __GNUC_MINOR__ >= 7 // 4.7 only!
 #define ATR_NOEXCEPT
+#define ATR_NOTHROW throw()
 #define ATR_CONSTEXPR
 #define ATR_OVERRIDE
 #define ATR_FINAL
 #else
 #define HAVE_FULL_CXX11 1
 #define ATR_NOEXCEPT noexcept
+#define ATR_NOTHROW noexcept
 #define ATR_CONSTEXPR constexpr
 #define ATR_OVERRIDE override
 #define ATR_FINAL final
@@ -52,6 +64,7 @@ written by
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER >= 190023026
 #define HAVE_FULL_CXX11 1
 #define ATR_NOEXCEPT noexcept
+#define ATR_NOTHROW noexcept
 #define ATR_CONSTEXPR constexpr
 #define ATR_OVERRIDE override
 #define ATR_FINAL final
@@ -63,7 +76,8 @@ written by
 #endif
 #else
 #define HAVE_CXX11 0
-#define ATR_NOEXCEPT // throw() - bad idea
+#define ATR_NOEXCEPT
+#define ATR_NOTHROW throw()
 #define ATR_CONSTEXPR
 #define ATR_OVERRIDE
 #define ATR_FINAL

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -70,6 +70,7 @@ written by
 #define ATR_FINAL final
 #else
 #define ATR_NOEXCEPT
+#define ATR_NOTHROW throw()
 #define ATR_CONSTEXPR
 #define ATR_OVERRIDE
 #define ATR_FINAL

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -686,7 +686,7 @@ void SrtCommon::ConnectClient(string host, int port)
 void SrtCommon::Error(string src, SRT_REJECT_REASON reason)
 {
     int errnov = 0;
-    int result = srt_getlasterror(&errnov);
+    const int result = srt_getlasterror(&errnov);
     string message = srt_getlasterror_str();
     if (result == SRT_ECONNREJ)
     {

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1272,10 +1272,10 @@ public:
         if (adapter != "")
         {
             sockaddr_in maddr = CreateAddrInet(adapter, 0);
-            in_addr addr = maddr.sin_addr.s_addr;
+            in_addr addr = maddr.sin_addr;
 
             int res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char*>(&addr), sizeof(addr));
-            if ( res == status_error )
+            if (res == -1)
             {
                 Error(SysError(), "setsockopt/IP_MULTICAST_IF: " + adapter);
             }

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -69,7 +69,7 @@ public:
 
 protected:
 
-    void Error(UDT::ERRORINFO& udtError, string src, SRT_REJECT_REASON reason = SRT_REJ_UNKNOWN);
+    void Error(string src, SRT_REJECT_REASON reason = SRT_REJ_UNKNOWN);
     void Init(string host, int port, map<string,string> par, SRT_EPOLL_OPT dir);
     int AddPoller(SRTSOCKET socket, int modes);
     virtual int ConfigurePost(SRTSOCKET sock);


### PR DESCRIPTION
Unfortunately `CUDTException` class is very hard to tear off the current code, so the following was done:

1. The CUDTException class was moved to `common.h`, which means that it is internal now.
2. The `UDT::getlasterror()` legacy API function is actually useless. It still returns the same reference to CUDTException, but this time you need additionally `common.h` to be included in order to access the returned object. Note that UDT legacy API is currently treated as deprecated - instead of this function you should use `srt_getlasterror()` and `srt_getlasterror_msg()`.
3. The `m_strMsg` field is turned `mutable` as it functions only as a cache for message string. Note that the major/minor fields are not intended to be altered during this object's runtime.

Fixes #861 