### PR TITLE
Fixed <*> case handling in helptext-type-parser and -opt:val case

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -168,6 +168,7 @@ options_t ProcessOptions(char* const* argv, int argc, std::vector<OptionScheme> 
         // cout << "*D ARG: '" << a << "'\n";
         if (moreoptions && a[0] == '-')
         {
+            bool arg_specified = false;
             size_t seppos; // (see goto, it would jump over initialization)
             current_key = a+1;
             if ( current_key == "-" )
@@ -190,6 +191,7 @@ options_t ProcessOptions(char* const* argv, int argc, std::vector<OptionScheme> 
                 // Old option specification.
                 extra_arg = current_key.substr(seppos + 1);
                 current_key = current_key.substr(0, 0 + seppos);
+                arg_specified = true; // Prevent eating args from option list
             }
 
             params[current_key].clear();
@@ -208,7 +210,11 @@ options_t ProcessOptions(char* const* argv, int argc, std::vector<OptionScheme> 
                 if (s.names().count(current_key))
                 {
                     // cout << "*D found '" << current_key << "' in scheme type=" << int(s.type) << endl;
-                    if (s.type == OptionScheme::ARG_NONE)
+                    // If argument was specified using the old way, like
+                    // -v:0 or "-v 0", then consider the argument specified and
+                    // treat further arguments as either no-option arguments or
+                    // new options.
+                    if (s.type == OptionScheme::ARG_NONE || arg_specified)
                     {
                         // Anyway, consider it already processed.
                         break;

--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -131,10 +131,13 @@ OptionScheme::Args OptionName::DetermineTypeFromHelpText(const std::string& help
         // When closing angle bracket isn't found, fallback to ARG_ONE.
         size_t pos = helptext.find('>');
         if (pos == std::string::npos)
-            return OptionScheme::ARG_ONE;
+            return OptionScheme::ARG_ONE; // mistake, but acceptable
 
         if (pos >= 4 && helptext.substr(pos-4, 4) == "...>")
             return OptionScheme::ARG_VAR;
+
+        // We have < and > without ..., simply one argument
+        return OptionScheme::ARG_ONE;
     }
 
     if (helptext[0] == '[')

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -263,7 +263,7 @@ int main( int argc, char** argv )
         o_chunk     ((optargs), "<chunk=1316> Single reading operation buffer size", "c",   "chunk"),
         o_bandwidth ((optargs), "<bw[ms]=0[unlimited]> Input reading speed limit", "b",   "bandwidth", "bitrate"),
         o_report    ((optargs), "<frequency[1/pkt]=0> Print bandwidth report periodically", "r",   "bandwidth-report", "bitrate-report"),
-        o_verbose   ((optargs), " Print size of every packet transferred on stdout", "v",   "verbose"),
+        o_verbose   ((optargs), "[channel=0|1] Print size of every packet transferred on stdout or specified [channel]", "v",   "verbose"),
         o_crash     ((optargs), " Core-dump when connection got broken by whatever reason (developer mode)", "k",   "crash"),
         o_loglevel  ((optargs), "<severity=fatal|error|note|warning|debug> Minimum severity for logs", "ll",  "loglevel"),
         o_logfa     ((optargs), "<FA=all> Enabled Functional Areas", "lfa", "logfa"),


### PR DESCRIPTION
Mistake: The "<argument but not terminated mistakenly" was the only effective way to enforce ARG_ONE type of option argument. The case "<argument> Specified properly" was then leading to ARG_NONE.

Also fixed the `-v` option in srt-test-live, which allows to optionally specify the channel used for verbose messages.

Another fix is that when an option was already specified the argument the old way, like `-v:2`, then the argument that follows that specification is always considered the next argument, regardless of the argument type of the option. The problem was that previously if you specified `-v udp://:9999 srt://:5555`, it was definitely specified incorrectly, but with `-v:1 udp://:9999 srt://:5555` it should consider the argument for `-v` option already specified, so the following arguments should be treated already as free arguments.