### PR TITLE
C++11 Threads Part 7: Added CThread Wrapper

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -240,7 +240,7 @@ int CUDTUnited::startup()
    CGuard gcinit(m_InitLock);
 
    if (m_iInstanceCount++ > 0)
-      return 0;
+      return 1;
 
    // Global initialization code
 #ifdef _WIN32
@@ -254,19 +254,15 @@ int CUDTUnited::startup()
 
    PacketFilter::globalInit();
 
-   //init CTimer::EventLock
-
    if (m_bGCStatus)
-      return true;
+      return 1;
 
    m_bClosing = false;
 
    setupMutex(m_GCStopLock, "GCStop");
    setupCond(m_GCStopCond, "GCStop");
-   {
-       ThreadName tn("SRT:GC");
-       pthread_create(&m_GCThread, NULL, garbageCollect, this);
-   }
+   if (!StartThread(m_GCThread, garbageCollect, this, "SRT:GC"))
+      return -1;
 
    m_bGCStatus = true;
 
@@ -291,7 +287,7 @@ int CUDTUnited::cleanup()
    // is set here above. Worst case secenario, this
    // pthread_join() call will block for 1 second.
    CSync::signal_relaxed(m_GCStopCond);
-   pthread_join(m_GCThread, NULL);
+   m_GCThread.join();
 
    // XXX There's some weird bug here causing this
    // to hangup on Windows. This might be either something

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -367,7 +367,7 @@ private:
    int m_iInstanceCount;				// number of startup() called by application
    bool m_bGCStatus;					// if the GC thread is working (true)
 
-   pthread_t m_GCThread;
+   srt::sync::CThread m_GCThread;
    static void* garbageCollect(void*);
 
    sockets_t m_ClosedSockets;   // temporarily store closed sockets

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1435,7 +1435,7 @@ private: // Receiving related data
     bool m_bTsbPd;                               // Peer sends TimeStamp-Based Packet Delivery Packets 
     bool m_bGroupTsbPd;                          // TSBPD should be used for GROUP RECEIVER instead.
 
-    pthread_t m_RcvTsbPdThread;                  // Rcv TsbPD Thread handle
+    srt::sync::CThread m_RcvTsbPdThread;         // Rcv TsbPD Thread handle
     srt::sync::Condition m_RcvTsbPdCond;         // TSBPD signals if reading is ready
     bool m_bTsbPdAckWakeup;                      // Signal TsbPd thread on Ack sent
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -401,12 +401,9 @@ public:
        m_bClosing = true;
    }
 
-   pthread_t threadId() { return m_WorkerThread; }
-
 private:
    static void* worker(void* param);
-   pthread_t m_WorkerThread;
-
+   srt::sync::CThread m_WorkerThread;
 
 private:
    CSndUList* m_pSndUList;              // List of UDT instances for data sending

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -527,3 +527,13 @@ void srt::sync::CTimer::tick()
     m_event.notify_one();
 }
 
+
+void srt::sync::CGlobEvent::triggerEvent()
+{
+    return g_Sync.notify_one();
+}
+
+bool srt::sync::CGlobEvent::waitForEvent()
+{
+    return g_Sync.lock_wait_for(milliseconds_from(10));
+}

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -13,7 +13,10 @@
 #include <stdexcept>
 #include "sync.h"
 #include "udt.h"
+#include "srt.h"
 #include "srt_compat.h"
+#include "logging.h"
+#include "common.h"
 
 #if defined(_WIN32)
 #define TIMING_USE_QPC
@@ -25,6 +28,12 @@
 #elif defined(ENABLE_MONOTONIC_CLOCK)
 #define TIMING_USE_CLOCK_GETTIME
 #endif
+
+namespace srt_logging
+{
+    extern Logger mglog;
+}
+using namespace srt_logging;
 
 namespace srt
 {
@@ -537,3 +546,117 @@ bool srt::sync::CGlobEvent::waitForEvent()
 {
     return g_Sync.lock_wait_for(milliseconds_from(10));
 }
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// CThread class
+//
+////////////////////////////////////////////////////////////////////////////////
+#ifndef USE_STDCXX_CHRONO
+
+srt::sync::CThread::CThread()
+{
+    m_thread = pthread_t();
+}
+
+srt::sync::CThread::CThread(void *(*start_routine) (void *), void *arg)
+{
+    create(start_routine, arg);
+}
+
+#if HAVE_FULL_CXX11
+srt::sync::CThread& srt::sync::CThread::operator=(CThread&& other)
+#else
+srt::sync::CThread& srt::sync::CThread::operator=(CThread& other)
+#endif
+{
+    if (joinable())
+    {
+        // If the thread has already terminated, then
+        // pthread_join() returns immediately.
+        // But we have to check it has terminated before replacing it.
+        LOGC(mglog.Error, log << "IPE: Assigning to a thread that is not terminated!");
+
+#ifndef DEBUG
+        // In case of production build the hanging thread should be terminated
+        // to avoid hang ups and align with C++11 implementation.
+        pthread_cancel(m_thread);
+#else
+        join();
+#endif
+    }
+
+    // Move thread handler from other
+    m_thread = other.m_thread;
+    other.m_thread = pthread_t();
+    return *this;
+}
+
+#if !HAVE_FULL_CXX11
+void srt::sync::CThread::create_thread(void *(*start_routine) (void *), void *arg)
+{
+    SRT_ASSERT(!joinable());
+    create(start_routine, arg);
+}
+#endif
+
+bool srt::sync::CThread::joinable() const
+{
+    return !pthread_equal(m_thread, pthread_t());
+}
+
+void srt::sync::CThread::join()
+{
+    void *retval;
+    const int ret SRT_ATR_UNUSED = pthread_join(m_thread, &retval);
+    if (ret != 0)
+    {
+        LOGC(mglog.Error, log << "pthread_join failed with " << ret);
+    }
+#ifdef HEAVY_LOGGING
+    else
+    {
+        LOGC(mglog.Debug, log << "pthread_join SUCCEEDED");
+    }
+#endif
+    // After joining, joinable should be false
+    m_thread = pthread_t();
+    return;
+}
+
+void srt::sync::CThread::create(void *(*start_routine) (void *), void *arg)
+{
+    const int st = pthread_create(&m_thread, NULL, start_routine, arg);
+    if (st != 0)
+    {
+        LOGC(mglog.Error, log << "pthread_create failed with " << st);
+        throw CThreadException(MJ_SYSTEMRES, MN_THREAD, 0);
+    }
+}
+
+#ifdef USE_STDCXX_CHRONO
+template< class Function >
+bool srt::sync::StartThread(CThread& th, Function&& f, void* args, const char* name)
+#else
+bool srt::sync::StartThread(CThread& th, void* (*f) (void*), void* args, const char* name)
+#endif
+{
+    ThreadName tn(name);
+    try
+    {
+#if HAVE_FULL_CXX11 || defined(USE_STDCXX_CHRONO)
+        th = CThread(f, args);
+#else
+        // No move semantics in C++03, therefore using a dedicated function
+        th.create_thread(f, args);
+#endif
+    }
+    catch (const CThreadException& e)
+    {
+        HLOGC(mglog.Debug, log << name << ": failed to start thread. " << e.what());
+        return false;
+    }
+    return true;
+}
+
+#endif // !defined(USE_STDCXX_CHRONO)

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -603,17 +603,6 @@ inline std::string FormatDuration(const steady_clock::duration& dur)
     return FormatDuration<DUNIT_US>(dur);
 }
 
-}; // namespace sync
-}; // namespace srt
-
-
-extern srt::sync::CEvent g_Sync;
-
-namespace srt
-{
-namespace sync
-{
-
 ////////////////////////////////////////////////////////////////////////////////
 //
 // CGlobEvent class
@@ -625,17 +614,11 @@ class CGlobEvent
 public:
     /// Triggers the event and notifies waiting threads.
     /// Simply calls notify_one().
-    static void inline triggerEvent()
-    {
-        return g_Sync.notify_one();
-    }
+    static void triggerEvent();
 
     /// Waits for the event to be triggered with 10ms timeout.
     /// Simply calls wait_for().
-    static bool waitForEvent()
-    {
-        return g_Sync.lock_wait_for(milliseconds_from(10));
-    }
+    static bool waitForEvent();
 };
 
 }; // namespace sync

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -15,8 +15,15 @@
 //#define ENABLE_CXX17
 
 #include <cstdlib>
+#ifdef USE_STDCXX_CHRONO
+#include <chrono>
+#include <thread>
+#else
 #include <pthread.h>
+#endif
 #include "utilities.h"
+
+class CUDTException;    // defined in common.h
 
 namespace srt
 {
@@ -620,6 +627,76 @@ public:
     /// Simply calls wait_for().
     static bool waitForEvent();
 };
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// CThread class
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef USE_STDCXX_CHRONO
+typedef std::system_error CThreadException;
+using CThread = std::thread;
+#else // pthreads wrapper version
+typedef ::CUDTException CThreadException;
+
+class CThread
+{
+public:
+    CThread();
+    /// @throws std::system_error if the thread could not be started.
+    CThread(void *(*start_routine) (void *), void *arg);
+
+#if HAVE_FULL_CXX11
+    CThread& operator=(CThread &other) = delete;
+    CThread& operator=(CThread &&other);
+#else
+    CThread& operator=(CThread &other);
+    /// To be used only in StartThread function.
+    /// Creates a new stread and assigns to this.
+    /// @throw CThreadException
+    inline void create_thread(void *(*start_routine) (void *), void *arg);
+#endif
+
+public: // Observers
+    /// Checks if the CThread object identifies an active thread of execution.
+    /// A default constructed thread is not joinable.
+    /// A thread that has finished executing code, but has not yet been joined
+    /// is still considered an active thread of execution and is therefore joinable.
+    bool joinable() const;
+
+public:
+    /// Blocks the current thread until the thread identified by *this finishes its execution.
+    /// If that thread has already terminated, then join() returns immediately.
+    ///
+    /// @throws std::system_error if an error occurs
+    void join();
+
+public: // Internal
+    /// Calls pthread_create, throws exception on failure.
+    /// @throw CThreadException
+    void create(void *(*start_routine) (void *), void *arg);
+
+private:
+    pthread_t m_thread;
+};
+#endif
+
+/// StartThread function should be used to do CThread assignments:
+/// @code
+/// CThread a();
+/// a = CThread(func, args);
+/// @endcode
+///
+/// @returns true if thread was started successfully,
+///          false on failure
+///
+#ifdef USE_STDCXX_CHRONO
+template< class Function >
+bool StartThread(CThread& th, Function&& f, void* args, const char* name);
+#else
+bool StartThread(CThread& th, void* (*f) (void*), void* args, const char* name);
+#endif
 
 }; // namespace sync
 }; // namespace srt


### PR DESCRIPTION
This PR introduces `srt::sync::CTimer` class to wrap threads operations:
1. CThread is directly mapped to C++11 threads if C++11 is enabled.
2. CThread wraps pthreads if C++11 is disabled.

See the roadmap #1103 