### PR TITLE
srt live transmit UDP buffer size config

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -751,7 +751,9 @@ Iface* CreateConsole() { return new typename Console<Iface>::type (); }
 SocketOption udp_options [] {
     { "iptos", IPPROTO_IP, IP_TOS, SocketOption::PRE, SocketOption::INT, nullptr },
     // IP_TTL and IP_MULTICAST_TTL are handled separately by a common option, "ttl".
-    { "mcloop", IPPROTO_IP, IP_MULTICAST_LOOP, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "mcloop", IPPROTO_IP, IP_MULTICAST_LOOP, SocketOption::PRE, SocketOption::INT, nullptr },
+    { "sndbuf", SOL_SOCKET, SO_SNDBUF, SocketOption::PRE, SocketOption::INT, nullptr},
+    { "rcvbuf", SOL_SOCKET, SO_RCVBUF, SocketOption::PRE, SocketOption::INT, nullptr}
 };
 
 static inline bool IsMulticast(in_addr adr)


### PR DESCRIPTION
Added the possibility to set the buffer size of the UDP socket.

It turned out at high and bursty data rates (~60 Mbps) the `epoll_wait(udp_socket)` is not fast enough to signal about the possibility to read from a socket. It results in loosing data when there 

Waiting on a UDP socket with `::select(...)` works perfect, but we can't use it in the current implementation of the `srt-live-transmit`.

UDP socket needs a bigger buffer to store incomming data. For example, setting 64 MB buffer seems to workaround the issue #933.

### Increase the system-default max rcv buffer size

```
$ cat /proc/sys/net/core/rmem_max
212992
$ sudo sysctl -w net.core.rmem_max=26214400
net.core.rmem_max = 26214400
$ cat /proc/sys/net/core/rmem_max
26214400
```

### Specify the size of the UDP socket buffer via the URI

Example URI:
```
"udp://:4200?rcvbuf=67108864"
```

Example full URI:
```
./srt-live-transmit "udp://:4200?rcvbuf=67108864" srt://192.168.0.10:4200 -v
```

### TODO

- [x] Remove verbose messages regarding the size of the buffer