### PR TITLE
Bugfix: use -1 as no-forced-isn

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2997,7 +2997,7 @@ SRTSOCKET accept(SRTSOCKET u, struct sockaddr* addr, int* addrlen)
 
 int connect(SRTSOCKET u, const struct sockaddr* name, int namelen)
 {
-   return CUDT::connect(u, name, namelen, 0);
+   return CUDT::connect(u, name, namelen, -1);
 }
 
 int close(SRTSOCKET u)

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -929,7 +929,7 @@ int CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, int srclen, const 
 
     // For a single socket, just do bind, then connect
     bind(s, source_addr);
-    return connectIn(s, target_addr, 0);
+    return connectIn(s, target_addr, -1);
 }
 
 int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3165,7 +3165,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     m_ConnReq.m_iID             = m_SocketID;
     CIPAddress::ntop(serv_addr, (m_ConnReq.m_piPeerIP));
 
-    if (forced_isn == 0)
+    if (forced_isn == -1)
     {
         // Random Initial Sequence Number (normal mode)
         srand(count_microseconds(steady_clock::now()));

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -37,7 +37,7 @@ int srt_bind(SRTSOCKET u, const struct sockaddr * name, int namelen) { return CU
 int srt_bind_acquire(SRTSOCKET u, UDPSOCKET udpsock) { return CUDT::bind(u, udpsock); }
 int srt_listen(SRTSOCKET u, int backlog) { return CUDT::listen(u, backlog); }
 SRTSOCKET srt_accept(SRTSOCKET u, struct sockaddr * addr, int * addrlen) { return CUDT::accept(u, addr, addrlen); }
-int srt_connect(SRTSOCKET u, const struct sockaddr * name, int namelen) { return CUDT::connect(u, name, namelen, 0); }
+int srt_connect(SRTSOCKET u, const struct sockaddr * name, int namelen) { return CUDT::connect(u, name, namelen, -1); }
 int srt_connect_debug(SRTSOCKET u, const struct sockaddr * name, int namelen, int forced_isn) { return CUDT::connect(u, name, namelen, forced_isn); }
 int srt_connect_bind(SRTSOCKET u,
         const struct sockaddr* source, int source_len,


### PR DESCRIPTION
The '0' value should not be used as a "no ISN number", as it can be as well a valid sequence number.