### PR TITLE
Added MinGW warning fixes

### DIFF
--- a/apps/verbose.hpp
+++ b/apps/verbose.hpp
@@ -72,7 +72,6 @@ public:
             std::cerr << arg;
         return *this;
     }
-
 };
 
 }

--- a/apps/verbose.hpp
+++ b/apps/verbose.hpp
@@ -59,7 +59,6 @@ public:
 
 class ErrLog: public Log
 {
-    bool noeol;
 public:
 
     template <class V>
@@ -73,6 +72,7 @@ public:
             std::cerr << arg;
         return *this;
     }
+
 };
 
 }

--- a/common/win_time.cpp
+++ b/common/win_time.cpp
@@ -27,7 +27,7 @@ void SRTCompat_timeradd(struct timeval *a, struct timeval *b, struct timeval *re
     }
 }
 
-int SRTCompat_gettimeofday(struct timeval* tp, struct timezone* tz)
+int SRTCompat_gettimeofday(struct timeval* tp, struct timezone*)
 {
     struct timeb tb;
     ftime(&tb);

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -93,12 +93,12 @@ void CChannel::createSocket(int family)
     m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
 
 #ifdef _WIN32
-    const int invalid = INVALID_SOCKET;
+    // use INVALID_SOCKET, as provided
 #else
-    const int invalid = -1;
+    static const int INVALID_SOCKET = -1;
 #endif
 
-    if (m_iSocket == invalid)
+    if (m_iSocket == INVALID_SOCKET)
         throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
 
     if ((m_iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -239,6 +239,9 @@ int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
       throw CUDTException();
 #else
 
+   // fake use 'events' to prevent warning. Remove when implemented.
+   (void)events;
+
 #ifdef _MSC_VER
 // Microsoft Visual Studio doesn't support the #warning directive - nonstandard anyway.
 // Use #pragma message with the same text.

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -241,6 +241,7 @@ int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
 
    // fake use 'events' to prevent warning. Remove when implemented.
    (void)events;
+   (void)s;
 
 #ifdef _MSC_VER
 // Microsoft Visual Studio doesn't support the #warning directive - nonstandard anyway.
@@ -418,6 +419,12 @@ int CEPoll::update_ssock(const int eid, const SYSSOCKET& s, const int* events)
    }
    if (kevent(p->second.m_iLocalID, ke, num, NULL, 0, NULL) < 0)
       throw CUDTException();
+#else
+
+   // fake use 'events' to prevent warning. Remove when implemented.
+   (void)events;
+   (void)s;
+
 #endif
 // Assuming add is used if not inserted
 //   p->second.m_sLocals.insert(s);

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -2,6 +2,7 @@
 #include <chrono>
 
 #ifdef _WIN32
+/*
 #define _WINSOCKAPI_ // to include Winsock2.h instead of Winsock.h from windows.h
 #include <winsock2.h>
 
@@ -11,6 +12,7 @@ extern "C" {
     WINSOCK_API_LINKAGE  PCSTR WSAAPI inet_ntop(INT  Family, PVOID pAddr, PSTR pStringBuf, size_t StringBufSize);
 }
 #endif
+*/
 
 #define INC__WIN_WINTIME // exclude gettimeofday from srt headers
 

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -2,20 +2,7 @@
 #include <chrono>
 
 #ifdef _WIN32
-/*
-#define _WINSOCKAPI_ // to include Winsock2.h instead of Winsock.h from windows.h
-#include <winsock2.h>
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-extern "C" {
-    WINSOCK_API_LINKAGE  INT WSAAPI inet_pton( INT Family, PCSTR pszAddrString, PVOID pAddrBuf);
-    WINSOCK_API_LINKAGE  PCSTR WSAAPI inet_ntop(INT  Family, PVOID pAddr, PSTR pStringBuf, size_t StringBufSize);
-}
-#endif
-*/
-
 #define INC__WIN_WINTIME // exclude gettimeofday from srt headers
-
 #else
 typedef int SOCKET;
 #define INVALID_SOCKET ((SOCKET)-1)

--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -13,17 +13,6 @@
 #include <gtest/gtest.h>
 
 #ifdef _WIN32
-#define _WINSOCKAPI_ // to include Winsock2.h instead of Winsock.h from windows.h
-#include <winsock2.h>
-
-//#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#if defined(__GNUC__) || defined(__MINGW32__)
-extern "C" {
-    WINSOCK_API_LINKAGE  INT WSAAPI inet_pton(INT Family, PCSTR pszAddrString, PVOID pAddrBuf);
-    WINSOCK_API_LINKAGE  PCSTR WSAAPI inet_ntop(INT  Family, PVOID pAddr, PSTR pStringBuf, size_t StringBufSize);
-}
-#endif
-
 #define INC__WIN_WINTIME // exclude gettimeofday from srt headers
 #endif
 

--- a/test/test_listen_callback.cpp
+++ b/test/test_listen_callback.cpp
@@ -4,6 +4,7 @@
 #include <map>
 
 #ifdef _WIN32
+/*
 #define _WINSOCKAPI_ // to include Winsock2.h instead of Winsock.h from windows.h
 #include <winsock2.h>
 
@@ -13,6 +14,7 @@ extern "C" {
     WINSOCK_API_LINKAGE  PCSTR WSAAPI inet_ntop(INT  Family, PVOID pAddr, PSTR pStringBuf, size_t StringBufSize);
 }
 #endif
+*/
 
 #define INC__WIN_WINTIME // exclude gettimeofday from srt headers
 #endif

--- a/test/test_listen_callback.cpp
+++ b/test/test_listen_callback.cpp
@@ -4,18 +4,6 @@
 #include <map>
 
 #ifdef _WIN32
-/*
-#define _WINSOCKAPI_ // to include Winsock2.h instead of Winsock.h from windows.h
-#include <winsock2.h>
-
-#if defined(__GNUC__) || defined(__MINGW32__)
-extern "C" {
-    WINSOCK_API_LINKAGE  INT WSAAPI inet_pton( INT Family, PCSTR pszAddrString, PVOID pAddrBuf);
-    WINSOCK_API_LINKAGE  PCSTR WSAAPI inet_ntop(INT  Family, PVOID pAddr, PSTR pStringBuf, size_t StringBufSize);
-}
-#endif
-*/
-
 #define INC__WIN_WINTIME // exclude gettimeofday from srt headers
 #endif
 


### PR DESCRIPTION
Fixes #1081

1. The `noeol` field in `ErrLog` class was actually a bug. This field exactly was generating the warning, while there weren't any announced functions in this class, so it was unused indeed. The field in use was the one derived from `Log` class, derived together with functions that use it.

2. I added the "fake usage" for the argument. This is better than adding `ATR_UNUSED` marker because maybe at some point we will provide some implementation using Windows API.

3. The warning for not implemented `add_ssock` on some platforms is intended and should appear. The only true way to eliminate it is to provide the implementation that is lacking.