### PR TITLE
Fixed bug: setting broken flag too early. Breaks too early data transmission

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1643,7 +1643,14 @@ int CUDTUnited::close(CUDTSocket* s)
    }
    else
    {
-       s->makeClosed();
+       // Removing from group NOW - groups are used only for live mode
+       // and it shouldn't matter if the transmission is broken in the middle of sending.
+       if (s->m_IncludedGroup)
+       {
+           HLOGC(mglog.Debug, log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_IncludedGroup->id() << " - REMOVING FROM GROUP");
+           s->removeFromGroup();
+       }
+       s->m_pUDT->close();
 
        // synchronize with garbage collection.
        HLOGC(mglog.Debug, log << "@" << u << "U::close done. GLOBAL CLOSE: " << s->m_pUDT->CONID() << ". Acquiring GLOBAL control lock");

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -124,9 +124,6 @@ SRT_SOCKSTATUS CUDTSocket::getStatus()
     return m_Status;
 }
 
-/// This makes the socket no longer capable of performing any transmission
-/// operation, but continues to be responsive in the connection in order
-/// to finish sending the data that were scheduled for sending so far.
 void CUDTSocket::makeShutdown()
 {
     if (m_IncludedGroup)

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -142,9 +142,16 @@ public:
 
    SRT_SOCKSTATUS getStatus();
 
-   // This function shall be called always wherever
-   // you'd like to call cudtsocket->m_pUDT->close().
+   /// This function shall be called always wherever
+   /// you'd like to call cudtsocket->m_pUDT->close(),
+   /// from within the GC thread only (that is, only when
+   /// the socket should be no longer visible in the
+   /// connection, including for sending remaining data).
    void makeClosed();
+
+   /// This makes the socket no longer capable of performing any transmission
+   /// operation, but continues to be responsive in the connection in order
+   /// to finish sending the data that were scheduled for sending so far.
    void makeShutdown();
    void removeFromGroup();
 

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -145,6 +145,7 @@ public:
    // This function shall be called always wherever
    // you'd like to call cudtsocket->m_pUDT->close().
    void makeClosed();
+   void makeShutdown();
    void removeFromGroup();
 
    // Instrumentally used by select() and also required for non-blocking


### PR DESCRIPTION
Fixes #1234 

The problem was that newly introduced function `makeClosed` was used in more places than it was necessary and therefore it was setting the `m_bBroken` flag too early. This caused inability to dispatch incoming packets and rejected any other transmission, which then led to closing the connection before the file can be completely transmitted.