### PR TITLE
[build] clang format short func alignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 # AllowShortCaseLabelsOnASingleLine: false
-# AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Inline
 # AllowShortIfStatementsOnASingleLine: false
 # AllowShortLoopsOnASingleLine: false
 # AlwaysBreakAfterDefinitionReturnType: None


### PR DESCRIPTION
Added `AllowShortFunctionsOnASingleLine: Inline` 
This allows only an empty function body and functions defined inside a class to be on the same line as the function declaration.
Refer to **AllowShortFunctionsOnASingleLine** in [Clang Format Style Options](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)

Example formatting of a code block of sync.cpp (this PR):
```
long long srt::sync::count_seconds(const steady_clock::duration& t)
{
    return t.count() / s_cpu_frequency / 1000000;
}

srt::sync::steady_clock::duration srt::sync::microseconds_from(long t_us)
{
    return steady_clock::duration(t_us * s_cpu_frequency);
}
```

Formatting of the same block with the current `.clang-format` from master:
```
long long srt::sync::count_seconds(const steady_clock::duration& t) { return t.count() / s_cpu_frequency / 1000000; }

srt::sync::steady_clock::duration srt::sync::microseconds_from(long t_us)
{
    return steady_clock::duration(t_us * s_cpu_frequency);
}
```