### PR TITLE
Fixed correct usage of next-exp in extension loop. Exposed functionality to extract extensions

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2303,7 +2303,7 @@ void SrtExtractHandshakeExtensions(const char* bufbegin, size_t buflength,
 
     for (;;) // ONE SHOT, but continuable loop
     {
-        int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
+        const int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
 
         if (cmd == SRT_CMD_NONE)
         {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2234,8 +2234,9 @@ bool CUDT::createSrtHandshake(
     return true;
 }
 
-static int FindExtensionBlock(uint32_t *begin, size_t total_length,
-        size_t& w_out_len, uint32_t*& w_next_block)
+template <class Integer>
+static inline int FindExtensionBlock(Integer* begin, size_t total_length,
+        size_t& w_out_len, Integer*& w_next_block)
 {
     // Check if there's anything to process
     if (total_length == 0)
@@ -2280,7 +2281,8 @@ static int FindExtensionBlock(uint32_t *begin, size_t total_length,
 
 // NOTE: the rule of order of arguments is broken here because this order
 // serves better the logics and readability.
-static inline bool NextExtensionBlock(uint32_t*& w_begin, uint32_t* next, size_t& w_length)
+template <class Integer>
+static inline bool NextExtensionBlock(Integer*& w_begin, Integer* next, size_t& w_length)
 {
     if (!next)
         return false;
@@ -2289,6 +2291,38 @@ static inline bool NextExtensionBlock(uint32_t*& w_begin, uint32_t* next, size_t
     w_begin  = next;
     return true;
 }
+
+void SrtExtractHandshakeExtensions(const char* bufbegin, size_t buflength,
+        vector<SrtHandshakeExtension>& w_output)
+{
+    const uint32_t *begin = reinterpret_cast<const uint32_t *>(bufbegin + CHandShake::m_iContentSize);
+    size_t    size  = buflength - CHandShake::m_iContentSize; // Due to previous cond check we grant it's >0
+    const uint32_t *next  = 0;
+    size_t    length   = size / sizeof(uint32_t);
+    size_t    blocklen = 0;
+
+    for (;;) // ONE SHOT, but continuable loop
+    {
+        int cmd = FindExtensionBlock(begin, length, (blocklen), (next));
+
+        if (cmd == SRT_CMD_NONE)
+        {
+            // End of blocks
+            break;
+        }
+
+        w_output.push_back(SrtHandshakeExtension(cmd));
+
+        SrtHandshakeExtension& ext = w_output.back();
+
+        std::copy(begin+1, begin+blocklen, back_inserter(ext.contents));
+
+        // Any other kind of message extracted. Search on.
+        if (!NextExtensionBlock((begin), next, (length)))
+            break;
+    }
+}
+
 
 bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
 {
@@ -11006,9 +11040,7 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs
             }
 
             // Any other kind of message extracted. Search on.
-            length -= (next - begin);
-            begin = next;
-            if (!begin)
+            if (!NextExtensionBlock((begin), next, (length)))
                 break;
         }
     }

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -46,6 +46,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INC__HANDSHAKE_H
 #define INC__HANDSHAKE_H
 
+#include <vector>
+
 #include "crypto.h"
 #include "utilities.h"
 
@@ -113,26 +115,19 @@ typedef Bits<15, 0> SRT_HS_LATENCY_SND;
 typedef Bits<15, 0> SRT_HS_LATENCY_LEG;
 
 
-// XXX These structures are currently unused. The code can be changed
-// so that these are used instead of manual tailoring of the messages.
 struct SrtHandshakeExtension
 {
-protected:
+    int16_t type;
+    std::vector<uint32_t> contents;
 
-   uint32_t m_SrtCommand; // Used only in extension
-
-public:
-   SrtHandshakeExtension(int cmd)
-   {
-       m_SrtCommand = cmd;
-   }
-
-   void setCommand(int cmd)
-   {
-       m_SrtCommand = cmd;
-   }
-
+    SrtHandshakeExtension(int16_t cmd): type(cmd) {}
 };
+
+// Implemented in core.cpp, so far
+void SrtExtractHandshakeExtensions(const char* bufbegin, size_t size,
+        std::vector<SrtHandshakeExtension>& w_output);
+
+
 
 struct SrtHSRequest: public SrtHandshakeExtension
 {


### PR DESCRIPTION
The call to `NextExtensionBlock` should have been placed there in the beginning. In the form before the fix it theoretically does nothing dangerous, except that it potentially calculates a length between NULL and a valid pointer, which isn't fortunately used for anything, but technically is wrong.

Additionally these functions for block extraction are used only there, while the functionality for extracting extensions is potentially needed in further extensions, external programs, as well as callbacks.