### PR TITLE
Added constants for "trap" representations for msgno and seqno

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1149,7 +1149,7 @@ int CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* ta
 
     // For a single socket, just do bind, then connect
     bind(s, source_addr);
-    return connectIn(s, target_addr, -1);
+    return connectIn(s, target_addr, SRT_SEQNO_NONE);
 }
 
 int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
@@ -3788,7 +3788,7 @@ SRTSOCKET accept(SRTSOCKET u, struct sockaddr* addr, int* addrlen)
 
 int connect(SRTSOCKET u, const struct sockaddr* name, int namelen)
 {
-   return CUDT::connect(u, name, namelen, -1);
+   return CUDT::connect(u, name, namelen, SRT_SEQNO_NONE);
 }
 
 int close(SRTSOCKET u)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -414,11 +414,11 @@ public:
       // Parameters (of the 1st packet queue, ready to play or not):
       /// @param [out] w_tsbpdtime localtime-based (uSec) packet time stamp including buffering delay of 1st packet or 0 if none
       /// @param [out] w_passack   true if 1st ready packet is not yet acknowleged (allowed to be delivered to the app)
-      /// @param [out] w_skipseqno -1 or seq number of 1st unacknowledged pkt ready to play preceeded by missing packets.
+      /// @param [out] w_skipseqno SRT_SEQNO_NONE or seq number of 1st unacknowledged pkt ready to play preceeded by missing packets.
       /// @retval true 1st packet ready to play (tsbpdtime <= now). Not yet acknowledged if passack == true
       /// @retval false IF tsbpdtime = 0: rcv buffer empty; ELSE:
-      ///                   IF skipseqno != -1, packet ready to play preceeded by missing packets.;
-      ///                   IF skipseqno == -1, no missing packet but 1st not ready to play.
+      ///                   IF skipseqno != SRT_SEQNO_NONE, packet ready to play preceeded by missing packets.;
+      ///                   IF skipseqno == SRT_SEQNO_NONE, no missing packet but 1st not ready to play.
 
 
    bool getRcvFirstMsg(time_point& w_tsbpdtime, bool& w_passack, int32_t& w_skipseqno, int32_t& w_curpktseq);

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -848,21 +848,21 @@ class StatsLossRecords
     std::bitset<SIZE> array;
 
 public:
-    StatsLossRecords(): initseq(-1) {}
+    StatsLossRecords(): initseq(SRT_SEQNO_NONE) {}
 
     // To check if this structure still keeps record of that sequence.
     // This is to check if the information about this not being found
     // is still reliable.
     bool exists(int32_t seq)
     {
-        return initseq != -1 && CSeqNo::seqcmp(seq, initseq) >= 0;
+        return initseq != SRT_SEQNO_NONE && CSeqNo::seqcmp(seq, initseq) >= 0;
     }
 
     int32_t base() { return initseq; }
 
     void clear()
     {
-        initseq = -1;
+        initseq = SRT_SEQNO_NONE;
         array.reset();
     }
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -317,8 +317,8 @@ public:
             // that was disconnected other than immediately closing it.
             if (m_Group.empty())
             {
-                m_iLastSchedSeqNo = -1;
-                setInitialRxSequence(-1);
+                m_iLastSchedSeqNo = SRT_SEQNO_NONE;
+                setInitialRxSequence(SRT_SEQNO_NONE);
             }
             s = true;
         }
@@ -633,7 +633,7 @@ private:
     ReadPos* checkPacketAhead();
 
     // This is the sequence number of a packet that has been previously
-    // delivered. Initially it should be set to -1 so that the sequence read
+    // delivered. Initially it should be set to SRT_SEQNO_NONE so that the sequence read
     // from the first delivering socket will be taken as a good deal.
     volatile int32_t m_RcvBaseSeqNo;
 
@@ -677,7 +677,7 @@ public:
         // The first provided one will be taken as a good deal; even if
         // this is going to be past the ISN, at worst it will be caused
         // by TLPKTDROP.
-        m_RcvBaseSeqNo = -1;
+        m_RcvBaseSeqNo = SRT_SEQNO_NONE;
     }
 
     bool applyGroupTime(time_point& w_start_time, time_point& w_peer_start_time)
@@ -782,7 +782,7 @@ public: //API
     static int setsockopt(SRTSOCKET u, int level, SRT_SOCKOPT optname, const void* optval, int optlen);
     static int send(SRTSOCKET u, const char* buf, int len, int flags);
     static int recv(SRTSOCKET u, char* buf, int len, int flags);
-    static int sendmsg(SRTSOCKET u, const char* buf, int len, int ttl = -1, bool inorder = false, uint64_t srctime = 0);
+    static int sendmsg(SRTSOCKET u, const char* buf, int len, int ttl = SRT_MSGTTL_INF, bool inorder = false, uint64_t srctime = 0);
     static int recvmsg(SRTSOCKET u, char* buf, int len, uint64_t& srctime);
     static int sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& mctrl);
     static int recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_mctrl);
@@ -1074,7 +1074,7 @@ private:
 
     SRT_ATR_NODISCARD int send(const char* data, int len)
     {
-        return sendmsg(data, len, -1, false, 0);
+        return sendmsg(data, len, SRT_MSGTTL_INF, false, 0);
     }
 
     /// Request UDT to receive data to a memory block "data" with size of "len".

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -703,7 +703,7 @@ bool FECFilterBuiltin::receive(const CPacket& rpkt, loss_seqs_t& loss_seqs)
     // matrix dismissal FIRST before this packet is going to be handled.
     CheckLargeDrop(rpkt.getSeqNo());
 
-    if (rpkt.getMsgSeq() == 0)
+    if (rpkt.getMsgSeq() == SRT_MSGNO_CONTROL)
     {
         // Interpret the first byte of the contents.
         const char* payload = rpkt.data();

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -119,7 +119,7 @@ private:
    /// Update existing element with the new range (increase only)
    /// @param pos     position of the element being updated
    /// @param seqno1  first seqnuence number in range
-   /// @param seqno2  last sequence number in range (-1 if no range)
+   /// @param seqno2  last sequence number in range (SRT_SEQNO_NONE if no range)
    bool updateElement(int pos, int32_t seqno1, int32_t seqno2);
 
 private:
@@ -169,7 +169,7 @@ public:
       /// Read the first (smallest) seq. no. in the list.
       /// @return the sequence number or -1 if the list is empty.
 
-   int getFirstLostSeq() const;
+   int32_t getFirstLostSeq() const;
 
       /// Get a encoded loss array for NAK report.
       /// @param [out] array the result list of seq. no. to be included in NAK.

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -168,7 +168,7 @@ bool PacketFilter::packControlPacket(int32_t seq, int kflg, CPacket& w_packet)
     // - Crypto
     // - Message Number
     // will be set to 0/false
-    w_packet.m_iMsgNo = MSGNO_PACKET_BOUNDARY::wrap(PB_SOLO);
+    w_packet.m_iMsgNo = SRT_MSGNO_CONTROL | MSGNO_PACKET_BOUNDARY::wrap(PB_SOLO);
 
     // ... and then fix only the Crypto flags
     w_packet.setMsgCryptoFlags(EncryptionKeySpec(kflg));

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -786,6 +786,19 @@ typedef struct SRT_MsgCtrl_
    size_t grpdata_size;
 } SRT_MSGCTRL;
 
+// Trap representation for sequence and message numbers
+// This value means that this is "unset", and it's never
+// a result of an operation made on this number.
+static const int32_t SRT_SEQNO_NONE = -1;    // -1: no seq (0 is a valid seqno!)
+static const int32_t SRT_MSGNO_NONE = -1;    // -1: unset
+static const int32_t SRT_MSGNO_CONTROL = 0;  //  0: control (used by packet filter)
+
+static const int SRT_MSGTTL_INF = -1; // unlimited TTL specification for message TTL
+
+// XXX Might be useful also other special uses of -1:
+// - -1 as infinity for srt_epoll_wait
+// - -1 as a trap index value used in list.cpp
+
 // You are free to use either of these two methods to set SRT_MSGCTRL object
 // to default values: either call srt_msgctrl_init(&obj) or obj = srt_msgctrl_default.
 SRT_API void srt_msgctrl_init(SRT_MSGCTRL* mctrl);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -54,7 +54,7 @@ int srt_bind_acquire(SRTSOCKET u, UDPSOCKET udpsock) { return CUDT::bind(u, udps
 int srt_listen(SRTSOCKET u, int backlog) { return CUDT::listen(u, backlog); }
 SRTSOCKET srt_accept(SRTSOCKET u, struct sockaddr * addr, int * addrlen) { return CUDT::accept(u, addr, addrlen); }
 SRTSOCKET srt_accept_bond(const SRTSOCKET lsns[], int lsize, int64_t msTimeOut) { return CUDT::accept_bond(lsns, lsize, msTimeOut); }
-int srt_connect(SRTSOCKET u, const struct sockaddr * name, int namelen) { return CUDT::connect(u, name, namelen, -1); }
+int srt_connect(SRTSOCKET u, const struct sockaddr * name, int namelen) { return CUDT::connect(u, name, namelen, SRT_SEQNO_NONE); }
 int srt_connect_debug(SRTSOCKET u, const struct sockaddr * name, int namelen, int forced_isn) { return CUDT::connect(u, name, namelen, forced_isn); }
 int srt_connect_bind(SRTSOCKET u,
         const struct sockaddr* source,
@@ -178,12 +178,12 @@ int64_t srt_recvfile(SRTSOCKET u, const char* path, int64_t* offset, int64_t siz
 
 extern const SRT_MSGCTRL srt_msgctrl_default = {
     0,     // no flags set
-    -1,    // -1 = infinity
+    SRT_MSGTTL_INF,
     false, // not in order (matters for msg mode only)
     PB_SUBSEQUENT,
     0,     // srctime: take "now" time
-    -1,    // -1: no seq (0 is a valid seqno!)
-    -1,    // -1: unset (0 is control, numbers start from 1)
+    SRT_SEQNO_NONE,
+    SRT_MSGNO_NONE,
     NULL,  // grpdata not supplied
     0      // idem
 };

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -97,7 +97,7 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
             if (i + 1 == r_iHead)
             {
                r_iTail = r_iHead = 0;
-               r_aSeq[0].iACKSeqNo = -1;
+               r_aSeq[0].iACKSeqNo = SRT_SEQNO_NONE;
             }
             else
                r_iTail = (i + 1) % size;

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -83,7 +83,7 @@ public:
         m_iHead(0),
         m_iTail(0)
     {
-        m_aSeq[0].iACKSeqNo = -1;
+        m_aSeq[0].iACKSeqNo = SRT_SEQNO_NONE;
     }
 
    ~CACKWindow() {}
@@ -146,7 +146,7 @@ public:
         m_tsLastArrTime(srt::sync::steady_clock::now()),
         m_tsCurrArrTime(),
         m_tsProbeTime(),
-        m_Probe1Sequence(-1)
+        m_Probe1Sequence(SRT_SEQNO_NONE)
     {
         srt::sync::setupMutex(m_lockPktWindow, "PktWindow");
         srt::sync::setupMutex(m_lockProbeWindow, "ProbeWindow");
@@ -256,7 +256,7 @@ public:
            // Reset the starting probe into "undefined", when
            // a packet has come as retransmitted before the
            // measurement at arrival of 17th could be taken.
-           m_Probe1Sequence = -1;
+           m_Probe1Sequence = SRT_SEQNO_NONE;
            return;
        }
 
@@ -276,7 +276,7 @@ public:
        // expected packet pair, behave as if the 17th packet was lost.
 
        // no start point yet (or was reset) OR not very next packet
-       if (m_Probe1Sequence == -1 || CSeqNo::incseq(m_Probe1Sequence) != pkt.m_iSeqNo)
+       if (m_Probe1Sequence == SRT_SEQNO_NONE || CSeqNo::incseq(m_Probe1Sequence) != pkt.m_iSeqNo)
            return;
 
        // Grab the current time before trying to acquire
@@ -291,7 +291,7 @@ public:
 
        // Reset the starting probe to prevent checking if the
        // measurement was already taken.
-       m_Probe1Sequence = -1;
+       m_Probe1Sequence = SRT_SEQNO_NONE;
 
        // record the probing packets interval
        // Adjust the time for what a complete packet would have take

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -222,6 +222,11 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
                 Error("With //group, the group 'type' must be specified.");
             }
 
+            if (m_group_type != "broadcast")
+            {
+                Error("With //group, only type=broadcast is currently supported");
+            }
+
             vector<string> nodes;
             Split(par["nodes"], ',', back_inserter(nodes));
 
@@ -1810,6 +1815,7 @@ RETRY_READING:
     Error("No data extracted");
     return output; // Just a marker - this above function throws an exception
 }
+
 #endif
 
 bytevector SrtSource::Read(size_t chunk)


### PR DESCRIPTION
Depends: #1184

This turns the values of:
* -1 - meaning a nonexistent seqno
* -1 - meaning a nonexistent msgno
* 0 - meaning a control msgno (used in packet filter)

This does not:
* Fix stupid msgno values used for special meaning (the behavior and actual values are preserved)
* Change into constant in cases when -1 is used as a special value for "no index" or "no offset"