### PR TITLE
Added support for the new group API

### DIFF
--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -69,6 +69,7 @@ protected:
     map<string, string> m_options; // All other options, as provided in the URI
     vector<Connection> m_group_nodes;
     string m_group_type;
+    string m_group_config;
     vector<SRT_SOCKGROUPDATA> m_group_data;
 #ifdef SRT_OLD_APP_READER
     int32_t m_group_seqno = -1;


### PR DESCRIPTION
1. The application supports the syntax for group type as "TYPE/CONFIG". Whether any config is supported by the group, it depends on the group type.
2. Introduced a new app-only SRT attribute `groupconfig`, which resolves into setting the `m_group_config` field, applied onto the configuration.
3. A configuration extracted from "TYPE/CONFIG" syntax is applied on the newly created group in caller mode.
4. A configuration extracted from `groupconfig` attribute is applied on the newly accepted group on the listener side.