### PR TITLE
Add srt_getversion API function

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -143,7 +143,12 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
     if (print_help)
     {
         cout << "SRT sample application to transmit files.\n";
-        cerr << "SRT Library version: " << SRT_VERSION << endl;
+        cerr << "Built with SRT Library version: " << SRT_VERSION << endl;
+        const uint32_t srtver = srt_getversion();
+        const int major = srtver / 0x10000;
+        const int minor = (srtver / 0x100) % 0x100;
+        const int patch = srtver % 0x100;
+        cerr << "SRT Library version: " << major << "." << minor << "." << patch << endl;
         cerr << "Usage: srt-file-transmit [options] <input-uri> <output-uri>\n";
         cerr << "\n";
 

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -224,7 +224,12 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
     if (print_help)
     {
         cout << "SRT sample application to transmit live streaming.\n";
-        cerr << "SRT Library version: " << SRT_VERSION << endl;
+        cerr << "Built with SRT Library version: " << SRT_VERSION << endl;
+        const uint32_t srtver = srt_getversion();
+        const int major = srtver / 0x10000;
+        const int minor = (srtver / 0x100) % 0x100;
+        const int patch = srtver % 0x100;
+        cerr << "SRT Library version: " << major << "." << minor << "." << patch << endl;
         cerr << "Usage: srt-live-transmit [options] <input-uri> <output-uri>\n";
         cerr << "\n";
 #ifndef _WIN32

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -24,6 +24,7 @@ SRT API Functions
   * [srt_getsockname](#srt_getsockname)
   * [srt_getsockopt, srt_getsockflag](#srt_getsockopt-srt_getsockflag)
   * [srt_setsockopt, srt_setsockflag](#srt_setsockopt-srt_setsockflag)
+  * [srt_getversion](#srt_getversion)
 - [**Helper data types for transmission**](#Helper-data-types-for-transmission)
   * [SRT_MSGCTRL](#SRT_MSGCTRL)
 - [**Transmission**](#Transmission)
@@ -548,6 +549,20 @@ type with the option value to be set.
   * `SRT_EINVOP`: Option `opt` indicates no valid option
   * Various other errors that may result from problems when setting a specific 
   option (see option description for details).
+
+### srt_getversion
+
+```
+uint32_t srt_getversion();
+```
+
+Get SRT version value. The version format in hex is 0xXXYYZZ for x.y.z in human readable form, 
+where x = ("%d", (version>>16) & 0xff), etc.
+
+- Returns:
+
+  * srt version as an unsigned 32-bit integer
+
 
 Helper data types for transmission
 ----------------------------------

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -833,7 +833,7 @@ inline int32_t SrtParseVersion(const char* v)
         return 0;
     }
 
-    return major*0x10000 + minor*0x100 + patch;
+    return SrtVersion(major, minor, patch);
 }
 
 inline std::string SrtVersionString(int version)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -740,6 +740,8 @@ SRT_API enum SRT_REJECT_REASON srt_getrejectreason(SRTSOCKET sock);
 SRT_API extern const char* const srt_rejectreason_msg [];
 const char* srt_rejectreason_str(enum SRT_REJECT_REASON id);
 
+SRT_API uint32_t srt_getversion();
+
 #ifdef __cplusplus
 }
 #endif

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -314,4 +314,9 @@ int srt_listen_callback(SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
     return CUDT::installAcceptHook(lsn, hook, opaq);
 }
 
+uint32_t srt_getversion()
+{
+    return SrtVersion(SRT_VERSION_MAJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH);
+}
+
 }


### PR DESCRIPTION
- Added `uint32_t srt_getversion();`
- Added description to the API docs
- Added usage in apps

Fixes partially #1016 (does not provide a git commit info)