### PR TITLE
[core] Fixed CBytePerfMon typedef in udt.h

### DIFF
--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -243,7 +243,7 @@ namespace UDT
 
 typedef CUDTException ERRORINFO;
 typedef CPerfMon TRACEINFO;
-typedef class CBytePerfMon TRACEBSTATS;
+typedef struct CBytePerfMon TRACEBSTATS;
 typedef ud_set UDSET;
 
 UDT_API extern const SRTSOCKET INVALID_SOCK;


### PR DESCRIPTION
PR #1023 has changed
`typedef CBytePerfMon TRACEBSTATS;` --> `typedef class CBytePerfMon TRACEBSTATS;`
while `CBytePerfMon` is declared as a struct in srt.h.

This PR fixes the type definition.