### PR TITLE
[core] Minor adjustments for sync timing compliance

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -161,7 +161,7 @@ void CSndBuffer::addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl)
     if (w_srctime == 0)
     {
         HLOGC(dlog.Debug, log << CONID() << "addBuffer: DEFAULT SRCTIME - overriding with current time.");
-        w_srctime = time.us_since_epoch();
+        w_srctime = count_microseconds(time.time_since_epoch());
     }
     int32_t inorder = w_mctrl.inorder ? MSGNO_PACKET_INORDER::mask : 0;
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -683,7 +683,7 @@ public:
     bool applyGroupTime(time_point& w_start_time, time_point& w_peer_start_time)
     {
         using srt_logging::mglog;
-        if (m_tsStartTime == steady_clock::zero())
+        if (srt::sync::is_zero(m_tsStartTime))
         {
             // The first socket, defines the group time for the whole group.
             m_tsStartTime = w_start_time;
@@ -692,7 +692,7 @@ public:
         }
 
         // Sanity check. This should never happen, fix the bug if found!
-        if (m_tsRcvPeerStartTime == steady_clock::zero())
+        if (srt::sync::is_zero(m_tsRcvPeerStartTime))
         {
             LOGC(mglog.Error, log << "IPE: only StartTime is set, RcvPeerStartTime still 0!");
             // Kinda fallback, but that's not too safe.
@@ -926,7 +926,7 @@ public: // internal API
         // So, this can be simply defined as: TS = (RTS - STS) % (MAX_TIMESTAMP+1)
         // XXX Would be nice to check if local_time > m_tsStartTime,
         // otherwise it may go unnoticed with clock skew.
-        return count_microseconds(from_time - m_stats.tsStartTime);
+        return srt::sync::count_microseconds(from_time - m_stats.tsStartTime);
     }
 
     void setPacketTS(CPacket& p, const time_point& local_time)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -683,7 +683,9 @@ public:
     bool applyGroupTime(time_point& w_start_time, time_point& w_peer_start_time)
     {
         using srt_logging::mglog;
-        if (srt::sync::is_zero(m_tsStartTime))
+        using srt::sync::is_zero;
+
+        if (is_zero(m_tsStartTime))
         {
             // The first socket, defines the group time for the whole group.
             m_tsStartTime = w_start_time;
@@ -692,7 +694,7 @@ public:
         }
 
         // Sanity check. This should never happen, fix the bug if found!
-        if (srt::sync::is_zero(m_tsRcvPeerStartTime))
+        if (is_zero(m_tsRcvPeerStartTime))
         {
             LOGC(mglog.Error, log << "IPE: only StartTime is set, RcvPeerStartTime still 0!");
             // Kinda fallback, but that's not too safe.

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -31,6 +31,15 @@ namespace sync
 {
 using namespace std;
 
+///////////////////////////////////////////////////////////////////////////////
+//
+// Duration class
+//
+///////////////////////////////////////////////////////////////////////////////
+
+/// Class template srt::sync::Duration represents a time interval.
+/// It consists of a count of ticks of _Clock.
+/// It is a wrapper of system timers in case of non-C++11 chrono build.
 template <class _Clock>
 class Duration
 {
@@ -72,6 +81,12 @@ private:
     int64_t m_duration;
 };
 
+///////////////////////////////////////////////////////////////////////////////
+//
+// TimePoint and steadt_clock classes
+//
+///////////////////////////////////////////////////////////////////////////////
+
 template <class _Clock>
 class TimePoint;
 
@@ -83,12 +98,12 @@ public:
 
 public:
     static time_point now();
-    static time_point zero();
 };
 
+/// Represents a point in time
 template <class _Clock>
 class TimePoint
-{ // represents a point in time
+{
 public:
     TimePoint()
         : m_timestamp(0)
@@ -146,24 +161,11 @@ public: //
 #endif
 
 public:
-    uint64_t         us_since_epoch() const;
     Duration<_Clock> time_since_epoch() const;
-
-public:
-    bool is_zero() const { return m_timestamp == 0; }
 
 private:
     uint64_t m_timestamp;
 };
-
-inline TimePoint<srt::sync::steady_clock> steady_clock::zero()
-{
-    return TimePoint<steady_clock>(0);
-}
-
-
-template <>
-uint64_t srt::sync::TimePoint<srt::sync::steady_clock>::us_since_epoch() const;
 
 template <>
 srt::sync::Duration<srt::sync::steady_clock> srt::sync::TimePoint<srt::sync::steady_clock>::time_since_epoch() const;
@@ -171,11 +173,6 @@ srt::sync::Duration<srt::sync::steady_clock> srt::sync::TimePoint<srt::sync::ste
 inline Duration<steady_clock> operator*(const int& lhs, const Duration<steady_clock>& rhs)
 {
     return rhs * lhs;
-}
-
-inline int64_t count_microseconds(const TimePoint<steady_clock> tp)
-{
-    return static_cast<int64_t>(tp.us_since_epoch());
 }
 
 int64_t count_microseconds(const steady_clock::duration& t);
@@ -186,7 +183,10 @@ Duration<steady_clock> microseconds_from(int64_t t_us);
 Duration<steady_clock> milliseconds_from(int64_t t_ms);
 Duration<steady_clock> seconds_from(int64_t t_s);
 
-inline bool is_zero(const TimePoint<steady_clock>& t) { return t.is_zero(); }
+inline bool is_zero(const TimePoint<steady_clock>& t)
+{
+    return t == TimePoint<steady_clock>();
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -215,7 +215,7 @@ public:
        m_tsCurrArrTime = srt::sync::steady_clock::now();
 
        // record the packet interval between the current and the last one
-       m_aPktWindow[m_iPktWindowPtr] = count_microseconds(m_tsCurrArrTime - m_tsLastArrTime);
+       m_aPktWindow[m_iPktWindowPtr] = srt::sync::count_microseconds(m_tsCurrArrTime - m_tsLastArrTime);
        m_aBytesWindow[m_iPktWindowPtr] = pktsz;
 
        // the window is logically circular
@@ -295,8 +295,8 @@ public:
 
        // record the probing packets interval
        // Adjust the time for what a complete packet would have take
-       int64_t timediff = count_microseconds(m_tsCurrArrTime - m_tsProbeTime);
-       int64_t timediff_times_pl_size = timediff * CPacket::SRT_MAX_PAYLOAD_SIZE;
+       const int64_t timediff = srt::sync::count_microseconds(m_tsCurrArrTime - m_tsProbeTime);
+       const int64_t timediff_times_pl_size = timediff * CPacket::SRT_MAX_PAYLOAD_SIZE;
 
        // Let's take it simpler than it is coded here:
        // (stating that a packet has never zero size)


### PR DESCRIPTION
During the development, some parts of the SRT sync lost their compatibility with the corresponding STD chrono API.
This PR brings compliance back.
It mainly changes checking for empty (zero) timepoint.

Changes extracted from #1266 that introduces C++11 STD chrono build option.