### PR TITLE
Eliminated ref_t. Some more convention fixes

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -19,6 +19,7 @@ written by
 #include <iterator>
 #include <vector>
 #include <map>
+#include <tuple>
 #include <stdexcept>
 #include <string>
 #include <csignal>
@@ -222,11 +223,8 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
 
 
 
-void ExtractPath(string path, ref_t<string> dir, ref_t<string> fname)
+tuple<string, string> ExtractPath(string path)
 {
-    //string& dir = r_dir;
-    //string& fname = r_fname;
-
     string directory = path;
     string filename = "";
 
@@ -272,8 +270,7 @@ void ExtractPath(string path, ref_t<string> dir, ref_t<string> fname)
         directory = wd + "/" + directory;
     }
 
-    *dir = directory;
-    *fname = filename;
+    return make_tuple(directory, filename);
 }
 
 bool DoUpload(UriParser& ut, string path, string filename,
@@ -648,7 +645,7 @@ bool Upload(UriParser& srt_target_uri, UriParser& fileuri,
 
     string path = fileuri.path();
     string directory, filename;
-    ExtractPath(path, ref(directory), ref(filename));
+    tie(directory, filename) = ExtractPath(path);
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
     // Set ID to the filename.
     // Directory will be preserved.
@@ -669,7 +666,7 @@ bool Download(UriParser& srt_source_uri, UriParser& fileuri,
     }
 
     string path = fileuri.path(), directory, filename;
-    ExtractPath(path, Ref(directory), Ref(filename));
+    tie(directory, filename) = ExtractPath(path);
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
 
     return DoDownload(srt_source_uri, directory, filename, cfg, out_stats);

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -19,7 +19,6 @@ written by
 #include <iterator>
 #include <vector>
 #include <map>
-#include <tuple>
 #include <stdexcept>
 #include <string>
 #include <csignal>
@@ -223,8 +222,11 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
 
 
 
-tuple<string, string> ExtractPath(string path)
+void ExtractPath(string path, string& w_dir, string& w_fname)
 {
+    //string& dir = r_dir;
+    //string& fname = r_fname;
+
     string directory = path;
     string filename = "";
 
@@ -270,7 +272,8 @@ tuple<string, string> ExtractPath(string path)
         directory = wd + "/" + directory;
     }
 
-    return make_tuple(directory, filename);
+    w_dir = directory;
+    w_fname = filename;
 }
 
 bool DoUpload(UriParser& ut, string path, string filename,
@@ -645,7 +648,7 @@ bool Upload(UriParser& srt_target_uri, UriParser& fileuri,
 
     string path = fileuri.path();
     string directory, filename;
-    tie(directory, filename) = ExtractPath(path);
+    ExtractPath(path,(directory), (filename));
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
     // Set ID to the filename.
     // Directory will be preserved.
@@ -666,7 +669,7 @@ bool Download(UriParser& srt_source_uri, UriParser& fileuri,
     }
 
     string path = fileuri.path(), directory, filename;
-    tie(directory, filename) = ExtractPath(path);
+    ExtractPath(path,(directory), (filename));
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
 
     return DoDownload(srt_source_uri, directory, filename, cfg, out_stats);

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -224,9 +224,6 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
 
 void ExtractPath(string path, string& w_dir, string& w_fname)
 {
-    //string& dir = r_dir;
-    //string& fname = r_fname;
-
     string directory = path;
     string filename = "";
 

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -221,7 +221,6 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
 }
 
 
-
 void ExtractPath(string path, string& w_dir, string& w_fname)
 {
     string directory = path;
@@ -645,7 +644,7 @@ bool Upload(UriParser& srt_target_uri, UriParser& fileuri,
 
     string path = fileuri.path();
     string directory, filename;
-    ExtractPath(path,(directory), (filename));
+    ExtractPath(path, (directory), (filename));
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
     // Set ID to the filename.
     // Directory will be preserved.
@@ -666,7 +665,7 @@ bool Download(UriParser& srt_source_uri, UriParser& fileuri,
     }
 
     string path = fileuri.path(), directory, filename;
-    ExtractPath(path,(directory), (filename));
+    ExtractPath(path, (directory), (filename));
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
 
     return DoDownload(srt_source_uri, directory, filename, cfg, out_stats);

--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -118,8 +118,8 @@ public:
     virtual int ReadInternal(char* output, int size) = 0;
     virtual bool IsErrorAgain() = 0;
 
-    ReadStatus Read(ref_t<bytevector> output);
-    virtual void Write(ref_t<bytevector> portion) = 0;
+    ReadStatus Read(bytevector& output);
+    virtual void Write(bytevector& portion) = 0;
 
     virtual void CreateListener() = 0;
     virtual void CreateCaller() = 0;
@@ -335,14 +335,14 @@ void Engine::Worker()
         try
         {
             which_medium = media[DIR_IN];
-            rdst = media[DIR_IN]->Read(Ref(outbuf));
+            rdst = media[DIR_IN]->Read((outbuf));
             switch (rdst)
             {
             case Medium::RD_DATA:
                 {
                     which_medium = media[DIR_OUT];
                     // We get the data, write them to the output
-                    media[DIR_OUT]->Write(Ref(outbuf));
+                    media[DIR_OUT]->Write((outbuf));
                 }
                 break;
 
@@ -411,7 +411,7 @@ public:
     virtual int ReadInternal(char* output, int size) override;
     virtual bool IsErrorAgain() override;
 
-    virtual void Write(ref_t<bytevector> portion) override;
+    virtual void Write(bytevector& portion) override;
     virtual void CreateListener() override;
     virtual void CreateCaller() override;
     virtual unique_ptr<Medium> Accept() override;
@@ -494,7 +494,7 @@ public:
     virtual const char* type() override { return "tcp"; }
     virtual int ReadInternal(char* output, int size) override;
     virtual bool IsErrorAgain() override;
-    virtual void Write(ref_t<bytevector> portion) override;
+    virtual void Write(bytevector& portion) override;
     virtual void CreateListener() override;
     virtual void CreateCaller() override;
     virtual unique_ptr<Medium> Accept() override;
@@ -691,17 +691,17 @@ void TcpMedium::Connect()
     ConfigurePost(m_socket);
 }
 
-int SrtMedium::ReadInternal(char* buffer, int size)
+int SrtMedium::ReadInternal(char* w_buffer, int size)
 {
-    int st = srt_recv(m_socket, buffer, size);
+    int st = srt_recv(m_socket, (w_buffer), size);
     if (st == SRT_ERROR)
         return -1;
     return st;
 }
 
-int TcpMedium::ReadInternal(char* buffer, int size)
+int TcpMedium::ReadInternal(char* w_buffer, int size)
 {
-    return ::recv(m_socket, buffer, size, 0);
+    return ::recv(m_socket, (w_buffer), size, 0);
 }
 
 bool SrtMedium::IsErrorAgain()
@@ -722,19 +722,17 @@ bool TcpMedium::IsErrorAgain()
 // This will cause the worker loop to redirect to Write immediately
 // thereafter and possibly will flush out the remains of the buffer.
 // It's still possible that the buffer won't be completely purged
-Medium::ReadStatus Medium::Read(ref_t<bytevector> r_output)
+Medium::ReadStatus Medium::Read(bytevector& w_output)
 {
-    bytevector& output = *r_output;
-
     // Don't read, but fake that you read
-    if (output.size() > m_chunk)
+    if (w_output.size() > m_chunk)
     {
         Verb() << "BUFFER EXCEEDED";
         return RD_DATA;
     }
 
     // Resize to maximum first
-    size_t shift = output.size();
+    size_t shift = w_output.size();
     if (shift && m_eof)
     {
         // You have nonempty buffer, but eof was already
@@ -747,8 +745,8 @@ Medium::ReadStatus Medium::Read(ref_t<bytevector> r_output)
 
     size_t pred_size = shift + m_chunk;
 
-    output.resize(pred_size);
-    int st = ReadInternal(output.data() + shift, m_chunk);
+    w_output.resize(pred_size);
+    int st = ReadInternal((w_output.data() + shift), m_chunk);
     if (st == -1)
     {
         if (IsErrorAgain())
@@ -769,22 +767,20 @@ Medium::ReadStatus Medium::Read(ref_t<bytevector> r_output)
             //
             // Set back the size this buffer had before we attempted
             // to read into it.
-            output.resize(shift);
+            w_output.resize(shift);
             return RD_DATA;
         }
-        output.clear();
+        w_output.clear();
         return RD_EOF;
     }
 
-    output.resize(shift+st);
+    w_output.resize(shift+st);
     return RD_DATA;
 }
 
-void SrtMedium::Write(ref_t<bytevector> r_buffer)
+void SrtMedium::Write(bytevector& w_buffer)
 {
-    bytevector& buffer = *r_buffer;
-
-    int st = srt_send(m_socket, buffer.data(), buffer.size());
+    int st = srt_send(m_socket, w_buffer.data(), w_buffer.size());
     if (st == SRT_ERROR)
     {
         Error(UDT::getlasterror(), "srt_send");
@@ -792,8 +788,8 @@ void SrtMedium::Write(ref_t<bytevector> r_buffer)
 
     // This should be ==, whereas > is not possible, but
     // this should simply embrace this case as a sanity check.
-    if (st >= int(buffer.size()))
-        buffer.clear();
+    if (st >= int(w_buffer.size()))
+        w_buffer.clear();
     else if (st == 0)
     {
         Error("Unexpected EOF on Write");
@@ -801,15 +797,13 @@ void SrtMedium::Write(ref_t<bytevector> r_buffer)
     else
     {
         // Remove only those bytes that were sent
-        buffer.erase(buffer.begin(), buffer.begin()+st);
+        w_buffer.erase(w_buffer.begin(), w_buffer.begin()+st);
     }
 }
 
-void TcpMedium::Write(ref_t<bytevector> r_buffer)
+void TcpMedium::Write(bytevector& w_buffer)
 {
-    bytevector& buffer = *r_buffer;
-
-    int st = ::send(m_socket, buffer.data(), buffer.size(), DEF_SEND_FLAG);
+    int st = ::send(m_socket, w_buffer.data(), w_buffer.size(), DEF_SEND_FLAG);
     if (st == -1)
     {
         Error(errno, "send");
@@ -817,8 +811,8 @@ void TcpMedium::Write(ref_t<bytevector> r_buffer)
 
     // This should be ==, whereas > is not possible, but
     // this should simply embrace this case as a sanity check.
-    if (st >= int(buffer.size()))
-        buffer.clear();
+    if (st >= int(w_buffer.size()))
+        w_buffer.clear();
     else if (st == 0)
     {
         Error("Unexpected EOF on Write");
@@ -826,7 +820,7 @@ void TcpMedium::Write(ref_t<bytevector> r_buffer)
     else
     {
         // Remove only those bytes that were sent
-        buffer.erase(buffer.begin(), buffer.begin()+st);
+        w_buffer.erase(w_buffer.begin(), w_buffer.begin()+st);
     }
 }
 

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -54,7 +54,7 @@ public:
             throw std::runtime_error(path + ": Can't open file for reading");
     }
 
-    int Read(size_t chunk, bytevector& data, ostream &SRT_ATR_UNUSED = cout) override
+    int Read(size_t chunk, bytevector& data, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         if (data.size() < chunk)
             data.resize(chunk);
@@ -83,7 +83,7 @@ public:
 
     FileTarget(const string& path): ofile(path, ios::out | ios::trunc | ios::binary) {}
 
-    int Write(const char* data, size_t size, ostream &SRT_ATR_UNUSED = cout) override
+    int Write(const char* data, size_t size, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         ofile.write(data, size);
         return !(ofile.bad()) ? (int) size : 0;
@@ -598,7 +598,7 @@ SrtModel::SrtModel(string host, int port, map<string,string> par)
     m_port = port;
 }
 
-void SrtModel::Establish(ref_t<std::string> name)
+void SrtModel::Establish(std::string& w_name)
 {
     // This does connect or accept.
     // When this returned true, the caller should create
@@ -614,10 +614,10 @@ void SrtModel::Establish(ref_t<std::string> name)
 
         PrepareClient();
 
-        if (name.get() != "")
+        if (w_name != "")
         {
-            Verb() << "Connect with requesting stream [" << name.get() << "]";
-            UDT::setstreamid(m_sock, *name);
+            Verb() << "Connect with requesting stream [" << w_name << "]";
+            UDT::setstreamid(m_sock, w_name);
         }
         else
         {
@@ -660,8 +660,8 @@ void SrtModel::Establish(ref_t<std::string> name)
         Verb() << "Accepting a client...";
         AcceptNewClient();
         // This rewrites m_sock with a new SRT socket ("accepted" socket)
-        *name = UDT::getstreamid(m_sock);
-        Verb() << "... GOT CLIENT for stream [" << name.get() << "]";
+        w_name = UDT::getstreamid(m_sock);
+        Verb() << "... GOT CLIENT for stream [" << w_name << "]";
     }
 }
 
@@ -686,7 +686,7 @@ public:
 #endif
     }
 
-    int Read(size_t chunk, bytevector& data, ostream &SRT_ATR_UNUSED = cout) override
+    int Read(size_t chunk, bytevector& data, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         if (data.size() < chunk)
             data.resize(chunk);
@@ -728,7 +728,7 @@ public:
         cout.flush();
     }
 
-    int Write(const char* data, size_t len, ostream &SRT_ATR_UNUSED = cout) override
+    int Write(const char* data, size_t len, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         cout.write(data, len);
         return (int) len;
@@ -958,7 +958,7 @@ public:
         eof = false;
     }
 
-    int Read(size_t chunk, bytevector& data, ostream &SRT_ATR_UNUSED = cout) override
+    int Read(size_t chunk, bytevector& data, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         if (data.size() < chunk)
             data.resize(chunk);
@@ -1007,7 +1007,7 @@ public:
 
     }
 
-    int Write(const char* data, size_t len, ostream &SRT_ATR_UNUSED = cout) override
+    int Write(const char* data, size_t len, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         int stat = sendto(m_sock, data, (int) len, 0, (sockaddr*)&sadr, sizeof sadr);
         if ( stat == -1 )

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -183,7 +183,7 @@ public:
 
 
     SrtModel(string host, int port, map<string,string> par);
-    void Establish(ref_t<std::string> name);
+    void Establish(std::string& name);
 
     void Close()
     {

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -318,12 +318,12 @@ SRTSOCKET CUDTUnited::newSocket()
    return ns->m_SocketID;
 }
 
-int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, CHandShake* hs, const CPacket& hspkt,
-        ref_t<SRT_REJECT_REASON> r_error)
+int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
+        CHandShake& w_hs, SRT_REJECT_REASON& w_error)
 {
    CUDTSocket* ns = NULL;
 
-   *r_error = SRT_REJ_IPE;
+   w_error = SRT_REJ_IPE;
 
    // Can't manage this error through an exception because this is
    // running in the listener loop.
@@ -335,7 +335,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
    }
 
    // if this connection has already been processed
-   if ((ns = locatePeer(peer, hs->m_iID, hs->m_iISN)) != NULL)
+   if ((ns = locatePeer(peer, w_hs.m_iID, w_hs.m_iISN)) != NULL)
    {
       if (ns->m_pUDT->m_bBroken)
       {
@@ -353,11 +353,11 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
          // connection already exist, this is a repeated connection request
          // respond with existing HS information
 
-         hs->m_iISN = ns->m_pUDT->m_iISN;
-         hs->m_iMSS = ns->m_pUDT->m_iMSS;
-         hs->m_iFlightFlagSize = ns->m_pUDT->m_iFlightFlagSize;
-         hs->m_iReqType = URQ_CONCLUSION;
-         hs->m_iID = ns->m_SocketID;
+         w_hs.m_iISN = ns->m_pUDT->m_iISN;
+         w_hs.m_iMSS = ns->m_pUDT->m_iMSS;
+         w_hs.m_iFlightFlagSize = ns->m_pUDT->m_iFlightFlagSize;
+         w_hs.m_iReqType = URQ_CONCLUSION;
+         w_hs.m_iID = ns->m_SocketID;
 
          return 0;
 
@@ -368,7 +368,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
    // exceeding backlog, refuse the connection request
    if (ls->m_pQueuedSockets->size() >= ls->m_uiBackLog)
    {
-       *r_error = SRT_REJ_BACKLOG;
+       w_error = SRT_REJ_BACKLOG;
        LOGC(mglog.Error, log << "newConnection: listen backlog=" << ls->m_uiBackLog << " EXCEEDED");
        return -1;
    }
@@ -382,7 +382,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
    }
    catch (...)
    {
-      *r_error = SRT_REJ_RESOURCE;
+      w_error = SRT_REJ_RESOURCE;
       delete ns;
       LOGC(mglog.Error, log << "IPE: newConnection: unexpected exception (probably std::bad_alloc)");
       return -1;
@@ -395,14 +395,14 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
 
    ns->m_ListenSocket = listen;
    ns->m_pUDT->m_SocketID = ns->m_SocketID;
-   ns->m_PeerID = hs->m_iID;
-   ns->m_iISN = hs->m_iISN;
+   ns->m_PeerID = w_hs.m_iID;
+   ns->m_iISN = w_hs.m_iISN;
 
    int error = 0;
 
    // Set the error code for all prospective problems below.
    // It won't be interpreted when result was successful.
-   *r_error = SRT_REJ_RESOURCE;
+   w_error = SRT_REJ_RESOURCE;
 
    // These can throw exception only when the memory allocation failed.
    // CUDT::connect() translates exception into CUDTException.
@@ -415,7 +415,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
        // this call causes sending the SRT Handshake through this socket.
        // Without this mapping the socket cannot be found and therefore
        // the SRT Handshake message would fail.
-       HLOGF(mglog.Debug, 
+       HLOGF(mglog.Debug,
                "newConnection: incoming %s, mapping socket %d",
                SockaddrToString(peer).c_str(), ns->m_SocketID);
        {
@@ -428,18 +428,18 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
        updateListenerMux(ns, ls);
        if (ls->m_pUDT->m_cbAcceptHook)
        {
-           if (!ls->m_pUDT->runAcceptHook(ns->m_pUDT, peer.get(), hs, hspkt))
+           if (!ls->m_pUDT->runAcceptHook(ns->m_pUDT, peer.get(), w_hs, hspkt))
            {
                error = 1;
                goto ERR_ROLLBACK;
            }
        }
-       ns->m_pUDT->acceptAndRespond(peer, hs, hspkt);
+       ns->m_pUDT->acceptAndRespond(peer, hspkt, (w_hs));
    }
    catch (...)
    {
        // Extract the error that was set in this new failed entity.
-       *r_error = ns->m_pUDT->m_RejectReason;
+       w_error = ns->m_pUDT->m_RejectReason;
        error = 1;
        goto ERR_ROLLBACK;
    }
@@ -1932,7 +1932,7 @@ int CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
    try
    {
        sockaddr_any sa (name, namelen);
-       if ( sa.len == 0 )
+       if (sa.len == 0)
        {
            // This happens if the namelen check proved it to be
            // too small for particular family, or that family is
@@ -2242,12 +2242,12 @@ int CUDT::sendmsg(
 }
 
 int CUDT::sendmsg2(
-   SRTSOCKET u, const char* buf, int len, ref_t<SRT_MSGCTRL> r_m)
+   SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
 {
    try
    {
       CUDT* udt = s_UDTUnited.lookup(u);
-      return udt->sendmsg2(buf, len, r_m);
+      return udt->sendmsg2(buf, len, (w_m));
    }
    catch (const CUDTException& e)
    {
@@ -2289,12 +2289,12 @@ int CUDT::recvmsg(SRTSOCKET u, char* buf, int len, uint64_t& srctime)
    }
 }
 
-int CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, ref_t<SRT_MSGCTRL> r_m)
+int CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
 {
    try
    {
       CUDT* udt = s_UDTUnited.lookup(u);
-      return udt->recvmsg2(buf, len, r_m);
+      return udt->recvmsg2(buf, len, (w_m));
    }
    catch (const CUDTException& e)
    {

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -155,8 +155,8 @@ public:
       /// @param [in,out] hs handshake information from peer side (in), negotiated value (out);
       /// @return If the new connection is successfully created: 1 success, 0 already exist, -1 error.
 
-   int newConnection(const SRTSOCKET listen, const sockaddr_any& peer, CHandShake* hs, const CPacket& hspkt,
-           ref_t<SRT_REJECT_REASON> r_error);
+   int newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
+           CHandShake& w_hs, SRT_REJECT_REASON& w_error);
 
    int installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);
 

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -138,10 +138,8 @@ CSndBuffer::~CSndBuffer()
    pthread_mutex_destroy(&m_BufLock);
 }
 
-void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint64_t srctime, ref_t<int32_t> r_msgno)
+void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint64_t srctime, int32_t& w_msgno)
 {
-    int32_t& msgno = *r_msgno;
-
     int size = len / m_iMSS;
     if ((len % m_iMSS) != 0)
         size ++;
@@ -163,7 +161,7 @@ void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint6
         << (inorder ? "" : " NOT") << " in order");
 
     Block* s = m_pLastBlock;
-    msgno = m_iNextMsgNo;
+    w_msgno = m_iNextMsgNo;
     for (int i = 0; i < size; ++ i)
     {
         int pktlen = len - i * m_iMSS;
@@ -171,7 +169,7 @@ void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint6
             pktlen = m_iMSS;
 
         HLOGC(dlog.Debug, log << "addBuffer: spreading from=" << (i*m_iMSS) << " size=" << pktlen << " TO BUFFER:" << (void*)s->m_pcData);
-        memcpy(s->m_pcData, data + i * m_iMSS, pktlen);
+        memcpy((s->m_pcData), data + i * m_iMSS, pktlen);
         s->m_iLength = pktlen;
 
         s->m_iMsgNoBitset = m_iNextMsgNo | inorder;
@@ -490,17 +488,15 @@ int CSndBuffer::getCurrBufSize() const
 
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
 
-int CSndBuffer::getAvgBufSize(ref_t<int> r_bytes, ref_t<int> r_tsp)
+int CSndBuffer::getAvgBufSize(int& w_bytes, int& w_tsp)
 {
-    int& bytes = *r_bytes;
-    int& timespan = *r_tsp;
     CGuard bufferguard(m_BufLock); /* Consistency of pkts vs. bytes vs. spantime */
 
     /* update stats in case there was no add/ack activity lately */
     updAvgBufSize(steady_clock::now());
 
-    bytes = m_iBytesCountMAvg;
-    timespan = m_TimespanMAvg;
+    w_bytes = m_iBytesCountMAvg;
+    w_tsp = m_TimespanMAvg;
     return(m_iCountMAvg);
 }
 
@@ -514,9 +510,9 @@ void CSndBuffer::updAvgBufSize(const steady_clock::time_point& now)
    if (1000 < elapsed_ms)
    {
       /* No sampling in last 1 sec, initialize average */
-      m_iCountMAvg = getCurrBufSize(Ref(m_iBytesCountMAvg), Ref(m_TimespanMAvg));
+      m_iCountMAvg = getCurrBufSize((m_iBytesCountMAvg), (m_TimespanMAvg));
       m_tsLastSamplingTime = now;
-   } 
+   }
    else //((1000000 / SRT_MAVG_SAMPLING_RATE) / 1000 <= elapsed_ms)
    {
       /*
@@ -528,7 +524,7 @@ void CSndBuffer::updAvgBufSize(const steady_clock::time_point& now)
       */
       int instspan;
       int bytescount;
-      int count = getCurrBufSize(Ref(bytescount), Ref(instspan));
+      int count = getCurrBufSize((bytescount), (instspan));
 
       HLOGC(dlog.Debug, log << "updAvgBufSize: " << elapsed_ms
               << ": " << count << " " << bytescount
@@ -543,15 +539,15 @@ void CSndBuffer::updAvgBufSize(const steady_clock::time_point& now)
 
 #endif /* SRT_ENABLE_SNDBUFSZ_MAVG */
 
-int CSndBuffer::getCurrBufSize(ref_t<int> bytes, ref_t<int> timespan)
+int CSndBuffer::getCurrBufSize(int& w_bytes, int& w_timespan)
 {
-   *bytes = m_iBytesCount;
+   w_bytes = m_iBytesCount;
    /* 
    * Timespan can be less then 1000 us (1 ms) if few packets. 
    * Also, if there is only one pkt in buffer, the time difference will be 0.
    * Therefore, always add 1 ms if not empty.
    */
-   *timespan = 0 < m_iCount ? count_milliseconds(m_tsLastOriginTime - m_pFirstBlock->m_tsOriginTime) + 1 : 0;
+   w_timespan = 0 < m_iCount ? count_milliseconds(m_tsLastOriginTime - m_pFirstBlock->m_tsOriginTime) + 1 : 0;
 
    return m_iCount;
 }
@@ -819,7 +815,7 @@ int CRcvBuffer::readBuffer(char* data, int len)
 
         HLOGC(dlog.Debug, log << CONID() << "readBuffer: copying buffer #" << p
                 << " targetpos=" << int(data-begin) << " sourcepos=" << m_iNotch << " size=" << unitsize << " left=" << (unitsize-rs));
-        memcpy(data, m_pUnit[p]->m_Packet.m_pcData + m_iNotch, unitsize);
+        memcpy((data), m_pUnit[p]->m_Packet.m_pcData + m_iNotch, unitsize);
         data += unitsize;
 
         if ((rs > unitsize) || (rs == int(m_pUnit[p]->m_Packet.getLength()) - m_iNotch))
@@ -929,13 +925,13 @@ bool CRcvBuffer::getRcvFirstMsg(steady_clock::time_point& w_tsbpdtime,
     // tsbpdtime will be retrieved by the below call
     // Returned values:
     // - tsbpdtime: real time when the packet is ready to play (whether ready to play or not)
-    // - passack: false (the report concerns a packet with an exactly next sequence)
-    // - skipseqno == -1: no packets to skip towards the first RTP
-    // - ppkt: that exactly packet that is reported (for debugging purposes)
+    // - w_passack: false (the report concerns a packet with an exactly next sequence)
+    // - w_skipseqno == -1: no packets to skip towards the first RTP
+    // - w_curpktseq: that exactly packet that is reported (for debugging purposes)
     // - @return: whether the reported packet is ready to play
 
     /* Check the acknowledged packets */
-    if (getRcvReadyMsg(w_tsbpdtime, w_curpktseq))
+    if (getRcvReadyMsg((w_tsbpdtime), (w_curpktseq)))
     {
         HLOGC(dlog.Debug, log << "getRcvFirstMsg: ready CONTIG packet: %" << w_curpktseq);
         return true;
@@ -950,9 +946,9 @@ bool CRcvBuffer::getRcvFirstMsg(steady_clock::time_point& w_tsbpdtime,
 
     // Below this line we have only two options:
     // - m_iMaxPos == 0, which means that no more packets are in the buffer
-    //    - returned: tsbpdtime=0, passack=true, skipseqno=-1, ppkt=0, @return false
+    //    - returned: tsbpdtime=0, w_passack=true, w_skipseqno=-1, w_curpktseq=<unchanged>, @return false
     // - m_iMaxPos > 0, which means that there are packets arrived after a lost packet:
-    //    - returned: tsbpdtime=PKT.TS, passack=true, skipseqno=PKT.SEQ, ppkt=PKT, @return LOCAL(PKT.TS) <= NOW
+    //    - returned: tsbpdtime=PKT.TS, w_passack=true, w_skipseqno=PKT.SEQ, w_curpktseq=PKT, @return LOCAL(PKT.TS) <= NOW
 
     /* 
      * No acked packets ready but caller want to know next packet to wait for
@@ -1614,7 +1610,7 @@ void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, pthread_mutex_t& 
 int CRcvBuffer::readMsg(char* data, int len)
 {
     SRT_MSGCTRL dummy = srt_msgctrl_default;
-    return readMsg(data, len, Ref(dummy));
+    return readMsg(data, len, (dummy));
 }
 
 
@@ -1633,13 +1629,12 @@ void CRcvBuffer::debugTraceJitter(uint64_t rplaytime)
 }
 #endif   /* SRT_DEBUG_TSBPD_OUTJITTER */
 
-int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
+int CRcvBuffer::readMsg(char* data, int len, SRT_MSGCTRL& w_msgctl)
 {
-    SRT_MSGCTRL& msgctl = *r_msgctl;
     int p, q;
     bool passack;
     bool empty = true;
-    uint64_t& rplaytime = msgctl.srctime;
+    uint64_t& w_playtime = w_msgctl.srctime;
 
 #ifdef ENABLE_HEAVY_LOGGING
     reportBufferStats();
@@ -1651,8 +1646,8 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
         int seq = 0;
 
         steady_clock::time_point play_time;
-        const bool isReady = getRcvReadyMsg(play_time, (seq));
-        rplaytime = count_microseconds(play_time.time_since_epoch());
+        const bool isReady = getRcvReadyMsg((play_time), (seq));
+        w_playtime = count_microseconds(play_time.time_since_epoch());
 
         if (isReady)
         {
@@ -1662,13 +1657,13 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
             // so in one "unit".
             p = q = m_iStartPos;
 
-            debugTraceJitter(rplaytime);
+            debugTraceJitter(w_playtime);
         }
     }
     else
     {
-        rplaytime = 0;
-        if (scanMsg(Ref(p), Ref(q), Ref(passack)))
+        w_playtime = 0;
+        if (scanMsg((p), (q), (passack)))
             empty = false;
 
     }
@@ -1682,8 +1677,8 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 
     // This returns the sequence number and message number to
     // the API caller.
-    msgctl.pktseq = pkt1.getSeqNo();
-    msgctl.msgno = pkt1.getMsgSeq();
+    w_msgctl.pktseq = pkt1.getSeqNo();
+    w_msgctl.msgno = pkt1.getMsgSeq();
 
     SRT_ASSERT(len > 0);
     int rs = len > 0 ? len : 0;
@@ -1702,7 +1697,7 @@ int CRcvBuffer::readMsg(char* data, int len, ref_t<SRT_MSGCTRL> r_msgctl)
 
         if (unitsize > 0)
         {
-            memcpy(data, m_pUnit[p]->m_Packet.m_pcData, unitsize);
+            memcpy((data), m_pUnit[p]->m_Packet.m_pcData, unitsize);
             data += unitsize;
             rs -= unitsize;
             IF_HEAVY_LOGGING(readMsgHeavyLogging(p));
@@ -1777,10 +1772,8 @@ void CRcvBuffer::readMsgHeavyLogging(int p)
 }
 #endif
 
-bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
+bool CRcvBuffer::scanMsg(int& w_p, int& w_q, bool& w_passack)
 {
-    int& p = *r_p;
-    int& q = *r_q;
 
     // empty buffer
     if ((m_iStartPos == m_iLastAckPos) && (m_iMaxPos <= 0))
@@ -1860,9 +1853,9 @@ bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
     //   in which case it returns with m_iStartPos <% m_iLastAckPos (earlier)
     // Also all units that lied before m_iStartPos are removed.
 
-    p = -1;                  // message head
-    q = m_iStartPos;         // message tail
-    *passack = m_iStartPos == m_iLastAckPos;
+    w_p = -1;                  // message head
+    w_q = m_iStartPos;         // message tail
+    w_passack = m_iStartPos == m_iLastAckPos;
     bool found = false;
 
     // looking for the first message
@@ -1898,31 +1891,31 @@ bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
 
     for (int i = 0, n = m_iMaxPos + getRcvDataSize(); i < n; ++ i)
     {
-        if (m_pUnit[q] && m_pUnit[q]->m_iFlag == CUnit::GOOD)
+        if (m_pUnit[w_q] && m_pUnit[w_q]->m_iFlag == CUnit::GOOD)
         {
             // Equivalent pseudocode:
-            // PacketBoundary bound = m_pUnit[q]->m_Packet.getMsgBoundary();
+            // PacketBoundary bound = m_pUnit[w_q]->m_Packet.getMsgBoundary();
             // if ( IsSet(bound, PB_FIRST) )
-            //     p = q;
-            // if ( IsSet(bound, PB_LAST) && p != -1 ) 
+            //     w_p = w_q;
+            // if ( IsSet(bound, PB_LAST) && w_p != -1 ) 
             //     found = true;
             //
-            // Not implemented this way because it uselessly check p for -1
+            // Not implemented this way because it uselessly check w_p for -1
             // also after setting it explicitly.
 
-            switch (m_pUnit[q]->m_Packet.getMsgBoundary())
+            switch (m_pUnit[w_q]->m_Packet.getMsgBoundary())
             {
             case PB_SOLO: // 11
-                p = q;
+                w_p = w_q;
                 found = true;
                 break;
 
             case PB_FIRST: // 10
-                p = q;
+                w_p = w_q;
                 break;
 
             case PB_LAST: // 01
-                if (p != -1)
+                if (w_p != -1)
                     found = true;
                 break;
 
@@ -1933,7 +1926,7 @@ bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
         else
         {
             // a hole in this message, not valid, restart search
-            p = -1;
+            w_p = -1;
         }
 
         // 'found' is set when the current iteration hit a message with PB_LAST
@@ -1941,7 +1934,7 @@ bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
         if (found)
         {
             // the msg has to be ack'ed or it is allowed to read out of order, and was not read before
-            if (!*passack || !m_pUnit[q]->m_Packet.getMsgOrderFlag())
+            if (!w_passack || !m_pUnit[w_q]->m_Packet.getMsgOrderFlag())
             {
                 HLOGC(mglog.Debug, log << "scanMsg: found next-to-broken message, delivering OUT OF ORDER.");
                 break;
@@ -1950,11 +1943,11 @@ bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
             found = false;
         }
 
-        if (++ q == m_iSize)
-            q = 0;
+        if (++ w_q == m_iSize)
+            w_q = 0;
 
-        if (q == m_iLastAckPos)
-            *passack = true;
+        if (w_q == m_iLastAckPos)
+            w_passack = true;
     }
 
     // no msg found
@@ -1962,24 +1955,24 @@ bool CRcvBuffer::scanMsg(ref_t<int> r_p, ref_t<int> r_q, ref_t<bool> passack)
     {
         // NOTE:
         // This situation may only happen if:
-        // - Found a packet with PB_FIRST, so p = q at the moment when it was found
-        // - Possibly found following components of that message up to shifted q
+        // - Found a packet with PB_FIRST, so w_p = w_q at the moment when it was found
+        // - Possibly found following components of that message up to shifted w_q
         // - Found no terminal packet (PB_LAST) for that message.
 
         // if the message is larger than the receiver buffer, return part of the message
-        if ((p != -1) && (shiftFwd(q) == p))
+        if ((w_p != -1) && (shiftFwd(w_q) == w_p))
         {
             HLOGC(mglog.Debug, log << "scanMsg: BUFFER FULL and message is INCOMPLETE. Returning PARTIAL MESSAGE.");
             found = true;
         }
         else
         {
-            HLOGC(mglog.Debug, log << "scanMsg: PARTIAL or NO MESSAGE found: p=" << p << " q=" << q);
+            HLOGC(mglog.Debug, log << "scanMsg: PARTIAL or NO MESSAGE found: p=" << w_p << " q=" << w_q);
         }
     }
     else
     {
-        HLOGC(mglog.Debug, log << "scanMsg: extracted message p=" << p << " q=" << q << " (" << ((q-p+m_iSize+1)%m_iSize) << " packets)");
+        HLOGC(mglog.Debug, log << "scanMsg: extracted message p=" << w_p << " q=" << w_q << " (" << ((w_q-w_p+m_iSize+1)%m_iSize) << " packets)");
     }
 
     return found;

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -81,7 +81,7 @@ public:
       /// @param [in] ttl time to live in milliseconds
       /// @param [in] order if the block should be delivered in order, for DGRAM only
 
-   void addBuffer(const char* data, int len, int ttl, bool order, uint64_t srctime, ref_t<int32_t> r_msgno);
+   void addBuffer(const char* data, int len, int ttl, bool order, uint64_t srctime, int32_t& w_msgno);
 
       /// Read a block of data from file and insert it into the sending list.
       /// @param [in] ifs input file stream.
@@ -124,9 +124,9 @@ public:
 
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
    void updAvgBufSize(const srt::sync::steady_clock::time_point& time);
-   int getAvgBufSize(ref_t<int> bytes, ref_t<int> timespan);
+   int getAvgBufSize(int& bytes, int& timespan);
 #endif /* SRT_ENABLE_SNDBUFSZ_MAVG */
-   int getCurrBufSize(ref_t<int> bytes, ref_t<int> timespan);
+   int getCurrBufSize(int& bytes, int& timespan);
 
    uint64_t getInRatePeriod() const { return m_InRatePeriod; }
 
@@ -342,7 +342,7 @@ public:
       /// @param [out] tsbpdtime localtime-based (uSec) packet time stamp including buffering delay
       /// @return actuall size of data read.
 
-   int readMsg(char* data, int len, ref_t<SRT_MSGCTRL> mctrl);
+   int readMsg(char* data, int len, SRT_MSGCTRL& w_mctrl);
 
       /// Query if data is ready to read (tsbpdtime <= now if TsbPD is active).
       /// @param [out] tsbpdtime localtime-based (uSec) packet time stamp including buffering delay
@@ -475,7 +475,7 @@ private:
    void countBytes(int pkts, int bytes, bool acked = false);
 
 private:
-   bool scanMsg(ref_t<int> start, ref_t<int> end, ref_t<bool> passack);
+   bool scanMsg(int& w_start, int& w_end, bool& w_passack);
 
    int shift(int basepos, int shift) const
    {

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -104,15 +104,15 @@ int CInfoBlock::getKey()
    return m_piIP[0] + m_piIP[1] + m_piIP[2] + m_piIP[3];
 }
 
-void CInfoBlock::convert(const sockaddr_any& addr, uint32_t ip[4])
+void CInfoBlock::convert(const sockaddr_any& addr, uint32_t aw_ip[4])
 {
    if (addr.family() == AF_INET)
    {
-      ip[0] = addr.sin.sin_addr.s_addr;
-      ip[1] = ip[2] = ip[3] = 0;
+      aw_ip[0] = addr.sin.sin_addr.s_addr;
+      aw_ip[1] = aw_ip[2] = aw_ip[3] = 0;
    }
    else
    {
-      memcpy((ip), addr.sin6.sin6_addr.s6_addr, 16);
+      memcpy((aw_ip), addr.sin6.sin6_addr.s6_addr, sizeof addr.sin6.sin6_addr.s6_addr);
    }
 }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -611,7 +611,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void *optval, int optlen)
         memset(&m_CryptoSecret, 0, sizeof(m_CryptoSecret));
         m_CryptoSecret.typ = HAICRYPT_SECTYP_PASSPHRASE;
         m_CryptoSecret.len = (optlen <= (int)sizeof(m_CryptoSecret.str) ? optlen : (int)sizeof(m_CryptoSecret.str));
-        memcpy(m_CryptoSecret.str, optval, m_CryptoSecret.len);
+        memcpy((m_CryptoSecret.str), optval, m_CryptoSecret.len);
 #else
         if (optlen == 0)
             break;
@@ -1415,7 +1415,7 @@ size_t CUDT::fillSrtHandshake(uint32_t *srtdata, size_t srtlen, int msgtype, int
 
     srtlen = SRT_HS__SIZE; // We use only that much space.
 
-    memset(srtdata, 0, sizeof(uint32_t) * srtlen);
+    memset((srtdata), 0, sizeof(uint32_t) * srtlen);
     /* Current version (1.x.x) SRT handshake */
     srtdata[SRT_HS_VERSION] = m_lSrtVersion; /* Required version */
     srtdata[SRT_HS_FLAGS] |= SrtVersionCapabilities();
@@ -1681,58 +1681,56 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
 // PREREQUISITE:
 // pkt must be set the buffer and configured for UMSG_HANDSHAKE.
 // Note that this function replaces also serialization for the HSv4.
-bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
-                              ref_t<CHandShake> r_hs,
-                              int               srths_cmd,
-                              int               srtkm_cmd,
-                              const uint32_t *  kmdata,
-                              size_t            kmdata_wordsize /* IN WORDS, NOT BYTES!!! */)
+bool CUDT::createSrtHandshake(
+        int             srths_cmd,
+        int             srtkm_cmd,
+        const uint32_t* kmdata,
+        size_t          kmdata_wordsize, // IN WORDS, NOT BYTES!!!
+        CPacket&        w_pkt,
+        CHandShake&     w_hs)
 {
-    CPacket &   pkt = *r_pkt;
-    CHandShake &hs  = *r_hs;
-
     // This function might be called before the opposite version was recognized.
     // Check if the version is exactly 4 because this means that the peer has already
     // sent something - asynchronously, and usually in rendezvous - and we already know
     // that the peer is version 4. In this case, agent must behave as HSv4, til the end.
     if (m_ConnRes.m_iVersion == HS_VERSION_UDT4)
     {
-        hs.m_iVersion = HS_VERSION_UDT4;
-        hs.m_iType    = UDT_DGRAM;
-        if (hs.m_extension)
+        w_hs.m_iVersion = HS_VERSION_UDT4;
+        w_hs.m_iType    = UDT_DGRAM;
+        if (w_hs.m_extension)
         {
             // Should be impossible
             LOGC(mglog.Error, log << "createSrtHandshake: IPE: EXTENSION SET WHEN peer reports version 4 - fixing...");
-            hs.m_extension = false;
+            w_hs.m_extension = false;
         }
     }
     else
     {
-        hs.m_iType = 0; // Prepare it for flags
+        w_hs.m_iType = 0; // Prepare it for flags
     }
 
     HLOGC(mglog.Debug,
-          log << "createSrtHandshake: buf size=" << pkt.getLength() << " hsx=" << MessageTypeStr(UMSG_EXT, srths_cmd)
+          log << "createSrtHandshake: buf size=" << w_pkt.getLength() << " hsx=" << MessageTypeStr(UMSG_EXT, srths_cmd)
               << " kmx=" << MessageTypeStr(UMSG_EXT, srtkm_cmd) << " kmdata_wordsize=" << kmdata_wordsize
-              << " version=" << hs.m_iVersion);
+              << " version=" << w_hs.m_iVersion);
 
     // Once you are certain that the version is HSv5, set the enc type flags
     // to advertise pbkeylen. Otherwise make sure that the old interpretation
     // will correctly pick up the type field. PBKEYLEN should be advertized
     // regardless of what URQ stage the handshake is (note that in case of rendezvous
     // CONCLUSION might be the FIRST MESSAGE EVER RECEIVED by a party).
-    if (hs.m_iVersion > HS_VERSION_UDT4)
+    if (w_hs.m_iVersion > HS_VERSION_UDT4)
     {
         // Check if there was a failure to receie HSREQ before trying to craft HSRSP.
         // If fillSrtHandshake_HSRSP catches the condition of m_tsRcvPeerStartTime == 0,
         // it will return size 0, which will mess up with further extension procedures;
         // PREVENT THIS HERE.
-        if (hs.m_iReqType == URQ_CONCLUSION && srths_cmd == SRT_CMD_HSRSP && is_zero(m_tsRcvPeerStartTime))
+        if (w_hs.m_iReqType == URQ_CONCLUSION && srths_cmd == SRT_CMD_HSRSP && is_zero(m_tsRcvPeerStartTime))
         {
             LOGC(mglog.Error,
                  log << "createSrtHandshake: IPE (non-fatal): Attempting to craft HSRSP without received HSREQ. "
                         "BLOCKING extensions.");
-            hs.m_extension = false;
+            w_hs.m_extension = false;
         }
 
         // The situation when this function is called without requested extensions
@@ -1742,8 +1740,9 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
         //
         // Keep 0 in the SRT_HSTYPE_HSFLAGS field, but still advertise PBKEYLEN
         // in the SRT_HSTYPE_ENCFLAGS field.
-        hs.m_iType                  = SrtHSRequest::wrapFlags(false /*no magic in HSFLAGS*/, m_iSndCryptoKeyLen);
-        bool whether SRT_ATR_UNUSED = m_iSndCryptoKeyLen != 0;
+        w_hs.m_iType                  = SrtHSRequest::wrapFlags(false /*no magic in HSFLAGS*/, m_iSndCryptoKeyLen);
+
+        IF_HEAVY_LOGGING(bool whether = m_iSndCryptoKeyLen != 0);
         HLOGC(mglog.Debug,
               log << "createSrtHandshake: " << (whether ? "" : "NOT ")
                   << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
@@ -1756,20 +1755,20 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
     }
     else
     {
-        hs.m_iType = UDT_DGRAM;
+        w_hs.m_iType = UDT_DGRAM;
     }
 
     // values > URQ_CONCLUSION include also error types
-    // if (hs.m_iVersion == HS_VERSION_UDT4 || hs.m_iReqType > URQ_CONCLUSION) <--- This condition was checked b4 and
+    // if (w_hs.m_iVersion == HS_VERSION_UDT4 || w_hs.m_iReqType > URQ_CONCLUSION) <--- This condition was checked b4 and
     // it's only valid for caller-listener mode
-    if (!hs.m_extension)
+    if (!w_hs.m_extension)
     {
         // Serialize only the basic handshake, if this is predicted for
         // Hsv4 peer or this is URQ_INDUCTION or URQ_WAVEAHAND.
-        size_t hs_size = pkt.getLength();
-        hs.store_to(pkt.m_pcData, Ref(hs_size));
-        pkt.setLength(hs_size);
-        HLOGC(mglog.Debug, log << "createSrtHandshake: (no ext) size=" << hs_size << " data: " << hs.show());
+        size_t hs_size = w_pkt.getLength();
+        w_hs.store_to((w_pkt.m_pcData), (hs_size));
+        w_pkt.setLength(hs_size);
+        HLOGC(mglog.Debug, log << "createSrtHandshake: (no ext) size=" << hs_size << " data: " << w_hs.show());
         return true;
     }
 
@@ -1789,14 +1788,14 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
     bool have_filter  = false;
 
     // Install the SRT extensions
-    hs.m_iType |= CHandShake::HS_EXT_HSREQ;
+    w_hs.m_iType |= CHandShake::HS_EXT_HSREQ;
 
     if (srths_cmd == SRT_CMD_HSREQ)
     {
         if (m_sStreamName != "")
         {
             have_sid = true;
-            hs.m_iType |= CHandShake::HS_EXT_CONFIG;
+            w_hs.m_iType |= CHandShake::HS_EXT_CONFIG;
             logext += ",SID";
         }
     }
@@ -1832,7 +1831,7 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
     if (peer_filter_capable && m_OPT_PktFilterConfigString != "")
     {
         have_filter = true;
-        hs.m_iType |= CHandShake::HS_EXT_CONFIG;
+        w_hs.m_iType |= CHandShake::HS_EXT_CONFIG;
         logext += ",filter";
     }
 
@@ -1840,7 +1839,7 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
     if (sm != "" && sm != "live")
     {
         have_congctl = true;
-        hs.m_iType |= CHandShake::HS_EXT_CONFIG;
+        w_hs.m_iType |= CHandShake::HS_EXT_CONFIG;
         logext += ",CONGCTL";
     }
 
@@ -1853,11 +1852,11 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
     if (m_CryptoSecret.len > 0 || kmdata_wordsize > 0)
     {
         have_kmreq = true;
-        hs.m_iType |= CHandShake::HS_EXT_KMREQ;
+        w_hs.m_iType |= CHandShake::HS_EXT_KMREQ;
         logext += ",KMX";
     }
 
-    HLOGC(mglog.Debug, log << "createSrtHandshake: (ext: " << logext << ") data: " << hs.show());
+    HLOGC(mglog.Debug, log << "createSrtHandshake: (ext: " << logext << ") data: " << w_hs.show());
 
     // NOTE: The HSREQ is practically always required, although may happen
     // in future that CONCLUSION can be sent multiple times for a separate
@@ -1865,14 +1864,14 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
     // Also, KMREQ may occur multiple times.
 
     // So, initially store the UDT legacy handshake.
-    size_t hs_size = pkt.getLength(), total_ra_size = (hs_size / sizeof(uint32_t)); // Maximum size of data
-    hs.store_to(pkt.m_pcData, Ref(hs_size));                                        // hs_size is updated
+    size_t hs_size = w_pkt.getLength(), total_ra_size = (hs_size / sizeof(uint32_t)); // Maximum size of data
+    w_hs.store_to((w_pkt.m_pcData), (hs_size));                                        // hs_size is updated
 
     size_t ra_size = hs_size / sizeof(int32_t);
 
     // Now attach the SRT handshake for HSREQ
     size_t    offset = ra_size;
-    uint32_t *p      = reinterpret_cast<uint32_t *>(pkt.m_pcData);
+    uint32_t *p      = reinterpret_cast<uint32_t *>(w_pkt.m_pcData);
     // NOTE: since this point, ra_size has a size in int32_t elements, NOT BYTES.
 
     // The first 4-byte item is the CMD/LENGTH spec.
@@ -1913,8 +1912,8 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
         size_t wordsize         = (m_sStreamName.size() + 3) / 4;
         size_t aligned_bytesize = wordsize * 4;
 
-        memset(p + offset, 0, aligned_bytesize);
-        memcpy(p + offset, m_sStreamName.data(), m_sStreamName.size());
+        memset((p + offset), 0, aligned_bytesize);
+        memcpy((p + offset), m_sStreamName.data(), m_sStreamName.size());
         // Preswap to little endian (in place due to possible padding zeros)
         HtoILA((uint32_t *)(p + offset), (uint32_t *)(p + offset), wordsize);
 
@@ -1945,9 +1944,9 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
         size_t wordsize         = (sm.size() + 3) / 4;
         size_t aligned_bytesize = wordsize * 4;
 
-        memset(p + offset, 0, aligned_bytesize);
+        memset((p + offset), 0, aligned_bytesize);
 
-        memcpy(p + offset, sm.data(), sm.size());
+        memcpy((p + offset), sm.data(), sm.size());
         // Preswap to little endian (in place due to possible padding zeros)
         HtoILA((uint32_t *)(p + offset), (uint32_t *)(p + offset), wordsize);
 
@@ -1969,8 +1968,8 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
         size_t wordsize         = (m_OPT_PktFilterConfigString.size() + 3) / 4;
         size_t aligned_bytesize = wordsize * 4;
 
-        memset(p + offset, 0, aligned_bytesize);
-        memcpy(p + offset, m_OPT_PktFilterConfigString.data(), m_OPT_PktFilterConfigString.size());
+        memset((p + offset), 0, aligned_bytesize);
+        memcpy((p + offset), m_OPT_PktFilterConfigString.data(), m_OPT_PktFilterConfigString.size());
 
         ra_size   = wordsize;
         *pcmdspec = HS_CMDSPEC_CMD::wrap(SRT_CMD_FILTER) | HS_CMDSPEC_SIZE::wrap(ra_size);
@@ -2083,38 +2082,36 @@ bool CUDT::createSrtHandshake(ref_t<CPacket>    r_pkt,
 
     // ra_size + offset has a value in element unit.
     // Switch it again to byte unit.
-    pkt.setLength((ra_size + offset) * sizeof(int32_t));
+    w_pkt.setLength((ra_size + offset) * sizeof(int32_t));
 
     HLOGC(mglog.Debug,
-          log << "createSrtHandshake: filled HSv5 handshake flags: " << CHandShake::ExtensionFlagStr(hs.m_iType)
-              << " length: " << pkt.getLength() << " bytes");
+          log << "createSrtHandshake: filled HSv5 handshake flags: " << CHandShake::ExtensionFlagStr(w_hs.m_iType)
+              << " length: " << w_pkt.getLength() << " bytes");
 
     return true;
 }
 
-static int
-FindExtensionBlock(uint32_t *begin, size_t total_length, ref_t<size_t> r_out_len, ref_t<uint32_t *> r_next_block)
+static int FindExtensionBlock(uint32_t *begin, size_t total_length,
+        size_t& w_out_len, uint32_t*& w_next_block)
 {
     // Check if there's anything to process
     if (total_length == 0)
     {
-        *r_next_block = NULL;
-        *r_out_len    = 0;
+        w_next_block = NULL;
+        w_out_len    = 0;
         return SRT_CMD_NONE;
     }
 
-    size_t &   out_len    = *r_out_len;
-    uint32_t *&next_block = *r_next_block;
     // This function extracts the block command from the block and its length.
     // The command value is returned as a function result.
-    // The size of that command block is stored into out_len.
-    // The beginning of the prospective next block is stored in next_block.
+    // The size of that command block is stored into w_out_len.
+    // The beginning of the prospective next block is stored in w_next_block.
 
     // The caller must be aware that:
     // - exactly one element holds the block header (cmd+size), so the actual data are after this one.
     // - the returned size is the number of uint32_t elements since that first data element
-    // - the remaining size should be manually calculated as total_length - 1 - out_len, or
-    // simply, as next_block - begin.
+    // - the remaining size should be manually calculated as total_length - 1 - w_out_len, or
+    // simply, as w_next_block - begin.
 
     // Note that if the total_length is too short to extract the whole block, it will return
     // SRT_CMD_NONE. Note that total_length includes this first CMDSPEC word.
@@ -2128,23 +2125,25 @@ FindExtensionBlock(uint32_t *begin, size_t total_length, ref_t<size_t> r_out_len
     if (size + 1 > total_length)
         return SRT_CMD_NONE;
 
-    out_len = size;
+    w_out_len = size;
 
     if (total_length == size + 1)
-        next_block = NULL;
+        w_next_block = NULL;
     else
-        next_block = begin + 1 + size;
+        w_next_block = begin + 1 + size;
 
     return cmd;
 }
 
-static inline bool NextExtensionBlock(ref_t<uint32_t *> begin, uint32_t *next, ref_t<size_t> length)
+// NOTE: the rule of order of arguments is broken here because this order
+// serves better the logics and readability.
+static inline bool NextExtensionBlock(uint32_t*& w_begin, uint32_t* next, size_t& w_length)
 {
     if (!next)
         return false;
 
-    *length = *length - (next - *begin);
-    *begin  = next;
+    w_length = w_length - (next - w_begin);
+    w_begin  = next;
     return true;
 }
 
@@ -2177,7 +2176,8 @@ bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
         {
             uint32_t srtdata_out[SRTDATA_MAXSIZE];
             size_t   len_out = 0;
-            res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, srtdata_out, Ref(len_out), CUDT::HS_VERSION_UDT4);
+            res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4,
+                    (srtdata_out), (len_out));
             if (res == SRT_CMD_KMRSP)
             {
                 if (len_out == 1)
@@ -2545,14 +2545,14 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t len, uint32_t ts, 
 }
 
 // This function is called only when the URQ_CONCLUSION handshake has been received from the peer.
-bool CUDT::interpretSrtHandshake(const CHandShake &hs,
-                                 const CPacket &   hspkt,
-                                 uint32_t *out_data SRT_ATR_UNUSED,
-                                 size_t *           out_len)
+bool CUDT::interpretSrtHandshake(const CHandShake& hs,
+                                 const CPacket&    hspkt,
+                                 uint32_t*         out_data,
+                                 size_t*           pw_len)
 {
-    // Initialize out_len to 0 to handle the unencrypted case
-    if (out_len)
-        *out_len = 0;
+    // Initialize pw_len to 0 to handle the unencrypted case
+    if (pw_len)
+        *pw_len = 0;
 
     // The version=0 statement as rejection is used only since HSv5.
     // The HSv4 sends the AGREEMENT handshake message with version=0, do not misinterpret it.
@@ -2602,7 +2602,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
 
         for (;;) // this is ONE SHOT LOOP
         {
-            int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
+            int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
 
             size_t bytelen = blocklen * sizeof(uint32_t);
 
@@ -2717,7 +2717,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
 
         for (;;) // This is one shot loop, unless REPEATED by 'continue'.
         {
-            int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
+            int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
 
             HLOGC(mglog.Debug,
                   log << "interpretSrtHandshake: found extension: (" << cmd << ") " << MessageTypeStr(UMSG_EXT, cmd));
@@ -2725,15 +2725,15 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
             size_t bytelen = blocklen * sizeof(uint32_t);
             if (cmd == SRT_CMD_KMREQ)
             {
-                if (!out_data || !out_len)
+                if (!out_data || !pw_len)
                 {
                     m_RejectReason = SRT_REJ_IPE;
                     LOGC(mglog.Fatal, log << "IPE: HS/KMREQ extracted without passing target buffer!");
                     return false;
                 }
 
-                int res =
-                    m_pCryptoControl->processSrtMsg_KMREQ(begin + 1, bytelen, out_data, Ref(*out_len), HS_VERSION_SRT1);
+                int res = m_pCryptoControl->processSrtMsg_KMREQ(begin + 1, bytelen, HS_VERSION_SRT1,
+                            (out_data), (*pw_len));
                 if (res != SRT_CMD_KMRSP)
                 {
                     m_RejectReason = SRT_REJ_IPE;
@@ -2742,7 +2742,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
                           log << "interpretSrtHandshake: IPE/EPE KMREQ processing failed - returned " << res);
                     return false;
                 }
-                if (*out_len == 1)
+                if (*pw_len == 1)
                 {
                     // This means that there was an abnormal encryption situation occurred.
                     // This is inacceptable in case of strict encryption.
@@ -2783,7 +2783,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
             else
             {
                 HLOGC(mglog.Debug, log << "interpretSrtHandshake: ... skipping " << MessageTypeStr(UMSG_EXT, cmd));
-                if (NextExtensionBlock(Ref(begin), next, Ref(length)))
+                if (NextExtensionBlock((begin), next, (length)))
                     continue;
             }
 
@@ -2829,7 +2829,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
 
         for (;;) // This is one shot loop, unless REPEATED by 'continue'.
         {
-            int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
+            int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
 
             HLOGC(mglog.Debug,
                   log << "interpretSrtHandshake: found extension: (" << cmd << ") " << MessageTypeStr(UMSG_EXT, cmd));
@@ -2853,8 +2853,8 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
                 // subsequent characters of the string plus at least one '\0' at the end. This will
                 // make it a perfect NUL-terminated string, to be used to initialize a string.
                 char target[MAX_SID_LENGTH + 1];
-                memset(target, 0, MAX_SID_LENGTH + 1);
-                memcpy(target, begin + 1, bytelen);
+                memset((target), 0, MAX_SID_LENGTH + 1);
+                memcpy((target), begin + 1, bytelen);
 
                 // Un-swap on big endian machines
                 ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
@@ -2884,8 +2884,8 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
                 have_congctl = true;
 
                 char target[MAX_SID_LENGTH + 1];
-                memset(target, 0, MAX_SID_LENGTH + 1);
-                memcpy(target, begin + 1, bytelen);
+                memset((target), 0, MAX_SID_LENGTH + 1);
+                memcpy((target), begin + 1, bytelen);
                 // Un-swap on big endian machines
                 ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
 
@@ -2921,8 +2921,8 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
                 // shall be normally limited somehow, especially if used
                 // together with SID!
                 char target[MAX_SID_LENGTH + 1];
-                memset(target, 0, MAX_SID_LENGTH + 1);
-                memcpy(target, begin + 1, bytelen);
+                memset((target), 0, MAX_SID_LENGTH + 1);
+                memcpy((target), begin + 1, bytelen);
                 string fltcfg = target;
 
                 HLOGC(mglog.Debug,
@@ -2945,7 +2945,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake &hs,
                 HLOGC(mglog.Debug, log << "interpretSrtHandshake: ... skipping " << MessageTypeStr(UMSG_EXT, cmd));
             }
 
-            if (!NextExtensionBlock(Ref(begin), next, Ref(length)))
+            if (!NextExtensionBlock((begin), next, (length)))
                 break;
         }
     }
@@ -3198,7 +3198,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     reqpkt.m_iID = 0;
 
     size_t hs_size = m_iMaxSRTPayloadSize;
-    m_ConnReq.store_to(reqpkt.m_pcData, Ref(hs_size));
+    m_ConnReq.store_to((reqpkt.m_pcData), (hs_size));
 
     // Note that CPacket::allocate() sets also the size
     // to the size of the allocated buffer, which not
@@ -3290,7 +3290,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 
         cst = CONN_CONTINUE;
         response.setLength(m_iMaxSRTPayloadSize);
-        if (m_pRcvQueue->recvfrom(m_SocketID, Ref(response)) > 0)
+        if (m_pRcvQueue->recvfrom(m_SocketID, (response)) > 0)
         {
             HLOGC(mglog.Debug, log << CONID() << "startConnect: got response for connect request");
             cst = processConnectResponse(response, &e, true /*synchro*/);
@@ -3326,7 +3326,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
                 // it means that it has done all that was required, however none of the below
                 // things has to be done (this function will do it by itself if needed).
                 // Otherwise the handshake rolling can be interrupted and considered complete.
-                cst = processRendezvous(Ref(reqpkt), response, serv_addr, true /*synchro*/, RST_OK);
+                cst = processRendezvous(response, serv_addr, true /*synchro*/, RST_OK, (reqpkt));
                 if (cst == CONN_CONTINUE)
                     continue;
                 break;
@@ -3372,7 +3372,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
             //
             // Now that this is fixed, the handshake messages from RendezvousQueue
             // are sent only when there is a rendezvous mode or non-blocking mode.
-            if (!createSrtHandshake(Ref(reqpkt), Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
+            if (!createSrtHandshake(SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0, (reqpkt), (m_ConnReq)))
             {
                 LOGC(mglog.Error, log << "createSrtHandshake failed - REJECTING.");
                 cst = CONN_REJECT;
@@ -3494,7 +3494,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
     if (cst == CONN_RENDEZVOUS)
     {
         HLOGC(mglog.Debug, log << "processAsyncConnectRequest: passing to processRendezvous");
-        cst = processRendezvous(Ref(request), response, serv_addr, false /*asynchro*/, rst);
+        cst = processRendezvous(response, serv_addr, false /*asynchro*/, rst, (request));
         if (cst == CONN_ACCEPT)
         {
             HLOGC(mglog.Debug,
@@ -3522,7 +3522,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
     {
         // (this procedure will be also run for HSv4 rendezvous)
         HLOGC(mglog.Debug, log << "processAsyncConnectRequest: serializing HS: buffer size=" << request.getLength());
-        if (!createSrtHandshake(Ref(request), Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
+        if (!createSrtHandshake(SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0, (request), (m_ConnReq)))
         {
             // All 'false' returns from here are IPE-type, mostly "invalid argument" plus "all keys expired".
             LOGC(mglog.Error, log << "IPE: processAsyncConnectRequest: createSrtHandshake failed, dismissing.");
@@ -3543,7 +3543,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
         // Set the version to 0 as "handshake rejection" status and serialize it
         CHandShake zhs;
         size_t size = request.getLength();
-        zhs.store_to(request.m_pcData, Ref(size));
+        zhs.store_to((request.m_pcData), (size));
         request.setLength(size);
         */
     }
@@ -3601,7 +3601,8 @@ void CUDT::cookieContest()
 }
 
 EConnectStatus CUDT::processRendezvous(
-    ref_t<CPacket> reqpkt, const CPacket& response, const sockaddr_any& serv_addr, bool synchro, EReadStatus rst)
+    const CPacket& response, const sockaddr_any& serv_addr,
+    bool synchro, EReadStatus rst, CPacket& w_reqpkt)
 {
     if (m_RdvState == CHandShake::RDV_CONNECTED)
     {
@@ -3611,7 +3612,6 @@ EConnectStatus CUDT::processRendezvous(
 
     uint32_t kmdata[SRTDATA_MAXSIZE];
     size_t   kmdatasize = SRTDATA_MAXSIZE;
-    CPacket &rpkt       = *reqpkt;
 
     cookieContest();
 
@@ -3635,7 +3635,7 @@ EConnectStatus CUDT::processRendezvous(
     int  ext_flags       = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
     bool needs_extension = ext_flags != 0; // Initial value: received HS has extensions.
     bool needs_hsrsp;
-    rendezvousSwitchState(Ref(rsp_type), Ref(needs_extension), Ref(needs_hsrsp));
+    rendezvousSwitchState((rsp_type), (needs_extension), (needs_hsrsp));
     if (rsp_type > URQ_FAILURE_TYPES)
     {
         m_RejectReason = RejectReasonForURQ(rsp_type);
@@ -3716,7 +3716,7 @@ EConnectStatus CUDT::processRendezvous(
 
                         // Just do the same thing as in CCryptoControl::processSrtMsg_KMREQ for that case,
                         // that is, copy the NOSECRET code into KMX message.
-                        memcpy(kmdata, &m_pCryptoControl->m_RcvKmState, sizeof(int32_t));
+                        memcpy((kmdata), &m_pCryptoControl->m_RcvKmState, sizeof(int32_t));
                         kmdatasize = 1;
                     }
                     break;
@@ -3746,14 +3746,14 @@ EConnectStatus CUDT::processRendezvous(
                     {
                         // Sanity check
                         LOGC(mglog.Error, log << "IPE: KMX data not aligned to 4 bytes! size=" << msgsize);
-                        memset(kmdata + (kmdatasize * 4), 0, msgsize - (kmdatasize * 4));
+                        memset((kmdata + (kmdatasize * 4)), 0, msgsize - (kmdatasize * 4));
                         ++kmdatasize;
                     }
 
                     HLOGC(mglog.Debug,
                           log << "processRendezvous: getting KM DATA from the fore-recorded KMX from KMREQ, size="
                               << kmdatasize);
-                    memcpy(kmdata, m_pCryptoControl->getKmMsg_data(0), msgsize);
+                    memcpy((kmdata), m_pCryptoControl->getKmMsg_data(0), msgsize);
                 }
             }
             else
@@ -3770,8 +3770,10 @@ EConnectStatus CUDT::processRendezvous(
         HLOGC(mglog.Debug,
               log << "processRendezvous: HSREQ extension ok, creating HSRSP response. kmdatasize=" << kmdatasize);
 
-        rpkt.setLength(m_iMaxSRTPayloadSize);
-        if (!createSrtHandshake(reqpkt, Ref(m_ConnReq), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
+        w_reqpkt.setLength(m_iMaxSRTPayloadSize);
+        if (!createSrtHandshake(SRT_CMD_HSRSP, SRT_CMD_KMRSP,
+                    kmdata, kmdatasize,
+                    (w_reqpkt), (m_ConnReq)))
         {
             HLOGC(mglog.Debug,
                   log << "processRendezvous: rejecting due to problems in createSrtHandshake. REQ-TIME: LOW");
@@ -3840,7 +3842,7 @@ EConnectStatus CUDT::processRendezvous(
     // serialization.
     m_ConnReq.m_extension = needs_extension;
 
-    rpkt.setLength(m_iMaxSRTPayloadSize);
+    w_reqpkt.setLength(m_iMaxSRTPayloadSize);
     if (m_RdvState == CHandShake::RDV_CONNECTED)
     {
         // When synchro=false, don't lock a mutex for rendezvous queue.
@@ -3871,7 +3873,8 @@ EConnectStatus CUDT::processRendezvous(
     // needs_extension here distinguishes between cases 1 and 3.
     // NOTE: in case when interpretSrtHandshake was run under the conditions above (to interpret HSRSP),
     // then createSrtHandshake below will create only empty AGREEMENT message.
-    if (!createSrtHandshake(reqpkt, Ref(m_ConnReq), SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0))
+    if (!createSrtHandshake(SRT_CMD_HSREQ, SRT_CMD_KMREQ, 0, 0,
+                (w_reqpkt), (m_ConnReq)))
     {
         // m_RejectReason already set
         LOGC(mglog.Error, log << "createSrtHandshake failed (IPE?), connection rejected. REQ-TIME: LOW");
@@ -3896,12 +3899,12 @@ EConnectStatus CUDT::processRendezvous(
         // AGREEMENT is missed, it may have kinda initial tearing.
 
         const steady_clock::time_point now = steady_clock::now();
-        m_tsLastReqTime                      = now;
-        rpkt.m_iTimeStamp                  = count_microseconds(now - m_stats.tsStartTime);
+        m_tsLastReqTime                    = now;
+        w_reqpkt.m_iTimeStamp              = count_microseconds(now - m_stats.tsStartTime);
         HLOGC(mglog.Debug,
               log << "processRendezvous: rsp=AGREEMENT, reporting ACCEPT and sending just this one, REQ-TIME HIGH.");
-
-        m_pSndQueue->sendto(serv_addr, rpkt);
+                  
+        m_pSndQueue->sendto(serv_addr, w_reqpkt);
 
         return CONN_ACCEPT;
     }
@@ -4170,7 +4173,7 @@ void CUDT::applyResponseSettings()
     m_iRcvCurrSeqNo    = m_ConnRes.m_iISN - 1;
     m_iRcvCurrPhySeqNo = m_ConnRes.m_iISN - 1;
     m_PeerID           = m_ConnRes.m_iID;
-    memcpy(m_piSelfIP, m_ConnRes.m_piPeerIP, sizeof m_piSelfIP);
+    memcpy((m_piSelfIP), m_ConnRes.m_piPeerIP, sizeof m_piSelfIP);
 
     HLOGC(mglog.Debug,
           log << CONID() << "applyResponseSettings: HANSHAKE CONCLUDED. SETTING: payload-size=" << m_iMaxSRTPayloadSize
@@ -4339,7 +4342,7 @@ void CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t ty
 }
 
 // Rendezvous
-void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> needs_extension, ref_t<bool> needs_hsrsp)
+void CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_extension, bool& w_needs_hsrsp)
 {
     UDTRequestType req           = m_ConnRes.m_iReqType;
     int            hs_flags      = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
@@ -4378,8 +4381,8 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
     // (actually to RDV_ATTENTION). There's also no exit to RDV_FINE from RDV_ATTENTION.
 
     // DEFAULT STATEMENT: don't attach extensions to URQ_CONCLUSION, neither HSREQ nor HSRSP.
-    *needs_extension = false;
-    *needs_hsrsp     = false;
+    w_needs_extension = false;
+    w_needs_hsrsp     = false;
 
     string reason;
 
@@ -4406,7 +4409,7 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                       << "ext:" << (needext ? (needrsp ? "HSRSP" : "HSREQ") : "NONE")
                       << (reason == "" ? string() : "reason:" + reason));
         }
-    } l_logend = {m_RdvState, req, m_RdvState, *rsptype, *needs_extension, *needs_hsrsp, reason};
+    } l_logend = {m_RdvState, req, m_RdvState, w_rsptype, w_needs_extension, w_needs_hsrsp, reason};
 
 #endif
 
@@ -4422,22 +4425,22 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
             m_RdvState = CHandShake::RDV_ATTENTION;
 
             // NOTE: if this->isWinner(), attach HSREQ
-            *rsptype = URQ_CONCLUSION;
+            w_rsptype = URQ_CONCLUSION;
             if (hsd == HSD_INITIATOR)
-                *needs_extension = true;
+                w_needs_extension = true;
             return;
         }
 
         if (req == URQ_CONCLUSION)
         {
             m_RdvState = CHandShake::RDV_FINE;
-            *rsptype   = URQ_CONCLUSION;
+            w_rsptype   = URQ_CONCLUSION;
 
-            *needs_extension = true; // (see below - this needs to craft either HSREQ or HSRSP)
+            w_needs_extension = true; // (see below - this needs to craft either HSREQ or HSRSP)
             // if this->isWinner(), then craft HSREQ for that response.
             // if this->isLoser(), then this packet should bring HSREQ, so craft HSRSP for the response.
             if (hsd == HSD_RESPONDER)
-                *needs_hsrsp = true;
+                w_needs_hsrsp = true;
             return;
         }
     }
@@ -4453,9 +4456,9 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
             // agent has switched to ATTENTION state and continues sending
             // waveahands. In this case, just remain in ATTENTION state and
             // retry with URQ_CONCLUSION, as normally.
-            *rsptype = URQ_CONCLUSION;
+            w_rsptype = URQ_CONCLUSION;
             if (hsd == HSD_INITIATOR)
-                *needs_extension = true;
+                w_needs_extension = true;
             return;
         }
 
@@ -4474,12 +4477,12 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                         mglog.Debug,
                         log << "rendezvousSwitchState: "
                                "{INITIATOR}[ATTENTION] awaits CONCLUSION+HSRSP, got CONCLUSION, remain in [ATTENTION]");
-                    *rsptype         = URQ_CONCLUSION;
-                    *needs_extension = true; // If you expect to receive HSRSP, continue sending HSREQ
+                    w_rsptype         = URQ_CONCLUSION;
+                    w_needs_extension = true; // If you expect to receive HSRSP, continue sending HSREQ
                     return;
                 }
                 m_RdvState = CHandShake::RDV_CONNECTED;
-                *rsptype   = URQ_AGREEMENT;
+                w_rsptype   = URQ_AGREEMENT;
                 return;
             }
 
@@ -4494,22 +4497,22 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                         mglog.Warn,
                         log << "rendezvousSwitchState: (IPE!)"
                                "{RESPONDER}[ATTENTION] awaits CONCLUSION+HSREQ, got CONCLUSION, remain in [ATTENTION]");
-                    *rsptype         = URQ_CONCLUSION;
-                    *needs_extension = false; // If you received WITHOUT extensions, respond WITHOUT extensions (wait
-                                              // for the right message)
+                    w_rsptype         = URQ_CONCLUSION;
+                    w_needs_extension = false; // If you received WITHOUT extensions, respond WITHOUT extensions (wait
+                                               // for the right message)
                     return;
                 }
                 m_RdvState       = CHandShake::RDV_INITIATED;
-                *rsptype         = URQ_CONCLUSION;
-                *needs_extension = true;
-                *needs_hsrsp     = true;
+                w_rsptype         = URQ_CONCLUSION;
+                w_needs_extension = true;
+                w_needs_hsrsp     = true;
                 return;
             }
 
             LOGC(mglog.Error, log << "RENDEZVOUS COOKIE DRAW! Cannot resolve to a valid state.");
             // Fallback for cookie draw
             m_RdvState = CHandShake::RDV_INVALID;
-            *rsptype   = URQFailure(SRT_REJ_RDVCOOKIE);
+            w_rsptype   = URQFailure(SRT_REJ_RDVCOOKIE);
             return;
         }
 
@@ -4528,7 +4531,7 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                 m_RdvState = CHandShake::RDV_CONNECTED;
 
                 // Both sides are connected, no need to send anything anymore.
-                *rsptype = URQ_DONE;
+                w_rsptype = URQ_DONE;
                 return;
             }
 
@@ -4538,15 +4541,15 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                 // we have to request this once again. Send URQ_CONCLUSION in order to
                 // inform the other party that we need the conclusion message once again.
                 // The ATTENTION state should be maintained.
-                *rsptype         = URQ_CONCLUSION;
-                *needs_extension = true;
-                *needs_hsrsp     = true;
+                w_rsptype         = URQ_CONCLUSION;
+                w_needs_extension = true;
+                w_needs_hsrsp     = true;
                 return;
             }
         }
     }
-        reason = "ATTENTION -> WAVEAHAND(conclusion), CONCLUSION(agreement/conclusion), AGREEMENT (done/conclusion)";
-        break;
+    reason = "ATTENTION -> WAVEAHAND(conclusion), CONCLUSION(agreement/conclusion), AGREEMENT (done/conclusion)";
+    break;
 
     case CHandShake::RDV_FINE:
     {
@@ -4591,16 +4594,16 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
 
             if (!correct_switch)
             {
-                *rsptype = URQ_CONCLUSION;
+                w_rsptype = URQ_CONCLUSION;
                 // initiator should send HSREQ, responder HSRSP,
                 // in both cases extension is needed
-                *needs_extension = true;
-                *needs_hsrsp     = hsd == HSD_RESPONDER;
+                w_needs_extension = true;
+                w_needs_hsrsp     = hsd == HSD_RESPONDER;
                 return;
             }
 
             m_RdvState = CHandShake::RDV_CONNECTED;
-            *rsptype   = URQ_AGREEMENT;
+            w_rsptype   = URQ_AGREEMENT;
             return;
         }
 
@@ -4614,7 +4617,7 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
             // This will be dispatched in the main loop and discarded.
 
             m_RdvState = CHandShake::RDV_CONNECTED;
-            *rsptype   = URQ_DONE;
+            w_rsptype   = URQ_DONE;
             return;
         }
     }
@@ -4637,7 +4640,7 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                 HLOGC(mglog.Debug, log << "<-- AGREEMENT: switched to connected");
             }
             m_RdvState = CHandShake::RDV_CONNECTED;
-            *rsptype   = URQ_DONE;
+            w_rsptype   = URQ_DONE;
             return;
         }
 
@@ -4646,15 +4649,15 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
             // Receiving conclusion in this state means that the other party
             // didn't get our conclusion, so send it again, the same as when
             // exiting the ATTENTION state.
-            *rsptype = URQ_CONCLUSION;
+            w_rsptype = URQ_CONCLUSION;
             if (hsd == HSD_RESPONDER)
             {
                 HLOGC(mglog.Debug,
                       log << "rendezvousSwitchState: "
                              "{RESPONDER}[INITIATED] awaits AGREEMENT, "
                              "got CONCLUSION, sending CONCLUSION+HSRSP");
-                *needs_extension = true;
-                *needs_hsrsp     = true;
+                w_needs_extension = true;
+                w_needs_hsrsp     = true;
                 return;
             }
 
@@ -4677,8 +4680,8 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
                              "{INITIATOR}[INITIATED] awaits AGREEMENT, "
                              "got CONCLUSION+HSREQ, responding CONCLUSION+HSRSP");
             }
-            *needs_extension = true;
-            *needs_hsrsp     = true;
+            w_needs_extension = true;
+            w_needs_hsrsp     = true;
             return;
         }
     }
@@ -4688,14 +4691,14 @@ void CUDT::rendezvousSwitchState(ref_t<UDTRequestType> rsptype, ref_t<bool> need
 
     case CHandShake::RDV_CONNECTED:
         // Do nothing. This theoretically should never happen.
-        *rsptype = URQ_DONE;
+        w_rsptype = URQ_DONE;
         return;
     }
 
     HLOGC(mglog.Debug, log << "rendezvousSwitchState: INVALID STATE TRANSITION, result: INVALID");
     // All others are treated as errors
     m_RdvState = CHandShake::RDV_WAVING;
-    *rsptype   = URQFailure(SRT_REJ_ROGUE);
+    w_rsptype   = URQFailure(SRT_REJ_ROGUE);
 }
 
 /*
@@ -4924,7 +4927,7 @@ bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUD
     return true;
 }
 
-void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPacket& hspkt)
+void CUDT::acceptAndRespond(const sockaddr_any& peer, const CPacket &hspkt, CHandShake& w_hs)
 {
     HLOGC(mglog.Debug, log << "acceptAndRespond: setting up data according to handshake");
 
@@ -4933,31 +4936,31 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
     m_tsRcvPeerStartTime = steady_clock::time_point(); // will be set correctly at SRT HS
 
     // Uses the smaller MSS between the peers
-    if (hs->m_iMSS > m_iMSS)
-        hs->m_iMSS = m_iMSS;
+    if (w_hs.m_iMSS > m_iMSS)
+        w_hs.m_iMSS = m_iMSS;
     else
-        m_iMSS = hs->m_iMSS;
+        m_iMSS = w_hs.m_iMSS;
 
     // exchange info for maximum flow window size
-    m_iFlowWindowSize     = hs->m_iFlightFlagSize;
-    hs->m_iFlightFlagSize = (m_iRcvBufSize < m_iFlightFlagSize) ? m_iRcvBufSize : m_iFlightFlagSize;
+    m_iFlowWindowSize     = w_hs.m_iFlightFlagSize;
+    w_hs.m_iFlightFlagSize = (m_iRcvBufSize < m_iFlightFlagSize) ? m_iRcvBufSize : m_iFlightFlagSize;
 
-    m_iPeerISN = hs->m_iISN;
+    m_iPeerISN = w_hs.m_iISN;
 
-    m_iRcvLastAck = hs->m_iISN;
+    m_iRcvLastAck = w_hs.m_iISN;
 #ifdef ENABLE_LOGGING
     m_iDebugPrevLastAck = m_iRcvLastAck;
 #endif
     m_iRcvLastSkipAck  = m_iRcvLastAck;
-    m_iRcvLastAckAck   = hs->m_iISN;
-    m_iRcvCurrSeqNo    = hs->m_iISN - 1;
-    m_iRcvCurrPhySeqNo = hs->m_iISN - 1;
+    m_iRcvLastAckAck   = w_hs.m_iISN;
+    m_iRcvCurrSeqNo    = w_hs.m_iISN - 1;
+    m_iRcvCurrPhySeqNo = w_hs.m_iISN - 1;
 
-    m_PeerID  = hs->m_iID;
-    hs->m_iID = m_SocketID;
+    m_PeerID  = w_hs.m_iID;
+    w_hs.m_iID = m_SocketID;
 
     // use peer's ISN and send it back for security check
-    m_iISN = hs->m_iISN;
+    m_iISN = w_hs.m_iISN;
 
     m_iLastDecSeq     = m_iISN - 1;
     m_iSndLastAck     = m_iISN;
@@ -4968,26 +4971,26 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
     m_SndLastAck2Time = steady_clock::now();
 
     // this is a reponse handshake
-    hs->m_iReqType = URQ_CONCLUSION;
+    w_hs.m_iReqType = URQ_CONCLUSION;
 
-    if (hs->m_iVersion > HS_VERSION_UDT4)
+    if (w_hs.m_iVersion > HS_VERSION_UDT4)
     {
         // The version is agreed; this code is executed only in case
         // when AGENT is listener. In this case, conclusion response
         // must always contain HSv5 handshake extensions.
-        hs->m_extension = true;
+        w_hs.m_extension = true;
     }
 
     // get local IP address and send the peer its IP address (because UDP cannot get local IP address)
-    memcpy(m_piSelfIP, hs->m_piPeerIP, sizeof m_piSelfIP);
-    CIPAddress::ntop(peer, hs->m_piPeerIP);
+    memcpy((m_piSelfIP), w_hs.m_piPeerIP, sizeof m_piSelfIP);
+    CIPAddress::ntop(peer, (w_hs.m_piPeerIP));
 
     int udpsize          = m_iMSS - CPacket::UDP_HDR_SIZE;
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
     HLOGC(mglog.Debug, log << "acceptAndRespond: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
 
     // Prepare all structures
-    if (!prepareConnectionObjects(*hs, HSD_DRAW, 0))
+    if (!prepareConnectionObjects(w_hs, HSD_DRAW, 0))
     {
         HLOGC(mglog.Debug, log << "acceptAndRespond: prepareConnectionObjects failed - responding with REJECT.");
         // If the SRT Handshake extension was provided and wasn't interpreted
@@ -4995,7 +4998,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
         //
         // Respond with the rejection message and exit with exception
         // so that the caller will know that this new socket should be deleted.
-        hs->m_iReqType = URQFailure(m_RejectReason);
+        w_hs.m_iReqType = URQFailure(m_RejectReason);
         throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
     }
     // Since now you can use m_pCryptoControl
@@ -5015,7 +5018,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
     // as UMSG_EXT.
     uint32_t kmdata[SRTDATA_MAXSIZE];
     size_t   kmdatasize = SRTDATA_MAXSIZE;
-    if (!interpretSrtHandshake(*hs, hspkt, kmdata, &kmdatasize))
+    if (!interpretSrtHandshake(w_hs, hspkt, (kmdata), (&kmdatasize)))
     {
         HLOGC(mglog.Debug, log << "acceptAndRespond: interpretSrtHandshake failed - responding with REJECT.");
         // If the SRT Handshake extension was provided and wasn't interpreted
@@ -5024,7 +5027,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
         // Respond with the rejection message and return false from
         // this function so that the caller will know that this new
         // socket should be deleted.
-        hs->m_iReqType = URQFailure(m_RejectReason);
+        w_hs.m_iReqType = URQFailure(m_RejectReason);
         throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
     }
 
@@ -5032,7 +5035,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
     // UNKNOWN used as a "no error" value
     if (rr != SRT_REJ_UNKNOWN)
     {
-        hs->m_iReqType = URQFailure(rr);
+        w_hs.m_iReqType = URQFailure(rr);
         m_RejectReason = rr;
         throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
     }
@@ -5060,7 +5063,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& peer, CHandShake* hs, const CPac
     // This will serialize the handshake according to its current form.
     HLOGC(mglog.Debug,
           log << "acceptAndRespond: creating CONCLUSION response (HSv5: with HSRSP/KMRSP) buffer size=" << size);
-    if (!createSrtHandshake(Ref(response), Ref(*hs), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
+    if (!createSrtHandshake(SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize, (response), (w_hs)))
     {
         LOGC(mglog.Error, log << "acceptAndRespond: error creating handshake response");
         throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
@@ -5273,12 +5276,17 @@ void CUDT::checkSndTimers(Whether2RegenKm regen)
     }
 }
 
-void CUDT::addressAndSend(CPacket &pkt)
+void CUDT::addressAndSend(CPacket& w_pkt)
 {
-    pkt.m_iID        = m_PeerID;
-    pkt.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
+    w_pkt.m_iID        = m_PeerID;
+    w_pkt.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
 
-    m_pSndQueue->sendto(m_PeerAddr, pkt);
+    // NOTE: w_pkt isn't modified in this call,
+    // just in CChannel::sendto it's modified in place
+    // before sending for performance purposes,
+    // and then modification is undone. Logically then
+    // there's no modification here.
+    m_pSndQueue->sendto(m_PeerAddr, w_pkt);
 }
 
 bool CUDT::close()
@@ -5414,7 +5422,7 @@ bool CUDT::close()
     CGuard sendguard(m_SendLock);
     CGuard recvguard(m_RecvLock);
 
-    // Locking m_RcvBufferLock to protect calling to m_pCryptoControl->decrypt(Ref(packet))
+    // Locking m_RcvBufferLock to protect calling to m_pCryptoControl->decrypt((packet))
     // from the processData(...) function while resetting Crypto Control.
     CGuard::enterCS(m_RcvBufferLock);
     m_pCryptoControl.reset();
@@ -5537,7 +5545,7 @@ int CUDT::receiveBuffer(char *data, int len)
     return res;
 }
 
-void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
+void CUDT::checkNeedDrop(bool& w_bCongestion)
 {
     if (!m_bPeerTLPktDrop)
         return;
@@ -5550,7 +5558,7 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
 
     int bytes, timespan_ms;
     // (returns buffer size in buffer units, ignored)
-    m_pSndBuffer->getCurrBufSize(Ref(bytes), Ref(timespan_ms));
+    m_pSndBuffer->getCurrBufSize((bytes), (timespan_ms));
 
     // high threshold (msec) at tsbpd_delay plus sender/receiver reaction time (2 * 10ms)
     // Minimum value must accomodate an I-Frame (~8 x average frame size)
@@ -5602,7 +5610,7 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
                   log << "drop " << realack << "-" << m_iSndCurrSeqNo << " seqs,"
                       << dpkts << " pkts," << dbytes << " bytes," << timespan_ms << " ms");
         }
-        *bCongestion = true;
+        w_bCongestion = true;
         CGuard::leaveCS(m_RecvAckLock);
     }
     else if (timespan_ms > (m_iPeerTsbPdDelay_ms / 2))
@@ -5610,7 +5618,7 @@ void CUDT::checkNeedDrop(ref_t<bool> bCongestion)
         HLOGC(mglog.Debug,
               log << "cong, BYTES " << bytes << ", TMSPAN " << timespan_ms << "ms");
 
-        *bCongestion = true;
+        w_bCongestion = true;
     }
 }
 
@@ -5620,12 +5628,11 @@ int CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, uint64_t s
     mctrl.msgttl      = msttl;
     mctrl.inorder     = inorder;
     mctrl.srctime     = srctime;
-    return this->sendmsg2(data, len, Ref(mctrl));
+    return this->sendmsg2(data, len, (mctrl));
 }
 
-int CUDT::sendmsg2(const char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
+int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
 {
-    SRT_MSGCTRL &mctrl       = *r_mctrl;
     bool         bCongestion = false;
 
     // throw an exception if not connected
@@ -5640,8 +5647,8 @@ int CUDT::sendmsg2(const char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
         return 0;
     }
 
-    int  msttl   = mctrl.msgttl;
-    bool inorder = mctrl.inorder;
+    int  msttl   = w_mctrl.msgttl;
+    bool inorder = w_mctrl.inorder;
 
     // Sendmsg isn't restricted to the congctl type, however the congctl
     // may want to have something to say here.
@@ -5707,7 +5714,7 @@ int CUDT::sendmsg2(const char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
 
     // checkNeedDrop(...) may lock m_RecvAckLock
     // to modify m_pSndBuffer and m_pSndLossList
-    checkNeedDrop(Ref(bCongestion));
+    checkNeedDrop((bCongestion));
 
     int minlen = 1; // Minimum sender buffer space required for STREAM API
     if (m_bMessageAPI)
@@ -5810,8 +5817,8 @@ int CUDT::sendmsg2(const char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
         CGuard recvAckLock(m_RecvAckLock);
         // insert the user buffer into the sending list
         // This should be protected by a mutex. m_SendLock does this.
-        m_pSndBuffer->addBuffer(data, size, mctrl.msgttl, mctrl.inorder, mctrl.srctime, Ref(mctrl.msgno));
-        HLOGC(dlog.Debug, log << CONID() << "sock:SENDING srctime: " << mctrl.srctime << "us DATA SIZE: " << size);
+        m_pSndBuffer->addBuffer(data, size, w_mctrl.msgttl, w_mctrl.inorder, w_mctrl.srctime, (w_mctrl.msgno));
+        HLOGC(dlog.Debug, log << CONID() << "sock:SENDING srctime: " << w_mctrl.srctime << "us DATA SIZE: " << size);
 
         if (sndBuffersLeft() < 1) // XXX Not sure if it should test if any space in the buffer, or as requried.
         {
@@ -5845,7 +5852,7 @@ int CUDT::recv(char *data, int len)
     if (m_bMessageAPI)
     {
         SRT_MSGCTRL mctrl = srt_msgctrl_default;
-        return receiveMessage(data, len, Ref(mctrl));
+        return receiveMessage(data, len, (mctrl));
     }
 
     return receiveBuffer(data, len);
@@ -5865,7 +5872,7 @@ int CUDT::recvmsg(char *data, int len, uint64_t &srctime)
     if (m_bMessageAPI)
     {
         SRT_MSGCTRL mctrl = srt_msgctrl_default;
-        int         ret   = receiveMessage(data, len, Ref(mctrl));
+        int         ret   = receiveMessage(data, len, (mctrl));
         srctime           = mctrl.srctime;
         return ret;
     }
@@ -5873,7 +5880,7 @@ int CUDT::recvmsg(char *data, int len, uint64_t &srctime)
     return receiveBuffer(data, len);
 }
 
-int CUDT::recvmsg2(char *data, int len, ref_t<SRT_MSGCTRL> mctrl)
+int CUDT::recvmsg2(char *data, int len, SRT_MSGCTRL& w_mctrl)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -5885,14 +5892,13 @@ int CUDT::recvmsg2(char *data, int len, ref_t<SRT_MSGCTRL> mctrl)
     }
 
     if (m_bMessageAPI)
-        return receiveMessage(data, len, mctrl);
+        return receiveMessage(data, len, (w_mctrl));
 
     return receiveBuffer(data, len);
 }
 
-int CUDT::receiveMessage(char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
+int CUDT::receiveMessage(char *data, int len, SRT_MSGCTRL& w_mctrl)
 {
-    SRT_MSGCTRL &mctrl = *r_mctrl;
     // Recvmsg isn't restricted to the congctl type, it's the most
     // basic method of passing the data. You can retrieve data as
     // they come in, however you need to match the size of the buffer.
@@ -5917,7 +5923,7 @@ int CUDT::receiveMessage(char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     if (m_bBroken || m_bClosing)
     {
         int res       = m_pRcvBuffer->readMsg(data, len);
-        mctrl.srctime = 0;
+        w_mctrl.srctime = 0;
 
         /* Kick TsbPd thread to schedule next wakeup (if running) */
         if (m_bTsbPd)
@@ -5942,7 +5948,7 @@ int CUDT::receiveMessage(char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
     if (!m_bSynRecving)
     {
 
-        int res = m_pRcvBuffer->readMsg(data, len, r_mctrl);
+        int res = m_pRcvBuffer->readMsg(data, len, (w_mctrl));
         if (res == 0)
         {
             // read is not available any more
@@ -6013,7 +6019,7 @@ int CUDT::receiveMessage(char *data, int len, ref_t<SRT_MSGCTRL> r_mctrl)
                 << " NMSG " << m_pRcvBuffer->getRcvMsgNum());
                 */
 
-        res = m_pRcvBuffer->readMsg(data, len, r_mctrl);
+        res = m_pRcvBuffer->readMsg(data, len, (w_mctrl));
 
         if (m_bBroken || m_bClosing)
         {
@@ -6404,14 +6410,14 @@ void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
             {
                 /* Get instant SndBuf instead of moving average for application-based Algorithm
                    (such as NAE) in need of fast reaction to network condition changes. */
-                perf->pktSndBuf = m_pSndBuffer->getCurrBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
+                perf->pktSndBuf = m_pSndBuffer->getCurrBufSize((perf->byteSndBuf), (perf->msSndBuf));
             }
             else
             {
-                perf->pktSndBuf = m_pSndBuffer->getAvgBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
+                perf->pktSndBuf = m_pSndBuffer->getAvgBufSize((perf->byteSndBuf), (perf->msSndBuf));
             }
 #else
-            perf->pktSndBuf = m_pSndBuffer->getCurrBufSize(Ref(perf->byteSndBuf), Ref(perf->msSndBuf));
+            perf->pktSndBuf = m_pSndBuffer->getCurrBufSize((perf->byteSndBuf), (perf->msSndBuf));
 #endif
             perf->byteSndBuf += (perf->pktSndBuf * pktHdrSize);
             //<
@@ -6860,7 +6866,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, const void *lparam, void *rparam, in
                 int rcvRate;
                 int ctrlsz = ACKD_TOTAL_SIZE_UDTBASE * ACKD_FIELD_SIZE; // Minimum required size
 
-                data[ACKD_RCVSPEED]  = m_RcvTimeWindow.getPktRcvSpeed(Ref(rcvRate));
+                data[ACKD_RCVSPEED]  = m_RcvTimeWindow.getPktRcvSpeed((rcvRate));
                 data[ACKD_BANDWIDTH] = m_RcvTimeWindow.getBandwidth();
 
                 //>>Patch while incompatible (1.0.2) receiver floating around
@@ -7250,7 +7256,7 @@ void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point
     CGuard::leaveCS(m_StatsLock);
 }
 
-void CUDT::processCtrl(CPacket &ctrlpkt)
+void CUDT::processCtrl(const CPacket &ctrlpkt)
 {
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
@@ -7526,7 +7532,8 @@ void CUDT::processCtrl(CPacket &ctrlpkt)
 
             // If createSrtHandshake failed, don't send anything. Actually it can only fail on IPE.
             // There is also no possible IPE condition in case of HSv4 - for this version it will always return true.
-            if (createSrtHandshake(Ref(response), Ref(initdata), SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize))
+            if (createSrtHandshake(SRT_CMD_HSRSP, SRT_CMD_KMRSP, kmdata, kmdatasize,
+                        (response), (initdata)))
             {
                 response.m_iID        = m_PeerID;
                 response.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
@@ -7699,32 +7706,32 @@ void CUDT::updateAfterSrtHandshake(int srt_cmd, int hsv)
     }
 }
 
-int CUDT::packLostData(CPacket &packet, steady_clock::time_point &origintime)
+int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime)
 {
     // protect m_iSndLastDataAck from updating by ACK processing
     CGuard ackguard(m_RecvAckLock);
 
-    while ((packet.m_iSeqNo = m_pSndLossList->popLostSeq()) >= 0)
+    while ((w_packet.m_iSeqNo = m_pSndLossList->popLostSeq()) >= 0)
     {
-        const int offset = CSeqNo::seqoff(m_iSndLastDataAck, packet.m_iSeqNo);
+        const int offset = CSeqNo::seqoff(m_iSndLastDataAck, w_packet.m_iSeqNo);
         if (offset < 0)
         {
             LOGC(dlog.Error,
-                 log << "IPE: packLostData: LOST packet negative offset: seqoff(m_iSeqNo " << packet.m_iSeqNo
+                 log << "IPE: packLostData: LOST packet negative offset: seqoff(m_iSeqNo " << w_packet.m_iSeqNo
                      << ", m_iSndLastDataAck " << m_iSndLastDataAck << ")=" << offset << ". Continue");
             continue;
         }
 
         int msglen;
 
-        const int payload = m_pSndBuffer->readData(&(packet.m_pcData), offset, packet.m_iMsgNo, origintime, msglen);
+        const int payload = m_pSndBuffer->readData(&(w_packet.m_pcData), offset, (w_packet.m_iMsgNo), (w_origintime), (msglen));
         SRT_ASSERT(payload != 0);
         if (payload == -1)
         {
             int32_t seqpair[2];
-            seqpair[0] = packet.m_iSeqNo;
+            seqpair[0] = w_packet.m_iSeqNo;
             seqpair[1] = CSeqNo::incseq(seqpair[0], msglen);
-            sendCtrl(UMSG_DROPREQ, &packet.m_iMsgNo, seqpair, 8);
+            sendCtrl(UMSG_DROPREQ, &w_packet.m_iMsgNo, seqpair, 8);
 
             // only one msg drop request is necessary
             m_pSndLossList->remove(seqpair[1]);
@@ -7762,7 +7769,7 @@ int CUDT::packLostData(CPacket &packet, steady_clock::time_point &origintime)
         // So, set here the rexmit flag if the peer understands it.
         if (m_bPeerRexmitFlag)
         {
-            packet.m_iMsgNo |= PACKET_SND_REXMIT;
+            w_packet.m_iMsgNo |= PACKET_SND_REXMIT;
         }
 
         return payload;
@@ -7771,7 +7778,7 @@ int CUDT::packLostData(CPacket &packet, steady_clock::time_point &origintime)
     return 0;
 }
 
-std::pair<int, steady_clock::time_point> CUDT::packData(CPacket &packet)
+std::pair<int, steady_clock::time_point> CUDT::packData(CPacket& w_packet)
 {
     int payload = 0;
     bool probe = false;
@@ -7788,16 +7795,16 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket &packet)
 
     string reason = "reXmit";
 
-    payload = packLostData(packet, origintime);
+    payload = packLostData((w_packet), (origintime));
     if (payload > 0)
     {
         reason = "reXmit";
     }
     else if (m_PacketFilter &&
-             m_PacketFilter.packControlPacket(Ref(packet), m_iSndCurrSeqNo, m_pCryptoControl->getSndCryptoFlags()))
+             m_PacketFilter.packControlPacket(m_iSndCurrSeqNo, m_pCryptoControl->getSndCryptoFlags(), (w_packet)))
     {
         HLOGC(mglog.Debug, log << "filter: filter/CTL packet ready - packing instead of data.");
-        payload        = packet.getLength();
+        payload        = w_packet.getLength();
         reason         = "filter";
         filter_ctl_pkt = true; // Mark that this packet ALREADY HAS timestamp field and it should not be set
 
@@ -7823,16 +7830,16 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket &packet)
             // It would be nice to research as to whether CSndBuffer::Block::m_iMsgNoBitset field
             // isn't a useless redundant state copy. If it is, then taking the flags here can be removed.
             kflg    = m_pCryptoControl->getSndCryptoFlags();
-            payload = m_pSndBuffer->readData(&(packet.m_pcData), packet.m_iMsgNo, origintime, kflg);
+            payload = m_pSndBuffer->readData((&w_packet.m_pcData), (w_packet.m_iMsgNo), (origintime), kflg);
             if (payload)
             {
                 m_iSndCurrSeqNo = CSeqNo::incseq(m_iSndCurrSeqNo);
                 // m_pCryptoControl->m_iSndCurrSeqNo = m_iSndCurrSeqNo;
 
-                packet.m_iSeqNo = m_iSndCurrSeqNo;
+                w_packet.m_iSeqNo = m_iSndCurrSeqNo;
 
                 // every 16 (0xF) packets, a packet pair is sent
-                if ((packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 0)
+                if ((w_packet.m_iSeqNo & PUMASK_SEQNO_PROBE) == 0)
                     probe = true;
 
                 new_packet_packed = true;
@@ -7874,25 +7881,25 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket &packet)
              * doesn't screw up the start time on the other side.
              */
             if (origintime >= m_stats.tsStartTime)
-                packet.m_iTimeStamp = count_microseconds(origintime - m_stats.tsStartTime);
+                w_packet.m_iTimeStamp = count_microseconds(origintime - m_stats.tsStartTime);
             else
-                packet.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
+                w_packet.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
         }
         else
         {
-            packet.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
+            w_packet.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
         }
     }
 
-    packet.m_iID = m_PeerID;
-    packet.setLength(payload);
+    w_packet.m_iID = m_PeerID;
+    w_packet.setLength(payload);
 
     /* Encrypt if 1st time this packet is sent and crypto is enabled */
     if (kflg)
     {
         // XXX Encryption flags are already set on the packet before calling this.
         // See readData() above.
-        if (m_pCryptoControl->encrypt(Ref(packet)))
+        if (m_pCryptoControl->encrypt((w_packet)))
         {
             // Encryption failed
             //>>Add stats for crypto failure
@@ -7900,20 +7907,20 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket &packet)
             // Encryption failed
             return std::make_pair(-1, enter_time);
         }
-        payload = packet.getLength(); /* Cipher may change length */
+        payload = w_packet.getLength(); /* Cipher may change length */
         reason += " (encrypted)";
     }
 
     if (new_packet_packed && m_PacketFilter)
     {
         HLOGC(mglog.Debug, log << "filter: Feeding packet for source clip");
-        m_PacketFilter.feedSource(Ref(packet));
+        m_PacketFilter.feedSource((w_packet));
     }
 
 #if ENABLE_HEAVY_LOGGING // Required because of referring to MessageFlagStr()
     HLOGC(mglog.Debug,
-          log << CONID() << "packData: " << reason << " packet seq=" << packet.m_iSeqNo << " (ACK=" << m_iSndLastAck
-              << " ACKDATA=" << m_iSndLastDataAck << " MSG/FLAGS: " << packet.MessageFlagStr() << ")");
+          log << CONID() << "packData: " << reason << " packet seq=" << w_packet.m_iSeqNo << " (ACK=" << m_iSndLastAck
+              << " ACKDATA=" << m_iSndLastDataAck << " MSG/FLAGS: " << w_packet.MessageFlagStr() << ")");
 #endif
 
     // Fix keepalive
@@ -7925,13 +7932,13 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket &packet)
     // the CSndQueue::worker thread. All others are reported from
     // CRcvQueue::worker. If you connect to this signal, make sure
     // that you are aware of prospective simultaneous access.
-    updateCC(TEV_SEND, &packet);
+    updateCC(TEV_SEND, &w_packet);
 
     // XXX This was a blocked code also originally in UDT. Probably not required.
     // Left untouched for historical reasons.
     // Might be possible that it was because of that this is send from
     // different thread than the rest of the signals.
-    // m_pSndTimeWindow->onPktSent(packet.m_iTimeStamp);
+    // m_pSndTimeWindow->onPktSent(w_packet.m_iTimeStamp);
 
     CGuard::enterCS(m_StatsLock);
     m_stats.traceBytesSent += payload;
@@ -8172,7 +8179,7 @@ int CUDT::processData(CUnit *in_unit)
         if (m_PacketFilter)
         {
             // Stuff this data into the filter
-            m_PacketFilter.receive(in_unit, Ref(incoming), Ref(filter_loss_seqs));
+            m_PacketFilter.receive(in_unit, (incoming), (filter_loss_seqs));
             HLOGC(mglog.Debug,
                   log << "(FILTER) fed data, received " << incoming.size() << " pkts, " << Printable(filter_loss_seqs)
                       << " loss to report, "
@@ -8277,7 +8284,7 @@ int CUDT::processData(CUnit *in_unit)
                 excessive = false;
                 if (u->m_Packet.getMsgCryptoFlags())
                 {
-                    EncryptionStatus rc = m_pCryptoControl ? m_pCryptoControl->decrypt(Ref(u->m_Packet)) : ENCS_NOTSUP;
+                    EncryptionStatus rc = m_pCryptoControl ? m_pCryptoControl->decrypt((u->m_Packet)) : ENCS_NOTSUP;
                     if (rc != ENCS_CLEAR)
                     {
                         // Could not decrypt
@@ -8910,7 +8917,7 @@ SRT_REJECT_REASON CUDT::processConnectRequest(const sockaddr_any& addr, CPacket&
                   << " Advertising PBKEYLEN - value = " << m_iSndCryptoKeyLen);
 
         size_t size = packet.getLength();
-        hs.store_to(packet.m_pcData, Ref(size));
+        hs.store_to((packet.m_pcData), (size));
         packet.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
         m_pSndQueue->sendto(addr, packet);
         return SRT_REJ_UNKNOWN; // EXCEPTION: this is a "no-error" code.
@@ -8988,7 +8995,7 @@ SRT_REJECT_REASON CUDT::processConnectRequest(const sockaddr_any& addr, CPacket&
         // mismatch, reject the request
         hs.m_iReqType = URQFailure(m_RejectReason);
         size_t size   = CHandShake::m_iContentSize;
-        hs.store_to(packet.m_pcData, Ref(size));
+        hs.store_to((packet.m_pcData), (size));
         packet.m_iID        = id;
         packet.m_iTimeStamp = count_microseconds(steady_clock::now() - m_stats.tsStartTime);
         m_pSndQueue->sendto(addr, packet);
@@ -8996,7 +9003,7 @@ SRT_REJECT_REASON CUDT::processConnectRequest(const sockaddr_any& addr, CPacket&
     else
     {
         SRT_REJECT_REASON error  = SRT_REJ_UNKNOWN;
-        int               result = s_UDTUnited.newConnection(m_SocketID, addr, &hs, packet, Ref(error));
+        int               result = s_UDTUnited.newConnection(m_SocketID, addr, packet, (hs), (error));
 
         // This is listener - m_RejectReason need not be set
         // because listener has no functionality of giving the app
@@ -9044,7 +9051,7 @@ SRT_REJECT_REASON CUDT::processConnectRequest(const sockaddr_any& addr, CPacket&
                   log << CONID() << "processConnectRequest: sending ABNORMAL handshake info req="
                       << RequestTypeStr(hs.m_iReqType));
             size_t size = CHandShake::m_iContentSize;
-            hs.store_to(packet.m_pcData, Ref(size));
+            hs.store_to((packet.m_pcData), (size));
             packet.m_iID        = id;
             packet.m_iTimeStamp = (int32_t) count_microseconds(steady_clock::now() - m_stats.tsStartTime);
             m_pSndQueue->sendto(addr, packet);
@@ -9398,7 +9405,7 @@ int CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
         return -1;
 
     int bytecount, timespan;
-    int count = b->getCurrBufSize(Ref(bytecount), Ref(timespan));
+    int count = b->getCurrBufSize((bytecount), (timespan));
 
     if (blocks)
         *blocks = count;
@@ -9418,20 +9425,20 @@ SRT_REJECT_REASON CUDT::rejectReason(SRTSOCKET u)
     return s->m_pUDT->m_RejectReason;
 }
 
-bool CUDT::runAcceptHook(CUDT *acore, const sockaddr *peer, const CHandShake *hs, const CPacket &hspkt)
+bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)
 {
     // Prepare the information for the hook.
 
     // We need streamid.
     char target[MAX_SID_LENGTH + 1];
-    memset(target, 0, MAX_SID_LENGTH + 1);
+    memset((target), 0, MAX_SID_LENGTH + 1);
 
     // Just for a case, check the length.
     // This wasn't done before, and we could risk memory crash.
     // In case of error, this will remain unset and the empty
     // string will be passed as streamid.
 
-    int ext_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(hs->m_iType);
+    int ext_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(hs.m_iType);
 
     // This tests if there are any extensions.
     if (hspkt.getLength() > CHandShake::m_iContentSize + 4 && IsSet(ext_flags, CHandShake::HS_EXT_CONFIG))
@@ -9444,7 +9451,7 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr *peer, const CHandShake *hs
 
         for (;;) // ONE SHOT, but continuable loop
         {
-            int cmd = FindExtensionBlock(begin, length, Ref(blocklen), Ref(next));
+            int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
 
             const size_t bytelen = blocklen * sizeof(uint32_t);
 
@@ -9458,10 +9465,10 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr *peer, const CHandShake *hs
                     return false;
                 }
                 // See comment at CUDT::interpretSrtHandshake().
-                memcpy(target, begin + 1, bytelen);
+                memcpy((target), begin + 1, bytelen);
 
                 // Un-swap on big endian machines
-                ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
+                ItoHLA(((uint32_t *)target), (uint32_t *)target, blocklen);
 
                 // Nothing more expected from connection block.
                 break;
@@ -9486,7 +9493,7 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr *peer, const CHandShake *hs
 
     try
     {
-        int result = CALLBACK_CALL(m_cbAcceptHook, acore->m_SocketID, hs->m_iVersion, peer, target);
+        int result = CALLBACK_CALL(m_cbAcceptHook, acore->m_SocketID, hs.m_iVersion, peer, target);
         if (result == -1)
             return false;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3903,7 +3903,7 @@ EConnectStatus CUDT::processRendezvous(
         w_reqpkt.m_iTimeStamp              = count_microseconds(now - m_stats.tsStartTime);
         HLOGC(mglog.Debug,
               log << "processRendezvous: rsp=AGREEMENT, reporting ACCEPT and sending just this one, REQ-TIME HIGH.");
-                  
+
         m_pSndQueue->sendto(serv_addr, w_reqpkt);
 
         return CONN_ACCEPT;
@@ -4927,7 +4927,7 @@ bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUD
     return true;
 }
 
-void CUDT::acceptAndRespond(const sockaddr_any& peer, const CPacket &hspkt, CHandShake& w_hs)
+void CUDT::acceptAndRespond(const sockaddr_any& peer, const CPacket& hspkt, CHandShake& w_hs)
 {
     HLOGC(mglog.Debug, log << "acceptAndRespond: setting up data according to handshake");
 

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -119,7 +119,8 @@ public:
     void updateKmState(int cmd, size_t srtlen);
 
     // Detailed processing
-    int processSrtMsg_KMREQ(const uint32_t* srtdata, size_t len, uint32_t* srtdata_out, ref_t<size_t> r_srtlen, int hsv);
+    int processSrtMsg_KMREQ(const uint32_t* srtdata, size_t len, int hsv,
+            uint32_t srtdata_out[], size_t&);
 
     // This returns:
     // 1 - the given payload is the same as the currently used key
@@ -218,7 +219,7 @@ public:
         m_iRcvKmKeyLen = keylen;
     }
 
-    bool createCryptoCtx(ref_t<HaiCrypt_Handle> rh, size_t keylen, HaiCrypt_CryptoDir tx);
+    bool createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir tx, HaiCrypt_Handle& rh);
 
     int getSndCryptoFlags() const
     {
@@ -253,14 +254,14 @@ public:
     /// the encryption will fail.
     /// XXX Encryption flags in the PH_MSGNO
     /// field in the header must be correctly set before calling.
-    EncryptionStatus encrypt(ref_t<CPacket> r_packet);
+    EncryptionStatus encrypt(CPacket& w_packet);
 
     /// Decrypts the packet. If the packet has ENCKEYSPEC part
     /// in PH_MSGNO set to EK_NOENC, it does nothing. It decrypts
     /// only if the encryption correctly configured, otherwise it
     /// fails. After successful decryption, the ENCKEYSPEC part
     // in PH_MSGNO is set to EK_NOENC.
-    EncryptionStatus decrypt(ref_t<CPacket> r_packet);
+    EncryptionStatus decrypt(CPacket& w_packet);
 
     ~CCryptoControl();
 };

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -654,11 +654,11 @@ void FECFilterBuiltin::PackControl(const Group& g, signed char index, SrtPacket&
     out[off++] = g.flag_clip;
 
     // Ok, now the length clip
-    memcpy(out+off, &g.length_clip, sizeof g.length_clip);
+    memcpy((out + off), &g.length_clip, sizeof g.length_clip);
     off += sizeof g.length_clip;
 
     // And finally the payload clip
-    memcpy(out+off, &g.payload_clip[0], g.payload_clip.size());
+    memcpy((out + off), &g.payload_clip[0], g.payload_clip.size());
 
     // Ready. Now fill the header and finalize other data.
     pkt.length = total_size;

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -74,10 +74,9 @@ m_extension(false)
       m_piPeerIP[i] = 0;
 }
 
-int CHandShake::store_to(char* buf, ref_t<size_t> r_size)
+int CHandShake::store_to(char* buf, size_t& w_size)
 {
-   size_t& size = *r_size;
-   if (size < m_iContentSize)
+   if (w_size < m_iContentSize)
       return -1;
 
    int32_t* p = reinterpret_cast<int32_t*>(buf);
@@ -92,7 +91,7 @@ int CHandShake::store_to(char* buf, ref_t<size_t> r_size)
    for (int i = 0; i < 4; ++ i)
       *p++ = m_piPeerIP[i];
 
-   size = m_iContentSize;
+   w_size = m_iContentSize;
 
    return 0;
 }

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -267,7 +267,7 @@ class CHandShake
 public:
    CHandShake();
 
-   int store_to(char* buf, ref_t<size_t> size);
+   int store_to(char* buf, size_t& size);
    int load_from(const char* buf, size_t size);
 
 public:

--- a/srtcore/md5.cpp
+++ b/srtcore/md5.cpp
@@ -166,7 +166,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 		X = (const md5_word_t *)data;
 	    } else {
 		/* not aligned */
-		memcpy(xbuf, data, 64);
+		memcpy((xbuf), data, 64);
 		X = xbuf;
 	    }
 	}
@@ -340,7 +340,7 @@ md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
     if (offset) {
 	int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
 
-	memcpy(pms->buf + offset, p, copy);
+	memcpy((pms->buf + offset), p, copy);
 	if (offset + copy < 64)
 	    return;
 	p += copy;
@@ -354,7 +354,7 @@ md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
 
     /* Process a final partial block. */
     if (left)
-	memcpy(pms->buf, p, left);
+	memcpy((pms->buf), p, left);
 }
 
 void

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -49,7 +49,7 @@ struct sockaddr_any
     void reset()
     {
         // sin6 is the largest field
-        memset(&sin6, 0, sizeof sin6);
+        memset((&sin6), 0, sizeof sin6);
         len = 0;
     }
 
@@ -91,12 +91,12 @@ struct sockaddr_any
         // all data required for particular family.
         if (source->sa_family == AF_INET)
         {
-            memcpy(&sin, source, sizeof sin);
+            memcpy((&sin), source, sizeof sin);
             len = sizeof sin;
         }
         else if (source->sa_family == AF_INET6)
         {
-            memcpy(&sin6, source, sizeof sin6);
+            memcpy((&sin6), source, sizeof sin6);
             len = sizeof sin6;
         }
         else
@@ -112,7 +112,7 @@ struct sockaddr_any
         // It's not safe to copy it directly, so check.
         if (source->sa_family == AF_INET && namelen >= sizeof sin)
         {
-            memcpy(&sin, source, sizeof sin);
+            memcpy((&sin), source, sizeof sin);
             len = sizeof sin;
         }
         else if (source->sa_family == AF_INET6 && namelen >= sizeof sin6)
@@ -120,7 +120,7 @@ struct sockaddr_any
             // Note: this isn't too safe, may crash for stupid values
             // of source->sa_family or any other data
             // in the source structure, so make sure it's correct first.
-            memcpy(&sin6, source, sizeof sin6);
+            memcpy((&sin6), source, sizeof sin6);
             len = sizeof sin6;
         }
         else

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -502,9 +502,9 @@ uint32_t CPacket::getMsgTimeStamp() const
 CPacket* CPacket::clone() const
 {
    CPacket* pkt = new CPacket;
-   memcpy(pkt->m_nHeader, m_nHeader, HDR_SIZE);
+   memcpy((pkt->m_nHeader), m_nHeader, HDR_SIZE);
    pkt->m_pcData = new char[m_PacketVector[PV_DATA].size()];
-   memcpy(pkt->m_pcData, m_pcData, m_PacketVector[PV_DATA].size());
+   memcpy((pkt->m_pcData), m_pcData, m_PacketVector[PV_DATA].size());
    pkt->m_PacketVector[PV_DATA].setLength(m_PacketVector[PV_DATA].size());
 
    return pkt;

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -60,17 +60,17 @@ struct SortBySequence
     }
 };
 
-void PacketFilter::receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming, ref_t<loss_seqs_t> r_loss_seqs)
+void PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_seqs_t& w_loss_seqs)
 {
     const CPacket& rpkt = unit->m_Packet;
 
-    if (m_filter->receive(rpkt, *r_loss_seqs))
+    if (m_filter->receive(rpkt, w_loss_seqs))
     {
         // For the sake of rebuilding MARK THIS UNIT GOOD, otherwise the
         // unit factory will supply it from getNextAvailUnit() as if it were not in use.
         unit->m_iFlag = CUnit::GOOD;
         HLOGC(mglog.Debug, log << "FILTER: PASSTHRU current packet %" << unit->m_Packet.getSeqNo());
-        r_incoming.get().push_back(unit);
+        w_incoming.push_back(unit);
     }
     else
     {
@@ -80,9 +80,9 @@ void PacketFilter::receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming,
         ++m_parent->m_stats.rcvFilterExtraTotal;
     }
 
-    // r_loss_seqs enters empty into this function and can be only filled here.
-    for (loss_seqs_t::iterator i = r_loss_seqs.get().begin();
-            i != r_loss_seqs.get().end(); ++i)
+    // w_loss_seqs enters empty into this function and can be only filled here. XXX ASSERT?
+    for (loss_seqs_t::iterator i = w_loss_seqs.begin();
+            i != w_loss_seqs.end(); ++i)
     {
         // Sequences here are low-high, if there happens any negative distance
         // here, simply skip and report IPE.
@@ -106,7 +106,7 @@ void PacketFilter::receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming,
         HLOGC(mglog.Debug, log << "FILTER: inserting REBUILT packets (" << m_provided.size() << "):");
 
         size_t nsupply = m_provided.size();
-        InsertRebuilt(*r_incoming, m_unitq);
+        InsertRebuilt(w_incoming, m_unitq);
 
         CGuard lg(m_parent->m_StatsLock);
         m_parent->m_stats.rcvFilterSupply += nsupply;
@@ -120,8 +120,7 @@ void PacketFilter::receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming,
     // with FREE and therefore will be returned at the next
     // call to getNextAvailUnit().
     unit->m_iFlag = CUnit::FREE;
-    vector<CUnit*>& inco = *r_incoming;
-    for (vector<CUnit*>::iterator i = inco.begin(); i != inco.end(); ++i)
+    for (vector<CUnit*>::iterator i = w_incoming.begin(); i != w_incoming.end(); ++i)
     {
         CUnit* u = *i;
         u->m_iFlag = CUnit::FREE;
@@ -129,7 +128,7 @@ void PacketFilter::receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming,
 
     // Packets must be sorted by sequence number, ascending, in order
     // not to challenge the SRT's contiguity checker.
-    sort(inco.begin(), inco.end(), SortBySequence());
+    sort(w_incoming.begin(), w_incoming.end(), SortBySequence());
 
     // For now, report immediately the irrecoverable packets
     // from the row.
@@ -147,7 +146,7 @@ void PacketFilter::receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming,
 
 }
 
-bool PacketFilter::packControlPacket(ref_t<CPacket> r_packet, int32_t seq, int kflg)
+bool PacketFilter::packControlPacket(int32_t seq, int kflg, CPacket& w_packet)
 {
     bool have = m_filter->packControlPacket(m_sndctlpkt, seq);
     if (!have)
@@ -155,12 +154,12 @@ bool PacketFilter::packControlPacket(ref_t<CPacket> r_packet, int32_t seq, int k
 
     // Now this should be repacked back to CPacket.
     // The header must be copied, it's always part of CPacket.
-    uint32_t* hdr = r_packet.get().getHeader();
-    memcpy(hdr, m_sndctlpkt.hdr, SRT_PH__SIZE * sizeof(*hdr));
+    uint32_t* hdr = w_packet.getHeader();
+    memcpy((hdr), m_sndctlpkt.hdr, SRT_PH__SIZE * sizeof(*hdr));
 
     // The buffer can be assigned.
-    r_packet.get().m_pcData = m_sndctlpkt.buffer;
-    r_packet.get().setLength(m_sndctlpkt.length);
+    w_packet.m_pcData = m_sndctlpkt.buffer;
+    w_packet.setLength(m_sndctlpkt.length);
 
     // This sets only the Packet Boundary flags, while all other things:
     // - Order
@@ -168,10 +167,10 @@ bool PacketFilter::packControlPacket(ref_t<CPacket> r_packet, int32_t seq, int k
     // - Crypto
     // - Message Number
     // will be set to 0/false
-    r_packet.get().m_iMsgNo = MSGNO_PACKET_BOUNDARY::wrap(PB_SOLO);
+    w_packet.m_iMsgNo = MSGNO_PACKET_BOUNDARY::wrap(PB_SOLO);
 
     // ... and then fix only the Crypto flags
-    r_packet.get().setMsgCryptoFlags(EncryptionKeySpec(kflg));
+    w_packet.setMsgCryptoFlags(EncryptionKeySpec(kflg));
 
     // Don't set the ID, it will be later set for any kind of packet.
     // Write the timestamp clip into the timestamp field.
@@ -202,8 +201,8 @@ void PacketFilter::InsertRebuilt(vector<CUnit*>& incoming, CUnitQueue* uq)
 
         CPacket& packet = u->m_Packet;
 
-        memcpy(packet.getHeader(), i->hdr, CPacket::HDR_SIZE);
-        memcpy(packet.m_pcData, i->buffer, i->length);
+        memcpy((packet.getHeader()), i->hdr, CPacket::HDR_SIZE);
+        memcpy((packet.m_pcData), i->buffer, i->length);
         packet.setLength(i->length);
 
         HLOGC(mglog.Debug, log << "FILTER: PROVIDING rebuilt packet %" << packet.getSeqNo());

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -173,10 +173,10 @@ public:
     ~PacketFilter();
 
     // Simple wrappers
-    void feedSource(ref_t<CPacket> r_packet);
+    void feedSource(CPacket& w_packet);
     SRT_ARQLevel arqLevel();
-    bool packControlPacket(ref_t<CPacket> r_packet, int32_t seq, int kflg);
-    void receive(CUnit* unit, ref_t< std::vector<CUnit*> > r_incoming, ref_t<loss_seqs_t> r_loss_seqs);
+    bool packControlPacket(int32_t seq, int kflg, CPacket& w_packet);
+    void receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_seqs_t& w_loss_seqs);
 
 protected:
     void InsertRebuilt(std::vector<CUnit*>& incoming, CUnitQueue* uq);
@@ -192,7 +192,7 @@ protected:
 };
 
 
-inline void PacketFilter::feedSource(ref_t<CPacket> r_packet) { SRT_ASSERT(m_filter); return m_filter->feedSource(*r_packet); }
+inline void PacketFilter::feedSource(CPacket& w_packet) { SRT_ASSERT(m_filter); return m_filter->feedSource((w_packet)); }
 inline SRT_ARQLevel PacketFilter::arqLevel() { SRT_ASSERT(m_filter); return m_filter->arqLevel(); }
 
 #endif

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -296,7 +296,7 @@ void CSndUList::update(const CUDT *u, EReschedule reschedule)
     insert_(steady_clock::now(), u);
 }
 
-int CSndUList::pop(sockaddr_any& addr, CPacket &pkt)
+int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 {
     CGuard listguard(m_ListLock);
 
@@ -322,12 +322,12 @@ int CSndUList::pop(sockaddr_any& addr, CPacket &pkt)
         return -1;
 
     // pack a packet from the socket
-    const std::pair<int, steady_clock::time_point> res_time = u->packData(pkt);
+    const std::pair<int, steady_clock::time_point> res_time = u->packData((w_pkt));
 
     if (res_time.first <= 0)
         return -1;
 
-    addr = u->m_PeerAddr;
+    w_addr = u->m_PeerAddr;
 
     // insert a new entry, ts is the next processing time
     const steady_clock::time_point send_time = res_time.second;
@@ -367,7 +367,7 @@ void CSndUList::realloc_()
         throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
     }
 
-    memcpy(temp, m_pHeap, sizeof(CSNode *) * m_iArrayLength);
+    memcpy((temp), m_pHeap, sizeof(CSNode *) * m_iArrayLength);
     m_iArrayLength *= 2;
     delete[] m_pHeap;
     m_pHeap = temp;
@@ -596,7 +596,6 @@ void *CSndQueue::worker(void *param)
         // it is time to send the next pkt
         sockaddr_any addr;
         CPacket      pkt;
-        sockaddr_any source_addr;
         if (self->m_pSndUList->pop((addr), (pkt)) < 0)
         {
             continue;
@@ -626,11 +625,11 @@ void *CSndQueue::worker(void *param)
     return NULL;
 }
 
-int CSndQueue::sendto(const sockaddr_any& addr, CPacket& packet)
+int CSndQueue::sendto(const sockaddr_any& w_addr, CPacket& w_packet)
 {
     // send out the packet immediately (high priority), this is a control packet
-    m_pChannel->sendto(addr, packet);
-    return (int)packet.getLength();
+    m_pChannel->sendto(w_addr, w_packet);
+    return (int)w_packet.getLength();
 }
 
 //
@@ -851,17 +850,16 @@ void CRendezvousQueue::remove(const SRTSOCKET &id, bool should_lock)
     }
 }
 
-CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, ref_t<SRTSOCKET> r_id)
+CUDT *CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
 {
     CGuard     vg(m_RIDVectorLock);
-    SRTSOCKET &id = *r_id;
 
     // TODO: optimize search
     for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
     {
-        if (i->m_PeerAddr == addr && ((id == 0) || (id == i->m_iID)))
+        if (i->m_PeerAddr == addr && ((w_id == 0) || (w_id == i->m_iID)))
         {
-            id = i->m_iID;
+            w_id = i->m_iID;
             return i->m_pUDT;
         }
     }
@@ -1097,7 +1095,7 @@ void *CRcvQueue::worker(void *param)
     while (!self->m_bClosing)
     {
         bool        have_received = false;
-        EReadStatus rst           = self->worker_RetrieveUnit(Ref(id), Ref(unit), (sa));
+        EReadStatus rst           = self->worker_RetrieveUnit((id), (unit), (sa));
         if (rst == RST_OK)
         {
             if (id < 0)
@@ -1234,7 +1232,7 @@ static string PacketInfo(const CPacket &pkt)
 }
 #endif
 
-EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_unit, sockaddr_any& w_addr)
+EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
 {
 #if !USE_BUSY_WAITING
     // This might be not really necessary, and probably
@@ -1256,8 +1254,8 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_
         }
     }
     // find next available slot for incoming packet
-    *r_unit = m_UnitQueue.getNextAvailUnit();
-    if (!*r_unit)
+    w_unit = m_UnitQueue.getNextAvailUnit();
+    if (!w_unit)
     {
         // no space, skip this packet
         CPacket temp;
@@ -1276,19 +1274,19 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(ref_t<int32_t> r_id, ref_t<CUnit*> r_
         return rst == RST_ERROR ? RST_ERROR : RST_AGAIN;
     }
 
-    r_unit->m_Packet.setLength(m_iPayloadSize);
+    w_unit->m_Packet.setLength(m_iPayloadSize);
 
     // reading next incoming packet, recvfrom returns -1 is nothing has been received
     THREAD_PAUSED();
-    EReadStatus rst = m_pChannel->recvfrom((w_addr), (r_unit->m_Packet));
+    EReadStatus rst = m_pChannel->recvfrom((w_addr), (w_unit->m_Packet));
     THREAD_RESUMED();
 
     if (rst == RST_OK)
     {
-        *r_id = r_unit->m_Packet.m_iID;
+        w_id = w_unit->m_Packet.m_iID;
         HLOGC(mglog.Debug,
               log << "INCOMING PACKET: BOUND=" << SockaddrToString(m_pChannel->bindAddressAny()) << " "
-                  << PacketInfo(r_unit->m_Packet));
+                  << PacketInfo(w_unit->m_Packet));
     }
     return rst;
 }
@@ -1396,7 +1394,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
     // stored in the rendezvous queue (see CRcvQueue::registerConnector)
     // or simply 0, but then at least the address must match one of these.
     // If the id was 0, it will be set to the actual socket ID of the returned CUDT.
-    CUDT *u = m_pRendezvousQueue->retrieve(addr, Ref(id));
+    CUDT *u = m_pRendezvousQueue->retrieve(addr, (id));
     if (!u)
     {
         // this socket is then completely unknown to the system.
@@ -1520,10 +1518,9 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
     return CONN_CONTINUE;
 }
 
-int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
+int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
 {
     CGuard   bufferlock(m_PassLock);
-    CPacket &packet = *r_packet;
 
     map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
 
@@ -1534,7 +1531,7 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
         i = m_mBuffer.find(id);
         if (i == m_mBuffer.end())
         {
-            packet.setLength(-1);
+            w_packet.setLength(-1);
             return -1;
         }
     }
@@ -1542,9 +1539,9 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
     // retrieve the earliest packet
     CPacket *newpkt = i->second.front();
 
-    if (packet.getLength() < newpkt->getLength())
+    if (w_packet.getLength() < newpkt->getLength())
     {
-        packet.setLength(-1);
+        w_packet.setLength(-1);
         return -1;
     }
 
@@ -1556,9 +1553,9 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
     // copies it into the passed packet and then the source packet
     // gets deleted. Why not simply return the originally stored packet,
     // without copying, allocation and deallocation?
-    memcpy(packet.m_nHeader, newpkt->m_nHeader, CPacket::HDR_SIZE);
-    memcpy(packet.m_pcData, newpkt->m_pcData, newpkt->getLength());
-    packet.setLength(newpkt->getLength());
+    memcpy((w_packet.m_nHeader), newpkt->m_nHeader, CPacket::HDR_SIZE);
+    memcpy((w_packet.m_pcData), newpkt->m_pcData, newpkt->getLength());
+    w_packet.setLength(newpkt->getLength());
 
     delete[] newpkt->m_pcData;
     delete newpkt;
@@ -1569,7 +1566,7 @@ int CRcvQueue::recvfrom(int32_t id, ref_t<CPacket> r_packet)
     if (i->second.empty())
         m_mBuffer.erase(i);
 
-    return (int)packet.getLength();
+    return (int)w_packet.getLength();
 }
 
 int CRcvQueue::setListener(CUDT *u)

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -850,7 +850,7 @@ void CRendezvousQueue::remove(const SRTSOCKET &id, bool should_lock)
     }
 }
 
-CUDT *CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
+CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
 {
     CGuard     vg(m_RIDVectorLock);
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -333,7 +333,7 @@ public:
    // and the lock IS ALREADY APPLIED, use false here to prevent
    // double locking and deadlock in result.
    void remove(const SRTSOCKET& id, bool should_lock);
-   CUDT* retrieve(const sockaddr_any& addr, ref_t<SRTSOCKET> id);
+   CUDT* retrieve(const sockaddr_any& addr, SRTSOCKET& id);
 
    void updateConnStatus(EReadStatus rst, EConnectStatus, const CPacket& response);
 
@@ -466,7 +466,7 @@ public:
       /// @param [out] packet received packet
       /// @return Data size of the packet
 
-   int recvfrom(int32_t id, ref_t<CPacket> packet);
+   int recvfrom(int32_t id, CPacket& to_packet);
 
    void setClosing()
    {
@@ -477,7 +477,7 @@ private:
    static void* worker(void* param);
    pthread_t m_WorkerThread;
    // Subroutines of worker
-   EReadStatus worker_RetrieveUnit(ref_t<int32_t> id, ref_t<CUnit*> unit, sockaddr_any& sa);
+   EReadStatus worker_RetrieveUnit(int32_t& id, CUnit*& unit, sockaddr_any& sa);
    EConnectStatus worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& sa);
    EConnectStatus worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& sa);
    EConnectStatus worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& sa);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -139,17 +139,17 @@ int srt_sendmsg2(SRTSOCKET u, const char * buf, int len, SRT_MSGCTRL *mctrl)
 {
     // Allow NULL mctrl in the API, but not internally.
     if (mctrl)
-        return CUDT::sendmsg2(u, buf, len, Ref(*mctrl));
+        return CUDT::sendmsg2(u, buf, len, (*mctrl));
     SRT_MSGCTRL mignore = srt_msgctrl_default;
-    return CUDT::sendmsg2(u, buf, len, Ref(mignore));
+    return CUDT::sendmsg2(u, buf, len, (mignore));
 }
 
 int srt_recvmsg2(SRTSOCKET u, char * buf, int len, SRT_MSGCTRL *mctrl)
 {
     if (mctrl)
-        return CUDT::recvmsg2(u, buf, len, Ref(*mctrl));
+        return CUDT::recvmsg2(u, buf, len, (*mctrl));
     SRT_MSGCTRL mignore = srt_msgctrl_default;
-    return CUDT::recvmsg2(u, buf, len, Ref(mignore));
+    return CUDT::recvmsg2(u, buf, len, (mignore));
 }
 
 const char* srt_getlasterror_str() { return UDT::getlasterror().getErrorMessage(); }

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -451,48 +451,6 @@ inline bool IsSet(int32_t bitset, int32_t flagset)
     return (bitset & flagset) == flagset;
 }
 
-// Homecooked version of ref_t. It's a copy of std::reference_wrapper
-// voided of unwanted properties and renamed to ref_t.
-
-
-#if HAVE_CXX11
-#include <functional>
-#endif
-
-template<typename Type>
-class ref_t
-{
-    Type* m_data;
-
-public:
-    typedef Type type;
-
-#if HAVE_CXX11
-    explicit ref_t(Type& __indata)
-        : m_data(std::addressof(__indata))
-        { }
-#else
-    explicit ref_t(Type& __indata)
-        : m_data((Type*)(&(char&)(__indata)))
-        { }
-#endif
-
-    ref_t(const ref_t<Type>& inref)
-        : m_data(inref.m_data)
-    { }
-
-#if HAVE_CXX11
-    ref_t(const std::reference_wrapper<Type>& i): m_data(std::addressof(i.get())) {}
-#endif
-
-    Type& operator*() { return *m_data; }
-
-    Type& get() const
-    { return *m_data; }
-
-    Type operator->() const
-    { return *m_data; }
-};
 
 // This is required for Printable function if you have a container of pairs,
 // but this function has a different definition for C++11 and C++03.
@@ -507,15 +465,6 @@ namespace srt_pair_op
 }
 
 #if HAVE_CXX11
-
-// This alias was created so that 'Ref' (not 'ref') is used everywhere.
-// Normally the C++11 'ref' fits perfectly here, however in C++03 mode
-// it would have to be newly created. This would then cause a conflict
-// between C++03 SRT and C++11 applications as well as between C++ standard
-// library and SRT when SRT is compiled in C++11 mode (as it happens on
-// Darwin/clang).
-template <class In>
-inline auto Ref(In& i) -> decltype(std::ref(i)) { return std::ref(i); }
 
 template <class In>
 inline auto Move(In& i) -> decltype(std::move(i)) { return std::move(i); }
@@ -592,12 +541,6 @@ auto map_getp(const Map& m, const Key& key) -> typename Map::mapped_type const*
 
 
 #else
-
-template <class Type>
-ref_t<Type> Ref(Type& arg)
-{
-    return ref_t<Type>(arg);
-}
 
 // The unique_ptr requires C++11, and the rvalue-reference feature,
 // so here we're simulate the behavior using the old std::auto_ptr.
@@ -934,8 +877,8 @@ inline std::string BufferStamp(const char* mem, size_t size)
 
     int n = 16-size;
     if (n > 0)
-        memset(spread+16-n, 0, n);
-    memcpy(spread, mem, min(size_t(16), size));
+        memset((spread + 16 - n), 0, n);
+    memcpy((spread), mem, min(size_t(16), size));
 
     // Now prepare 4 cells for uint32_t.
     union
@@ -943,7 +886,7 @@ inline std::string BufferStamp(const char* mem, size_t size)
         uint32_t sum;
         char cells[4];
     };
-    memset(cells, 0, 4);
+    memset((cells), 0, 4);
 
     for (size_t x = 0; x < 4; ++x)
         for (size_t y = 0; y < 4; ++y)
@@ -1021,7 +964,7 @@ ATR_CONSTEXPR size_t Size(const V (&)[N]) ATR_NOEXCEPT { return N; }
 template <size_t DEPRLEN, typename ValueType>
 inline ValueType avg_iir(ValueType old_value, ValueType new_value)
 {
-    return (old_value*(DEPRLEN-1) + new_value)/DEPRLEN;
+    return (old_value * (DEPRLEN - 1) + new_value) / DEPRLEN;
 }
 
 // Property accessor definitions

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -167,19 +167,19 @@ public:
    /// Calculate the packets arrival speed.
    /// @return Packet arrival speed (packets per second).
 
-   int getPktRcvSpeed(ref_t<int> bytesps) const
+   int getPktRcvSpeed(int& w_bytesps) const
    {
        // Lock access to the packet Window
        CGuard cg(m_lockPktWindow);
 
        int pktReplica[ASIZE];          // packet information window (inter-packet time)
-       return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, *bytesps);
+       return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, (w_bytesps));
    }
 
    int getPktRcvSpeed() const
    {
        int bytesps;
-       return getPktRcvSpeed(Ref(bytesps));
+       return getPktRcvSpeed((bytesps));
    }
 
    /// Estimate the bandwidth.

--- a/testing/srt-test-file.cpp
+++ b/testing/srt-test-file.cpp
@@ -20,6 +20,7 @@ written by
 #include <iterator>
 #include <vector>
 #include <map>
+#include <tuple>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -170,7 +171,7 @@ int main( int argc, char** argv )
     return 0;
 }
 
-void ExtractPath(string path, ref_t<string> dir, ref_t<string> fname)
+tuple<string, string> ExtractPath(string path)
 {
     //string& dir = r_dir;
     //string& fname = r_fname;
@@ -214,8 +215,7 @@ void ExtractPath(string path, ref_t<string> dir, ref_t<string> fname)
         directory = wd + "/" + directory;
     }
 
-    *dir = directory;
-    *fname = filename;
+    return make_tuple(directory, filename);
 }
 
 bool DoUpload(UriParser& ut, string path, string filename)
@@ -225,7 +225,7 @@ bool DoUpload(UriParser& ut, string path, string filename)
     string id = filename;
     Verb() << "Passing '" << id << "' as stream ID\n";
 
-    m.Establish(Ref(id));
+    m.Establish((id));
 
     // Check if the filename was changed
     if (id != filename)
@@ -313,7 +313,7 @@ bool DoDownload(UriParser& us, string directory, string filename)
     SrtModel m(us.host(), us.portno(), us.parameters());
 
     string id = filename;
-    m.Establish(Ref(id));
+    m.Establish((id));
 
     // Disregard the filename, unless the destination file exists.
 
@@ -391,7 +391,7 @@ bool Upload(UriParser& srt_target_uri, UriParser& fileuri)
 
     string path = fileuri.path();
     string directory, filename;
-    ExtractPath(path, ref(directory), ref(filename));
+    tie(directory, filename) = ExtractPath(path);
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
     // Set ID to the filename.
     // Directory will be preserved.
@@ -411,7 +411,7 @@ bool Download(UriParser& srt_source_uri, UriParser& fileuri)
     }
 
     string path = fileuri.path(), directory, filename;
-    ExtractPath(path, Ref(directory), Ref(filename));
+    tie(directory, filename) = ExtractPath(path);
 
     srt_source_uri["transtype"] = "file";
 

--- a/testing/srt-test-multiplex.cpp
+++ b/testing/srt-test-multiplex.cpp
@@ -593,7 +593,7 @@ int main( int argc, char** argv )
         for(;;)
         {
             string id = *ids.begin();
-            m.Establish(Ref(id));
+            m.Establish((id));
 
             // The 'id' could have been altered.
             // If Establish did connect(), then it gave this stream id,
@@ -604,7 +604,7 @@ int main( int argc, char** argv )
             // close the stream and ignore it.
 
             // Select medium from parameters.
-            if ( SelectAndLink(m, id, mode_output) )
+            if (SelectAndLink(m, id, mode_output))
             {
                 ids.erase(id);
                 if (ids.empty())

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -623,7 +623,7 @@ SrtMainLoop::SrtMainLoop(const string& srt_uri, bool input_echoback, const strin
     Verb() << "Establishing SRT connection: " << srt_uri;
 
     ::g_pending_model = &m;
-    m.Establish(Ref(id));
+    m.Establish((id));
 
     ::g_program_established = true;
     ::g_pending_model = nullptr;

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -910,7 +910,7 @@ SrtModel::SrtModel(string host, int port, map<string,string> par)
     m_port = port;
 }
 
-void SrtModel::Establish(ref_t<std::string> name)
+void SrtModel::Establish(std::string& w_name)
 {
     // This does connect or accept.
     // When this returned true, the caller should create
@@ -930,10 +930,10 @@ void SrtModel::Establish(ref_t<std::string> name)
 
         PrepareClient();
 
-        if (name.get() != "")
+        if (w_name != "")
         {
-            Verb() << "Connect with requesting stream [" << name.get() << "]";
-            UDT::setstreamid(m_sock, *name);
+            Verb() << "Connect with requesting stream [" << w_name << "]";
+            UDT::setstreamid(m_sock, w_name);
         }
         else
         {
@@ -976,8 +976,8 @@ void SrtModel::Establish(ref_t<std::string> name)
         Verb() << "Accepting a client...";
         AcceptNewClient();
         // This rewrites m_sock with a new SRT socket ("accepted" socket)
-        *name = UDT::getstreamid(m_sock);
-        Verb() << "... GOT CLIENT for stream [" << name.get() << "]";
+        w_name = UDT::getstreamid(m_sock);
+        Verb() << "... GOT CLIENT for stream [" << w_name << "]";
     }
 }
 

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -207,7 +207,7 @@ public:
 
 
     SrtModel(string host, int port, map<string,string> par);
-    void Establish(ref_t<std::string> name);
+    void Establish(std::string& w_name);
 
     void Close()
     {


### PR DESCRIPTION
Fixes #943, #945

The new convention for passing parameters by writable reference applied. The use of `ref_t` and `Ref` has been eliminated, as well as the definitions thereof.

The new convention is:

1. Reference parameters must have `w_` prefix and pointer parameters - `pw_` prefix.
2. Passing **any expression** that resolves to a reference to a writable object requires `(extra_parentheses)` around the whole expression. This applies to:
   - passing single variable to a function
   - passing a field of a structure
   - passing a pointer to a writable object, both as pointer or as reference
   - assigning a pointer to a pointer-type field of another structure to be later passed to a function for writing
   - regardless if this reference variable is a local variable, or a parameter pass-through

The above rules don't embrace passing a non-writable object, usually preferred as const, but also when it's required to be passed by writable pointer or reference, but the function doesn't modify it.

Also the order of parameters is changed to the convention - writable reference parameters should be placed after value parameters.