### PR TITLE
Bugfix: close the crypto under correct conditions

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5395,8 +5395,6 @@ bool CUDT::close()
             sendCtrl(UMSG_SHUTDOWN);
         }
 
-        m_pCryptoControl->close();
-
         // Store current connection information.
         CInfoBlock ib;
         ib.m_iIPversion = m_PeerAddr.family();
@@ -5407,6 +5405,9 @@ bool CUDT::close()
 
         m_bConnected = false;
     }
+
+    if (m_pCryptoControl)
+        m_pCryptoControl->close();
 
     if (m_bTsbPd && !pthread_equal(m_RcvTsbPdThread, pthread_t()))
     {


### PR DESCRIPTION
During the tests that have been involving closing the socket being members of a group in various unsynchronized conditions it has happened sometimes that a socket was attempted to be closed while it was during the process of closing. Normally all mutexes protecting internal data were preventing any clashes that could result from it. In the case of closing the crypto control object it was happening, however, that one has closed the crypto without having all flags updated, so it was happening that the crypto wasn't closed and therefore deferred the close up to the destructor (which was unwanted in cases when the destruction was called together with the application) or was attempted to be twice destroyed.

The fix has made this destruction relying on the object that represents the real state of existence of the object and attempted in every case when closing was requested.