### PR TITLE
Fixed not-read-ready case in srt-live-transmit

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -709,7 +709,7 @@ int main(int argc, char** argv)
                 // note that this implies live streams and does not
                 // work for cached/file sources
                 std::list<std::shared_ptr<bytevector>> dataqueue;
-                if (src.get() && (srtrfdslen || sysrfdslen))
+                if (src.get() && src->IsOpen() && (srtrfdslen || sysrfdslen))
                 {
                     while (dataqueue.size() < 10)
                     {


### PR DESCRIPTION
Fixes #817 

The problem was that the reading part of the loop didn't check if the source medium is ready to read from. For a case of both-listener it made that after handling the target listener the loop was stated as capable of running, without checking if the source medium is ready for reading - which wasn't the case when the source was also an SRT listener and not yet accepted a connection.