### PR TITLE
Added special container to collect loss stats. Added reorder stats

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -332,6 +332,7 @@ struct CBytePerfMon
    int      pktRecvACKTotal;            // total number of received ACK packets
    int      pktSentNAKTotal;            // total number of sent NAK packets
    int      pktRecvNAKTotal;            // total number of received NAK packets
+   int      pktRcvReorderTotal;         // total number of packets received in different order than sent
    int64_t  usSndDurationTotal;         // total time duration when UDT is sending data (idle time exclusive)
    //>new
    int      pktSndDropTotal;            // number of too-late-to-send dropped packets
@@ -369,6 +370,7 @@ struct CBytePerfMon
    int      pktSndDrop;                 // number of too-late-to-send dropped packets
    int      pktRcvDrop;                 // number of too-late-to play missing packets
    int      pktRcvUndecrypt;            // number of undecrypted packets
+   int      pktRcvReorder;              // number of packets received in different order than sent
    uint64_t byteSent;                   // number of sent data bytes, including retransmissions
    uint64_t byteRecv;                   // number of received bytes
 #ifdef SRT_ENABLE_LOSTBYTESCOUNT


### PR DESCRIPTION
Fixes #899.

The calculation of loss stats is given up to a separate container. The collection relies on the following rules:

1. The jump-over sequence is treated as MISSING packet - we don't know yet if it will turn out to be lost or reordered. It's then added to the container.

2. If a late packet (with sequence behind the current top) comes in, it's being "unlost" from the stats container so that it won't be notified as lost packet in the stats later.

3. When ACK is about to be sent, we state that all packets that didn't arrive so far, but have been fake-acked (dropped) can be treated as lost. Although it's possible in theory that a reordered packet has been received with a delay that exceeds the latency, this probability is negligible enough. Therefore at this moment all packets recorded as lost are treated as really lost, the loss statistics are updated, and records removed.

4. As precaution for a case that the stats loss container might swell out of control, there's a size limit also applied. If during adding it turns out that it would make the size exceed this limit, the oldest record is removed from the container. This record is not completely forgotten though (the size of the loss range will be still reported in the stats), just there's no longer a chance to qualify a packet in this range as reordered. The size is set as a half of the receiver buffer size, which should cover the biggest possible number of loss records.