### PR TITLE
Introducing sync Mutex wrapper class

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1879,7 +1879,7 @@ void* CUDTUnited::garbageCollect(void* p)
       if (empty)
          break;
 
-      CTimer::sleep();
+      SleepFor(milliseconds_from(1));
    }
 
    THREAD_EXIT();

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -97,13 +97,13 @@ public:
    std::set<SRTSOCKET>* m_pAcceptSockets;    //< set of accept()ed connections
 
    pthread_cond_t m_AcceptCond;              //< used to block "accept" call
-   pthread_mutex_t m_AcceptLock;             //< mutex associated to m_AcceptCond
+   srt::sync::Mutex m_AcceptLock;            //< mutex associated to m_AcceptCond
 
    unsigned int m_uiBackLog;                 //< maximum number of connections in queue
 
    int m_iMuxID;                             //< multiplexer ID
 
-   pthread_mutex_t m_ControlLock;            //< lock this socket exclusively for control APIs: bind/listen/connect
+   srt::sync::Mutex m_ControlLock;           //< lock this socket exclusively for control APIs: bind/listen/connect
 
    static int64_t getPeerSpec(SRTSOCKET id, int32_t isn)
    {
@@ -212,10 +212,10 @@ private:
 private:
    std::map<SRTSOCKET, CUDTSocket*> m_Sockets;       // stores all the socket structures
 
-   pthread_mutex_t m_GlobControlLock;                // used to synchronize UDT API
+   srt::sync::Mutex m_GlobControlLock;               // used to synchronize UDT API
 
-   pthread_mutex_t m_IDLock;                         // used to synchronize ID generation
-   SRTSOCKET m_SocketIDGenerator;                             // seed to generate a new unique socket ID
+   srt::sync::Mutex m_IDLock;                        // used to synchronize ID generation
+   SRTSOCKET m_SocketIDGenerator;                    // seed to generate a new unique socket ID
 
    std::map<int64_t, std::set<SRTSOCKET> > m_PeerRec;// record sockets from peers to avoid repeated connection request, int64_t = (socker_id << 30) + isn
 
@@ -231,17 +231,17 @@ private:
 
 private:
    std::map<int, CMultiplexer> m_mMultiplexer;		// UDP multiplexer
-   pthread_mutex_t m_MultiplexerLock;
+   srt::sync::Mutex            m_MultiplexerLock;
 
 private:
    CCache<CInfoBlock>* m_pCache;			// UDT network information cache
 
 private:
    volatile bool m_bClosing;
-   pthread_mutex_t m_GCStopLock;
+   srt::sync::Mutex m_GCStopLock;
    pthread_cond_t m_GCStopCond;
 
-   pthread_mutex_t m_InitLock;
+   srt::sync::Mutex m_InitLock;
    int m_iInstanceCount;				// number of startup() called by application
    bool m_bGCStatus;					// if the GC thread is working (true)
 

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -112,8 +112,6 @@ CSndBuffer::CSndBuffer(int size, int mss)
    }
 
    m_pFirstBlock = m_pCurrBlock = m_pLastBlock = m_pBlock;
-
-   pthread_mutex_init(&m_BufLock, NULL);
 }
 
 CSndBuffer::~CSndBuffer()
@@ -134,8 +132,6 @@ CSndBuffer::~CSndBuffer()
       delete [] temp->m_pcData;
       delete temp;
    }
-
-   pthread_mutex_destroy(&m_BufLock);
 }
 
 void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint64_t srctime, ref_t<int32_t> r_msgno)
@@ -197,7 +193,7 @@ void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint6
     }
     m_pLastBlock = s;
 
-    CGuard::enterCS(m_BufLock);
+    enterCS(m_BufLock);
     m_iCount += size;
 
     m_iBytesCount += len;
@@ -209,7 +205,7 @@ void CSndBuffer::addBuffer(const char* data, int len, int ttl, bool order, uint6
     updAvgBufSize(time);
 #endif
 
-    CGuard::leaveCS(m_BufLock);
+    leaveCS(m_BufLock);
 
 
     // MSGNO_SEQ::mask has a form: 00000011111111...
@@ -316,11 +312,11 @@ int CSndBuffer::addBufferFromFile(fstream& ifs, int len)
    }
    m_pLastBlock = s;
 
-   CGuard::enterCS(m_BufLock);
+   enterCS(m_BufLock);
    m_iCount += size;
    m_iBytesCount += total;
 
-   CGuard::leaveCS(m_BufLock);
+   leaveCS(m_BufLock);
 
    m_iNextMsgNo ++;
    if (m_iNextMsgNo == int32_t(MSGNO_SEQ::mask))
@@ -711,8 +707,6 @@ m_iNotch(0)
    memset(m_TsbPdDriftHisto100us, 0, sizeof(m_TsbPdDriftHisto100us));
    memset(m_TsbPdDriftHisto1ms, 0, sizeof(m_TsbPdDriftHisto1ms));
 #endif
-
-   pthread_mutex_init(&m_BytesCountLock, NULL);
 }
 
 CRcvBuffer::~CRcvBuffer()
@@ -726,8 +720,6 @@ CRcvBuffer::~CRcvBuffer()
    }
 
    delete [] m_pUnit;
-
-   pthread_mutex_destroy(&m_BytesCountLock);
 }
 
 void CRcvBuffer::countBytes(int pkts, int bytes, bool acked)
@@ -1564,7 +1556,7 @@ void CRcvBuffer::printDriftOffset(int tsbPdOffset, int tsbPdDriftAvg)
 }
 #endif /* SRT_DEBUG_TSBPD_DRIFT */
 
-void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, pthread_mutex_t& mutex_to_lock)
+void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, Mutex& mutex_to_lock)
 {
     if (!m_bTsbPdMode) // Not checked unless in TSBPD mode
         return;
@@ -1588,7 +1580,7 @@ void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, pthread_mutex_t& 
 
     const steady_clock::duration iDrift = steady_clock::now() - (getTsbPdTimeBase(timestamp_us) + microseconds_from(timestamp_us));
 
-    CGuard::enterCS(mutex_to_lock);
+    enterCS(mutex_to_lock);
 
     bool updated = m_DriftTracer.update(count_microseconds(iDrift));
 
@@ -1616,7 +1608,7 @@ void CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, pthread_mutex_t& 
         HLOGC(dlog.Debug, log << "DRIFT=" << count_milliseconds(iDrift) << "ms TB REMAINS: " << FormatTime(m_tsTsbPdTimeBase));
     }
 
-    CGuard::leaveCS(mutex_to_lock);
+    leaveCS(mutex_to_lock);
 }
 
 int CRcvBuffer::readMsg(char* data, int len)
@@ -1750,9 +1742,9 @@ void CRcvBuffer::readMsgHeavyLogging(int p)
 {
     static steady_clock::time_point prev_now;
     static steady_clock::time_point prev_srctime;
-    CPacket& pkt = m_pUnit[p]->m_Packet;
+    const CPacket& pkt = m_pUnit[p]->m_Packet;
 
-    int32_t seq = pkt.m_iSeqNo;
+    const int32_t seq = pkt.m_iSeqNo;
 
     steady_clock::time_point nowtime = steady_clock::now();
     steady_clock::time_point srctime = getPktTsbPdTime(m_pUnit[p]->m_Packet.getMsgTimeStamp());

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -161,7 +161,7 @@ private:    // Constants
     static const int      INPUTRATE_INITIAL_BYTESPS = BW_INFINITE;
 
 private:
-   pthread_mutex_t m_BufLock;           // used to synchronize buffer operation
+   srt::sync::Mutex m_BufLock;           // used to synchronize buffer operation
 
    struct Block
    {
@@ -376,7 +376,7 @@ public:
       /// @param [in] timestamp packet time stamp
       /// @param [ref] lock Mutex that should be locked for the operation
 
-   void addRcvTsbPdDriftSample(uint32_t timestamp, pthread_mutex_t& lock);
+   void addRcvTsbPdDriftSample(uint32_t timestamp, srt::sync::Mutex& lock);
 
 #ifdef SRT_DEBUG_TSBPD_DRIFT
    void printDriftHistogram(int64_t iDrift);
@@ -457,7 +457,7 @@ public:
    srt::sync::steady_clock::time_point getPktTsbPdTime(uint32_t timestamp);
    int debugGetSize() const;
    srt::sync::steady_clock::time_point debugGetDeliveryTime(int offset);
-   
+
    // Required by PacketFilter facility to use as a storage
    // for provided packets
    CUnitQueue* getUnitQueue()
@@ -514,7 +514,7 @@ private:
                                         // up to which data are already retrieved;
                                         // in message reading mode it's unused and always 0)
 
-   pthread_mutex_t m_BytesCountLock;    // used to protect counters operations
+   srt::sync::Mutex m_BytesCountLock;   // used to protect counters operations
    int m_iBytesCount;                   // Number of payload bytes in the buffer
    int m_iAckedPktsCount;               // Number of acknowledged pkts in the buffer
    int m_iAckedBytesCount;              // Number of acknowledged payload bytes in the buffer

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -83,13 +83,11 @@ public:
    m_iCurrSize(0)
    {
       m_vHashPtr.resize(m_iHashSize);
-      CGuard::createMutex(m_Lock);
    }
 
    ~CCache()
    {
       clear();
-      CGuard::releaseMutex(m_Lock);
    }
 
 public:
@@ -99,7 +97,7 @@ public:
 
    int lookup(T* data)
    {
-      CGuard cacheguard(m_Lock);
+      srt::sync::CGuard cacheguard(m_Lock);
 
       int key = data->getKey();
       if (key < 0)
@@ -127,7 +125,7 @@ public:
 
    int update(T* data)
    {
-      CGuard cacheguard(m_Lock);
+      srt::sync::CGuard cacheguard(m_Lock);
 
       int key = data->getKey();
       if (key < 0)
@@ -224,7 +222,7 @@ private:
    int m_iHashSize;
    int m_iCurrSize;
 
-   pthread_mutex_t m_Lock;
+   srt::sync::Mutex m_Lock;
 
 private:
    CCache(const CCache&);

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -209,15 +209,6 @@ CTimer::EWait CTimer::waitForEvent()
     return reason == ETIMEDOUT ? WT_TIMEOUT : reason == 0 ? WT_EVENT : WT_ERROR;
 }
 
-void CTimer::sleep()
-{
-   #ifndef _WIN32
-      usleep(10);
-   #else
-      Sleep(1);
-   #endif
-}
-
 int CTimer::condTimedWaitUS(pthread_cond_t* cond, pthread_mutex_t* mutex, uint64_t delay) {
     timeval now;
     gettimeofday(&now, 0);

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -560,11 +560,7 @@ public:
       /// @retval WT_ERROR The function has exit due to an error
 
    static EWait waitForEvent();
-
-      /// sleep for a short interval. exact sleep time does not matter
-
-   static void sleep();
-   
+ 
       /// Wait for condition with timeout 
       /// @param [in] cond Condition variable to wait for
       /// @param [in] mutex locked mutex associated with the condition variable

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -560,7 +560,7 @@ public:
       /// @retval WT_ERROR The function has exit due to an error
 
    static EWait waitForEvent();
- 
+   
       /// Wait for condition with timeout 
       /// @param [in] cond Condition variable to wait for
       /// @param [in] mutex locked mutex associated with the condition variable
@@ -574,64 +574,12 @@ private:
    srt::sync::steady_clock::time_point m_tsSchedTime;             // next schedulled time
 
    pthread_cond_t m_TickCond;
-   pthread_mutex_t m_TickLock;
+   srt::sync::Mutex m_TickLock;
 
    static pthread_cond_t m_EventCond;
-   static pthread_mutex_t m_EventLock;
+   static srt::sync::Mutex m_EventLock;
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
-class CGuard
-{
-public:
-   /// Constructs CGuard, which locks the given mutex for
-   /// the scope where this object exists.
-   /// @param lock Mutex to lock
-   /// @param if_condition If this is false, CGuard will do completely nothing
-   CGuard(pthread_mutex_t& lock, bool if_condition = true);
-   ~CGuard();
-
-public:
-   static int enterCS(pthread_mutex_t& lock);
-   static int leaveCS(pthread_mutex_t& lock);
-
-   static void createMutex(pthread_mutex_t& lock);
-   static void releaseMutex(pthread_mutex_t& lock);
-
-   static void createCond(pthread_cond_t& cond);
-   static void releaseCond(pthread_cond_t& cond);
-
-   void forceUnlock();
-
-private:
-   pthread_mutex_t& m_Mutex;            // Alias name of the mutex to be protected
-   int m_iLocked;                       // Locking status
-
-   CGuard& operator=(const CGuard&);
-};
-
-class InvertedGuard
-{
-    pthread_mutex_t* m_pMutex;
-public:
-
-    InvertedGuard(pthread_mutex_t* smutex): m_pMutex(smutex)
-    {
-        if ( !smutex )
-            return;
-
-        CGuard::leaveCS(*smutex);
-    }
-
-    ~InvertedGuard()
-    {
-        if ( !m_pMutex )
-            return;
-
-        CGuard::enterCS(*m_pMutex);
-    }
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -691,7 +691,7 @@ private: // Receiving related data
 
     bool m_bTsbPd;                               // Peer sends TimeStamp-Based Packet Delivery Packets 
     pthread_t m_RcvTsbPdThread;                  // Rcv TsbPD Thread handle
-    pthread_cond_t m_RcvTsbPdCond;
+    pthread_cond_t m_RcvTsbPdCond;               // TSBPD signals if reading is ready
     bool m_bTsbPdAckWakeup;                      // Signal TsbPd thread on Ack sent
 
     CallbackHolder<srt_listen_callback_fn> m_cbAcceptHook;
@@ -710,26 +710,22 @@ private:
 
 
 private: // synchronization: mutexes and conditions
-    pthread_mutex_t m_ConnectionLock;            // used to synchronize connection operation
+    srt::sync::Mutex m_ConnectionLock;           // used to synchronize connection operation
 
     pthread_cond_t m_SendBlockCond;              // used to block "send" call
-    pthread_mutex_t m_SendBlockLock;             // lock associated to m_SendBlockCond
+    srt::sync::Mutex m_SendBlockLock;            // lock associated to m_SendBlockCond
 
-    pthread_mutex_t m_RcvBufferLock;             // Protects the state of the m_pRcvBuffer
-
+    srt::sync::Mutex m_RcvBufferLock;            // Protects the state of the m_pRcvBuffer
     // Protects access to m_iSndCurrSeqNo, m_iSndLastAck
-    pthread_mutex_t m_RecvAckLock;               // Protects the state changes while processing incomming ACK (UDT_EPOLL_OUT)
-
+    srt::sync::Mutex m_RecvAckLock;              // Protects the state changes while processing incomming ACK (UDT_EPOLL_OUT)
 
     pthread_cond_t m_RecvDataCond;               // used to block "recv" when there is no data
-    pthread_mutex_t m_RecvDataLock;              // lock associated to m_RecvDataCond
+    srt::sync::Mutex m_RecvDataLock;             // lock associated to m_RecvDataCond
 
-    pthread_mutex_t m_SendLock;                  // used to synchronize "send" call
-    pthread_mutex_t m_RecvLock;                  // used to synchronize "recv" call
-
-    pthread_mutex_t m_RcvLossLock;               // Protects the receiver loss list (access: CRcvQueue::worker, CUDT::tsbpd)
-
-    pthread_mutex_t m_StatsLock;                 // used to synchronize access to trace statistics
+    srt::sync::Mutex m_SendLock;                 // used to synchronize "send" call
+    srt::sync::Mutex m_RecvLock;                 // used to synchronize "recv" call
+    srt::sync::Mutex m_RcvLossLock;              // Protects the receiver loss list (access: CRcvQueue::worker, CUDT::tsbpd)
+    srt::sync::Mutex m_StatsLock;                // used to synchronize access to trace statistics
 
     void initSynch();
     void destroySynch();

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -80,12 +80,10 @@ using namespace srt_logging;
 CEPoll::CEPoll():
 m_iIDSeed(0)
 {
-    CGuard::createMutex(m_EPollLock);
 }
 
 CEPoll::~CEPoll()
 {
-   CGuard::releaseMutex(m_EPollLock);
 }
 
 int CEPoll::create()

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -385,10 +385,10 @@ public: // for CUDT to acknowledge IO status
 
 private:
    int m_iIDSeed;                            // seed to generate a new ID
-   pthread_mutex_t m_SeedLock;
+   srt::sync::Mutex m_SeedLock;
 
    std::map<int, CEPollDesc> m_mPolls;       // all epolls
-   pthread_mutex_t m_EPollLock;
+   srt::sync::Mutex m_EPollLock;
 };
 
 

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -75,15 +75,11 @@ m_ListLock()
       m_caSeq[i].data1 = -1;
       m_caSeq[i].data2 = -1;
    }
-
-   // sender list needs mutex protection
-   pthread_mutex_init(&m_ListLock, 0);
 }
 
 CSndLossList::~CSndLossList()
 {
     delete [] m_caSeq;
-    pthread_mutex_destroy(&m_ListLock);
 }
 
 int CSndLossList::insert(int32_t seqno1, int32_t seqno2)

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -99,7 +99,7 @@ private:
    int m_iSize;                         // size of the static array
    int m_iLastInsertPos;                // position of last insert node
 
-   mutable pthread_mutex_t m_ListLock; // used to synchronize list operation
+   mutable srt::sync::Mutex m_ListLock; // used to synchronize list operation
 
 private:
    CSndLossList(const CSndLossList&);

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -104,7 +104,7 @@ struct LogConfig
     std::ostream* log_stream;
     SRT_LOG_HANDLER_FN* loghandler_fn;
     void* loghandler_opaque;
-    pthread_mutex_t mutex;
+    srt::sync::Mutex mutex;
     int flags;
 
     LogConfig(const fa_bitset_t& efa,
@@ -117,16 +117,14 @@ struct LogConfig
         , loghandler_opaque()
         , flags()
     {
-        pthread_mutex_init(&mutex, NULL);
     }
 
     ~LogConfig()
     {
-        pthread_mutex_destroy(&mutex);
     }
 
-    void lock() { pthread_mutex_lock(&mutex); }
-    void unlock() { pthread_mutex_unlock(&mutex); }
+    void lock() { mutex.lock(); }
+    void unlock() { mutex.unlock(); }
 };
 
 // The LogDispatcher class represents the object that is responsible for
@@ -139,7 +137,6 @@ private:
     static const size_t MAX_PREFIX_SIZE = 32;
     char prefix[MAX_PREFIX_SIZE+1];
     LogConfig* src_config;
-    pthread_mutex_t mutex;
 
     bool isset(int flg) { return (src_config->flags & flg) != 0; }
 
@@ -166,12 +163,10 @@ public:
             strcat(prefix, ":");
             strcat(prefix, logger_pfx);
         }
-        pthread_mutex_init(&mutex, 0);
     }
 
     ~LogDispatcher()
     {
-        pthread_mutex_destroy(&mutex);
     }
 
     bool CheckEnabled();

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -23,6 +23,7 @@
 
 using namespace std;
 using namespace srt_logging;
+using namespace srt::sync;
 
 bool ParseFilterConfig(std::string s, SrtFilterConfig& out)
 {

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -516,8 +516,8 @@ private:
    pthread_mutex_t m_IDLock;
 
    std::map<int32_t, std::queue<CPacket*> > m_mBuffer;	// temporary buffer for rendezvous connection request
-   pthread_mutex_t m_PassLock;
-   pthread_cond_t m_PassCond;
+   pthread_mutex_t m_BufferLock;
+   pthread_cond_t m_BufferCond;
 
 private:
    CRcvQueue(const CRcvQueue&);

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -215,9 +215,9 @@ private:
    int m_iArrayLength;			// physical length of the array
    int m_iLastEntry;			// position of last entry on the heap array
 
-   pthread_mutex_t m_ListLock;
+   srt::sync::Mutex m_ListLock;
 
-   pthread_mutex_t* m_pWindowLock;
+   srt::sync::Mutex* m_pWindowLock;
    pthread_cond_t* m_pWindowCond;
 
    CTimer* m_pTimer;
@@ -347,7 +347,7 @@ private:
    };
    std::list<CRL> m_lRendezvousID;    // The sockets currently in rendezvous mode
 
-   pthread_mutex_t m_RIDVectorLock;
+   srt::sync::Mutex m_RIDVectorLock;
 };
 
 class CSndQueue
@@ -411,7 +411,7 @@ private:
    CChannel* m_pChannel;                // The UDP channel for data sending
    CTimer* m_pTimer;                    // Timing facility
 
-   pthread_mutex_t m_WindowLock;
+   srt::sync::Mutex m_WindowLock;
    pthread_cond_t m_WindowCond;
 
    volatile bool m_bClosing;            // closing the worker
@@ -508,15 +508,15 @@ private:
    void storePkt(int32_t id, CPacket* pkt);
 
 private:
-   pthread_mutex_t m_LSLock;
+   srt::sync::Mutex m_LSLock;
    CUDT* m_pListener;                                   // pointer to the (unique, if any) listening UDT entity
    CRendezvousQueue* m_pRendezvousQueue;                // The list of sockets in rendezvous mode
 
    std::vector<CUDT*> m_vNewEntry;                      // newly added entries, to be inserted
-   pthread_mutex_t m_IDLock;
+   srt::sync::Mutex m_IDLock;
 
    std::map<int32_t, std::queue<CPacket*> > m_mBuffer;	// temporary buffer for rendezvous connection request
-   pthread_mutex_t m_BufferLock;
+   srt::sync::Mutex m_BufferLock;
    pthread_cond_t m_BufferCond;
 
 private:

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -189,6 +189,66 @@ std::string srt::sync::FormatTimeSys(const steady_clock::time_point& timestamp)
     return out.str();
 }
 
+srt::sync::Mutex::Mutex()
+{
+    pthread_mutex_init(&m_mutex, NULL);
+}
+
+srt::sync::Mutex::~Mutex()
+{
+    pthread_mutex_destroy(&m_mutex);
+}
+
+int srt::sync::Mutex::lock()
+{
+    return pthread_mutex_lock(&m_mutex);
+}
+
+int srt::sync::Mutex::unlock()
+{
+    return pthread_mutex_unlock(&m_mutex);
+}
+
+bool srt::sync::Mutex::try_lock()
+{
+    return (pthread_mutex_trylock(&m_mutex) == 0);
+}
+
+srt::sync::ScopedLock::ScopedLock(Mutex& m)
+    : m_mutex(m)
+{
+    m_mutex.lock();
+}
+
+srt::sync::ScopedLock::~ScopedLock()
+{
+    m_mutex.unlock();
+}
+
+//
+//
+//
+
+srt::sync::UniqueLock::UniqueLock(Mutex& m)
+    : m_Mutex(m)
+{
+    m_iLocked = m_Mutex.lock();
+}
+
+srt::sync::UniqueLock::~UniqueLock()
+{
+    unlock();
+}
+
+void srt::sync::UniqueLock::unlock()
+{
+    if (m_iLocked == 0)
+    {
+        m_Mutex.unlock();
+        m_iLocked = -1;
+    }
+}
+
 int srt::sync::SyncEvent::wait_for(pthread_cond_t* cond, pthread_mutex_t* mutex, const Duration<steady_clock>& rel_time)
 {
     timespec timeout;

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -60,7 +60,7 @@ public: // Assignment operators
     inline Duration operator-(const Duration& rhs) const { return Duration(m_duration - rhs.m_duration); }
     inline Duration operator*(const int& rhs) const { return Duration(m_duration * rhs); }
 
-  private:
+private:
     // int64_t range is from -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
     int64_t m_duration;
 };
@@ -176,7 +176,98 @@ inline bool is_zero(const TimePoint<steady_clock>& t) { return t.is_zero(); }
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-// Common pthread/chrono section
+// Mutex section
+//
+///////////////////////////////////////////////////////////////////////////////
+
+/// Mutex is a class wrapper, that should mimic the std::chrono::mutex class.
+/// At the moment the extra function ref() is temporally added to allow calls
+/// to pthread_cond_timedwait(). Will be removed by introducing CEvent.
+class Mutex
+{
+    friend class SyncEvent;
+
+public:
+    Mutex();
+    ~Mutex();
+
+public:
+    int lock();
+    int unlock();
+
+    /// @return     true if the lock was acquired successfully, otherwise false
+    bool try_lock();
+
+    // TODO: To be removed with introduction of the CEvent.
+    pthread_mutex_t& ref() { return m_mutex; }
+
+private:
+    pthread_mutex_t m_mutex;
+};
+
+/// A pthread version of std::chrono::scoped_lock<mutex> (or lock_guard for C++11)
+class ScopedLock
+{
+public:
+    ScopedLock(Mutex& m);
+    ~ScopedLock();
+
+private:
+    Mutex& m_mutex;
+};
+
+/// A pthread version of std::chrono::unique_lock<mutex>
+class UniqueLock
+{
+    friend class SyncEvent;
+
+public:
+    UniqueLock(Mutex &m);
+    ~UniqueLock();
+
+public:
+    void unlock();
+
+private:
+    int m_iLocked;
+    Mutex& m_Mutex;
+};
+
+/// The purpose of this typedef is to reduce the number of changes in the code (renamings)
+/// and produce less merge conflicts with some other parallel work done.
+/// TODO: Replace CGuard with ScopedLock. Use UniqueLock only when required.
+typedef UniqueLock CGuard;
+
+
+inline void enterCS(Mutex &m) { m.lock(); }
+inline void leaveCS(Mutex &m) { m.unlock(); }
+
+
+class InvertedLock
+{
+    Mutex *m_pMutex;
+
+  public:
+    InvertedLock(Mutex *m)
+        : m_pMutex(m)
+    {
+        if (!m_pMutex)
+            return;
+
+        leaveCS(*m_pMutex);
+    }
+
+    ~InvertedLock()
+    {
+        if (!m_pMutex)
+            return;
+        enterCS(*m_pMutex);
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Event (CV) section
 //
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -180,6 +180,15 @@ inline bool is_zero(const TimePoint<steady_clock>& t) { return t.is_zero(); }
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+inline void SleepFor(const steady_clock::duration& t)
+{
+#ifndef _WIN32
+    usleep(count_microseconds(t)); // microseconds
+#else
+    Sleep(count_milliseconds(t));
+#endif
+}
+
 class SyncEvent
 {
 public:

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -92,7 +92,7 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
             r_ack = r_aSeq[i].iACK;
 
             // calculate RTT
-            int rtt = count_microseconds(steady_clock::now() - r_aSeq[i].tsTimeStamp);
+            const int rtt = count_microseconds(steady_clock::now() - r_aSeq[i].tsTimeStamp);
 
             if (i + 1 == r_iHead)
             {
@@ -121,7 +121,7 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
          r_ack = r_aSeq[j].iACK;
 
          // calculate RTT
-         int rtt = count_microseconds(steady_clock::now() - r_aSeq[j].tsTimeStamp);
+         const int rtt = count_microseconds(steady_clock::now() - r_aSeq[j].tsTimeStamp);
 
          if (j == r_iHead)
          {

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -148,17 +148,14 @@ public:
         m_tsProbeTime(),
         m_Probe1Sequence(-1)
     {
-        pthread_mutex_init(&m_lockPktWindow, NULL);
-        pthread_mutex_init(&m_lockProbeWindow, NULL);
         CPktTimeWindowTools::initializeWindowArrays(m_aPktWindow, m_aProbeWindow, m_aBytesWindow, ASIZE, PSIZE);
     }
 
    ~CPktTimeWindow()
    {
-       pthread_mutex_destroy(&m_lockPktWindow);
-       pthread_mutex_destroy(&m_lockProbeWindow);
    }
 
+public:
    /// read the minimum packet sending interval.
    /// @return minimum packet sending interval (microseconds).
 
@@ -170,7 +167,7 @@ public:
    int getPktRcvSpeed(ref_t<int> bytesps) const
    {
        // Lock access to the packet Window
-       CGuard cg(m_lockPktWindow);
+       srt::sync::CGuard cg(m_lockPktWindow);
 
        int pktReplica[ASIZE];          // packet information window (inter-packet time)
        return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, *bytesps);
@@ -188,7 +185,7 @@ public:
    int getBandwidth() const
    {
        // Lock access to the packet Window
-       CGuard cg(m_lockProbeWindow);
+       srt::sync::CGuard cg(m_lockProbeWindow);
 
        int probeReplica[PSIZE];
        return getBandwidth_in(m_aProbeWindow, probeReplica, PSIZE);
@@ -211,7 +208,7 @@ public:
 
    void onPktArrival(int pktsz = 0)
    {
-       CGuard cg(m_lockPktWindow);
+       srt::sync::CGuard cg(m_lockPktWindow);
 
        m_tsCurrArrTime = srt::sync::steady_clock::now();
 
@@ -286,7 +283,7 @@ public:
        const srt::sync::steady_clock::time_point now = srt::sync::steady_clock::now();
 
        // Lock access to the packet Window
-       CGuard cg(m_lockProbeWindow);
+       srt::sync::CGuard cg(m_lockProbeWindow);
 
        m_tsCurrArrTime = now;
 
@@ -326,11 +323,11 @@ private:
    int m_aPktWindow[ASIZE];          // packet information window (inter-packet time)
    int m_aBytesWindow[ASIZE];        // 
    int m_iPktWindowPtr;         // position pointer of the packet info. window.
-   mutable pthread_mutex_t m_lockPktWindow; // used to synchronize access to the packet window
+   mutable srt::sync::Mutex m_lockPktWindow; // used to synchronize access to the packet window
 
    int m_aProbeWindow[PSIZE];        // record inter-packet time for probing packet pairs
    int m_iProbeWindowPtr;       // position pointer to the probing window
-   mutable pthread_mutex_t m_lockProbeWindow; // used to synchronize access to the probe window
+   mutable srt::sync::Mutex m_lockProbeWindow; // used to synchronize access to the probe window
 
    int m_iLastSentTime;         // last packet sending time
    int m_iMinPktSndInt;         // Minimum packet sending interval


### PR DESCRIPTION
This is the second subset of PR #800 on the way to C++11 support.

`srt::sync::Mutex` class is introduced. The class wraps pthread mutex.
In future it is expected to be directly mapped to `std::mutex` in case SRT is built with C++11 threads.

### Shortlist of Changes

1. Introduced `srt::sync::Mutex` class that wraps pthread mutex.
2. Replaced `CGuard` with `ScopedLock` and `UniqueLock`. Added CGuard typedef to reduce the number of renaming until #1049 is merged.
3. Renamed `CRcvQueue::m_PassLock` to `CRcvQueue::m_BufferLock`
4. Renamed `CRcvQueue::m_PassCond` to `CRcvQueue::m_BufferCond`
5. Replaced `CTimer::sleep()` by `srt::sync::SleepFor(const Duration&)`

Blocks #1049 