### PR TITLE
[core] Thread-local error for C++11 and pthreads

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -812,7 +812,7 @@ int CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* h
     }
     catch (CUDTException& e)
     {
-        SetThreadLocalError(new CUDTException(e));
+        SetThreadLocalError(e);
         return SRT_ERROR;
     }
 
@@ -2668,12 +2668,12 @@ SRTSOCKET CUDT::socket()
    }
    catch (const CUDTException& e)
    {
-      SetThreadLocalError(new CUDTException(e));
+      SetThreadLocalError(e);
       return INVALID_SOCK;
    }
-   catch (bad_alloc&)
+   catch (const bad_alloc&)
    {
-      SetThreadLocalError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+      SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
    }
    catch (const std::exception& ee)
@@ -2681,19 +2681,19 @@ SRTSOCKET CUDT::socket()
       LOGC(mglog.Fatal, log << "socket: UNEXPECTED EXCEPTION: "
          << typeid(ee).name()
          << ": " << ee.what());
-      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return INVALID_SOCK;
    }
 }
 
 CUDT::APIError::APIError(const CUDTException& e)
 {
-    SetThreadLocalError(new CUDTException(e));
+    SetThreadLocalError(e);
 }
 
 CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
 {
-    SetThreadLocalError(new CUDTException(mj, mn, syserr));
+    SetThreadLocalError(CUDTException(mj, mn, syserr));
 }
 
 // This is an internal function; 'type' should be pre-checked if it has a correct value.
@@ -2934,19 +2934,19 @@ SRTSOCKET CUDT::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msT
    }
    catch (const CUDTException& e)
    {
-      SetThreadLocalError(new CUDTException(e));
+      SetThreadLocalError(e);
       return INVALID_SOCK;
    }
    catch (bad_alloc&)
    {
-      SetThreadLocalError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+      SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "accept_bond: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return INVALID_SOCK;
    }
 }
@@ -2959,19 +2959,19 @@ SRTSOCKET CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
    }
    catch (const CUDTException& e)
    {
-      SetThreadLocalError(new CUDTException(e));
+      SetThreadLocalError(e);
       return INVALID_SOCK;
    }
    catch (bad_alloc&)
    {
-      SetThreadLocalError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+      SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "accept: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return INVALID_SOCK;
    }
 }
@@ -3632,14 +3632,14 @@ CUDT* CUDT::getUDTHandle(SRTSOCKET u)
    }
    catch (const CUDTException& e)
    {
-      SetThreadLocalError(new CUDTException(e));
+      SetThreadLocalError(e);
       return NULL;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "getUDTHandle: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return NULL;
    }
 }
@@ -3666,16 +3666,16 @@ SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
       }
       return s_UDTUnited.getStatus(u);
    }
-   catch (const CUDTException &e)
+   catch (const CUDTException& e)
    {
-      SetThreadLocalError(new CUDTException(e));
+      SetThreadLocalError(e);
       return SRTS_NONEXIST;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "getsockstate: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return SRTS_NONEXIST;
    }
 }

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2392,9 +2392,11 @@ void CUDTUnited::setError(CUDTException* e)
     SetThreadLocalError(e);
 }
 
-CUDTException* CUDTUnited::getError()
+CUDTException& CUDTUnited::getError()
 {
-    return GetThreadLocalError();
+    if (!GetThreadLocalError())
+        SetThreadLocalError(new CUDTException);
+    return *GetThreadLocalError();
 }
 
 void CUDTUnited::updateMux(
@@ -3611,7 +3613,7 @@ int CUDT::epoll_release(const int eid)
 
 CUDTException& CUDT::getlasterror()
 {
-   return *s_UDTUnited.getError();
+   return s_UDTUnited.getError();
 }
 
 int CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -812,7 +812,7 @@ int CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* h
     }
     catch (CUDTException& e)
     {
-        setError(new CUDTException(e));
+        SetThreadLocalError(new CUDTException(e));
         return SRT_ERROR;
     }
 
@@ -2387,18 +2387,6 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
    }
 }
 
-void CUDTUnited::setError(CUDTException* e)
-{
-    SetThreadLocalError(e);
-}
-
-CUDTException& CUDTUnited::getError()
-{
-    if (!GetThreadLocalError())
-        SetThreadLocalError(new CUDTException);
-    return *GetThreadLocalError();
-}
-
 void CUDTUnited::updateMux(
    CUDTSocket* s, const sockaddr_any& addr, const UDPSOCKET* udpsock /*[[nullable]]*/)
 {
@@ -2680,12 +2668,12 @@ SRTSOCKET CUDT::socket()
    }
    catch (const CUDTException& e)
    {
-      s_UDTUnited.setError(new CUDTException(e));
+      SetThreadLocalError(new CUDTException(e));
       return INVALID_SOCK;
    }
    catch (bad_alloc&)
    {
-      s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+      SetThreadLocalError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
    }
    catch (const std::exception& ee)
@@ -2693,19 +2681,19 @@ SRTSOCKET CUDT::socket()
       LOGC(mglog.Fatal, log << "socket: UNEXPECTED EXCEPTION: "
          << typeid(ee).name()
          << ": " << ee.what());
-      s_UDTUnited.setError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return INVALID_SOCK;
    }
 }
 
 CUDT::APIError::APIError(const CUDTException& e)
 {
-    CUDT::s_UDTUnited.setError(new CUDTException(e));
+    SetThreadLocalError(new CUDTException(e));
 }
 
 CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
 {
-    CUDT::s_UDTUnited.setError(new CUDTException(mj, mn, syserr));
+    SetThreadLocalError(new CUDTException(mj, mn, syserr));
 }
 
 // This is an internal function; 'type' should be pre-checked if it has a correct value.
@@ -2946,19 +2934,19 @@ SRTSOCKET CUDT::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msT
    }
    catch (const CUDTException& e)
    {
-      s_UDTUnited.setError(new CUDTException(e));
+      SetThreadLocalError(new CUDTException(e));
       return INVALID_SOCK;
    }
    catch (bad_alloc&)
    {
-      s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+      SetThreadLocalError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "accept_bond: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      s_UDTUnited.setError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return INVALID_SOCK;
    }
 }
@@ -2971,19 +2959,19 @@ SRTSOCKET CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
    }
    catch (const CUDTException& e)
    {
-      s_UDTUnited.setError(new CUDTException(e));
+      SetThreadLocalError(new CUDTException(e));
       return INVALID_SOCK;
    }
    catch (bad_alloc&)
    {
-      s_UDTUnited.setError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+      SetThreadLocalError(new CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
       return INVALID_SOCK;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "accept: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      s_UDTUnited.setError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return INVALID_SOCK;
    }
 }
@@ -3613,7 +3601,7 @@ int CUDT::epoll_release(const int eid)
 
 CUDTException& CUDT::getlasterror()
 {
-   return s_UDTUnited.getError();
+   return GetThreadLocalError();
 }
 
 int CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
@@ -3644,14 +3632,14 @@ CUDT* CUDT::getUDTHandle(SRTSOCKET u)
    }
    catch (const CUDTException& e)
    {
-      s_UDTUnited.setError(new CUDTException(e));
+      SetThreadLocalError(new CUDTException(e));
       return NULL;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "getUDTHandle: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      s_UDTUnited.setError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return NULL;
    }
 }
@@ -3680,14 +3668,14 @@ SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
    }
    catch (const CUDTException &e)
    {
-      s_UDTUnited.setError(new CUDTException(e));
+      SetThreadLocalError(new CUDTException(e));
       return SRTS_NONEXIST;
    }
    catch (const std::exception& ee)
    {
       LOGC(mglog.Fatal, log << "getsockstate: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
-      s_UDTUnited.setError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      SetThreadLocalError(new CUDTException(MJ_UNKNOWN, MN_NONE, 0));
       return SRTS_NONEXIST;
    }
 }

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -245,15 +245,13 @@ public:
    int32_t epoll_set(const int eid, int32_t flags);
    int epoll_release(const int eid);
 
-      /// record the UDT exception.
-      /// @param [in] e pointer to a UDT exception instance.
-
+   /// record the UDT exception.
+   /// @param [in] e pointer to a UDT exception instance.
    void setError(CUDTException* e);
 
-      /// look up the most recent UDT exception.
-      /// @return pointer to a UDT exception instance.
-
-   CUDTException* getError();
+   /// look up the most recent UDT exception.
+   /// @return reference to a UDT exception instance.
+   CUDTException& getError();
 
    CUDTGroup& addGroup(SRTSOCKET id, SRT_GROUP_TYPE type)
    {

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -245,14 +245,6 @@ public:
    int32_t epoll_set(const int eid, int32_t flags);
    int epoll_release(const int eid);
 
-   /// record the UDT exception.
-   /// @param [in] e pointer to a UDT exception instance.
-   void setError(CUDTException* e);
-
-   /// look up the most recent UDT exception.
-   /// @return reference to a UDT exception instance.
-   CUDTException& getError();
-
    CUDTGroup& addGroup(SRTSOCKET id, SRT_GROUP_TYPE type)
    {
        srt::sync::CGuard cg (m_GlobControlLock);

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -347,10 +347,6 @@ private:
    std::map<int64_t, std::set<SRTSOCKET> > m_PeerRec;// record sockets from peers to avoid repeated connection request, int64_t = (socker_id << 30) + isn
 
 private:
-   pthread_key_t m_TLSError;                         // thread local error record (last error)
-   static void TLSDestroy(void* e) {if (NULL != e) delete (CUDTException*)e;}
-
-private:
    friend struct FLookupSocketWithEvent;
 
    CUDTSocket* locateSocket(SRTSOCKET u, ErrorHandling erh = ERH_RETURN);

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -442,7 +442,13 @@ void srt::sync::CEvent::wait(UniqueLock& lock)
     return m_cond.wait(lock);
 }
 
+namespace srt {
+namespace sync {
+
 srt::sync::CEvent g_Sync;
+
+} // namespace sync
+} // namespace srt
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -703,9 +709,15 @@ private:
     pthread_key_t m_TLSError;
 };
 
+namespace srt {
+namespace sync {
+
 // Threal local error will be used by CUDTUnited
 // that has a static scope
 static CThreadError s_thErr;
+
+} // namespace sync
+} // namespace srt
 
 void srt::sync::SetThreadLocalError(CUDTException* e)
 {

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -670,6 +670,8 @@ bool srt::sync::StartThread(CThread& th, void* (*f) (void*), void* args, const c
 // CThreadError class - thread local storage error wrapper
 //
 ////////////////////////////////////////////////////////////////////////////////
+namespace srt {
+namespace sync {
 
 class CThreadError
 {
@@ -709,24 +711,21 @@ private:
     pthread_key_t m_TLSError;
 };
 
-namespace srt {
-namespace sync {
-
 // Threal local error will be used by CUDTUnited
 // that has a static scope
 static CThreadError s_thErr;
 
-} // namespace sync
-} // namespace srt
-
-void srt::sync::SetThreadLocalError(CUDTException* e)
+void SetThreadLocalError(CUDTException* e)
 {
     s_thErr.set(e);
 }
 
-CUDTException* srt::sync::GetThreadLocalError()
+CUDTException* GetThreadLocalError()
 {
     return s_thErr.get();
 }
+
+} // namespace sync
+} // namespace srt
 
 #endif // !defined(USE_STDCXX_CHRONO)

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -715,9 +715,9 @@ private:
 // that has a static scope
 static CThreadError s_thErr;
 
-void SetThreadLocalError(CUDTException* e)
+void SetThreadLocalError(const CUDTException& e)
 {
-    s_thErr.set(e);
+    s_thErr.set(new CUDTException(e));
 }
 
 CUDTException& GetThreadLocalError()

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -700,7 +700,6 @@ public:
         if (!pthread_getspecific(m_TLSError))
         {
             pthread_setspecific(m_TLSError, new CUDTException);
-            return NULL;
         }
         return (CUDTException*)pthread_getspecific(m_TLSError);
     }

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -688,16 +688,20 @@ public:
     }
 
 public:
-    void set(CUDTException* e)
+    void set(const CUDTException& e)
     {
-        delete (CUDTException*)pthread_getspecific(m_TLSError);
-        pthread_setspecific(m_TLSError, e);
+        CUDTException* cur = get();
+        SRT_ASSERT(cur != NULL);
+        *cur = e;
     }
 
     CUDTException* get()
     {
-        if(!pthread_getspecific(m_TLSError))
+        if (!pthread_getspecific(m_TLSError))
+        {
+            pthread_setspecific(m_TLSError, new CUDTException);
             return NULL;
+        }
         return (CUDTException*)pthread_getspecific(m_TLSError);
     }
 
@@ -717,13 +721,11 @@ static CThreadError s_thErr;
 
 void SetThreadLocalError(const CUDTException& e)
 {
-    s_thErr.set(new CUDTException(e));
+    s_thErr.set(e);
 }
 
 CUDTException& GetThreadLocalError()
 {
-    if (s_thErr.get() == NULL)
-        s_thErr.set(new CUDTException);
     return *s_thErr.get();
 }
 

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -720,9 +720,11 @@ void SetThreadLocalError(CUDTException* e)
     s_thErr.set(e);
 }
 
-CUDTException* GetThreadLocalError()
+CUDTException& GetThreadLocalError()
 {
-    return s_thErr.get();
+    if (s_thErr.get() == NULL)
+        s_thErr.set(new CUDTException);
+    return *s_thErr.get();
 }
 
 } // namespace sync

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -699,15 +699,16 @@ public:
     {
         if (!pthread_getspecific(m_TLSError))
         {
-            pthread_setspecific(m_TLSError, new CUDTException);
+            CUDTException* ne = new CUDTException();
+            pthread_setspecific(m_TLSError, ne);
+            return ne;
         }
         return (CUDTException*)pthread_getspecific(m_TLSError);
     }
 
     static void TLSDestroy(void* e)
     {
-        if (NULL != e)
-            delete (CUDTException*)e;
+        delete (CUDTException*)e;
     }
 
 private:

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -706,7 +706,7 @@ bool StartThread(CThread& th, void* (*f) (void*), void* args, const char* name);
 
 /// Set thread local error
 /// @param e new CUDTException
-void SetThreadLocalError(CUDTException* e);
+void SetThreadLocalError(const CUDTException& e);
 
 /// Get thread local error
 /// @returns CUDTException pointer

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -712,7 +712,7 @@ void SetThreadLocalError(CUDTException* e);
 /// @returns CUDTException pointer
 CUDTException* GetThreadLocalError();
 
-}; // namespace sync
-}; // namespace srt
+} // namespace sync
+} // namespace srt
 
 #endif // __SRT_SYNC_H__

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -698,6 +698,20 @@ bool StartThread(CThread& th, Function&& f, void* args, const char* name);
 bool StartThread(CThread& th, void* (*f) (void*), void* args, const char* name);
 #endif
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// CThreadError class - thread local storage wrapper
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/// Set thread local error
+/// @param e new CUDTException
+void SetThreadLocalError(CUDTException* e);
+
+/// Get thread local error
+/// @returns CUDTException pointer
+CUDTException* GetThreadLocalError();
+
 }; // namespace sync
 }; // namespace srt
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -710,7 +710,7 @@ void SetThreadLocalError(CUDTException* e);
 
 /// Get thread local error
 /// @returns CUDTException pointer
-CUDTException* GetThreadLocalError();
+CUDTException& GetThreadLocalError();
 
 } // namespace sync
 } // namespace srt

--- a/srtcore/sync_cxx11.cpp
+++ b/srtcore/sync_cxx11.cpp
@@ -51,5 +51,45 @@ void srt::sync::CCondVar::notify_all()
     m_cv.notify_all();
 }
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// CThreadError class - thread local storage error wrapper
+//
+////////////////////////////////////////////////////////////////////////////////
+
+struct CThreadError
+{
+    ~CThreadError()
+    {
+        delete tls_object;
+    }
+
+    void set(CUDTException *e)
+    {
+        delete tls_object;
+        tls_object = e;
+    }
+
+    CUDTException* get()
+    {
+        return tls_object;
+    }
+
+    CUDTException* tls_object = nullptr;
+};
+
+// Threal local error will be used by CUDTUnited
+// that has a static scope
+static thread_local CThreadError s_thErr;
+
+void srt::sync::SetThreadLocalError(CUDTException* e)
+{
+    s_thErr.set(e);
+}
+
+CUDTException* srt::sync::GetThreadLocalError()
+{
+    return s_thErr.get();
+}
 
 #endif // USE_STDCXX_CHRONO

--- a/srtcore/sync_cxx11.cpp
+++ b/srtcore/sync_cxx11.cpp
@@ -57,41 +57,18 @@ void srt::sync::CCondVar::notify_all()
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-struct CThreadError
-{
-    ~CThreadError()
-    {
-        delete tls_object;
-    }
-
-    void set(CUDTException *e)
-    {
-        delete tls_object;
-        tls_object = e;
-    }
-
-    CUDTException* get()
-    {
-        return tls_object;
-    }
-
-    CUDTException* tls_object = nullptr;
-};
-
 // Threal local error will be used by CUDTUnited
-// that has a static scope
-static thread_local CThreadError s_thErr;
+// with a static scope, therefore static thread_local
+static thread_local CUDTException s_thErr;
 
 void srt::sync::SetThreadLocalError(const CUDTException& e)
 {
-    s_thErr.set(new CUDTException(e));
+    s_thErr = e;
 }
 
 CUDTException& srt::sync::GetThreadLocalError()
 {
-    if (!s_thErr.get())
-        s_thErr.set(new CUDTException);
-    return *s_thErr.get();
+    return s_thErr;
 }
 
 #endif // USE_STDCXX_CHRONO

--- a/srtcore/sync_cxx11.cpp
+++ b/srtcore/sync_cxx11.cpp
@@ -82,9 +82,9 @@ struct CThreadError
 // that has a static scope
 static thread_local CThreadError s_thErr;
 
-void srt::sync::SetThreadLocalError(CUDTException* e)
+void srt::sync::SetThreadLocalError(const CUDTException& e)
 {
-    s_thErr.set(e);
+    s_thErr.set(new CUDTException(e));
 }
 
 CUDTException& srt::sync::GetThreadLocalError()

--- a/srtcore/sync_cxx11.cpp
+++ b/srtcore/sync_cxx11.cpp
@@ -87,9 +87,11 @@ void srt::sync::SetThreadLocalError(CUDTException* e)
     s_thErr.set(e);
 }
 
-CUDTException* srt::sync::GetThreadLocalError()
+CUDTException& srt::sync::GetThreadLocalError()
 {
-    return s_thErr.get();
+    if (!s_thErr.get())
+        s_thErr.set(new CUDTException);
+    return *s_thErr.get();
 }
 
 #endif // USE_STDCXX_CHRONO


### PR DESCRIPTION
Added thread-local storage wrapper for C++11 and pthreads.
C++11 keyword `thread_local` can be used only at a static or extern scope, and can't apply to a regular class member. Therefore, `m_TLSError` was removed from `CUDTUnited` and places as a static object of `srt::sync` module.