### PR TITLE
Bugfixes for balancing groups

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8898,7 +8898,7 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket& w_packet)
 
         // check congestion/flow window limit
         const int cwnd    = std::min(int(m_iFlowWindowSize), int(m_dCongestionWindow));
-        const int flightspan = getFlightSpan() + 1;
+        const int flightspan = getFlightSpan();
         if (cwnd >= flightspan)
         {
             // XXX Here it's needed to set kflg to msgno_bitset in the block stored in the

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -903,11 +903,11 @@ public: // internal API
         // Note that normally m_iSndLastAck should be PAST m_iSndCurrSeqNo,
         // however in a case when the sending stopped and all packets were
         // ACKed, the m_iSndLastAck is one sequence ahead of m_iSndCurrSeqNo.
-        // Therefore in order to get the real distance, we need to:
-        // - increment m_iSndCurrSeqNo by 1, so that the all-ack results with 0 diff
-        // - result is decreased by 1 so that in the above situation result is -1
-        //   ("one sequence ahead").
-        return CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
+        // Therefore we increase m_iSndCurrSeqNo by 1 forward and then
+        // get the distance towards the last ACK. This way this value may
+        // be only positive or 0.
+
+        return CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo));
     }
 
     int minSndSize(int len = 0) const

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -897,7 +897,7 @@ public: // internal API
     duration minNAKInterval() const { return m_tdMinNakInterval; }
     sockaddr_any peerAddr() const { return m_PeerAddr; }
 
-    uint32_t getFlightSpan()
+    int32_t getFlightSpan()
     {
         // This is a number of unacknowledged packets at this moment
         // Note that normally m_iSndLastAck should be PAST m_iSndCurrSeqNo,

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -897,7 +897,7 @@ public: // internal API
     duration minNAKInterval() const { return m_tdMinNakInterval; }
     sockaddr_any peerAddr() const { return m_PeerAddr; }
 
-    int32_t getFlightSpan()
+    int32_t getFlightSpan() const
     {
         // This is a number of unacknowledged packets at this moment
         // Note that normally m_iSndLastAck should be PAST m_iSndCurrSeqNo,

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -174,13 +174,14 @@ typedef Bits<26, 0> MSGNO_SEQ_OLD;
 // The message should be extracted as PMASK_MSGNO_SEQ, if REXMIT is supported, and PMASK_MSGNO_SEQ_OLD otherwise.
 
 const uint32_t PACKET_SND_NORMAL = 0, PACKET_SND_REXMIT = MSGNO_REXMIT::mask;
+const int MSGNO_SEQ_MAX = MSGNO_SEQ::mask;
 
 #else
 // Old bit breakdown - no rexmit flag
 typedef Bits<26, 0> MSGNO_SEQ;
 #endif
 
-typedef RollNumber<MSGNO_SEQ::size, 1> MsgNo;
+typedef RollNumber<MSGNO_SEQ::size-1, 1> MsgNo;
 
 
 // constexpr in C++11 !

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -183,7 +183,7 @@ extern const SRT_MSGCTRL srt_msgctrl_default = {
     PB_SUBSEQUENT,
     0,     // srctime: take "now" time
     -1,    // -1: no seq (0 is a valid seqno!)
-    -1,     // 0: no msg/control packet
+    -1,    // -1: unset (0 is control, numbers start from 1)
     NULL,  // grpdata not supplied
     0      // idem
 };

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -183,7 +183,7 @@ extern const SRT_MSGCTRL srt_msgctrl_default = {
     PB_SUBSEQUENT,
     0,     // srctime: take "now" time
     -1,    // -1: no seq (0 is a valid seqno!)
-    0,     // 0: no msg/control packet
+    -1,     // 0: no msg/control packet
     NULL,  // grpdata not supplied
     0      // idem
 };


### PR DESCRIPTION
1. Default ("trap") value for msgno is -1 (0 is reserved for PacketFilter control packet).

There's a new feature added that affects also single sending that the msgno can be enforced. But "do not enforce" value is checked as -1, so this should be the default value.

2. The definition of `MsgNo` based on `RollNumber` should use N-1 value as the furthest bit number up to which the occupied bits spread (N is the number of these bits).

The problem: `RollNumber` gets the N value so that it can use it with `Bits` template, which requires the left size argument the first bit of the used series. This represents the maximum value for the rolling number (after crossing which it should revert back to the minimum value). What should be the maximum value of the message number, please refer to the definition of `MSGNO_SEQ` in `packet.h`.

3. `getFlightSpan` should return `int32_t` even though it grants to not return a negative value because this value will be then compared against another `int32_t` value. Using an unsigned would be simply inconvenient.