### PR TITLE
Fixed: copy whole size of the block for an extension

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2314,7 +2314,7 @@ void SrtExtractHandshakeExtensions(const char* bufbegin, size_t buflength,
 
         SrtHandshakeExtension& ext = w_output.back();
 
-        std::copy(begin+1, begin+blocklen, back_inserter(ext.contents));
+        std::copy(begin+1, begin+blocklen+1, back_inserter(ext.contents));
 
         // Any other kind of message extracted. Search on.
         if (!NextExtensionBlock((begin), next, (length)))


### PR DESCRIPTION
This function is unused, only exposed for external users that might want to extract extension information manually.

The size of  the whole extension block was set incorrectly, as the size is measured since the first word behind the TYPE/SIZE block, while the `+1` at the first argument was shifting already by 1 towards the beginning. So should have been the end shifted.