### PR TITLE
Fixed invalid default caller mode for group connections

### DIFF
--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -262,6 +262,12 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
 
             par.erase("type");
             par.erase("nodes");
+
+            // For a group-connect specification, it's
+            // always the caller mode.
+            // XXX change it here if maybe rendezvous is also
+            // possible in future.
+            par["mode"] = "caller";
         }
     }
 


### PR DESCRIPTION
The fix for rendezvous handling destroyed the default caller mode for group caller. This fix forcefully sets the mode as "caller" just to prevent the mode detection to be run in this case, as with a specification for a group, for which the general syntax is `srt:////group?type=broadcast&nodes=node1:port,node2:port` (that is, with empty host and port), this detection won't work properly anyway, but OTOH this is anyway only a caller specification possible.