### PR TITLE
Fixed monotonic clock build option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
           - RUN_SONARCUBE=1
         - env:
           - BUILD_TYPE=Debug
-          - BUILD_OPTS=-DENABLE_LOGGING=OFF
+          - BUILD_OPTS='-DENABLE_LOGGING=OFF -DENABLE_MONOTONIC_CLOCK=ON'
         - os: linux
           env: BUILD_TYPE=Release
         - os: osx

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1885,7 +1885,7 @@ void* CUDTUnited::garbageCollect(void* p)
        self->checkBrokenSockets();
 
        HLOGC(mglog.Debug, log << "GC: sleep 1 s");
-       SyncEvent::wait_for(&self->m_GCStopCond, &self->m_GCStopLock, seconds_from(1));
+       SyncEvent::wait_for_monotonic(&self->m_GCStopCond, &self->m_GCStopLock, seconds_from(1));
    }
 
    // remove all sockets and multiplexers

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -193,6 +193,8 @@ public:
     /// @return result of pthread_cond_wait(...) function call
     ///
     static int wait_for(pthread_cond_t* cond, pthread_mutex_t* mutex, const steady_clock::duration& rel_time);
+
+    static int wait_for_monotonic(pthread_cond_t* cond, pthread_mutex_t* mutex, const steady_clock::duration& rel_time);
 };
 
 /// Print steady clock timepoint in a human readable way.

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -261,34 +261,62 @@ TEST(SyncTimePoint, OperatorMinusEqDuration)
  */
 /*****************************************************************************/
 
-TEST(SyncEvent, WaitFor)
+template <bool USE_MONOTONIC_CLOCK = false>
+void TestSyncWaitFor()
 {
     pthread_cond_t  cond;
     pthread_mutex_t mutex;
+#if ENABLE_MONOTONIC_CLOCK
+    if (USE_MONOTONIC_CLOCK)
+    {
+        pthread_condattr_t  CondAttribs;
+        pthread_condattr_init(&CondAttribs);
+        pthread_condattr_setclock(&CondAttribs, CLOCK_MONOTONIC);
+        pthread_cond_init(&cond, &CondAttribs);
+    }
+    else
+    {
+        pthread_cond_init(&cond, NULL);
+    }
+#else
     pthread_cond_init(&cond, NULL);
+#endif
     pthread_mutex_init(&mutex, NULL);
 
     for (int tout_us : {50, 100, 500, 1000, 101000, 1001000})
     {
         const steady_clock::duration   timeout = microseconds_from(tout_us);
-        const steady_clock::time_point start   = steady_clock::now();
-        EXPECT_FALSE(SyncEvent::wait_for(&cond, &mutex, timeout) == 0);
+        const steady_clock::time_point start = steady_clock::now();
+        EXPECT_FALSE(SyncEvent::wait_for<USE_MONOTONIC_CLOCK>(&cond, &mutex, timeout) == 0);
         const steady_clock::time_point stop = steady_clock::now();
         if (tout_us < 1000)
         {
             cerr << "SyncEvent::wait_for(" << count_microseconds(timeout) << "us) took " << count_microseconds(stop - start)
-                 << "us" << endl;
+                << "us" << endl;
         }
         else
         {
             cerr << "SyncEvent::wait_for(" << count_milliseconds(timeout) << " ms) took "
-                 << count_microseconds(stop - start) / 1000.0 << " ms" << endl;
+                << count_microseconds(stop - start) / 1000.0 << " ms" << endl;
         }
     }
 
     pthread_mutex_destroy(&mutex);
     pthread_cond_destroy(&cond);
 }
+
+
+TEST(SyncEvent, WaitFor)
+{
+    TestSyncWaitFor();
+}
+
+#if ENABLE_MONOTONIC_CLOCK
+TEST(SyncEvent, WaitForMonotonic)
+{
+    TestSyncWaitFor<true>();
+}
+#endif
 
 TEST(SyncEvent, WaitForNotifyOne)
 {


### PR DESCRIPTION
## Monotonic CVs

CVs that can use monotonic clock are 
* `CUDTUnited::m_GCStopCond` 
* `CTimer::m_TickCond`

Other CVs use regular clock, as in v.1.4.1. 
Therefore, `srt::sync::rdtsc(...)` function does not use MONOTONIC_CLOCK, but always uses regular clock. This is required for other waits on CVs to work properly.

Fixes #1034

## CI Build

Added `ENABLE_MONOTONIC_CLOCK=ON` build configuration to Travis.

## Unit Tests

Added `SyncEvent.WaitForMonotonic` test case that is built when the monotonic clock is enabled.


## Note

This is a fix to have the current master version working with the monotonic clock as in v.1.4.1.
To be revised in PR #800.