### PR TITLE
Demoted too heavy error logs into warnings

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -524,7 +524,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
    if (ls->m_pQueuedSockets->size() >= ls->m_uiBackLog)
    {
        w_error = SRT_REJ_BACKLOG;
-       LOGC(mglog.Error, log << "newConnection: listen backlog=" << ls->m_uiBackLog << " EXCEEDED");
+       LOGC(mglog.Note, log << "newConnection: listen backlog=" << ls->m_uiBackLog << " EXCEEDED");
        return -1;
    }
 
@@ -771,11 +771,11 @@ ERR_ROLLBACK:
 #if ENABLE_LOGGING
        static const char* why [] = {
            "UNKNOWN ERROR",
-           "CONNECTION REJECTED",
+           "INTERNAL REJECTION",
            "IPE when mapping a socket",
            "IPE when inserting a socket"
        };
-       LOGC(mglog.Error, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: " << why[error]);
+       LOGC(mglog.Note, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: " << why[error]);
 #endif
       SRTSOCKET id = ns->m_SocketID;
       ns->makeClosed();

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -775,7 +775,7 @@ ERR_ROLLBACK:
            "IPE when mapping a socket",
            "IPE when inserting a socket"
        };
-       LOGC(mglog.Note, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: " << why[error]);
+       LOGC(mglog.Warn, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: " << why[error]);
 #endif
       SRTSOCKET id = ns->m_SocketID;
       ns->makeClosed();

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -1287,7 +1287,7 @@ void FECFilterBuiltin::RcvRebuild(Group& g, int32_t seqno, Group::Type tp)
     uint16_t length_hw = ntohs(g.length_clip);
     if (length_hw > payloadSize())
     {
-        LOGC(mglog.Error, log << "FEC: DECLIPPED length '" << length_hw << "' exceeds payload size. NOT REBUILDING.");
+        LOGC(mglog.Warn, log << "FEC: DECLIPPED length '" << length_hw << "' exceeds payload size. NOT REBUILDING.");
         return;
     }
 
@@ -1438,7 +1438,7 @@ int FECFilterBuiltin::ExtendRows(int rowx)
 
     if (rowx > int(m_number_cols*3))
     {
-        LOGC(mglog.Error, log << "FEC/H: OFFSET=" << rowx << " exceeds maximum row container size, SHRINKING rows and cells");
+        LOGC(mglog.Warn, log << "FEC/H: OFFSET=" << rowx << " exceeds maximum row container size, SHRINKING rows and cells");
 
         rcv.rowq.erase(rcv.rowq.begin(), rcv.rowq.begin() + m_number_cols);
         rowx -= m_number_cols;
@@ -2154,7 +2154,7 @@ int FECFilterBuiltin::ExtendColumns(int colgx)
     {
         // This shouldn't happen because columns should be dismissed
         // once the last row of the first series is closed.
-        LOGC(mglog.Error, log << "FEC/V: OFFSET=" << colgx << " exceeds maximum col container size, SHRINKING container by " << sizeRow());
+        LOGC(mglog.Warn, log << "FEC/V: OFFSET=" << colgx << " exceeds maximum col container size, SHRINKING container by " << sizeRow());
 
         // Delete one series of columns.
         int32_t oldbase SRT_ATR_UNUSED = rcv.colq[0].base;

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -476,60 +476,6 @@ void CPacket::setMsgCryptoFlags(EncryptionKeySpec spec)
     m_nHeader[SRT_PH_MSGNO] = clr_msgno | EncryptionKeyBits(spec);
 }
 
-/*
-   Leaving old code for historical reasons. This is moved to CSRTCC.
-EncryptionStatus CPacket::encrypt(HaiCrypt_Handle hcrypto)
-{
-    if ( !hcrypto )
-    {
-        LOGC(mglog.Error, log << "IPE: NULL crypto passed to CPacket::encrypt!");
-        return ENCS_FAILED;
-    }
-
-   int rc = HaiCrypt_Tx_Data(hcrypto, (uint8_t *)m_nHeader.raw(), (uint8_t *)m_pcData, m_PacketVector[PV_DATA].iov_len);
-   if ( rc < 0 )
-   {
-       // -1: encryption failure
-       // 0: key not received yet
-       return ENCS_FAILED;
-   } else if (rc > 0) {
-       m_PacketVector[PV_DATA].iov_len = rc;
-   }
-   return ENCS_CLEAR;
-}
-
-EncryptionStatus CPacket::decrypt(HaiCrypt_Handle hcrypto)
-{
-   if (getMsgCryptoFlags() == EK_NOENC)
-   {
-       //HLOGC(mglog.Debug, log << "CPacket::decrypt: packet not encrypted");
-       return ENCS_CLEAR; // not encrypted, no need do decrypt, no flags to be modified
-   }
-
-   if (!hcrypto)
-   {
-        LOGC(mglog.Error, log << "IPE: NULL crypto passed to CPacket::decrypt!");
-        return ENCS_FAILED; // "invalid argument" (leave encryption flags untouched)
-   }
-
-   int rc = HaiCrypt_Rx_Data(hcrypto, (uint8_t *)m_nHeader.raw(), (uint8_t *)m_pcData, m_PacketVector[PV_DATA].iov_len);
-   if ( rc <= 0 )
-   {
-       // -1: decryption failure
-       // 0: key not received yet
-       return ENCS_FAILED;
-   }
-   // Otherwise: rc == decrypted text length.
-   m_PacketVector[PV_DATA].iov_len = rc; // In case clr txt size is different from cipher txt
-
-   // Decryption succeeded. Update flags.
-   m_nHeader[SRT_PH_MSGNO] &= ~MSGNO_ENCKEYSPEC::mask; // sets EK_NOENC to ENCKEYSPEC bits.
-
-   return ENCS_CLEAR;
-}
-
-*/
-
 uint32_t CPacket::getMsgTimeStamp() const
 {
    // SRT_DEBUG_TSBPD_WRAP may enable smaller timestamp for faster wraparoud handling tests


### PR DESCRIPTION
1. Demoting Error logs into Warn or Note in case when it potentially might be spread very often and harm the processing. Removed also SND-DROPPED log that is repeated then by Debug and may be spread lots of times during the transmission.

2. Minor cosmetic fixes:
   - using stable expression of "enforced encryption"
   - Removed commented-out encrypt/decrypt functions that have been once moved to `CCryptoControl` (detected during the search for Error logs).