### PR TITLE
[core] Introducing sync::CEvent

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -744,7 +744,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
       // acknowledge users waiting for new connections on the listening socket
       m_EPoll.update_events(listen, ls->m_pUDT->m_sPollID, SRT_EPOLL_ACCEPT, true);
 
-      g_Sync.notify_one();
+      CGlobEvent::triggerEvent();
 
       // XXX the exact value of 'error' is ignored
       if (error > 0)
@@ -767,7 +767,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
       // acknowledge INTERNAL users waiting for new connections on the listening socket
       // that are reported when a new socket is connected within an already connected group.
       m_EPoll.update_events(listen, ls->m_pUDT->m_sPollID, SRT_EPOLL_UPDATE, true);
-      g_Sync.notify_one();
+      CGlobEvent::triggerEvent();
    }
 
 ERR_ROLLBACK:
@@ -1628,7 +1628,7 @@ int CUDTUnited::close(CUDTSocket* s)
        m_ClosedSockets[s->m_SocketID] = s;
        HLOGC(mglog.Debug, log << "@" << u << "U::close: Socket MOVED TO CLOSED for collecting later.");
 
-       g_Sync.notify_one();
+       CGlobEvent::triggerEvent();
    }
 
    HLOGC(mglog.Debug, log << "@" << u << ": GLOBAL: CLOSING DONE");
@@ -1680,7 +1680,7 @@ int CUDTUnited::close(CUDTSocket* s)
 
            HLOGC(mglog.Debug, log << "@" << u << " GLOBAL CLOSING: ... still waiting for any update.");
            // How to handle a possible error here?
-           g_Sync.wait_for(milliseconds_from(10));
+           CGlobEvent::waitForEvent();
 
            // Continue waiting in case when an event happened or 1s waiting time passed for checkpoint.
        }
@@ -1851,7 +1851,7 @@ int CUDTUnited::select(
       if (0 < count)
          break;
 
-      g_Sync.wait_for(milliseconds_from(10));
+      CGlobEvent::waitForEvent();
    } while (timeo > steady_clock::now() - entertime);
 
    if (readfds)
@@ -1934,7 +1934,7 @@ int CUDTUnited::selectEx(
       if (count > 0)
          break;
 
-      g_Sync.wait_for(milliseconds_from(10));
+      CGlobEvent::waitForEvent();
    } while (timeo > steady_clock::now() - entertime);
 
    return count;

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -516,7 +516,7 @@ void CSndBuffer::ackData(int offset)
    updAvgBufSize(steady_clock::now());
 #endif
 
-   CTimer::triggerEvent();
+   g_Sync.notify_one();
 }
 
 int CSndBuffer::getCurrBufSize() const
@@ -944,7 +944,7 @@ int CRcvBuffer::ackData(int len)
    if (m_iMaxPos < 0)
       m_iMaxPos = 0;
 
-   CTimer::triggerEvent();
+   g_Sync.notify_one();
 
    // Returned value is the distance towards the starting
    // position from m_iLastAckPos, which is in sync with CUDT::m_iRcvLastSkipAck.

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -516,7 +516,7 @@ void CSndBuffer::ackData(int offset)
    updAvgBufSize(steady_clock::now());
 #endif
 
-   g_Sync.notify_one();
+   CGlobEvent::triggerEvent();
 }
 
 int CSndBuffer::getCurrBufSize() const
@@ -944,7 +944,7 @@ int CRcvBuffer::ackData(int len)
    if (m_iMaxPos < 0)
       m_iMaxPos = 0;
 
-   g_Sync.notify_one();
+   CGlobEvent::triggerEvent();
 
    // Returned value is the distance towards the starting
    // position from m_iLastAckPos, which is in sync with CUDT::m_iRcvLastSkipAck.

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -71,8 +71,6 @@ modified by
 using namespace srt::sync;
 
 
-Mutex CTimer::m_EventLock;
-pthread_cond_t CTimer::m_EventCond = PTHREAD_COND_INITIALIZER;
 
 CTimer::CTimer()
     : m_tsSchedTime()
@@ -179,32 +177,6 @@ void CTimer::tick()
 }
 
 
-void CTimer::triggerEvent()
-{
-    pthread_cond_signal(&m_EventCond);
-}
-
-CTimer::EWait CTimer::waitForEvent()
-{
-    timeval now;
-    timespec timeout;
-    gettimeofday(&now, 0);
-    if (now.tv_usec < 990000)
-    {
-        timeout.tv_sec = now.tv_sec;
-        timeout.tv_nsec = (now.tv_usec + 10000) * 1000;
-    }
-    else
-    {
-        timeout.tv_sec = now.tv_sec + 1;
-        timeout.tv_nsec = (now.tv_usec + 10000 - 1000000) * 1000;
-    }
-    enterCS(m_EventLock);
-    int reason = pthread_cond_timedwait(&m_EventCond, &m_EventLock.ref(), &timeout);
-    leaveCS(m_EventLock);
-
-    return reason == ETIMEDOUT ? WT_TIMEOUT : reason == 0 ? WT_EVENT : WT_ERROR;
-}
 
 CUDTException::CUDTException(CodeMajor major, CodeMinor minor, int err):
 m_iMajor(major),

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -562,36 +562,11 @@ public:
 
    void tick();
 
-public:
-
-      /// trigger an event such as new connection, close, new data, etc. for "select" call.
-
-   static void triggerEvent();
-
-   enum EWait {WT_EVENT, WT_ERROR, WT_TIMEOUT};
-
-      /// wait for an event to br triggered by "triggerEvent".
-      /// @retval WT_EVENT The event has happened
-      /// @retval WT_TIMEOUT The event hasn't happened, the function exited due to timeout
-      /// @retval WT_ERROR The function has exit due to an error
-
-   static EWait waitForEvent();
-   
-      /// Wait for condition with timeout 
-      /// @param [in] cond Condition variable to wait for
-      /// @param [in] mutex locked mutex associated with the condition variable
-      /// @param [in] delay timeout in microseconds
-      /// @retval 0 Wait was successfull
-      /// @retval ETIMEDOUT The wait timed out
-
 private:
    srt::sync::steady_clock::time_point m_tsSchedTime;             // next schedulled time
 
    pthread_cond_t m_TickCond;
    srt::sync::Mutex m_TickLock;
-
-   static pthread_cond_t m_EventCond;
-   static srt::sync::Mutex m_EventLock;
 };
 
 // UDT Sequence Number 0 - (2^31 - 1)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5510,7 +5510,7 @@ void *CUDT::tsbpd(void *param)
                 // When the group is read-ready, it should update its pollers as it sees fit.
                 self->m_parent->m_IncludedGroup->updateReadState(self->m_SocketID, current_pkt_seq);
             }
-            g_Sync.notify_one();
+            CGlobEvent::triggerEvent();
             tsbpdtime = steady_clock::time_point();
         }
 
@@ -7547,7 +7547,7 @@ int32_t CUDT::ackDataUpTo(int32_t ack)
 
         // Signal threads waiting in CTimer::waitForEvent(),
         // which are select(), selectEx() and epoll_wait().
-        g_Sync.notify_one();
+        CGlobEvent::triggerEvent();
 
         return CSeqNo::decseq(ack, distance);
     }
@@ -7696,7 +7696,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam,
                     // When the group is read-ready, it should update its pollers as it sees fit.
                     m_parent->m_IncludedGroup->updateReadState(m_SocketID, first_seq);
                 }
-                g_Sync.notify_one();
+                CGlobEvent::triggerEvent();
             }
             enterCS(m_RcvBufferLock);
         }
@@ -8498,7 +8498,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
         // Unblock any call so they learn the connection_broken error
         s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_ERR, true);
 
-        g_Sync.notify_one();
+        CGlobEvent::triggerEvent();
 
         break;
 
@@ -9057,7 +9057,7 @@ void CUDT::processClose()
     s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_ERR, true);
 
     HLOGP(mglog.Debug, "processClose: triggering timer event to spread the bad news");
-    g_Sync.notify_one();
+    CGlobEvent::triggerEvent();
 }
 
 void CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
@@ -10475,7 +10475,7 @@ bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_rea
         // app can call any UDT API to learn the connection_broken error
         s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR, true);
 
-        g_Sync.notify_one();
+        CGlobEvent::triggerEvent();
 
         return true;
     }

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -690,10 +690,7 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
             throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
         }
 
-#ifdef ENABLE_HEAVY_LOGGING
-        const bool wait_signaled =
-#endif
-        CGlobEvent::waitForEvent();
+        const bool wait_signaled ATR_UNUSED = CGlobEvent::waitForEvent();
         HLOGC(mglog.Debug, log << "CEPoll::wait: EVENT WAITING: "
             << (wait_signaled ? "TRIGGERED" : "CHECKPOINT"));
     }

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -497,7 +497,7 @@ int CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t m
         if ((msTimeOut >= 0) && (count_microseconds(srt::sync::steady_clock::now() - entertime) >= msTimeOut * int64_t(1000)))
             break; // official wait does: throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
 
-        CGlobEvent::triggerEvent();
+        CGlobEvent::waitForEvent();
     }
 
     return 0;

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -497,7 +497,7 @@ int CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t m
         if ((msTimeOut >= 0) && (count_microseconds(srt::sync::steady_clock::now() - entertime) >= msTimeOut * int64_t(1000)))
             break; // official wait does: throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
 
-        g_Sync.notify_one();
+        CGlobEvent::triggerEvent();
     }
 
     return 0;
@@ -693,7 +693,7 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
 #ifdef ENABLE_HEAVY_LOGGING
         const bool wait_signaled =
 #endif
-        g_Sync.pause();
+        CGlobEvent::waitForEvent();
         HLOGC(mglog.Debug, log << "CEPoll::wait: EVENT WAITING: "
             << (wait_signaled ? "TRIGGERED" : "CHECKPOINT"));
     }
@@ -776,7 +776,7 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
             return 0; // meaning "none is ready"
         }
 
-        g_Sync.wait_for(milliseconds_from(10));
+        CGlobEvent::waitForEvent();
     }
 
     return 0;

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -497,7 +497,7 @@ int CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t m
         if ((msTimeOut >= 0) && (count_microseconds(srt::sync::steady_clock::now() - entertime) >= msTimeOut * int64_t(1000)))
             break; // official wait does: throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
 
-        CTimer::waitForEvent();
+        g_Sync.notify_one();
     }
 
     return 0;
@@ -690,9 +690,12 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
             throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
         }
 
-        CTimer::EWait wt ATR_UNUSED = CTimer::waitForEvent();
+#ifdef ENABLE_HEAVY_LOGGING
+        const bool wait_signaled =
+#endif
+        g_Sync.pause();
         HLOGC(mglog.Debug, log << "CEPoll::wait: EVENT WAITING: "
-            << (wt == CTimer::WT_TIMEOUT ? "CHECKPOINT" : wt == CTimer::WT_EVENT ? "TRIGGERED" : "ERROR"));
+            << (wait_signaled ? "TRIGGERED" : "CHECKPOINT"));
     }
 
     return 0;
@@ -773,7 +776,7 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
             return 0; // meaning "none is ready"
         }
 
-        CTimer::waitForEvent();
+        g_Sync.wait_for(milliseconds_from(10));
     }
 
     return 0;

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -411,7 +411,7 @@ private:
 private:
    CSndUList* m_pSndUList;              // List of UDT instances for data sending
    CChannel* m_pChannel;                // The UDP channel for data sending
-   CTimer* m_pTimer;         // Timing facility
+   CTimer* m_pTimer;                    // Timing facility
 
    srt::sync::Mutex m_WindowLock;
    srt::sync::Condition m_WindowCond;
@@ -498,8 +498,8 @@ private:
 
    CRcvUList* m_pRcvUList;		// List of UDT instances that will read packets from the queue
    CHash* m_pHash;			// Hash table for UDT socket looking up
-   CChannel* m_pChannel;        // UDP channel for receving packets
-   CTimer* m_pTimer;	// shared timer with the snd queue
+   CChannel* m_pChannel;		// UDP channel for receving packets
+   CTimer* m_pTimer;			// shared timer with the snd queue
 
    int m_iPayloadSize;                  // packet payload size
 
@@ -543,7 +543,7 @@ struct CMultiplexer
    CSndQueue* m_pSndQueue;  // The sending queue
    CRcvQueue* m_pRcvQueue;  // The receiving queue
    CChannel* m_pChannel;    // The UDP channel for sending and receiving
-   CTimer* m_pTimer;  // The timer
+   CTimer* m_pTimer;        // The timer
 
    int m_iPort;         // The UDP port number of this multiplexer
    int m_iIPversion;    // Address family (AF_INET or AF_INET6)

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -411,7 +411,7 @@ private:
 private:
    CSndUList* m_pSndUList;              // List of UDT instances for data sending
    CChannel* m_pChannel;                // The UDP channel for data sending
-   CTimer* m_pTimer;                    // Timing facility
+   CTimer* m_pTimer;         // Timing facility
 
    srt::sync::Mutex m_WindowLock;
    srt::sync::Condition m_WindowCond;
@@ -498,8 +498,8 @@ private:
 
    CRcvUList* m_pRcvUList;		// List of UDT instances that will read packets from the queue
    CHash* m_pHash;			// Hash table for UDT socket looking up
-   CChannel* m_pChannel;		// UDP channel for receving packets
-   CTimer* m_pTimer;			// shared timer with the snd queue
+   CChannel* m_pChannel;        // UDP channel for receving packets
+   CTimer* m_pTimer;	// shared timer with the snd queue
 
    int m_iPayloadSize;                  // packet payload size
 
@@ -543,7 +543,7 @@ struct CMultiplexer
    CSndQueue* m_pSndQueue;  // The sending queue
    CRcvQueue* m_pRcvQueue;  // The receiving queue
    CChannel* m_pChannel;    // The UDP channel for sending and receiving
-   CTimer* m_pTimer;        // The timer
+   CTimer* m_pTimer;  // The timer
 
    int m_iPort;         // The UDP port number of this multiplexer
    int m_iIPversion;    // Address family (AF_INET or AF_INET6)

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -478,7 +478,7 @@ srt::sync::CEvent::~CEvent()
 }
 
 
-bool srt::sync::CEvent::wait_until(const TimePoint<steady_clock>& tp)
+bool srt::sync::CEvent::lock_wait_until(const TimePoint<steady_clock>& tp)
 {
     UniqueLock lock(m_lock);
     return m_cond.wait_until(lock, tp);
@@ -494,7 +494,7 @@ void srt::sync::CEvent::notify_all()
     return m_cond.notify_all();
 }
 
-bool srt::sync::CEvent::wait_for(const Duration<steady_clock>& rel_time)
+bool srt::sync::CEvent::lock_wait_for(const Duration<steady_clock>& rel_time)
 {
     UniqueLock lock(m_lock);
     return m_cond.wait_for(lock, rel_time);

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -505,7 +505,7 @@ bool srt::sync::CEvent::wait_for(UniqueLock& lock, const Duration<steady_clock>&
     return m_cond.wait_for(lock, rel_time);
 }
 
-void srt::sync::CEvent::wait()
+void srt::sync::CEvent::lock_wait()
 {
     UniqueLock lock(m_lock);
     return wait(lock);

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -446,3 +446,65 @@ int srt::sync::SyncEvent::wait_for_monotonic(pthread_cond_t* cond, pthread_mutex
     return wait_for(cond, mutex, rel_time);
 }
 #endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// CEvent class
+//
+////////////////////////////////////////////////////////////////////////////////
+
+srt::sync::CEvent::CEvent()
+{
+    m_cond.init();
+}
+
+
+srt::sync::CEvent::~CEvent()
+{
+    m_cond.destroy();
+}
+
+
+bool srt::sync::CEvent::wait_until(const TimePoint<steady_clock>& tp)
+{
+    UniqueLock lock(m_lock);
+    return m_cond.wait_until(lock, tp);
+}
+
+void srt::sync::CEvent::notify_one()
+{
+    return m_cond.notify_one();
+}
+
+void srt::sync::CEvent::notify_all()
+{
+    return m_cond.notify_all();
+}
+
+bool srt::sync::CEvent::wait_for(const Duration<steady_clock>& rel_time)
+{
+    UniqueLock lock(m_lock);
+    return m_cond.wait_for(lock, rel_time);
+}
+
+bool srt::sync::CEvent::wait_for(UniqueLock& lock, const Duration<steady_clock>& rel_time)
+{
+    return m_cond.wait_for(lock, rel_time);
+}
+
+void srt::sync::CEvent::wait()
+{
+    UniqueLock lock(m_lock);
+    return wait(lock);
+}
+
+void srt::sync::CEvent::wait(UniqueLock& lock)
+{
+    return m_cond.wait(lock);
+}
+
+
+srt::sync::CEvent g_Sync;
+
+

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -274,10 +274,18 @@ namespace sync
 {
 
 template<>
-CCondVar<true>::CCondVar() {}
+CCondVar<true>::CCondVar()
+#ifdef _WIN32
+    : m_cv(PTHREAD_COND_INITIALIZER)
+#endif
+{}
 
 template<>
-CCondVar<false>::CCondVar() {}
+CCondVar<false>::CCondVar()
+#ifdef _WIN32
+    : m_cv(PTHREAD_COND_INITIALIZER)
+#endif
+{}
 
 template<>
 CCondVar<true>::~CCondVar() {}
@@ -456,13 +464,17 @@ int srt::sync::SyncEvent::wait_for_monotonic(pthread_cond_t* cond, pthread_mutex
 
 srt::sync::CEvent::CEvent()
 {
+#ifndef _WIN32
     m_cond.init();
+#endif
 }
 
 
 srt::sync::CEvent::~CEvent()
 {
+#ifndef _WIN32
     m_cond.destroy();
+#endif
 }
 
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -537,7 +537,7 @@ public:
     ///         false on timeout
     bool wait_for(UniqueLock& lk, const steady_clock::duration& rel_time);
 
-    void wait();
+    void lock_wait();
 
     void wait(UniqueLock& lk);
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -609,4 +609,36 @@ inline std::string FormatDuration(const steady_clock::duration& dur)
 
 extern srt::sync::CEvent g_Sync;
 
+namespace srt
+{
+namespace sync
+{
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// CGlobEvent class
+//
+////////////////////////////////////////////////////////////////////////////////
+
+class CGlobEvent
+{
+public:
+    /// Triggers the event and notifies waiting threads.
+    /// Simply calls notify_one().
+    static void inline triggerEvent()
+    {
+        return g_Sync.notify_one();
+    }
+
+    /// Waits for the event to be triggered with 10ms timeout.
+    /// Simply calls wait_for().
+    static bool waitForEvent()
+    {
+        return g_Sync.wait_for(milliseconds_from(10));
+    }
+};
+
+}; // namespace sync
+}; // namespace srt
+
 #endif // __SRT_SYNC_H__

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -508,12 +508,12 @@ public:
     Mutex& mutex() { return m_lock; }
 
 public:
-    /// wait_until causes the current thread to block until
+    /// Causes the current thread to block until
     /// a specific time is reached.
     ///
     /// @return true  if condition occured or spuriously woken up
     ///         false on timeout
-    bool wait_until(const steady_clock::time_point& tp);
+    bool lock_wait_until(const steady_clock::time_point& tp);
 
     /// Blocks the current executing thread,
     /// and adds it to the list of threads waiting on* this.
@@ -524,7 +524,7 @@ public:
     ///
     /// @return true  if condition occured or spuriously woken up
     ///         false on timeout
-    bool wait_for(const steady_clock::duration& rel_time);
+    bool lock_wait_for(const steady_clock::duration& rel_time);
 
     /// Atomically releases lock, blocks the current executing thread,
     /// and adds it to the list of threads waiting on* this.
@@ -634,7 +634,7 @@ public:
     /// Simply calls wait_for().
     static bool waitForEvent()
     {
-        return g_Sync.wait_for(milliseconds_from(10));
+        return g_Sync.lock_wait_for(milliseconds_from(10));
     }
 };
 


### PR DESCRIPTION
Introducing `sync::CEvent` and `sync::CGlobEvent` to replace static functionality of the `CTimer`

The global CEvent g_Event is now used for synchronization.
Static CV and mutex were used in the previous implementation that is to be replaced. A static CV can't be initialized to use a monotonic clock. Therefore, switched to a global CV.


### Topics for discussion

1. Problem: the CV of the global CEvent g_Event should be initialized with `PTHREAD_COND_INITIALIZER`. Otherwise, it fails on Windows.

2. `CTimer::triggerEvent()` is being replaced with `g_Sync.notify_one()`  according to the previous implementation of the `triggerEvent()`. Although to me notify_all() makes more sense.

3. `CTimer::waitForEvent()` is being replaced with `g_Sync.wait_for(milliseconds_from(10))` according to the implementation of the `waitForEvent()`. Might be better to retain this function `waitForEvent()` to wait implicitelly for 10 ms.