### PR TITLE
Small improvements of CSndLossList::insert

### DIFF
--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -148,7 +148,11 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
                 i = m_caSeq[i].inext;
 
             // 3. Check if seqno1 overlaps with (seqbegin, seqend)
-            if ((-1 == m_caSeq[i].seqend) || (CSeqNo::seqcmp(m_caSeq[i].seqend, seqno1) < 0))
+            const int seqend = m_caSeq[i].seqend == -1
+                ? m_caSeq[i].seqstart
+                : m_caSeq[i].seqend;
+
+            if (CSeqNo::seqcmp(seqend, seqno1) < 0 && CSeqNo::incseq(seqend) != seqno1)
             {
                 // No overlap
                 insertAfter(loc, i, seqno1, seqno2);
@@ -158,11 +162,11 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
                 // TODO: Replace with updateElement(i, seqno1, seqno2).
                 // Some changes to updateElement(..) are required.
                 m_iLastInsertPos = i;
-                if (CSeqNo::seqcmp(m_caSeq[i].seqend, seqno2) >= 0)
+                if (CSeqNo::seqcmp(seqend, seqno2) >= 0)
                     return 0;
 
                 // overlap, coalesce with prior node, insert(3, 7) to [2, 5], ... becomes [2, 7]
-                m_iLength += CSeqNo::seqlen(m_caSeq[i].seqend, seqno2) - 1;
+                m_iLength += CSeqNo::seqlen(seqend, seqno2) - 1;
                 m_caSeq[i].seqend = seqno2;
 
                 loc = i;

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -93,6 +93,20 @@ CSndLossList::~CSndLossList()
     releaseMutex(m_ListLock);
 }
 
+void CSndLossList::traceState() const
+{
+    int pos = m_iHead;
+    while (pos != -1)
+    {
+        ::cout << pos << ":[" << m_caSeq[pos].seqstart;
+        if (m_caSeq[pos].seqend != -1)
+            ::cout << ", " << m_caSeq[pos].seqend;
+        ::cout << "], ";
+        pos = m_caSeq[pos].inext;
+    }
+    ::cout << "\n";
+}
+
 int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 {
     CGuard listguard(m_ListLock);
@@ -103,10 +117,10 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
         return m_iLength;
     }
 
-    // otherwise find the position where the data can be inserted
-    int origlen = m_iLength;
-    int offset  = CSeqNo::seqoff(m_caSeq[m_iHead].seqstart, seqno1);
-    int loc     = (m_iHead + offset + m_iSize) % m_iSize;
+    // Find the insert position in the non-empty list
+    const int origlen = m_iLength;
+    const int offset  = CSeqNo::seqoff(m_caSeq[m_iHead].seqstart, seqno1);
+    int       loc     = (m_iHead + offset + m_iSize) % m_iSize;
 
     if (offset < 0)
     {
@@ -122,44 +136,36 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
         }
         else
         {
-            // searching the prior node
-            int i;
-            if ((-1 != m_iLastInsertPos) && (CSeqNo::seqcmp(m_caSeq[m_iLastInsertPos].seqstart, seqno1) < 0))
+            // Find the prior node.
+            // It should be the highest sequence number less than seqno1.
+            // 1. Start the search either from m_iHead, or from m_iLastInsertPos
+            int i = m_iHead;
+            if ((m_iLastInsertPos != -1) && (CSeqNo::seqcmp(m_caSeq[m_iLastInsertPos].seqstart, seqno1) < 0))
                 i = m_iLastInsertPos;
-            else
-                i = m_iHead;
 
-            while ((-1 != m_caSeq[i].inext) && (CSeqNo::seqcmp(m_caSeq[m_caSeq[i].inext].seqstart, seqno1) < 0))
+            // 2. Find the highest sequence number less than seqno1.
+            while (m_caSeq[i].inext != -1 && CSeqNo::seqcmp(m_caSeq[m_caSeq[i].inext].seqstart, seqno1) < 0)
                 i = m_caSeq[i].inext;
 
+            // 3. Check if seqno1 overlaps with (seqbegin, seqend)
             if ((-1 == m_caSeq[i].seqend) || (CSeqNo::seqcmp(m_caSeq[i].seqend, seqno1) < 0))
             {
-                m_iLastInsertPos = loc;
-
-                // no overlap, create new node
-                m_caSeq[loc].seqstart = seqno1;
-                if (seqno2 != seqno1)
-                    m_caSeq[loc].seqend = seqno2;
-
-                m_caSeq[loc].inext = m_caSeq[i].inext;
-                m_caSeq[i].inext   = loc;
-
-                m_iLength += CSeqNo::seqlen(seqno1, seqno2);
+                // No overlap
+                insertAfter(loc, i, seqno1, seqno2);
             }
             else
             {
+                // TODO: Replace with updateElement(i, seqno1, seqno2).
+                // Some changes to updateElement(..) are required.
                 m_iLastInsertPos = i;
+                if (CSeqNo::seqcmp(m_caSeq[i].seqend, seqno2) >= 0)
+                    return 0;
 
                 // overlap, coalesce with prior node, insert(3, 7) to [2, 5], ... becomes [2, 7]
-                if (CSeqNo::seqcmp(m_caSeq[i].seqend, seqno2) < 0)
-                {
-                    m_iLength += CSeqNo::seqlen(m_caSeq[i].seqend, seqno2) - 1;
-                    m_caSeq[i].seqend = seqno2;
+                m_iLength += CSeqNo::seqlen(m_caSeq[i].seqend, seqno2) - 1;
+                m_caSeq[i].seqend = seqno2;
 
-                    loc = i;
-                }
-                else
-                    return 0;
+                loc = i;
             }
         }
     }
@@ -340,6 +346,7 @@ int32_t CSndLossList::popLostSeq()
 void CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
 {
     m_caSeq[pos].seqstart = seqno1;
+    SRT_ASSERT(m_caSeq[pos].seqend == -1);
     if (seqno2 != seqno1)
         m_caSeq[pos].seqend = seqno2;
 
@@ -347,6 +354,20 @@ void CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
     m_caSeq[pos].inext = m_iHead;
     m_iHead            = pos;
     m_iLastInsertPos   = pos;
+
+    m_iLength += CSeqNo::seqlen(seqno1, seqno2);
+}
+
+void CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2)
+{
+    m_caSeq[pos].seqstart = seqno1;
+    SRT_ASSERT(m_caSeq[pos].seqend == -1);
+    if (seqno2 != seqno1)
+        m_caSeq[pos].seqend = seqno2;
+
+    m_caSeq[pos].inext       = m_caSeq[pos_after].inext;
+    m_caSeq[pos_after].inext = pos;
+    m_iLastInsertPos         = pos;
 
     m_iLength += CSeqNo::seqlen(seqno1, seqno2);
 }

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -86,6 +86,8 @@ public:
 
    int32_t popLostSeq();
 
+   void traceState() const;
+
 private:
    struct Seq
    {
@@ -105,6 +107,10 @@ private:
    /// Inserts an element to the beginning and updates head pointer.
    /// No lock.
    void insertHead(int pos, int32_t seqno1, int32_t seqno2);
+
+   /// Inserts an element after previous element.
+   /// No lock.
+   void insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2);
 
    /// Check if it is possible to coalesce element at loc with further elements.
    /// @param loc - last changed location

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -84,6 +84,19 @@ TEST_F(CSndLossListTest, InsertPopTwoElems)
     CheckEmptyArray();
 }
 
+/// Insert 1 and 2 and pop() one by one
+TEST_F(CSndLossListTest, InsertPopTwoSerialElems)
+{
+    EXPECT_EQ(m_lossList->insert(1, 1), 1);
+    EXPECT_EQ(m_lossList->insert(2, 2), 1);
+
+    EXPECT_EQ(m_lossList->getLossLength(), 2);
+    EXPECT_EQ(m_lossList->popLostSeq(), 1);
+    EXPECT_EQ(m_lossList->getLossLength(), 1);
+    EXPECT_EQ(m_lossList->popLostSeq(), 2);
+    CheckEmptyArray();
+}
+
 /// Insert (1,2) and 4, then pop one by one
 TEST_F(CSndLossListTest, InsertPopRangeAndSingle)
 {
@@ -113,6 +126,24 @@ TEST_F(CSndLossListTest, InsertPopFourElems)
     EXPECT_EQ(m_lossList->popLostSeq(), 1);
     EXPECT_EQ(m_lossList->getLossLength(), 2);
     EXPECT_EQ(m_lossList->popLostSeq(), 2);
+    EXPECT_EQ(m_lossList->getLossLength(), 1);
+    EXPECT_EQ(m_lossList->popLostSeq(), 4);
+    CheckEmptyArray();
+}
+
+/// Insert (1,2) and 4, then pop one by one
+TEST_F(CSndLossListTest, InsertCoalesce)
+{
+    EXPECT_EQ(m_lossList->insert(1, 2), 2);
+    EXPECT_EQ(m_lossList->insert(4, 4), 1);
+    EXPECT_EQ(m_lossList->insert(3, 3), 1);
+
+    EXPECT_EQ(m_lossList->getLossLength(), 4);
+    EXPECT_EQ(m_lossList->popLostSeq(), 1);
+    EXPECT_EQ(m_lossList->getLossLength(), 3);
+    EXPECT_EQ(m_lossList->popLostSeq(), 2);
+    EXPECT_EQ(m_lossList->getLossLength(), 2);
+    EXPECT_EQ(m_lossList->popLostSeq(), 3);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->popLostSeq(), 4);
     CheckEmptyArray();


### PR DESCRIPTION
1. Added several unit tests.
2. Minor refactoring of the `CSndLossList::insert(..)`.
3. Improved `CSndLossList::insert(..)` for the serial element.

Example of the improvement. Three insert operations:
```
insert(1, 2);
insert(4, 4);
insert(3, 3);
```

The state of the list after every insert operation was (**format** `pos:[seqstart, seqend]`):
```
0:[1, 2]
0:[1, 2], 3:[4]
0:[1, 2], 2:[3], 3:[4]
```
After this PR:
```
0:[1, 2], 
0:[1, 2], 3:[4] 
0:[1, 4] 
```

Taken from `TEST_F(CSndLossListTest, InsertCoalesce)`