### PR TITLE
BALANCING GROUPS: prefax and utilities

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2817,6 +2817,22 @@ SRTSOCKET CUDT::getGroupOfSocket(SRTSOCKET socket)
     return s->m_IncludedGroup->id();
 }
 
+int CUDT::configureGroup(SRTSOCKET groupid, const char* str)
+{
+    if ( (groupid & SRTGROUP_MASK) == 0)
+    {
+        return APIError(MJ_NOTSUP, MN_INVAL, 0);
+    }
+
+    CUDTGroup* g = s_UDTUnited.locateGroup(groupid, s_UDTUnited.ERH_RETURN);
+    if (!g)
+    {
+        return APIError(MJ_NOTSUP, MN_INVAL, 0);
+    }
+
+    return g->configure(str);
+}
+
 int CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize)
 {
     if ( (groupid & SRTGROUP_MASK) == 0)

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1192,6 +1192,17 @@ steady_clock::time_point CRcvBuffer::debugGetDeliveryTime(int offset)
     return getPktTsbPdTime(u->m_Packet.getMsgTimeStamp());
 }
 
+int32_t CRcvBuffer::getTopMsgno()
+{
+    if (m_iStartPos == m_iLastAckPos)
+        return -1; // No message is waiting
+
+    if (!m_pUnit[m_iStartPos])
+        return -1; // pity
+
+    return m_pUnit[m_iStartPos]->m_Packet.getMsgSeq();
+}
+
 bool CRcvBuffer::getRcvReadyMsg(steady_clock::time_point& w_tsbpdtime, int32_t& w_curpktseq, int upto)
 {
     const bool havelimit = upto != -1;

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -177,7 +177,7 @@ void CSndBuffer::addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl)
 
     Block* s = m_pLastBlock;
 
-    if (w_msgno == 0) // DEFAULT-UNCHANGED msgno supplied
+    if (w_msgno == -1) // DEFAULT-UNCHANGED msgno supplied
     {
         HLOGC(dlog.Debug, log << "addBuffer: using internally managed msgno=" << m_iNextMsgNo);
         w_msgno = m_iNextMsgNo;
@@ -1192,7 +1192,7 @@ steady_clock::time_point CRcvBuffer::debugGetDeliveryTime(int offset)
     return getPktTsbPdTime(u->m_Packet.getMsgTimeStamp());
 }
 
-int32_t CRcvBuffer::getTopMsgno()
+int32_t CRcvBuffer::getTopMsgno() const
 {
     if (m_iStartPos == m_iLastAckPos)
         return -1; // No message is waiting

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -482,6 +482,8 @@ public:
 
 public:
 
+   int32_t getTopMsgno();
+
    // @return Wrap check value
    bool getInternalTimeBase(time_point& w_tb, duration& w_udrift);
 

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -482,7 +482,7 @@ public:
 
 public:
 
-   int32_t getTopMsgno();
+   int32_t getTopMsgno() const;
 
    // @return Wrap check value
    bool getInternalTimeBase(time_point& w_tb, duration& w_udrift);

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -741,6 +741,7 @@ SRT_API       int srt_include      (SRTSOCKET socket, SRTSOCKET group);
 SRT_API       int srt_exclude      (SRTSOCKET socket);
 SRT_API SRTSOCKET srt_groupof      (SRTSOCKET socket);
 SRT_API       int srt_group_data   (SRTSOCKET socketgroup, SRT_SOCKGROUPDATA* output, size_t* inoutlen);
+SRT_API       int srt_group_configure(SRTSOCKET socketgroup, const char* str);
 
 SRT_API       int srt_bind         (SRTSOCKET u, const struct sockaddr* name, int namelen);
 SRT_API       int srt_bind_acquire (SRTSOCKET u, UDPSOCKET sys_udp_sock);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -42,6 +42,10 @@ int srt_exclude(SRTSOCKET socket) { return CUDT::removeSocketFromGroup(socket); 
 SRTSOCKET srt_groupof(SRTSOCKET socket) { return CUDT::getGroupOfSocket(socket); }
 int srt_group_data(SRTSOCKET socketgroup, SRT_SOCKGROUPDATA* output, size_t* inoutlen)
 { return CUDT::getGroupData(socketgroup, output, inoutlen); }
+int srt_group_configure(SRTSOCKET socketgroup, const char* str)
+{
+    return CUDT::configureGroup(socketgroup, str);
+}
 // int srt_bind_multicast()
 
 // Binding and connection management


### PR DESCRIPTION
First portion of changes for balancing groups. Included:
 - `getFlightSpan` utility
 - new Group container (maintains the "last used link" pointer)
 - the "configure" function (for balancing groups it is used to set the balancing algorithm)
 - previous refax for Backup groups slightly changed to be also useful for Balancing