### PR TITLE
[core] Avoid reporting packets rebuilt by FEC as lost.

### DIFF
--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -741,14 +741,14 @@ bool FECFilterBuiltin::receive(const CPacket& rpkt, loss_seqs_t& loss_seqs)
 
         HLOGC(mglog.Debug, log << "FEC: RECEIVED %" << rpkt.getSeqNo() << " msgno=" << rpkt.getMsgSeq() << " DATA PACKET.");
         MarkCellReceived(rpkt.getSeqNo());
-    }
 
-    // Remember this simply every time a packet comes in. In live mode usually
-    // this flag is ORD_RELAXED (false), but some earlier versions used ORD_REQUIRED.
-    // Even though this flag is now usually ORD_RELAXED, it's fate in live mode
-    // isn't completely decided yet, so stay flexible. We believe at least that this
-    // flag will stay unchanged during whole connection.
-    rcv.order_required = rpkt.getMsgOrderFlag();
+        // Remember this simply every time a packet comes in. In live mode usually
+        // this flag is ORD_RELAXED (false), but some earlier versions used ORD_REQUIRED.
+        // Even though this flag is now usually ORD_RELAXED, it's fate in live mode
+        // isn't completely decided yet, so stay flexible. We believe at least that this
+        // flag will stay unchanged during whole connection.
+        rcv.order_required = rpkt.getMsgOrderFlag();
+    }
 
     loss_seqs_t irrecover_row, irrecover_col;
 

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -1335,13 +1335,13 @@ void FECFilterBuiltin::RcvRebuild(Group& g, int32_t seqno, Group::Type tp)
             << " size=" << length_hw
             << " !" << BufferStamp(p.buffer, p.length));
 
+    // Mark this packet received
+    MarkCellReceived(seqno);
+
     // If this is a single request (filled from row and m_number_cols == 1),
     // do not attempt recursive rebuilding
     if (tp == Group::SINGLE)
         return;
-
-    // Mark this packet received
-    MarkCellReceived(seqno);
 
     // This flips HORIZ/VERT
     Group::Type crosstype = Group::Type(!tp);


### PR DESCRIPTION
For rebuilt packets, * FEC * may still report it as a lost packet. This happens in `row-only` mode.

The following transmission is configured as `cols:10,rows:1,layout:even,arq:onreq`:
```
UDT type: data seqno: 90 msgno: 91
UDT type: ack  seqno: 90
UDT type: ack2
UDT type: data seqno: 91 msgno: 92
UDT type: ack  seqno: 92
UDT type: ack2
UDT type: data seqno: 92 msgno: 93
UDT type: data seqno: 93 msgno: 94
UDT type: ack  seqno: 93
UDT type: ack2
UDT type: ack  seqno: 94
UDT type: ack2
UDT type: data seqno: 94 msgno: 95
UDT type: data seqno: 95 msgno: 96
UDT type: data seqno: 96 msgno: 97
UDT type: ack  seqno: 97
UDT type: ack2
UDT type: data seqno: 98 msgno: 99
UDT type: data seqno: 99 msgno: 100
UDT type: data seqno: 99 msgno: 0
UDT type: ack  seqno: 100
UDT type: ack2
UDT type: data seqno: 100 msgno: 101
UDT type: data seqno: 101 msgno: 102
UDT type: data seqno: 102 msgno: 103
UDT type: ack  seqno: 101
UDT type: ack2
UDT type: data seqno: 103 msgno: 104
UDT type: ack  seqno: 104
UDT type: data seqno: 105 msgno: 106
UDT type: data seqno: 106 msgno: 107
UDT type: data seqno: 107 msgno: 108
UDT type: data seqno: 109 msgno: 110
UDT type: data seqno: 109 msgno: 0
UDT type: ack  seqno: 104
UDT type: ack2
UDT type: data seqno: 110 msgno: 111
UDT type: data seqno: 111 msgno: 112
UDT type: nak missing:97
UDT type: data seqno: 112 msgno: 113
UDT type: data seqno: 113 msgno: 114
```

The packet `seqno == 97` is lost, but the same row packets and the control packet is received successfully, so it can be rebuilt. It was indeed successfully rebuilt because of the next ack `seqno` is `100`.

The problem is: when rebuilt with `rows == 1`, the cell is not marked as received, because of the following codes:
```C++
// https://github.com/Haivision/srt/blob/v1.4.1/srtcore/fec.cpp#L1340
// void FECFilterBuiltin::RcvRebuild(Group& g, int32_t seqno, Group::Type tp)

// If this is a single request (filled from row and m_number_cols == 1),
// do not attempt recursive rebuilding
if (tp == Group::SINGLE)
    return;

// Mark this packet received
MarkCellReceived(seqno);
```