### PR TITLE
Restore mistakenly removed connection watchdog timer in control packets

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7263,8 +7263,8 @@ void CUDT::processCtrl(CPacket &ctrlpkt)
 {
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
-    m_tsLastRspTime = steady_clock::now();
     const steady_clock::time_point currtime = steady_clock::now();
+    m_tsLastRspTime = currtime;
     bool using_rexmit_flag = m_bPeerRexmitFlag;
 
     HLOGC(mglog.Debug,

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7263,6 +7263,7 @@ void CUDT::processCtrl(CPacket &ctrlpkt)
 {
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
+    m_tsLastRspTime = steady_clock::now();
     const steady_clock::time_point currtime = steady_clock::now();
     bool using_rexmit_flag = m_bPeerRexmitFlag;
 


### PR DESCRIPTION
This fix restores the fallen-out update of the last response timer watchdog in the control packet handler. Without this, it it would break the connection at the sending side as it receives no data and control packets wouldn't reset it.

It also restores the code that was there before.