### PR TITLE
Minor fixes of typos (permon -> perfmon)

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1341,7 +1341,7 @@ would be 0x7FFFFFE0, the "distance" is 0x20.
 // perfmon with Byte counters for better bitrate estimation.
 int srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear);
 
-// permon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
+// perfmon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
 int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int instantaneous);
 ```
 

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1338,10 +1338,10 @@ would be 0x7FFFFFE0, the "distance" is 0x20.
 
 ### srt_bstats, srt_bistats
 ```
-// perfmon with Byte counters for better bitrate estimation.
+// Performance monitor with Byte counters for better bitrate estimation.
 int srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear);
 
-// perfmon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
+// Performance monitor with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
 int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int instantaneous);
 ```
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -853,10 +853,10 @@ SRT_API        int  srt_getlasterror(int* errno_loc);
 SRT_API const char* srt_strerror(int code, int errnoval);
 SRT_API       void  srt_clearlasterror(void);
 
-// performance track
-// perfmon with Byte counters for better bitrate estimation.
+// Performance tracking
+// Performance monitor with Byte counters for better bitrate estimation.
 SRT_API int srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear);
-// perfmon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
+// Performance monitor with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
 SRT_API int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int instantaneous);
 
 // Socket Status (for problem tracking)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -856,7 +856,7 @@ SRT_API       void  srt_clearlasterror(void);
 // performance track
 // perfmon with Byte counters for better bitrate estimation.
 SRT_API int srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear);
-// permon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
+// perfmon with Byte counters and instantaneous stats instead of moving averages for Snd/Rcvbuffer sizes.
 SRT_API int srt_bistats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear, int instantaneous);
 
 // Socket Status (for problem tracking)


### PR DESCRIPTION
Fixed typos: permon -> perfmon.