### PR TITLE
Enhanced and customizable reject reason

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -785,11 +785,12 @@ ERR_ROLLBACK:
 #if ENABLE_LOGGING
        static const char* why [] = {
            "UNKNOWN ERROR",
-           "CONNECTION REJECTED",
+           "EXPLICIT REJECTION",
            "IPE when mapping a socket",
            "IPE when inserting a socket"
        };
-       LOGC(mglog.Error, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: " << why[error]);
+       LOGC(mglog.Error, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: "
+               << why[error] << " - " << RequestTypeStr(URQFailure(w_error)));
 #endif
       SRTSOCKET id = ns->m_SocketID;
       ns->makeClosed();

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -470,7 +470,7 @@ SRTSOCKET CUDTUnited::newSocket(CUDTSocket** pps)
 }
 
 int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
-        CHandShake& w_hs, int& w_error)
+        CHandShake& w_hs, int& w_error, string& w_streaminfo)
 {
    CUDTSocket* ns = NULL;
 
@@ -588,6 +588,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
    // CUDT::open() may only throw original std::bad_alloc from new.
    // This is only to make the library extra safe (when your machine lacks
    // memory, it will continue to work, but fail to accept connection).
+
    try
    {
        // This assignment must happen b4 the call to CUDT::connect() because
@@ -610,6 +611,10 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
            if (!ls->m_pUDT->runAcceptHook(ns->m_pUDT, peer.get(), w_hs, hspkt))
            {
                w_error = ns->m_pUDT->m_RejectReason;
+
+               // Save the STREAMID contents in case when a user changed it
+               // in the listener callback
+               w_streaminfo = ns->m_pUDT->m_sStreamName;
                error = 1;
                goto ERR_ROLLBACK;
            }

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -470,7 +470,7 @@ SRTSOCKET CUDTUnited::newSocket(CUDTSocket** pps)
 }
 
 int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
-        CHandShake& w_hs, SRT_REJECT_REASON& w_error)
+        CHandShake& w_hs, int& w_error)
 {
    CUDTSocket* ns = NULL;
 
@@ -549,6 +549,8 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
       return -1;
    }
 
+   ns->m_pUDT->m_RejectReason = SRT_REJ_UNKNOWN; // pre-set a universal value
+
    try
    {
        ns->m_SocketID = generateSocketID();
@@ -607,6 +609,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
        {
            if (!ls->m_pUDT->runAcceptHook(ns->m_pUDT, peer.get(), w_hs, hspkt))
            {
+               w_error = ns->m_pUDT->m_RejectReason;
                error = 1;
                goto ERR_ROLLBACK;
            }
@@ -4089,9 +4092,14 @@ SRT_API std::string getstreamid(SRTSOCKET u)
     return CUDT::getstreamid(u);
 }
 
-SRT_REJECT_REASON getrejectreason(SRTSOCKET u)
+int getrejectreason(SRTSOCKET u)
 {
     return CUDT::rejectReason(u);
+}
+
+int setrejectreason(SRTSOCKET u, int value)
+{
+    return CUDT::rejectReason(u, value);
 }
 
 }  // namespace UDT

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -197,7 +197,7 @@ public:
       /// @return If the new connection is successfully created: 1 success, 0 already exist, -1 error.
 
    int newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
-           CHandShake& w_hs, int& w_error);
+           CHandShake& w_hs, int& w_error, std::string& w_streaminfo);
 
    int installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);
 

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -197,7 +197,7 @@ public:
       /// @return If the new connection is successfully created: 1 success, 0 already exist, -1 error.
 
    int newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
-           CHandShake& w_hs, SRT_REJECT_REASON& w_error);
+           CHandShake& w_hs, int& w_error);
 
    int installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);
 

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -681,9 +681,16 @@ extern const char* const srt_rejectreason_msg [] = {
     "Group settings collision"
 };
 
-const char* srt_rejectreason_str(SRT_REJECT_REASON rid)
+const char* srt_rejectreason_str(int id)
 {
-    int id = rid;
+    if (id > SRT_REJC_SERVER)
+    {
+        if (id > SRT_REJC_USER)
+            return "USER ERROR";
+
+        return "SERVER ERROR";
+    }
+
     static const size_t ra_size = Size(srt_rejectreason_msg);
     if (size_t(id) >= ra_size)
         return srt_rejectreason_msg[0];

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -832,6 +832,7 @@ private:
     SRT_ATR_NODISCARD int processSrtMsg_HSREQ(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv);
     SRT_ATR_NODISCARD int processSrtMsg_HSRSP(const uint32_t* srtdata, size_t len, uint32_t ts, int hsv);
     SRT_ATR_NODISCARD bool interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uint32_t* out_data, size_t* out_len);
+                      void interpretRejectionMessage(const CHandShake& hs, const CPacket& pkt);
     SRT_ATR_NODISCARD bool checkApplyFilterConfig(const std::string& cs);
 
     static CUDTGroup& newGroup(const int); // defined EXCEPTIONALLY in api.cpp for convenience reasons

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -615,7 +615,8 @@ public: //API
     static bool setstreamid(SRTSOCKET u, const std::string& sid);
     static std::string getstreamid(SRTSOCKET u);
     static int getsndbuffer(SRTSOCKET u, size_t* blocks, size_t* bytes);
-    static SRT_REJECT_REASON rejectReason(SRTSOCKET s);
+    static int rejectReason(SRTSOCKET s);
+    static int rejectReason(SRTSOCKET s, int value);
 
 public: // internal API
     // This is public so that it can be used directly in API implementation functions.
@@ -1087,7 +1088,7 @@ private:
     volatile bool m_bShutdown;                   // If the peer side has shutdown the connection
     volatile bool m_bBroken;                     // If the connection has been broken
     volatile bool m_bPeerHealth;                 // If the peer status is normal
-    volatile SRT_REJECT_REASON m_RejectReason;
+    volatile int m_RejectReason;
     bool m_bOpened;                              // If the UDT entity has been opened
     int m_iBrokenCounter;                        // a counter (number of GC checks) to let the GC tag this socket as disconnected
 
@@ -1314,6 +1315,7 @@ private: // Generation and processing of packets
     int processData(CUnit* unit);
     void processClose();
     SRT_REJECT_REASON processConnectRequest(const sockaddr_any& addr, CPacket& packet);
+    size_t addHandshakeExtension(char *data, int cmd, size_t hs_size, std::string contents);
     static void addLossRecord(std::vector<int32_t>& lossrecord, int32_t lo, int32_t hi);
     int32_t bake(const sockaddr_any& addr, int32_t previous_cookie = 0, int correction = 0);
     int32_t ackDataUpTo(int32_t seq);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1314,7 +1314,9 @@ private: // Generation and processing of packets
 
     int processData(CUnit* unit);
     void processClose();
-    SRT_REJECT_REASON processConnectRequest(const sockaddr_any& addr, CPacket& packet);
+
+    /// Returns: URQ code, possibly containing reject reason
+    int processConnectRequest(const sockaddr_any& addr, CPacket& packet);
     size_t addHandshakeExtension(char *data, int cmd, size_t hs_size, std::string contents);
     static void addLossRecord(std::vector<int32_t>& lossrecord, int32_t lo, int32_t hi);
     int32_t bake(const sockaddr_any& addr, int32_t previous_cookie = 0, int correction = 0);

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -147,9 +147,9 @@ std::string RequestTypeStr(UDTRequestType rq)
         if (id < SRT_REJ__SIZE)
             rt << srt_rejectreason_name[id];
         else if (id < SRT_REJC_USER)
-            rt << " SERVER:" << (id - SRT_REJC_SERVER);
+            rt << "SERVER:" << (id - SRT_REJC_SERVER);
         else
-            rt << " USER:" << (id - SRT_REJC_USER);
+            rt << "USER:" << (id - SRT_REJC_USER);
 
         return rt.str();
     }

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -141,9 +141,17 @@ std::string RequestTypeStr(UDTRequestType rq)
 {
     if (rq >= URQ_FAILURE_TYPES)
     {
-        SRT_REJECT_REASON rej = RejectReasonForURQ(rq);
-        int id = rej;
-        return std::string("ERROR:") + srt_rejectreason_name[id];
+        std::ostringstream rt;
+        rt << "ERROR:";
+        int id = RejectReasonForURQ(rq);
+        if (id < SRT_REJ__SIZE)
+            rt << srt_rejectreason_name[id];
+        else if (id < SRT_REJC_USER)
+            rt << " SERVER:" << (id - SRT_REJC_SERVER);
+        else
+            rt << " USER:" << (id - SRT_REJC_USER);
+
+        return rt.str();
     }
 
     switch ( rq )

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -232,14 +232,21 @@ enum UDTRequestType
 
     // Errors reported by the peer, also used as useless error codes
     // in handshake processing functions.
-    URQ_FAILURE_TYPES = 1000
+    URQ_FAILURE_TYPES = 1000,
 
     // NOTE: codes above 1000 are reserved for failure codes for
     // rejection reason, as per `SRT_REJECT_REASON` enum. DO NOT
-    // add any new values here.
+    // add any new values here (below 1000).
+
+    // This is in order to return standard error codes for server
+    // data retrieval failures.
+    URQ_SERVER_FAILURE_TYPES = 2000,
+
+    // This is for a completely user-defined reject reasons.
+    URQ_USER_FAILURE_TYPES = 3000
 };
 
-inline UDTRequestType URQFailure(SRT_REJECT_REASON reason)
+inline UDTRequestType URQFailure(int reason)
 {
     return UDTRequestType(URQ_FAILURE_TYPES + int(reason));
 }

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -251,11 +251,11 @@ inline UDTRequestType URQFailure(int reason)
     return UDTRequestType(URQ_FAILURE_TYPES + int(reason));
 }
 
-inline SRT_REJECT_REASON RejectReasonForURQ(UDTRequestType req)
+inline int RejectReasonForURQ(UDTRequestType req)
 {
     if (req < URQ_FAILURE_TYPES || req - URQ_FAILURE_TYPES >= SRT_REJ__SIZE)
         return SRT_REJ_UNKNOWN;
-    return SRT_REJECT_REASON(req - URQ_FAILURE_TYPES);
+    return req - URQ_FAILURE_TYPES;
 }
 
 // DEPRECATED values. Use URQFailure(SRT_REJECT_REASON).

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -253,8 +253,12 @@ inline UDTRequestType URQFailure(int reason)
 
 inline int RejectReasonForURQ(UDTRequestType req)
 {
-    if (req < URQ_FAILURE_TYPES || req - URQ_FAILURE_TYPES >= SRT_REJ__SIZE)
+    if (req < URQ_FAILURE_TYPES)
         return SRT_REJ_UNKNOWN;
+
+    if (req < URQ_SERVER_FAILURE_TYPES && req - URQ_FAILURE_TYPES >= SRT_REJ__SIZE)
+        return SRT_REJ_UNKNOWN;
+
     return req - URQ_FAILURE_TYPES;
 }
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1306,7 +1306,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     // that another thread could have closed the socket at
     // the same time and inject a bug between checking the
     // pointer for NULL and using it.
-    SRT_REJECT_REASON listener_ret  = SRT_REJ_UNKNOWN;
+    int listener_ret  = SRT_REJ_UNKNOWN;
     bool              have_listener = false;
     {
         CGuard cg(m_LSLock);

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -561,6 +561,14 @@ enum SRT_REJECT_REASON
     SRT_REJ__SIZE,
 };
 
+// Reject category codes:
+
+#define SRT_REJC_VALUE(code) (1000 * (code/1000))
+#define SRT_REJC_SYSTEM 0     // Codes from above SRT_REJECT_REASON enum
+#define SRT_REJC_SERVER 1000  // Standard server error codes
+#define SRT_REJC_USER 2000    // User defined error codes
+
+
 // Logging API - specialization for SRT.
 
 // Define logging functional areas for log selection.
@@ -882,9 +890,10 @@ SRT_API void srt_setlogflags(int flags);
 
 SRT_API int srt_getsndbuffer(SRTSOCKET sock, size_t* blocks, size_t* bytes);
 
-SRT_API enum SRT_REJECT_REASON srt_getrejectreason(SRTSOCKET sock);
+SRT_API int srt_getrejectreason(SRTSOCKET sock);
+SRT_API int srt_setrejectreason(SRTSOCKET sock, int value);
 SRT_API extern const char* const srt_rejectreason_msg [];
-const char* srt_rejectreason_str(enum SRT_REJECT_REASON id);
+const char* srt_rejectreason_str(int id);
 
 #ifdef __cplusplus
 }

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -340,9 +340,14 @@ int srt_getsndbuffer(SRTSOCKET sock, size_t* blocks, size_t* bytes)
     return CUDT::getsndbuffer(sock, blocks, bytes);
 }
 
-enum SRT_REJECT_REASON srt_getrejectreason(SRTSOCKET sock)
+int srt_getrejectreason(SRTSOCKET sock)
 {
     return CUDT::rejectReason(sock);
+}
+
+int srt_setrejectreason(SRTSOCKET sock, int value)
+{
+    return CUDT::rejectReason(sock, value);
 }
 
 int srt_listen_callback(SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -931,7 +931,7 @@ void SrtCommon::ConnectClient(string host, int port)
     int stat = srt_connect(m_sock, psa, sizeof sa);
     if (stat == SRT_ERROR)
     {
-        SRT_REJECT_REASON reason = srt_getrejectreason(m_sock);
+        int reason = srt_getrejectreason(m_sock);
 #if PLEASE_LOG
         extern srt_logging::Logger applog;
         LOGP(applog.Error, "ERROR reported by srt_connect - closing socket @", m_sock);
@@ -967,7 +967,7 @@ void SrtCommon::ConnectClient(string host, int port)
         Error("ConfigurePost");
 }
 
-void SrtCommon::Error(string src, SRT_REJECT_REASON reason)
+void SrtCommon::Error(string src, int reason)
 {
     int errnov = 0;
     const int result = srt_getlasterror(&errnov);

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -936,8 +936,9 @@ void SrtCommon::ConnectClient(string host, int port)
         extern srt_logging::Logger applog;
         LOGP(applog.Error, "ERROR reported by srt_connect - closing socket @", m_sock);
 #endif
+        string info = UDT::getstreamid(m_sock);
         srt_close(m_sock);
-        Error("srt_connect", reason);
+        Error("srt_connect", info, reason);
     }
 
     // Wait for REAL connected state if nonblocking mode
@@ -967,7 +968,7 @@ void SrtCommon::ConnectClient(string host, int port)
         Error("ConfigurePost");
 }
 
-void SrtCommon::Error(string src, int reason)
+void SrtCommon::Error(string src, string streaminfo, int reason)
 {
     int errnov = 0;
     const int result = srt_getlasterror(&errnov);
@@ -982,11 +983,13 @@ void SrtCommon::Error(string src, int reason)
         if ( Verbose::on )
             Verb() << "FAILURE\n" << src << ": [" << result << "] "
                 << "Connection rejected: [" << int(reason) << "]: "
-                << srt_rejectreason_str(reason);
+                << srt_rejectreason_str(reason) << ": "
+                << streaminfo;
         else
             cerr << "\nERROR #" << result
                 << ": Connection rejected: [" << int(reason) << "]: "
-                << srt_rejectreason_str(reason);
+                << srt_rejectreason_str(reason) << ": "
+                << streaminfo;
     }
     else
     {

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -109,7 +109,7 @@ public:
 
 protected:
 
-    void Error(string src, int reason = SRT_REJ_UNKNOWN);
+    void Error(string src, string streaminfo = string(), int reason = SRT_REJ_UNKNOWN);
     void Init(string host, int port, string path, map<string,string> par, SRT_EPOLL_OPT dir);
     int AddPoller(SRTSOCKET socket, int modes);
     virtual int ConfigurePost(SRTSOCKET sock);

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -109,7 +109,7 @@ public:
 
 protected:
 
-    void Error(string src, SRT_REJECT_REASON reason = SRT_REJ_UNKNOWN);
+    void Error(string src, int reason = SRT_REJ_UNKNOWN);
     void Init(string host, int port, string path, map<string,string> par, SRT_EPOLL_OPT dir);
     int AddPoller(SRTSOCKET socket, int modes);
     virtual int ConfigurePost(SRTSOCKET sock);


### PR DESCRIPTION
1. The reject reason is no longer a closed enum. The value can be in 3 categories:
 - below 1000 - system codes (SRT internal)
 - above 1000 - server errors (same as HTTP server errors, but maintained by the doc standard)
 - above 2000 - user errors (completely user defined codes for free use of the application)

These are represented by constants with `SRT_REJC_` prefix.

2. The STREAMID extension field together with associated `SRTO_STREAMID` option is reused for the purpose of returning the error message.

USAGE:

The listener callback handler is allowed to:

1. Call the `srt_setrejectreason()` function. Note that system codes are NOT allowed, although you can use codes like `SRT_REJC_SERVER + 404`, for example. This will set the code that will be sent back and will be visible on the connector socket when retrieved through `srt_getrejectreason()`.

2. Set the streamid string either through `SRTO_STREAMID` option or `UDT::setstreamid` extension function on the connecting socket passed to the handler. This very message will be then able to be extracted from the connector socket through the same option (or `UDT::getstreamid`).

Note that on the caller side the user should:
1. Check that the error was `SRT_ECONNREJ`.
2. Extract the reject reason from `srt_getrejectreason()`.
3. Check the category - can use `SRT_REJC_VALUE` on the result to be compared against other `SRT_REJC_*` constants. Errors from system and server category should be able to be easily interpreted, although for server error code compliance it's the application responsible.
4. Get the STREAMID value. If this is not empty, it should contain a string message that the server has passed to the caller.

The `srt-test-live` application contains the example hook that simply rejects every connection with customizable error code and message. The caller side should display it.