### PR TITLE
Removing rendezvous restriction for matching local and remote ports

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -605,8 +605,6 @@ setting the `SRTO_RENDEZVOUS` option to true, and doing `srt_connect`.
   * `SRT_ECONNSOCK`: Socket `u` is already connected
   * `SRT_ECONNREJ`: Connection has been rejected
 
-**NOTE:** The port value shall be the same in `local_name` and `remote_name`.
-
 IMPORTANT: It's not allowed to perform a rendezvous connection to two
 different families (that is, both `local_name` and `remote_name` must be `AF_INET` or
 `AF_INET6`).

--- a/docs/srt-live-transmit.md
+++ b/docs/srt-live-transmit.md
@@ -217,7 +217,7 @@ specified in the URI:
     -   The *host* part specifies the remote host to contact.
     -   The *port* part specifies **both local and remote port**. Note that the local port is this way both listening port and outgoing port.
     -   The **adapter** parameter can be used to specify the adapter.
-    -   The **port** parameter is not used.
+    -   The **port** parameter can be used to specify the local port to bind to.
 
 Some parameters handled for SRT medium are specific, all others are socket options. The following parameters are handled special way by *srt-live-transmit*:
 

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -103,11 +103,8 @@ int srt_rendezvous(SRTSOCKET u, const struct sockaddr* local_name, int local_nam
     sockaddr_in* local_sin = (sockaddr_in*)local_name;
     sockaddr_in* remote_sin = (sockaddr_in*)remote_name;
 
-    if (local_sin->sin_port != remote_sin->sin_port)
-        return CUDT::APIError(MJ_NOTSUP, MN_INVAL, 0);
-
-    int st = srt_bind(u, local_name, local_namelen);
-    if ( st != 0 )
+    const int st = srt_bind(u, local_name, local_namelen);
+    if (st != 0)
         return st;
 
     return srt_connect(u, remote_name, remote_namelen);


### PR DESCRIPTION
### Changes

- Small improvements of srt-live-transmit doc regarding rendezvous mode parameters.
- `srt_rendezvous(..)` in API.md has the following note: "The port value shall be the same in `local_name` and `remote_name`." Deleted.
- `srt_rendezvous(..)` function has a port check: remote should match to local. Removed.

### TODO

- [x] Check firewall traversal in case of different local and remote ports

### TODO in case of the restriction is valid

- Fix API-functions.md: return value INVAL is missing
- Check why srt-live-transmit allows to configure a different rendezvous port
`"srt://192.168.178.182:4200?adapter=192.168.1.237&port=4201"`

### See Also
* PR #1198 Fixed rendezvous handling