### PR TITLE
Fix of sync duration from long

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1424,7 +1424,7 @@ steady_clock::time_point CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp_us)
     * In this period, timestamps smaller than 30 seconds are considered to have wrapped around (then adjusted).
     * The wrap check period ends 30 seconds after the wrap point, afterwhich time base has been adjusted.
     */
-    uint64_t carryover = 0;
+    int64_t carryover = 0;
 
     // This function should generally return the timebase for the given timestamp_us.
     // It's assumed that the timestamp_us, for which this function is being called,
@@ -1448,7 +1448,7 @@ steady_clock::time_point CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp_us)
 
         if (timestamp_us < TSBPD_WRAP_PERIOD)
         {
-            carryover = uint64_t(CPacket::MAX_TIMESTAMP) + 1;
+            carryover = int64_t(CPacket::MAX_TIMESTAMP) + 1;
         }
         //
         else if ((timestamp_us >= TSBPD_WRAP_PERIOD)
@@ -1456,7 +1456,7 @@ steady_clock::time_point CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp_us)
         {
             /* Exiting wrap check period (if for packet delivery head) */
             m_bTsbPdWrapCheck = false;
-            m_tsTsbPdTimeBase += microseconds_from(uint64_t(CPacket::MAX_TIMESTAMP) + 1);
+            m_tsTsbPdTimeBase += microseconds_from(int64_t(CPacket::MAX_TIMESTAMP) + 1);
             tslog.Debug("tsbpd wrap period ends");
         }
     }

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1768,7 +1768,7 @@ void CRcvBuffer::readMsgHeavyLogging(int p)
     LOGC(dlog.Debug, log << CONID() << "readMsg: DELIVERED seq=" << seq
             << " T=" << FormatTime(srctime)
             << " in " << timediff_ms << "ms - TIME-PREVIOUS: PKT: "
-            << FormatTime(srctime) << " LOCAL: " << nowdiff_ms
+            << srctimediff_ms << " LOCAL: " << nowdiff_ms
             << " !" << BufferStamp(pkt.data(), pkt.size())
             << " NEXT pkt T=" << next_playtime);
 

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -216,7 +216,7 @@ private:
         return SrtCongestion::SRM_FASTREXMIT;
     }
 
-    uint64_t updateNAKInterval(uint64_t nakint_us, int /*rcv_speed*/, size_t /*loss_length*/) ATR_OVERRIDE
+    int64_t updateNAKInterval(int64_t nakint_us, int /*rcv_speed*/, size_t /*loss_length*/) ATR_OVERRIDE
     {
         /*
          * duB:
@@ -237,7 +237,7 @@ private:
         return nakint_us / m_iNakReportAccel;
     }
 
-    uint64_t minNAKInterval() ATR_OVERRIDE
+    int64_t minNAKInterval() ATR_OVERRIDE
     {
         return m_iMinNakInterval_us;
     }

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -192,15 +192,15 @@ public:
 
     virtual SrtCongestion::RexmitMethod rexmitMethod() = 0; // Implementation enforced.
 
-    virtual uint64_t updateNAKInterval(uint64_t nakint_us, int rcv_speed, size_t loss_length)
+    virtual int64_t updateNAKInterval(int64_t nakint_us, int rcv_speed, size_t loss_length)
     {
         if (rcv_speed > 0)
-            nakint_us += (loss_length * uint64_t(1000000) / rcv_speed);
+            nakint_us += (loss_length * int64_t(1000000) / rcv_speed);
 
         return nakint_us;
     }
 
-    virtual uint64_t minNAKInterval()
+    virtual int64_t minNAKInterval()
     {
         return 0; // Leave default
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6613,7 +6613,7 @@ bool CUDT::updateCC(ETransmissionEvent evt, EventVariant arg)
         // NOTE: THESE things come from CCC class:
         // - m_dPktSndPeriod
         // - m_dCWndSize
-        m_tdSendInterval      = srt::sync::microseconds_from((long)m_CongCtl->pktSndPeriod_us());
+        m_tdSendInterval      = srt::sync::microseconds_from((int64_t)m_CongCtl->pktSndPeriod_us());
         m_dCongestionWindow = m_CongCtl->cgWindowSize();
 #if ENABLE_HEAVY_LOGGING
         HLOGC(mglog.Debug,

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -1,4 +1,14 @@
-﻿#include <iomanip>
+﻿/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+#include <iomanip>
 #include <math.h>
 #include <stdexcept>
 #include "sync.h"

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -118,32 +118,32 @@ srt::sync::TimePoint<srt::sync::steady_clock> srt::sync::steady_clock::now()
     return TimePoint<steady_clock>(x);
 }
 
-long long srt::sync::count_microseconds(const steady_clock::duration& t)
+int64_t srt::sync::count_microseconds(const steady_clock::duration& t)
 {
     return t.count() / s_cpu_frequency;
 }
 
-long long srt::sync::count_milliseconds(const steady_clock::duration& t)
+int64_t srt::sync::count_milliseconds(const steady_clock::duration& t)
 {
     return t.count() / s_cpu_frequency / 1000;
 }
 
-long long srt::sync::count_seconds(const steady_clock::duration& t)
+int64_t srt::sync::count_seconds(const steady_clock::duration& t)
 {
     return t.count() / s_cpu_frequency / 1000000;
 }
 
-srt::sync::steady_clock::duration srt::sync::microseconds_from(long t_us)
+srt::sync::steady_clock::duration srt::sync::microseconds_from(int64_t t_us)
 {
     return steady_clock::duration(t_us * s_cpu_frequency);
 }
 
-srt::sync::steady_clock::duration srt::sync::milliseconds_from(long t_ms)
+srt::sync::steady_clock::duration srt::sync::milliseconds_from(int64_t t_ms)
 {
     return steady_clock::duration((1000 * t_ms) * s_cpu_frequency);
 }
 
-srt::sync::steady_clock::duration srt::sync::seconds_from(long t_s)
+srt::sync::steady_clock::duration srt::sync::seconds_from(int64_t t_s)
 {
     return steady_clock::duration((1000000 * t_s) * s_cpu_frequency);
 }

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -1,6 +1,6 @@
 /*
  * SRT - Secure, Reliable, Transport
- * Copyright (c) 2018 Haivision Systems Inc.
+ * Copyright (c) 2019 Haivision Systems Inc.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,6 +8,8 @@
  *
  */
 #pragma once
+#ifndef __SRT_SYNC_H__
+#define __SRT_SYNC_H__
 
 //#define USE_STL_CHRONO
 //#define ENABLE_CXX17
@@ -209,3 +211,5 @@ std::string FormatTimeSys(const steady_clock::time_point& time);
 
 }; // namespace sync
 }; // namespace srt
+
+#endif // __SRT_SYNC_H__

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -157,18 +157,18 @@ inline Duration<steady_clock> operator*(const int& lhs, const Duration<steady_cl
     return rhs * lhs;
 }
 
-inline long long count_microseconds(const TimePoint<steady_clock> tp)
+inline int64_t count_microseconds(const TimePoint<steady_clock> tp)
 {
-    return static_cast<long long>(tp.us_since_epoch());
+    return static_cast<int64_t>(tp.us_since_epoch());
 }
 
-long long count_microseconds(const steady_clock::duration& t);
-long long count_milliseconds(const steady_clock::duration& t);
-long long count_seconds(const steady_clock::duration& t);
+int64_t count_microseconds(const steady_clock::duration& t);
+int64_t count_milliseconds(const steady_clock::duration& t);
+int64_t count_seconds(const steady_clock::duration& t);
 
-Duration<steady_clock> microseconds_from(long t_us);
-Duration<steady_clock> milliseconds_from(long t_ms);
-Duration<steady_clock> seconds_from(long t_s);
+Duration<steady_clock> microseconds_from(int64_t t_us);
+Duration<steady_clock> milliseconds_from(int64_t t_ms);
+Duration<steady_clock> seconds_from(int64_t t_s);
 
 inline bool is_zero(const TimePoint<steady_clock>& t) { return t.is_zero(); }
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -46,6 +46,21 @@ TEST(SyncDuration, BasicChecks)
     EXPECT_EQ(count_seconds(a), 0);
 }
 
+/// Check operations on (uint32_t + 1)
+TEST(SyncDuration, DurationFrom)
+{
+    const int64_t val = int64_t(numeric_limits<uint32_t>::max()) + 1;
+
+    const steady_clock::duration us_from = microseconds_from(val);
+    EXPECT_EQ(count_microseconds(us_from), val);
+
+    const steady_clock::duration ms_from = milliseconds_from(val);
+    EXPECT_EQ(count_milliseconds(ms_from), val);
+
+    const steady_clock::duration s_from = seconds_from(val);
+    EXPECT_EQ(count_seconds(s_from), val);
+}
+
 TEST(SyncDuration, RelOperators)
 {
     const steady_clock::duration a;


### PR DESCRIPTION
The following chang (1st commit) fixes #1033 

### 1. Changed duration_from functions

* `microseconds_from(long t_us);` ->`microseconds_from(int64_t t_ms);`
* `milliseconds_from(long t_us);` ->`milliseconds_from(int64_t t_ms);`
* `seconds_from(long t_us);` ->`seconds_from(int64_t t_ms);`

### 2. Fixed uint64_t conversions:

`m_tsTsbPdTimeBase += microseconds_from(uint64_t(CPacket::MAX_TIMESTAMP) + 1);`
changed to 
`m_tsTsbPdTimeBase += microseconds_from(int64_t(CPacket::MAX_TIMESTAMP) + 1);`

`CPacket::MAX_TIMESTAMP` = 0xFFFFFFFF` (UINT32_MAX)

## Other changes

1. Removed excessive usage or `srt::sync` namespace resolution.
2. Added unit test for "duration from" functions.