### PR TITLE
apputil.hpp: conditionally define STON for size_t

### DIFF
--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -101,7 +101,8 @@ static inline Number StrToNumber(const std::string& )
 template<> inline type StrToNumber(const std::string& s) { return function (s, 0, 0); }
 
 STON(int, stoi);
-#ifndef _WIN32 // On Windows this type seems to be an alias to some others below
+/* In some architectures like i386, size_t is defined as 'unsigned int' */
+#if defined (size_t) && (__SIZEOF_SIZE_T__ != __SIZEOF_INT__)
 STON(size_t, stoul);
 #endif
 STON(unsigned int, stoul);


### PR DESCRIPTION
In some architectures like i386, `size_t` is same as `unsigned int`.
Then it causes redefinition error.

```
/<<PKGBUILDDIR>>/apps/apputil.hpp:101:24: error: redefinition of ‘Number StrToNumber(const string&) [with Number = unsigned int; std::__cxx11::string = std::__cxx11::basic_string<char>]’
 template<> inline type StrToNumber(const std::string& s) { return function (s, 0, 0); }
                        ^~~~~~~~~~~
/<<PKGBUILDDIR>>/apps/apputil.hpp:107:1: note: in expansion of macro ‘STON’
 STON(unsigned int, stoul);
 ^~~~
/<<PKGBUILDDIR>>/apps/apputil.hpp:101:24: note: ‘Number StrToNumber(const string&) [with Number = unsigned int; std::__cxx11::string = std::__cxx11::basic_string<char>]’ previously declared here
 template<> inline type StrToNumber(const std::string& s) { return function (s, 0, 0); }
                        ^~~~~~~~~~~
/<<PKGBUILDDIR>>/apps/apputil.hpp:105:1: note: in expansion of macro ‘STON’
 STON(size_t, stoul);
```