### PR TITLE
Extracting group type from the incoming handshake for listener callback

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -542,6 +542,21 @@ not be available to the `srt_accept` call.
 
 ---
 
+| OptName               | Since | Binding | Type              | Units  | Default  | Range  |
+| --------------------- | ----- | ------- | ----------------- | ------ | -------- | ------ |
+| `SRTO_GROUPTYPE`      |       | pre     | `SRT_GROUP_TYPE`  |        |          | enum   |
+
+- This option is read-only and it is intended to be called inside the listener
+callback handler (see `srt_listen_callback`). Possible values are defined in
+the `SRT_GROUP_TYPE` enumeration type.
+
+- This option returns the group type that is declared in the incoming connection.
+If the incoming connection is not going to make a group-member connection, then
+the value returned is `SRT_GTYPE_UNDEFINED`. If this option is read in any other
+context than inside the listener callback handler, the value is undefined.
+
+---
+
 | OptName               | Since | Binding | Type   | Units  | Default  | Range  |
 | --------------------- | ----- | ------- | ------ | ------ | -------- | ------ |
 | `SRTO_GROUPSTABTIMEO` |       | pre     | `int`  | ms     | 40       | 10+    |

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11145,7 +11145,6 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs
                     uint32_t gd = groupdata[GRPD_GROUPDATA];
                     gt = SRT_GROUP_TYPE(SrtHSRequest::HS_GROUP_TYPE::unwrap(gd));
                 }
-
             }
             else if (cmd == SRT_CMD_NONE)
             {

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1280,6 +1280,7 @@ private: // Identification
     int m_iOverheadBW;                           // Percent above input stream rate (applies if m_llMaxBW == 0)
     bool m_bRcvNakReport;                        // Enable Receiver Periodic NAK Reports
     int m_iIpV6Only;                             // IPV6_V6ONLY option (-1 if not set)
+    SRT_GROUP_TYPE m_HSGroupType;   // group type about-to-be-set in the handshake
 
 private:
     UniquePtr<CCryptoControl> m_pCryptoControl;                            // congestion control SRT class (small data extension)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -219,6 +219,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_PEERIDLETIMEO,       // Peer-idle timeout (max time of silence heard from peer) in [ms]
    SRTO_GROUPCONNECT,        // Set on a listener to allow group connection
    SRTO_GROUPSTABTIMEO,      // Stability timeout (backup groups) in [us]
+   SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake
    // (some space left)
    SRTO_PACKETFILTER = 60          // Add and configure a packet filter
 } SRT_SOCKOPT;

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -283,10 +283,31 @@ namespace srt_logging
 
 extern "C" int SrtCheckGroupHook(void* , SRTSOCKET acpsock, int , const sockaddr*, const char* )
 {
+    static string gtypes[] = {
+        "undefined", // SRT_GTYPE_UNDEFINED
+        "broadcast",
+        "backup",
+        "balancing",
+        "multicast"
+    };
+
     int type;
     int size = sizeof type;
     srt_getsockflag(acpsock, SRTO_GROUPCONNECT, &type, &size);
-    Verb() << "listener: @" << acpsock << " - accepting " << (type ? "GROUP" : "SINGLE") << " connection";
+    Verb() << "listener: @" << acpsock << " - accepting " << (type ? "GROUP" : "SINGLE") << VerbNoEOL;
+    if (type != 0)
+    {
+        SRT_GROUP_TYPE gt;
+        size = sizeof gt;
+        if (-1 != srt_getsockflag(acpsock, SRTO_GROUPTYPE, &gt, &size))
+        {
+            if (gt < Size(gtypes))
+                Verb() << " type=" << gtypes[gt] << VerbNoEOL;
+            else
+                Verb() << " type=" << int(gt) << VerbNoEOL;
+        }
+    }
+    Verb() << " connection";
 
     return 0;
 }


### PR DESCRIPTION
Changes:

1. Added field that will be assigned the group type extracted from the handshake extension.
2. Added a socket option: `SRT_GROUPTYPE`, read only.

Tested: the listener callback for `groupcheck` correctly extracts the group type through this option and can make decisions basing on it.