### PR TITLE
[core] Fixed MAVG msRcvBuf and msSndBuf

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1611,9 +1611,9 @@ void CRcvBuffer::updRcvAvgDataSize(const steady_clock::time_point& now)
            *   +----------------------------------+-------+
            *  -1 sec                             LST      0(now)
            */
-          m_iCountMAvg      = (int)(((m_iCountMAvg      * (1000 - elapsed_ms)) + (count      * elapsed_ms)) / 1000);
-          m_iBytesCountMAvg = (int)(((m_iBytesCountMAvg * (1000 - elapsed_ms)) + (bytescount * elapsed_ms)) / 1000);
-          m_TimespanMAvg    = (int)(((m_TimespanMAvg    * (1000 - elapsed_ms)) + (instspan   * elapsed_ms)) / 1000);
+          m_iCountMAvg      = avg_iir_w<1000>(m_iCountMAvg,      count,      elapsed_ms);
+          m_iBytesCountMAvg = avg_iir_w<1000>(m_iBytesCountMAvg, bytescount, elapsed_ms);
+          m_TimespanMAvg    = avg_iir_w<1000>(m_TimespanMAvg,    instspan,   elapsed_ms);
       }
       m_tsLastSamplingTime = now;
 

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1602,9 +1602,9 @@ void CRcvBuffer::updRcvAvgDataSize(const steady_clock::time_point& now)
       int bytescount;
       int count = getRcvDataSize(bytescount, instspan);
 
-      m_iCountMAvg      = (int)(((count      * (1000 - elapsed_ms)) + (count      * elapsed_ms)) / 1000);
-      m_iBytesCountMAvg = (int)(((bytescount * (1000 - elapsed_ms)) + (bytescount * elapsed_ms)) / 1000);
-      m_TimespanMAvg    = (int)(((instspan   * (1000 - elapsed_ms)) + (instspan   * elapsed_ms)) / 1000);
+      m_iCountMAvg      = (int)(((m_iCountMAvg      * (1000 - elapsed_ms)) + (count      * elapsed_ms)) / 1000);
+      m_iBytesCountMAvg = (int)(((m_iBytesCountMAvg * (1000 - elapsed_ms)) + (bytescount * elapsed_ms)) / 1000);
+      m_TimespanMAvg    = (int)(((m_TimespanMAvg    * (1000 - elapsed_ms)) + (instspan   * elapsed_ms)) / 1000);
       m_tsLastSamplingTime = now;
 
       HLOGC(dlog.Debug, log << "getRcvDataSize: " << count << " " << bytescount << " " << instspan

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -985,6 +985,12 @@ inline ValueType avg_iir(ValueType old_value, ValueType new_value)
     return (old_value * (DEPRLEN - 1) + new_value) / DEPRLEN;
 }
 
+template <size_t DEPRLEN, typename ValueType>
+inline ValueType avg_iir_w(ValueType old_value, ValueType new_value, size_t new_val_weight)
+{
+    return (old_value * (DEPRLEN - new_val_weight) + new_value * new_val_weight) / DEPRLEN;
+}
+
 // Property accessor definitions
 //
 // "Property" is a special method that accesses given field.


### PR DESCRIPTION
There was a mistake in the calculation of the moving average values of msRcvBuf and msSndBuf.

Note. Initial values of `m_iCountMAvg`, `m_iBytesCountMAvg` and `m_TimespanMAvg` are zero.
It means, at the start, the update will be:
```
m_iCountMAvg      = (int)((0 + (count * elapsed_ms)) / 1000);
```

Probably better to initialize with `-1` and set the initial value to the instant value.
@mbakholdina What do you think?

Fixes #1272 