### PR TITLE
Added a note in docs regarding accept time and failing accept-timeout tests

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1214,6 +1214,21 @@ sender and can be useful in situations where it is important to know whether a
 connection is possible. The inability to decrypt an incoming transmission can
 be then reported as a different kind of problem.
 
+**IMPORTANT**: There is an unusual behavior in case when this flag is TRUE on
+the caller and FALSE on the listener. This is because the listener accepts the
+connection and considers itself connected, while it doesn't know yet that the
+caller will reject it. The result is a short-living "spurious" connection
+report on the listener socket. If the application is fast enough to catch it,
+it will get the socket from `srt_accept`, only to learn soon that the
+connection is broken, otherwise the connection could be removed from the
+listener backlog before the application can be aware of its existence. How fast
+the connection is broken, it depends on the network parameters, in particular,
+whether the `UMSG_SHUTDOWN` message sent by the caller is delivered (in this
+case the time of one RTT) or missed (then up to the connection timeout, default
+5 seconds). It is therefore strongly recommended to use this flag (that is,
+set to FALSE) only when you are able to ensure that this flag is also set FALSE
+on the caller side.
+
 ---
 
 | OptName           | Since | Binding | Type            | Units | Default  | Range  |

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -297,7 +297,11 @@ public:
     template<typename TResult>
     void TestConnect(TEST_CASE test_case/*, bool is_blocking*/)
     {
-        const bool is_blocking = std::is_same<TResult, TestResultBlocking>::value;
+        if (std::is_same<TResult, TestResultBlocking>::value)
+            return TestConnectBlocking(test_case);
+
+        bool is_blocking = false;
+
         if (is_blocking)
         {
             ASSERT_NE(srt_setsockopt(  m_caller_socket, 0, SRTO_RCVSYN, &s_yes, sizeof s_yes), SRT_ERROR);
@@ -440,6 +444,8 @@ public:
             accepting_thread.join();
         }
     }
+
+    void TestConnectBlocking(TEST_CASE test_case);
 
     void TestAcceptTime()
     {
@@ -601,6 +607,131 @@ const TestCase<TestResultNonBlocking>& TestEnforcedEncryption::GetTestMatrix<Tes
 {
     return g_test_matrix_non_blocking[test_case];
 }
+
+void TestEnforcedEncryption::TestConnectBlocking(TEST_CASE test_case)
+{
+    ASSERT_NE(srt_setsockopt(  m_caller_socket, 0, SRTO_RCVSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+    ASSERT_NE(srt_setsockopt(  m_caller_socket, 0, SRTO_SNDSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+    ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_RCVSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+    ASSERT_NE(srt_setsockopt(m_listener_socket, 0, SRTO_SNDSYN, &s_yes, sizeof s_yes), SRT_ERROR);
+
+    // Prepare input state
+    const TestCase<TestResultBlocking> &test = GetTestMatrix<TestResultBlocking>(test_case);
+    ASSERT_EQ(SetEnforcedEncryption(PEER_CALLER, test.enforcedenc[PEER_CALLER]), SRT_SUCCESS);
+    ASSERT_EQ(SetEnforcedEncryption(PEER_LISTENER, test.enforcedenc[PEER_LISTENER]), SRT_SUCCESS);
+
+    ASSERT_EQ(SetPassword(PEER_CALLER, test.password[PEER_CALLER]), SRT_SUCCESS);
+    ASSERT_EQ(SetPassword(PEER_LISTENER, test.password[PEER_LISTENER]), SRT_SUCCESS);
+
+    const TestResultBlocking &expect = test.expected_result;
+
+    // Start testing
+    sockaddr_in sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons(5200);
+    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr), 1);
+    sockaddr* psa = (sockaddr*)&sa;
+    ASSERT_NE(srt_bind(m_listener_socket, psa, sizeof sa), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_socket, 4), SRT_ERROR);
+
+    volatile bool accept_starting = false;
+    volatile bool accept_finished = false;
+
+    auto accepting_thread = std::thread([&] {
+
+        // In a blocking mode we expect a socket returned from srt_accept() if the srt_connect succeeded.
+        // In a non-blocking mode we expect a socket returned from srt_accept() if the srt_connect succeeded,
+        // otherwise SRT_INVALID_SOCKET after the listening socket is closed.
+        sockaddr_in client_address;
+        int length = sizeof(sockaddr_in);
+        accept_starting = true;
+        SRTSOCKET accepted_socket = srt_accept(m_listener_socket, (sockaddr*)&client_address, &length);
+
+        accept_finished = true;
+
+        EXPECT_NE(accepted_socket, 0);
+        if (expect.accept_ret == SRT_INVALID_SOCK)
+            EXPECT_EQ(accepted_socket, SRT_INVALID_SOCK);
+        else
+            EXPECT_NE(accepted_socket, SRT_INVALID_SOCK);
+
+        if (accepted_socket != SRT_INVALID_SOCK)
+        {
+            // We have to wait some time for the socket to be able to process the HS responce from the caller.
+            // In test cases B2 - B4 the socket is expected to change its state from CONNECTED to BROKEN
+            // due to KM mismatches
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            EXPECT_EQ(srt_getsockstate(accepted_socket), expect.socket_state[CHECK_SOCKET_ACCEPTED]);
+            EXPECT_EQ(GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE), expect.km_state[CHECK_SOCKET_ACCEPTED]);
+            if (m_is_tracing)
+            {
+                std::cerr << "Socket state accepted: " << m_socket_state[srt_getsockstate(accepted_socket)] << "\n";
+                std::cerr << "KM State accepted:     " << m_km_state[GetKMState(accepted_socket)] << '\n';
+                std::cerr << "RCV KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_RCVKMSTATE)] << '\n';
+                std::cerr << "SND KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE)] << '\n';
+            }
+        }
+        else
+        {
+            std::cerr << "ACCEPT ERROR: " << srt_getlasterror_str() << std::endl;
+        }
+    });
+
+    // Give it time to start. Roll until you get readiness
+    do
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    while (!accept_starting);
+
+    // Sleep additional 50ms just for a case. This should yield this thread
+    // up to the moment when accept call starts hanging on a CV. We are unable
+    // to check if it happened.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const int connect_ret = srt_connect(m_caller_socket, psa, sizeof sa);
+    EXPECT_EQ(connect_ret, expect.connect_ret);
+
+    if (connect_ret == SRT_ERROR && connect_ret != expect.connect_ret)
+    {
+        std::cerr << "UNEXPECTED! srt_connect returned error: "
+            << srt_getlasterror_str() << " (code " << srt_getlasterror(NULL) << ")\n";
+    }
+
+    if (m_is_tracing)
+    {
+        std::cerr << "Socket state caller:   " << m_socket_state[srt_getsockstate(m_caller_socket)] << "\n";
+        std::cerr << "Socket state listener: " << m_socket_state[srt_getsockstate(m_listener_socket)] << "\n";
+        std::cerr << "KM State caller:       " << m_km_state[GetKMState(m_caller_socket)] << '\n';
+        std::cerr << "RCV KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE)] << '\n';
+        std::cerr << "SND KM State caller:   " << m_km_state[GetSocetkOption(m_caller_socket, SRTO_SNDKMSTATE)] << '\n';
+        std::cerr << "KM State listener:     " << m_km_state[GetKMState(m_listener_socket)] << '\n';
+    }
+
+    // If a blocking call to srt_connect() returned error, then the state is not valid,
+    // but we still check it because we know what it should be. This way we may see potential changes in the core behavior.
+    EXPECT_EQ(srt_getsockstate(m_caller_socket), expect.socket_state[CHECK_SOCKET_CALLER]);
+    EXPECT_EQ(GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE), expect.km_state[CHECK_SOCKET_CALLER]);
+
+    EXPECT_EQ(srt_getsockstate(m_listener_socket), SRTS_LISTENING);
+    EXPECT_EQ(GetKMState(m_listener_socket), SRT_KM_S_UNSECURED);
+
+    std::cerr << "STATE CHECK FINISHED\n";
+
+    // srt_accept() has no timeout, so we have to close the socket and wait for the thread to exit.
+    // Just give it some time and close the socket.
+    int wait_ms = 0;
+    while (!accept_finished && wait_ms < 5000)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        wait_ms += 10;
+    }
+    std::cerr << "ACCEPT WAITING TIME: " << wait_ms << " (timeout: 50000) - CLOSING SOCKET\n";
+    ASSERT_NE(srt_close(m_listener_socket), SRT_ERROR);
+    accepting_thread.join();
+}
+
 
 
 

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -390,6 +390,10 @@ public:
                     std::cerr << "SND KM State accepted:     " << m_km_state[GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE)] << '\n';
                 }
             }
+            else
+            {
+                std::cerr << "ACCEPT ERROR: " << srt_getlasterror_str() << std::endl;
+            }
         });
 
         if (is_blocking == false)
@@ -413,11 +417,15 @@ public:
         EXPECT_EQ(srt_getsockstate(m_listener_socket), SRTS_LISTENING);
         EXPECT_EQ(GetKMState(m_listener_socket), SRT_KM_S_UNSECURED);
 
+        std::cerr << "STATE CHECK FINISHED\n";
+
         if (is_blocking)
         {
             // We need to ensure the accepting thread is up and running
             std::unique_lock<std::mutex> lock(ready_to_accept_mtx);
             ready_to_accept.wait(lock, [&accept_ready] { return accept_ready; });
+
+            std::cerr << "CV UNLOCKED, STARTING TEST\n";
 
             // srt_accept() has no timeout, so we have to close the socket and wait for the thread to exit.
             // Just give it some time and close the socket.
@@ -531,7 +539,7 @@ private:
     const int s_yes = 1;
     const int s_no  = 0;
 
-    const bool          m_is_tracing = false;
+    const bool          m_is_tracing = true;
     static const char*  m_km_state[];
     static const char*  m_socket_state[];
 };


### PR DESCRIPTION
That's simply a copy of `TestConnect` method with removed unused parts replaced with always using blocking mode and without encryption. The time spent by accept is measured with 10ms resolution. Normally it should collect just one case of 10ms waiting, but it waits until the boolean flag is set that marks the last instruction in the thread and finished call to `srt_accept`.