### PR TITLE
Minor fixes: crysp test and catch exception by value

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2087,7 +2087,7 @@ int CUDT::connect(
    {
       return s_UDTUnited.connect(u, name, namelen, forced_isn);
    }
-   catch (const CUDTException e)
+   catch (const CUDTException &e)
    {
       s_UDTUnited.setError(new CUDTException(e));
       return ERROR;

--- a/test/test_cryspr.cpp
+++ b/test/test_cryspr.cpp
@@ -1,6 +1,8 @@
 #include <stdio.h>
 #include <string.h>
 #include "gtest/gtest.h"
+
+#ifdef SRT_ENABLE_ENCRYPTION
 #include "common.h"
 #include "hcrypt.h"
 #include "version.h"
@@ -791,3 +793,5 @@ TEST_F(TestCRYSPRcypto, DecryptAESctr_tv1_256)
     test_AESctr(cryspr_m, cryspr_cb, 2, DECRYPT);
 }
 #endif /* CRYSPR_HAS_AESCTR */
+
+#endif /* SRT_ENABLE_ENCRYPTION */


### PR DESCRIPTION
1. When SRT library is built with `ENABLE_ENCRYPTION=OFF`, CRYSP test should be excluded.
2. Fixed warning "catching polymorphic type by value" (CUDTException)