### PR TITLE
srt_group_data(..) returns group size even without output array

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -708,26 +708,33 @@ int srt_group_data(SRTSOCKET socketgroup, SRT_SOCKGROUPDATA output[], size_t* in
 
 * `socketgroup` an existing socket group ID
 * `output` points to an output array
-* `inoutlen` points to a variable set to array's size
+* `inoutlen` points to a variable that stores the size of the `output` array,
+  and is set to the filled array's size
 
 This function obtains the current member state of the group specified in
 `socketgroup`. The `output` should point to an array large enough to hold
-all the elements, and `inoutlen` to a variable preset to the size of this array.
-The current number of members will be written back to `inoutlen`. If the size
-is enough for the current number of members, the `output` array will be
-filled with group data and the function will return 0. Otherwise the array
-will not be filled and `SRT_ERROR` will be returned.
+all the elements. The `inoutlen` should point to a variable initially set
+to the size of the `output` array.
+The current number of members will be written back to `inoutlen`.
+
+If the size of the `output` array is enough for the current number of members,
+the `output` array will be filled with group data and the function will return 0.
+Otherwise the array will not be filled and `SRT_ERROR` will be returned.
+
+This function can be used to get the group size by setting `output` to `NULL`,
+and providing `socketgroup` and `inoutlen`.
 
 - Returns:
 
-   * 0, if successful
+   * 0, on success
    * -1, on error
 
 - Errors:
 
    * `SRT_EINVPARAM` reported if `socketgroup` is not an existing group ID
-   * `SRT_SUCCESS` if the array was too small
 
+Note that is if the array was too small for all group members,
+no error code is set, but `-1` is returned.
 
 
 ### srt_connect_group

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -733,7 +733,7 @@ and providing `socketgroup` and `inoutlen`.
 
    * `SRT_EINVPARAM` reported if `socketgroup` is not an existing group ID
 
-Note that is if the array was too small for all group members,
+Note that if the array was too small for all group members,
 no error code is set, but `-1` is returned.
 
 

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -718,7 +718,8 @@ to the size of the `output` array.
 The current number of members will be written back to `inoutlen`.
 
 If the size of the `output` array is enough for the current number of members,
-the `output` array will be filled with group data and the function will return 0.
+the `output` array will be filled with group data and the function will return
+the number of elements filled.
 Otherwise the array will not be filled and `SRT_ERROR` will be returned.
 
 This function can be used to get the group size by setting `output` to `NULL`,
@@ -726,15 +727,21 @@ and providing `socketgroup` and `inoutlen`.
 
 - Returns:
 
-   * 0, on success
+   * the number of data elements filled, on success
    * -1, on error
 
 - Errors:
 
    * `SRT_EINVPARAM` reported if `socketgroup` is not an existing group ID
+   * `SRT_ELARGEMSG` reported if `inoutlen` if less than the size of the group
 
-Note that if the array was too small for all group members,
-no error code is set, but `-1` is returned.
+| in:output | in:inoutlen    | returns      | out:output | out:inoutlen | Error |
+|-----------|----------------|--------------|-----------|--------------|--------|
+| NULL      | NULL           | -1           | NULL      | NULL         | `SRT_EINVPARAM` |
+| NULL      | ptr            | 0            | NULL      | group.size() | ✖️ |
+| ptr       | NULL           | -1           | ✖️         | NULL         | `SRT_EINVPARAM` |
+| ptr       | ≥ group.size   | group.size() | group.data | group.size | ✖️ |
+| ptr       | < group.size   | -1           | ✖️         | group.size  | `SRT_ELARGEMSG` |
 
 
 ### srt_connect_group

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2856,17 +2856,18 @@ int CUDT::configureGroup(SRTSOCKET groupid, const char* str)
 
 int CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize)
 {
-    if ( (groupid & SRTGROUP_MASK) == 0)
+    if ((groupid & SRTGROUP_MASK) == 0 || !psize)
     {
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
     }
 
     CUDTGroup* g = s_UDTUnited.locateGroup(groupid, s_UDTUnited.ERH_RETURN);
-    if (!g || !pdata || !psize)
+    if (!g)
     {
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
     }
 
+    // To get only the size of the group pdata=NULL can be used
     return g->getGroupData(pdata, psize);
 }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -12501,7 +12501,7 @@ int CUDTGroup::getGroupData(SRT_SOCKGROUPDATA* pdata, size_t* psize)
         memcpy(&pdata[i].peeraddr, &d->peer, d->peer.size());
     }
 
-    return 0;
+    return m_Group.size();
 }
 
 void CUDTGroup::getGroupCount(size_t& w_size, bool& w_still_alive)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -12468,12 +12468,18 @@ int CUDTGroup::getGroupData(SRT_SOCKGROUPDATA* pdata, size_t* psize)
         return CUDT::APIError(MJ_NOTSUP, MN_INVAL);
 
     CGuard gl (m_GroupLock);
-
-    size_t size = *psize;
+    
+    SRT_ASSERT(psize != NULL);
+    const size_t size = *psize;
     // Rewrite correct size
     *psize = m_Group.size();
 
-    if (m_Group.size() > size || !pdata)
+    if (!pdata)
+    {
+        return 0;
+    }
+
+    if (m_Group.size() > size)
     {
         // Not enough space to retrieve the data.
         return CUDT::APIError(MJ_NOTSUP, MN_XSIZE);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -41,7 +41,9 @@ int srt_include(SRTSOCKET socket, SRTSOCKET group) { return CUDT::addSocketToGro
 int srt_exclude(SRTSOCKET socket) { return CUDT::removeSocketFromGroup(socket); }
 SRTSOCKET srt_groupof(SRTSOCKET socket) { return CUDT::getGroupOfSocket(socket); }
 int srt_group_data(SRTSOCKET socketgroup, SRT_SOCKGROUPDATA* output, size_t* inoutlen)
-{ return CUDT::getGroupData(socketgroup, output, inoutlen); }
+{
+    return CUDT::getGroupData(socketgroup, output, inoutlen);
+}
 int srt_group_configure(SRTSOCKET socketgroup, const char* str)
 {
     return CUDT::configureGroup(socketgroup, str);


### PR DESCRIPTION
`srt_group_data(..)` now returns group size (via argument `inoutlen`) even if no output array to fill is provided.
This behavior can be used to retrieve the size of the SRT socket group without providing any array to fill with group data.

| in:output | in:inoutlen    | returns      | out:output | out:inoutlen | Error |
|-----------|----------------|--------------|-----------|--------------|--------|
| NULL      | NULL           | -1           | NULL      | NULL         | `SRT_EINVPARAM` |
| NULL      | ptr            | 0            | NULL      | group.size() | ✖️ |
| ptr       | NULL           | -1           | ✖️         | NULL         | `SRT_EINVPARAM` |
| ptr       | ≥ group.size   | group.size() | group.data | group.size | ✖️ |
| ptr       | < group.size   | -1           | ✖️         | group.size  | `SRT_ELARGEMSG` |
