### PR TITLE
Epoll improvements necessary for socket groups external implementation

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1273,8 +1273,8 @@ closed and its state can be verified with a call to `srt_getsockstate`.
 int srt_epoll_clear_usocks(int eid);
 ```
 
-This function removes all subscriptions from the `eid`, only user sockets
-(not system sockets).
+This function removes all SRT ("user") socket subscriptions from the epoll
+container identified by `eid`.
 
 - Returns:
   * 0 on success

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1098,18 +1098,29 @@ Possible epoll flags are the following:
    * `SRT_EPOLL_IN`: report readiness for reading or incoming connection on a listener socket
    * `SRT_EPOLL_OUT`: report readiness for writing or a successful connection
    * `SRT_EPOLL_ERR`: report errors on the socket
+   * `SRT_EPOLL_UPDATE`: group-listening socket gets a new connection established
    * `SRT_EPOLL_ET`: the event will be edge-triggered
 
-The readiness states reported in by default are **level-triggered**.
-If `SRT_EPOLL_ET` flag is specified, the reported states are
-**edge-triggered**. Note that at this time the edge-triggered mode
-is supported only for SRT sockets, not for system sockets.
+All flags except `SRT_EPOLL_ET` are event type flags (important for functions
+that expect only event types and not other flags).
+
+The `SRT_EPOLL_IN`, `SRT_EPOLL_OUT` and `SRT_EPOLL_ERR` events are by
+default **level-triggered**. With `SRT_EPOLL_ET` flag they become
+**edge-triggered**. The `SRT_EPOLL_UPDATE` flag is always edge-triggered
+and it designates a special event that happens only for a listening
+socket that is set the `SRTO_GROUPCONNECT` flag. This event is predicted
+for internal use only and it is set ready for group connections in case
+when a new link has been established for the group that is already connected
+(that is, has at least one connection established).
+
+Note that at this time the edge-triggered mode is supported only for SRT
+sockets, not for system sockets.
 
 In the **edge-triggered** mode the function will only return socket states that
-have changed since the last call. All events reported in particular call of
-the waiting function will be cleared in the internal flags and will not be
-reported until the internal signaling logic clears this state and raises it
-again.
+have changed since the last call of the waiting function. All events reported
+in particular call of the waiting function will be cleared in the internal
+flags and will not be reported until the internal signaling logic clears this
+state and raises it again.
 
 In the **level-triggered** mode the function will always return the readiness
 state as long as it lasts, until the internal signaling logic clear it.

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1268,6 +1268,22 @@ Note that when the `SRT_EPOLL_ERR` is set, the underlying socket error
 can't be retrieved with `srt_getlasterror()`. The socket will be automatically
 closed and its state can be verified with a call to `srt_getsockstate`.
 
+### srt_epoll_clear_usocks
+```
+int srt_epoll_clear_usocks(int eid);
+```
+
+This function removes all subscriptions from the `eid`, only user sockets
+(not system sockets).
+
+- Returns:
+  * 0 on success
+  * -1 in case of error
+
+- Errors:
+
+  * `SRT_EINVPOLLID`: `eid` parameter doesn't refer to a valid epoll container
+
 ### srt_epoll_set
 ```
 int32_t srt_epoll_set(int eid, int32_t flags);

--- a/docs/API.md
+++ b/docs/API.md
@@ -351,6 +351,14 @@ within each function but unprotected between the two calls. It is then possible
 to lose an `SRT_EPOLL_IN` event if it fires while the socket is not in the
 epoll list.
 
+Event flags are of various categories: `IN`, `OUT` and `ERR` are events,
+which are level-triggered by default and become edge-triggered if combined
+with `SRT_EPOLL_ET` flag. The latter is only an edge-triggered flag, not
+an event. There's also an `SRT_EPOLL_UPDATE` flag, which is an edge-triggered
+only event, and it reports an event on the listener socket that handles socket
+group new connection for an already connected group - this is for internal use
+only and it's used in the internal code for socket groups.
+
 Once the subscriptions are made, you can call an SRT polling function
 (`srt_epoll_wait` or `srt_epoll_uwait`) that will block until an event
 is raised on any of the subscribed sockets. This function will exit as

--- a/docs/API.md
+++ b/docs/API.md
@@ -332,7 +332,7 @@ Synopsis
                         int64_t msTimeOut,
                         SYSSOCKET* lrfds, int* lrnum, SYSSOCKET* lwfds, int* lwnum);
     int srt_epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
-    
+    int srt_epoll_clear_usocks(int eid);
 
 SRT Usage
 ---------
@@ -416,6 +416,9 @@ Every item reports a single socket with all events as flags.
 
 When the timeout is not -1, and no sockets are ready until the timeout time
 passes, this function returns 0. This behavior is different in `srt_epoll_wait`.
+
+The extra `srt_epoll_clear_usocks` function removes all subscriptions from
+the epoll container.
 
 The SRT EPoll system does not supports all features of Linux epoll. For
 example, it only supports level-triggered events for system sockets.

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1407,6 +1407,11 @@ int CUDTUnited::epoll_create()
    return m_EPoll.create();
 }
 
+int CUDTUnited::epoll_clear_usocks(int eid)
+{
+    return m_EPoll.clear_usocks(eid);
+}
+
 int CUDTUnited::epoll_add_usock(
    const int eid, const SRTSOCKET u, const int* events)
 {
@@ -1475,17 +1480,6 @@ int CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
 int CUDTUnited::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
    return m_EPoll.remove_ssock(eid, s);
-}
-
-int CUDTUnited::epoll_wait(
-   const int eid,
-   set<SRTSOCKET>* readfds,
-   set<SRTSOCKET>* writefds,
-   int64_t msTimeOut,
-   set<SYSSOCKET>* lrfds,
-   set<SYSSOCKET>* lwfds)
-{
-   return m_EPoll.wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
 }
 
 int CUDTUnited::epoll_uwait(
@@ -2646,6 +2640,26 @@ int CUDT::epoll_create()
    }
 }
 
+int CUDT::epoll_clear_usocks(int eid)
+{
+   try
+   {
+      return s_UDTUnited.epoll_clear_usocks(eid);
+   }
+   catch (CUDTException e)
+   {
+      s_UDTUnited.setError(new CUDTException(e));
+      return ERROR;
+   }
+   catch (std::exception& ee)
+   {
+      LOGC(mglog.Fatal, log << "epoll_clear_usocks: UNEXPECTED EXCEPTION: "
+         << typeid(ee).name() << ": " << ee.what());
+      s_UDTUnited.setError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      return ERROR;
+   }
+}
+
 int CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
 {
    try
@@ -2779,8 +2793,8 @@ int CUDT::epoll_wait(
 {
    try
    {
-      return s_UDTUnited.epoll_wait(
-         eid, readfds, writefds, msTimeOut, lrfds, lwfds);
+      return s_UDTUnited.epollmg().wait(
+              eid, readfds, writefds, msTimeOut, lrfds, lwfds);
    }
    catch (const CUDTException& e)
    {
@@ -3120,6 +3134,11 @@ int selectEx(
 int epoll_create()
 {
    return CUDT::epoll_create();
+}
+
+int epoll_clear_usocks(int eid)
+{
+    return CUDT::epoll_clear_usocks(eid);
 }
 
 int epoll_add_usock(int eid, SRTSOCKET u, const int* events)

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2793,7 +2793,7 @@ int CUDT::epoll_wait(
 {
    try
    {
-      return s_UDTUnited.epollmg().wait(
+      return s_UDTUnited.epoll_ref().wait(
               eid, readfds, writefds, msTimeOut, lrfds, lwfds);
    }
    catch (const CUDTException& e)

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -235,7 +235,7 @@ public:
    CUDTException* getError();
 
 
-   CEPoll& epollmg() { return m_EPoll; }
+   CEPoll& epoll_ref() { return m_EPoll; }
 
 private:
 //   void init();

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -213,13 +213,13 @@ public:
    int select(ud_set* readfds, ud_set* writefds, ud_set* exceptfds, const timeval* timeout);
    int selectEx(const std::vector<SRTSOCKET>& fds, std::vector<SRTSOCKET>* readfds, std::vector<SRTSOCKET>* writefds, std::vector<SRTSOCKET>* exceptfds, int64_t msTimeOut);
    int epoll_create();
+   int epoll_clear_usocks(int eid);
    int epoll_add_usock(const int eid, const SRTSOCKET u, const int* events = NULL);
    int epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
    int epoll_remove_usock(const int eid, const SRTSOCKET u);
    int epoll_remove_ssock(const int eid, const SYSSOCKET s);
    int epoll_update_usock(const int eid, const SRTSOCKET u, const int* events = NULL);
    int epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
-   int epoll_wait(const int eid, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, int64_t msTimeOut, std::set<SYSSOCKET>* lrfds = NULL, std::set<SYSSOCKET>* lwfds = NULL);
    int epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
    int32_t epoll_set(const int eid, int32_t flags);
    int epoll_release(const int eid);
@@ -233,6 +233,9 @@ public:
       /// @return pointer to a UDT exception instance.
 
    CUDTException* getError();
+
+
+   CEPoll& epollmg() { return m_EPoll; }
 
 private:
 //   void init();

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -195,13 +195,15 @@ public: //API
     static int select(int nfds, ud_set* readfds, ud_set* writefds, ud_set* exceptfds, const timeval* timeout);
     static int selectEx(const std::vector<SRTSOCKET>& fds, std::vector<SRTSOCKET>* readfds, std::vector<SRTSOCKET>* writefds, std::vector<SRTSOCKET>* exceptfds, int64_t msTimeOut);
     static int epoll_create();
+    static int epoll_clear_usocks(int eid);
     static int epoll_add_usock(const int eid, const SRTSOCKET u, const int* events = NULL);
     static int epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
     static int epoll_remove_usock(const int eid, const SRTSOCKET u);
     static int epoll_remove_ssock(const int eid, const SYSSOCKET s);
     static int epoll_update_usock(const int eid, const SRTSOCKET u, const int* events = NULL);
     static int epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
-    static int epoll_wait(const int eid, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, int64_t msTimeOut, std::set<SYSSOCKET>* lrfds = NULL, std::set<SYSSOCKET>* wrfds = NULL);
+    static int epoll_wait(const int eid, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds,
+            int64_t msTimeOut, std::set<SYSSOCKET>* lrfds = NULL, std::set<SYSSOCKET>* wrfds = NULL);
     static int epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
     static int32_t epoll_set(const int eid, int32_t flags);
     static int epoll_release(const int eid);

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -712,6 +712,15 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
     return 0;
 }
 
+/// Lightweit and more internal-reaching version of `uwait` for internal use only.
+/// This function wait for sockets to be ready and reports them in `st` map.
+///
+/// @param d the internal structure of the epoll container
+/// @param st output container for the results: { socket_type, event }
+/// @param msTimeOut timeout after which return with empty output is allowed
+/// @param report_by_exception if true, errors will result in exception intead of returning -1
+/// @retval -1 error occurred
+/// @retval >=0 number of ready sockets (actually size of `st`)
 int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, bool report_by_exception)
 {
     {

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -787,10 +787,7 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
             return 0; // meaning "none is ready"
         }
 
-#if (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
-#else
         CTimer::waitForEvent();
-#endif
     }
 
     return 0;

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -712,15 +712,6 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
     return 0;
 }
 
-/// Lightweit and more internal-reaching version of `uwait` for internal use only.
-/// This function wait for sockets to be ready and reports them in `st` map.
-///
-/// @param d the internal structure of the epoll container
-/// @param st output container for the results: { socket_type, event }
-/// @param msTimeOut timeout after which return with empty output is allowed
-/// @param report_by_exception if true, errors will result in exception intead of returning -1
-/// @retval -1 error occurred
-/// @retval >=0 number of ready sockets (actually size of `st`)
 int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, bool report_by_exception)
 {
     {

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -116,6 +116,12 @@ struct CEPollDesc
 
        int edgeOnly() { return edge & watch; }
 
+       /// Clear all flags for given direction from the notices
+       /// and subscriptions, and checks if this made the event list
+       /// for this watch completely empty.
+       /// @param direction event type that has to be cleared
+       /// @return true, if this cleared the last event (the caller
+       /// want to remove the subscription for this socket)
        bool clear(int direction)
        {
            if (watch & direction)
@@ -311,6 +317,17 @@ public:
        return false;
    }
 
+   /// This should work in a loop around the notice container of
+   /// the given eid container and clear out the notice for
+   /// particular event type. If this has cleared effectively the
+   /// last existing event, it should return the socket id
+   /// so that the caller knows to remove it also from subscribers.
+   ///
+   /// @param i iterator in the notice container
+   /// @param event event type to be cleared
+   /// @retval (socket) Socket to be removed from subscriptions
+   /// @retval SRT_INVALID_SOCK Nothing to be done (associated socket
+   ///         still has other subscriptions)
    SRTSOCKET clearEventSub(enotice_t::iterator i, int event)
    {
        // We need to remove the notice and subscription

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -130,9 +130,7 @@ struct CEPollDesc
                edge &= ~direction;
                state &= ~direction;
 
-               if (watch == 0)
-                   return true;
-               return false;
+               return watch == 0;
            }
 
            return false;
@@ -334,11 +332,11 @@ public:
        // for this event. The 'i' iterator is safe to
        // delete, even indirectly.
 
-       // This works merely like checkEdge, just it's predicted
-       // to get the notice cleared of reporting given event.
+       // This works merely like checkEdge, just on request to clear the
+       // identified event, if found.
        if (i->events & event)
        {
-           // The notice has a readiness notice on this event.
+           // The notice has a readiness flag on this event.
            // This means that there exists also a subscription.
            Wait* w = i->parent;
            if (w->clear(event))
@@ -360,9 +358,8 @@ public:
 
 public: // for CUDTUnited API
 
-      /// create a new EPoll.
-      /// @return new EPoll ID if success, otherwise an error number.
-
+   /// create a new EPoll.
+   /// @return new EPoll ID if success, otherwise an error number.
    int create(CEPollDesc** ppd = 0);
 
 
@@ -371,59 +368,59 @@ public: // for CUDTUnited API
    /// @return 0 
    int clear_usocks(int eid);
 
-      /// add a UDT socket to an EPoll.
-      /// @param [in] eid EPoll ID.
-      /// @param [in] u UDT Socket ID.
-      /// @param [in] events events to watch.
-      /// @return 0 if success, otherwise an error number.
+   /// add a UDT socket to an EPoll.
+   /// @param [in] eid EPoll ID.
+   /// @param [in] u UDT Socket ID.
+   /// @param [in] events events to watch.
+   /// @return 0 if success, otherwise an error number.
 
    int add_usock(const int eid, const SRTSOCKET& u, const int* events = NULL) { return update_usock(eid, u, events); }
 
-      /// add a system socket to an EPoll.
-      /// @param [in] eid EPoll ID.
-      /// @param [in] s system Socket ID.
-      /// @param [in] events events to watch.
-      /// @return 0 if success, otherwise an error number.
+   /// add a system socket to an EPoll.
+   /// @param [in] eid EPoll ID.
+   /// @param [in] s system Socket ID.
+   /// @param [in] events events to watch.
+   /// @return 0 if success, otherwise an error number.
 
    int add_ssock(const int eid, const SYSSOCKET& s, const int* events = NULL);
 
-      /// remove a UDT socket event from an EPoll; socket will be removed if no events to watch.
-      /// @param [in] eid EPoll ID.
-      /// @param [in] u UDT socket ID.
-      /// @return 0 if success, otherwise an error number.
+   /// remove a UDT socket event from an EPoll; socket will be removed if no events to watch.
+   /// @param [in] eid EPoll ID.
+   /// @param [in] u UDT socket ID.
+   /// @return 0 if success, otherwise an error number.
 
    int remove_usock(const int eid, const SRTSOCKET& u) { static const int Null(0); return update_usock(eid, u, &Null);}
 
-      /// remove a system socket event from an EPoll; socket will be removed if no events to watch.
-      /// @param [in] eid EPoll ID.
-      /// @param [in] s system socket ID.
-      /// @return 0 if success, otherwise an error number.
+   /// remove a system socket event from an EPoll; socket will be removed if no events to watch.
+   /// @param [in] eid EPoll ID.
+   /// @param [in] s system socket ID.
+   /// @return 0 if success, otherwise an error number.
 
    int remove_ssock(const int eid, const SYSSOCKET& s);
-      /// update a UDT socket events from an EPoll.
-      /// @param [in] eid EPoll ID.
-      /// @param [in] u UDT socket ID.
-      /// @param [in] events events to watch.
-      /// @return 0 if success, otherwise an error number.
+   /// update a UDT socket events from an EPoll.
+   /// @param [in] eid EPoll ID.
+   /// @param [in] u UDT socket ID.
+   /// @param [in] events events to watch.
+   /// @return 0 if success, otherwise an error number.
 
    int update_usock(const int eid, const SRTSOCKET& u, const int* events);
 
-      /// update a system socket events from an EPoll.
-      /// @param [in] eid EPoll ID.
-      /// @param [in] u UDT socket ID.
-      /// @param [in] events events to watch.
-      /// @return 0 if success, otherwise an error number.
+   /// update a system socket events from an EPoll.
+   /// @param [in] eid EPoll ID.
+   /// @param [in] u UDT socket ID.
+   /// @param [in] events events to watch.
+   /// @return 0 if success, otherwise an error number.
 
    int update_ssock(const int eid, const SYSSOCKET& s, const int* events = NULL);
 
-      /// wait for EPoll events or timeout.
-      /// @param [in] eid EPoll ID.
-      /// @param [out] readfds UDT sockets available for reading.
-      /// @param [out] writefds UDT sockets available for writing.
-      /// @param [in] msTimeOut timeout threshold, in milliseconds.
-      /// @param [out] lrfds system file descriptors for reading.
-      /// @param [out] lwfds system file descriptors for writing.
-      /// @return number of sockets available for IO.
+   /// wait for EPoll events or timeout.
+   /// @param [in] eid EPoll ID.
+   /// @param [out] readfds UDT sockets available for reading.
+   /// @param [out] writefds UDT sockets available for writing.
+   /// @param [in] msTimeOut timeout threshold, in milliseconds.
+   /// @param [out] lrfds system file descriptors for reading.
+   /// @param [out] lwfds system file descriptors for writing.
+   /// @return number of sockets available for IO.
 
    int wait(const int eid, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, int64_t msTimeOut, std::set<SYSSOCKET>* lrfds, std::set<SYSSOCKET>* lwfds);
 
@@ -440,6 +437,10 @@ public: // for CUDTUnited API
    /// @retval >=0 number of ready sockets (actually size of `st`)
    int swait(CEPollDesc& d, fmap_t& st, int64_t msTimeOut, bool report_by_exception = true);
 
+   /// Reports which events are ready on the given socket.
+   /// @param mp socket event map retirned by `swait`
+   /// @param sock which socket to ask
+   /// @return event flags for given socket, or 0 if none
    static int ready(const fmap_t& mp, SRTSOCKET sock)
    {
        fmap_t::const_iterator y = mp.find(sock);
@@ -448,6 +449,11 @@ public: // for CUDTUnited API
        return y->second;
    }
 
+   /// Reports whether socket is ready for given event.
+   /// @param mp socket event map retirned by `swait`
+   /// @param sock which socket to ask
+   /// @param event which events it should be ready for
+   /// @return true if the given socket is ready for given event
    static bool isready(const fmap_t& mp, SRTSOCKET sock, SRT_EPOLL_OPT event)
    {
        return (ready(mp, sock) & event) != 0;
@@ -456,29 +462,29 @@ public: // for CUDTUnited API
    // Could be a template directly, but it's now hidden in the imp file.
    void clear_ready_usocks(CEPollDesc& d, int direction);
 
-      /// wait for EPoll events or timeout optimized with explicit EPOLL_ERR event and the edge mode option.
-      /// @param [in] eid EPoll ID.
-      /// @param [out] fdsSet array of user socket events (SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR).
-      /// @param [int] fdsSize of fds array
-      /// @param [in] msTimeOut timeout threshold, in milliseconds.
-      /// @return total of available events in the epoll system (can be greater than fdsSize)
+   /// wait for EPoll events or timeout optimized with explicit EPOLL_ERR event and the edge mode option.
+   /// @param [in] eid EPoll ID.
+   /// @param [out] fdsSet array of user socket events (SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR).
+   /// @param [int] fdsSize of fds array
+   /// @param [in] msTimeOut timeout threshold, in milliseconds.
+   /// @return total of available events in the epoll system (can be greater than fdsSize)
 
    int uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
- 
-      /// close and release an EPoll.
-      /// @param [in] eid EPoll ID.
-      /// @return 0 if success, otherwise an error number.
+
+   /// close and release an EPoll.
+   /// @param [in] eid EPoll ID.
+   /// @return 0 if success, otherwise an error number.
 
    int release(const int eid);
 
 public: // for CUDT to acknowledge IO status
 
-      /// Update events available for a UDT socket.
-      /// @param [in] uid UDT socket ID.
-      /// @param [in] eids EPoll IDs to be set
-      /// @param [in] events Combination of events to update
-      /// @param [in] enable true -> enable, otherwise disable
-      /// @return 0 if success, otherwise an error number
+   /// Update events available for a UDT socket.
+   /// @param [in] uid UDT socket ID.
+   /// @param [in] eids EPoll IDs to be set
+   /// @param [in] events Combination of events to update
+   /// @param [in] enable true -> enable, otherwise disable
+   /// @return 0 if success, otherwise an error number
 
    int update_events(const SRTSOCKET& uid, std::set<int>& eids, int events, bool enable);
 

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -429,6 +429,15 @@ public: // for CUDTUnited API
 
    typedef std::map<SRTSOCKET, int> fmap_t;
 
+   /// Lightweit and more internal-reaching version of `uwait` for internal use only.
+   /// This function wait for sockets to be ready and reports them in `st` map.
+   ///
+   /// @param d the internal structure of the epoll container
+   /// @param st output container for the results: { socket_type, event }
+   /// @param msTimeOut timeout after which return with empty output is allowed
+   /// @param report_by_exception if true, errors will result in exception intead of returning -1
+   /// @retval -1 error occurred
+   /// @retval >=0 number of ready sockets (actually size of `st`)
    int swait(CEPollDesc& d, fmap_t& st, int64_t msTimeOut, bool report_by_exception = true);
 
    static int ready(const fmap_t& mp, SRTSOCKET sock)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -437,7 +437,7 @@ enum CodeMinor
     MN_BUSY            = 11,
     MN_XSIZE           = 12,
     MN_EIDINVAL        = 13,
-    MN_EEMPTY = 14,
+    MN_EEMPTY          = 14,
     // MJ_AGAIN
     MN_WRAVAIL         =  1,
     MN_RDAVAIL         =  2,

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -783,7 +783,7 @@ SRT_API int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int inst
 SRT_API SRT_SOCKSTATUS srt_getsockstate(SRTSOCKET u);
 
 SRT_API int srt_epoll_create(void);
-SRT_API extern int srt_epoll_clear_usocks(int eid);
+SRT_API int srt_epoll_clear_usocks(int eid);
 SRT_API int srt_epoll_add_usock(int eid, SRTSOCKET u, const int* events);
 SRT_API int srt_epoll_add_ssock(int eid, SYSSOCKET s, const int* events);
 SRT_API int srt_epoll_remove_usock(int eid, SRTSOCKET u);

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -437,6 +437,7 @@ enum CodeMinor
     MN_BUSY            = 11,
     MN_XSIZE           = 12,
     MN_EIDINVAL        = 13,
+    MN_EEMPTY = 14,
     // MJ_AGAIN
     MN_WRAVAIL         =  1,
     MN_RDAVAIL         =  2,
@@ -491,6 +492,7 @@ typedef enum SRT_ERRNO
     SRT_EDUPLISTEN      = MN(NOTSUP, BUSY),
     SRT_ELARGEMSG       = MN(NOTSUP, XSIZE),
     SRT_EINVPOLLID      = MN(NOTSUP, EIDINVAL),
+    SRT_EPOLLEMPTY      = MN(NOTSUP, EEMPTY),
 
     SRT_EASYNCFAIL      = MJ(AGAIN),
     SRT_EASYNCSND       = MN(AGAIN, WRAVAIL),
@@ -563,15 +565,72 @@ enum SRT_KM_STATE
 enum SRT_EPOLL_OPT
 {
    SRT_EPOLL_OPT_NONE = 0x0, // fallback
-   // this values are defined same as linux epoll.h
+
+   // Values intended to be the same as in `<sys/epoll.h>`.
    // so that if system values are used by mistake, they should have the same effect
+   // This applies to: IN, OUT, ERR and ET.
+
+   /// Ready for 'recv' operation:
+   ///
+   /// - For stream mode it means that at least 1 byte is available.
+   /// In this mode the buffer may extract only a part of the packet,
+   /// leaving next data possible for extraction later.
+   ///
+   /// - For message mode it means that there is at least one packet
+   /// available (this may change in future, as it is desired that
+   /// one full message should only wake up, not single packet of a
+   /// not yet extractable message).
+   ///
+   /// - For live mode it means that there's at least one packet
+   /// ready to play.
+   ///
+   /// - For listener sockets, this means that there is a new connection
+   /// waiting for pickup through the `srt_accept()` call, that is,
+   /// the next call to `srt_accept()` will succeed without blocking
+   /// (see an alias SRT_EPOLL_ACCEPT below).
    SRT_EPOLL_IN       = 0x1,
+
+   /// Ready for 'send' operation.
+   ///
+   /// - For stream mode it means that there's a free space in the
+   /// sender buffer for at least 1 byte of data. The next send
+   /// operation will only allow to send as much data as it is free
+   /// space in the buffer.
+   ///
+   /// - For message mode it means that there's a free space for at
+   /// least one UDP packet. The edge-triggered mode can be used to
+   /// pick up updates as the free space in the sender buffer grows.
+   ///
+   /// - For live mode it means that there's a free space for at least
+   /// one UDP packet. On the other hand, no readiness for OUT usually
+   /// means an extraordinary congestion on the link, meaning also that
+   /// you should immediately slow down the sending rate or you may get
+   /// a connection break soon.
+   ///
+   /// - For non-blocking sockets used with `srt_connect*` operation,
+   /// this flag simply means that the connection was established.
    SRT_EPOLL_OUT      = 0x4,
+
+   /// The socket has encountered an error in the last operation
+   /// and the next operation on that socket will end up with error.
+   /// You can retry the operation, but getting the error from it
+   /// is certain, so you may as well close the socket.
    SRT_EPOLL_ERR      = 0x8,
+
+   // To avoid confusion in the internal code, the following
+   // duplicates are introduced to improve clarity.
+   SRT_EPOLL_CONNECT = SRT_EPOLL_OUT,
+   SRT_EPOLL_ACCEPT = SRT_EPOLL_IN,
+
+   SRT_EPOLL_UPDATE = 0x10,
    SRT_EPOLL_ET       = 1u << 31
 };
 // These are actually flags - use a bit container:
 typedef int32_t SRT_EPOLL_T;
+
+// Define which epoll flags determine events. All others are special flags.
+#define SRT_EPOLL_EVENTTYPES (SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_UPDATE | SRT_EPOLL_ERR)
+#define SRT_EPOLL_ETONLY (SRT_EPOLL_UPDATE)
 
 enum SRT_EPOLL_FLAGS
 {
@@ -724,6 +783,7 @@ SRT_API int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int inst
 SRT_API SRT_SOCKSTATUS srt_getsockstate(SRTSOCKET u);
 
 SRT_API int srt_epoll_create(void);
+SRT_API extern int srt_epoll_clear_usocks(int eid);
 SRT_API int srt_epoll_add_usock(int eid, SRTSOCKET u, const int* events);
 SRT_API int srt_epoll_add_ssock(int eid, SYSSOCKET s, const int* events);
 SRT_API int srt_epoll_remove_usock(int eid, SRTSOCKET u);
@@ -733,10 +793,14 @@ SRT_API int srt_epoll_update_ssock(int eid, SYSSOCKET s, const int* events);
 
 SRT_API int srt_epoll_wait(int eid, SRTSOCKET* readfds, int* rnum, SRTSOCKET* writefds, int* wnum, int64_t msTimeOut,
                            SYSSOCKET* lrfds, int* lrnum, SYSSOCKET* lwfds, int* lwnum);
-typedef struct SRT_EPOLL_EVENT_
+typedef struct SRT_EPOLL_EVENT_STR
 {
     SRTSOCKET fd;
     int       events; // SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR
+#ifdef __cplusplus
+    SRT_EPOLL_EVENT_STR(SRTSOCKET s, int ev): fd(s), events(ev) {}
+    SRT_EPOLL_EVENT_STR() {} // NOTE: allows singular values, no init.
+#endif
 } SRT_EPOLL_EVENT;
 SRT_API int srt_epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
 


### PR DESCRIPTION
Summary of changes:

1. Introduced handling of the edge-triggered-only events. Normally events can be level-triggered or edge-triggered, depending on extra flag `SRT_EPOLL_ET`. Some others can be only edge-triggered and no flag is needed to mark it (this is also what exists in kevent and Linux epoll).

2. Added a new edge-only event type, `SRT_EPOLL_UPDATE`. This will be used in the group code in a situation when a new connection is added to the group while the group as a whole is still considered connected. This event is required to update groups of types that allow member connections to be idle (currently: backup group).

3. Added new functions for clearing out socket subscriptions, be it everything at all or just those ready.

4. The error code for a case when a waiting function has been called for an eid without subscriptions has been changed - new error type for that occasion has been introduced. This is because the so far used INVAL was inappropriate, as well as it couldn't be properly handled in the internal group code.

Annotations available.