### PR TITLE
srt_rendezvous

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -548,8 +548,21 @@ first on the automatically created socket for the connection.
 * `target`: Address to connect
 * `len`: size of the original structure of `source` and `target`
 
-The result is similar as with `srt_connect`. Errors may be those reported
-by `srt_bind` as well.
+- Returns:
+
+  * `SRT_ERROR` (-1) in case of error
+  * 0 in case when used for `u` socket
+  * Socket ID created for connection for `u` group
+
+- Errors:
+
+  * `SRT_EINVSOCK`: Socket passed as `u` designates no valid socket
+  * `SRT_EINVOP`: Socket already bound
+  * `SRT_ECONNSETUP`: Internal creation of a UDP socket failed
+  * `SRT_ESOCKFAIL`: Internal configuration of a UDP socket (`bind`, `setsockopt`) failed
+  * `SRT_ERDVUNBOUND`: Internal error (`srt_connect` should not report it after `srt_bind` was called)
+  * `SRT_ECONNSOCK`: Socket `u` is already connected
+  * `SRT_ECONNREJ`: Connection has been rejected
 
 IMPORTANT: It's not allowed to bind and connect the same socket to two
 different families (that is, both `source` and `target` must be `AF_INET` or
@@ -578,8 +591,25 @@ setting the `SRTO_RENDEZVOUS` option to true, and doing `srt_connect`.
 * `local_name`: specifies the local network interface and port to bind
 * `remote_name`: specifies the remote party's IP address and port
 
+- Returns:
+
+  * `SRT_ERROR` (-1) in case of error, otherwise 0
+
+- Errors:
+
+  * `SRT_EINVSOCK`: Socket passed as `u` designates no valid socket
+  * `SRT_EINVOP`: Socket already bound
+  * `SRT_ECONNSETUP`: Internal creation of a UDP socket failed
+  * `SRT_ESOCKFAIL`: Internal configuration of a UDP socket (`bind`, `setsockopt`) failed
+  * `SRT_ERDVUNBOUND`: Internal error (`srt_connect` should not report it after `srt_bind` was called)
+  * `SRT_ECONNSOCK`: Socket `u` is already connected
+  * `SRT_ECONNREJ`: Connection has been rejected
+
 **NOTE:** The port value shall be the same in `local_name` and `remote_name`.
 
+IMPORTANT: It's not allowed to perform a rendezvous connection to two
+different families (that is, both `local_name` and `remote_name` must be `AF_INET` or
+`AF_INET6`).
 
 Socket group management
 -----------------------

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -98,13 +98,13 @@ int srt_rendezvous(SRTSOCKET u, const struct sockaddr* local_name, int local_nam
     // Just as a safety precaution, check the structs.
     if ( (local_name->sa_family != AF_INET && local_name->sa_family != AF_INET6)
             || local_name->sa_family != remote_name->sa_family)
-        return SRT_EINVPARAM;
+        return CUDT::APIError(MJ_NOTSUP, MN_INVAL, 0);
 
     sockaddr_in* local_sin = (sockaddr_in*)local_name;
     sockaddr_in* remote_sin = (sockaddr_in*)remote_name;
 
     if (local_sin->sin_port != remote_sin->sin_port)
-        return SRT_EINVPARAM;
+        return CUDT::APIError(MJ_NOTSUP, MN_INVAL, 0);
 
     int st = srt_bind(u, local_name, local_namelen);
     if ( st != 0 )


### PR DESCRIPTION
Hi,

I notice that C API srt_rendezvous() returns value such as "5003". To be SRT API compliant, it should return "CUDT::APIError" instead. This PR fixed srt_rendezvous() returned value.
I also add missing information on srt_rendezvous() API.

Regards,