### PR TITLE
Added group support for stats probing

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -328,16 +328,19 @@ public:
         output << "},";
         output << "\"send\":{";
         output << "\"packets\":" << mon.pktSent << ",";
+        output << "\"packetsUnique\":" << mon.pktSentUnique << ",";
         output << "\"packetsLost\":" << mon.pktSndLoss << ",";
         output << "\"packetsDropped\":" << mon.pktSndDrop << ",";
         output << "\"packetsRetransmitted\":" << mon.pktRetrans << ",";
         output << "\"packetsFilterExtra\":" << mon.pktSndFilterExtra << ",";
         output << "\"bytes\":" << mon.byteSent << ",";
+        output << "\"bytesUnique\":" << mon.byteSentUnique << ",";
         output << "\"bytesDropped\":" << mon.byteSndDrop << ",";
         output << "\"mbitRate\":" << mon.mbpsSendRate;
         output << "},";
         output << "\"recv\": {";
         output << "\"packets\":" << mon.pktRecv << ",";
+        output << "\"packetsUnique\":" << mon.pktRecvUnique << ",";
         output << "\"packetsLost\":" << mon.pktRcvLoss << ",";
         output << "\"packetsDropped\":" << mon.pktRcvDrop << ",";
         output << "\"packetsRetransmitted\":" << mon.pktRcvRetrans << ",";
@@ -346,6 +349,7 @@ public:
         output << "\"packetsFilterSupply\":" << mon.pktRcvFilterSupply << ",";
         output << "\"packetsFilterLoss\":" << mon.pktRcvFilterLoss << ",";
         output << "\"bytes\":" << mon.byteRecv << ",";
+        output << "\"bytesUnique\":" << mon.byteRecvUnique << ",";
         output << "\"bytesLost\":" << mon.byteRcvLoss << ",";
         output << "\"bytesDropped\":" << mon.byteRcvDrop << ",";
         output << "\"mbitRate\":" << mon.mbpsRecvRate;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3635,6 +3635,9 @@ CUDTException& CUDT::getlasterror()
 
 int CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
 {
+   if (u & SRTGROUP_MASK)
+       return groupsockbstats(u, perf, clear);
+
    try
    {
       CUDT* udt = s_UDTUnited.locateSocket(u, s_UDTUnited.ERH_THROW)->m_pUDT;
@@ -3650,6 +3653,28 @@ int CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous
       LOGC(mglog.Fatal, log << "bstats: UNEXPECTED EXCEPTION: "
          << typeid(ee).name() << ": " << ee.what());
       return APIError(MJ_UNKNOWN, MN_NONE, 0);
+   }
+}
+
+int CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
+{
+   try
+   {
+      CUDTGroup* g = s_UDTUnited.locateGroup(u, s_UDTUnited.ERH_THROW);
+      g->bstatsSocket(perf, clear);
+      return 0;
+   }
+   catch (const CUDTException& e)
+   {
+      SetThreadLocalError(e);
+      return ERROR;
+   }
+   catch (const std::exception& ee)
+   {
+      LOGC(mglog.Fatal, log << "bstats: UNEXPECTED EXCEPTION: "
+         << typeid(ee).name() << ": " << ee.what());
+      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+      return ERROR;
    }
 }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -13251,7 +13251,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 // kangaroo, we can simply return it.
 
                 // Check how many were skipped and add them to the stats
-                int32_t jump = (CSeqNo(slowest_kangaroo->second.mctrl.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;
+                const int32_t jump = (CSeqNo(slowest_kangaroo->second.mctrl.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;
                 if (jump > 0)
                 {
                     m_stats.recvDrop.UpdateTimes(jump, avgRcvPacketSize());

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -12405,6 +12405,9 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
         throw CUDTException(major, minor, 0);
     }
 
+    // Now that at least one link has succeeded, update sending stats.
+    m_stats.sent.Update(len);
+
     // Pity that the blocking mode only determines as to whether this function should
     // block or not, but the epoll flags must be updated regardless of the mode.
 
@@ -12705,6 +12708,10 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 len = pos->packet.size();
                 pos->packet.clear();
 
+                // Update stats as per delivery
+                m_stats.recv.Update(len);
+                updateAvgPayloadSize(len);
+
                 // We predict to have only one packet ahead, others are pending to be reported by tsbpd.
                 // This will be "re-enabled" if the later check puts any new packet into ahead.
                 m_pGlobal->m_EPoll.update_events(id(), m_sPollID, SRT_EPOLL_IN, false);
@@ -13004,6 +13011,10 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                     stat = ps->core().receiveMessage((lostbuf), SRT_LIVE_MAX_PLSIZE, (mctrl), CUDTUnited::ERH_RETURN);
                     HLOGC(dlog.Debug, log << "group/recv: @" << id << " IGNORED data with %" << mctrl.pktseq << " #" << mctrl.msgno
                             << ": " << (stat <= 0 ? "(NOTHING)" : BufferStamp(lostbuf, stat)));
+                    if (stat > 0)
+                    {
+                        m_stats.recvDiscard.Update(stat);
+                    }
                 }
                 else
                 {
@@ -13099,6 +13110,10 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 HLOGC(dlog.Debug, log << "group/recv: @" << id << " %" << mctrl.pktseq << " #" << mctrl.msgno << " DELIVERING");
                 output_size = stat;
                 fillGroupData((w_mc), mctrl, (out_grpdata), out_grpdata_size);
+
+                // Update stats as per delivery
+                m_stats.recv.Update(output_size);
+                updateAvgPayloadSize(output_size);
 
                 // Record, but do not update yet, until all sockets are handled.
                 next_seq = mctrl.pktseq;
@@ -13235,6 +13250,13 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 // As we already have the packet delivered by the slowest
                 // kangaroo, we can simply return it.
 
+                // Check how many were skipped and add them to the stats
+                int32_t jump = (CSeqNo(slowest_kangaroo->second.mctrl.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;
+                if (jump > 0)
+                {
+                    m_stats.recvDrop.UpdateTimes(jump, avgRcvPacketSize());
+                }
+
                 m_RcvBaseSeqNo = slowest_kangaroo->second.mctrl.pktseq;
                 vector<char>& pkt = slowest_kangaroo->second.packet;
                 if (size_t(len) < pkt.size())
@@ -13249,6 +13271,10 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 fillGroupData((w_mc), slowest_kangaroo->second.mctrl, (out_grpdata), out_grpdata_size);
                 len = pkt.size();
                 pkt.clear();
+
+                // Update stats as per delivery
+                m_stats.recv.Update(len);
+                updateAvgPayloadSize(len);
 
                 // It is unlikely to have a packet ahead because usually having one packet jumped-ahead
                 // clears the possibility of having aheads at all.
@@ -13377,6 +13403,47 @@ void CUDTGroup::synchronizeDrift(CUDT* cu, steady_clock::duration udrift, steady
     }
 }
 
+void CUDTGroup::bstatsSocket(CBytePerfMon *perf, bool clear)
+{
+    if (!m_bConnected)
+        throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
+    if (m_bClosing)
+        throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
+
+    const steady_clock::time_point currtime = steady_clock::now();
+
+    memset(perf, 0, sizeof *perf);
+
+    CGuard gg (m_GroupLock);
+
+    perf->msTimeStamp         = count_milliseconds(currtime - m_tsStartTime);
+
+    perf->pktSentUnique       = m_stats.sent.local.pkts;
+    perf->pktRecvUnique       = m_stats.recv.local.pkts;
+    perf->pktRcvDrop          = m_stats.recvDrop.local.pkts;
+
+    perf->byteSentUnique      = m_stats.sent.local.fullBytes();
+    perf->byteRecvUnique      = m_stats.recv.local.fullBytes();
+    perf->byteRcvDrop         = m_stats.recvDrop.local.fullBytes();
+
+    perf->pktSentUniqueTotal  = m_stats.sent.total.pkts;
+    perf->pktRecvUniqueTotal  = m_stats.recv.total.pkts;
+    perf->pktRcvDropTotal     = m_stats.recvDrop.total.pkts;
+
+    perf->byteSentUniqueTotal = m_stats.sent.total.fullBytes();
+    perf->byteRecvUniqueTotal = m_stats.recv.total.fullBytes();
+    perf->byteRcvDropTotal    = m_stats.recvDrop.total.fullBytes();
+
+    double interval = count_microseconds(currtime - m_stats.tsLastSampleTime);
+
+    perf->mbpsSendRate = double(perf->byteSent) * 8.0 / interval;
+    perf->mbpsRecvRate = double(perf->byteRecv) * 8.0 / interval;
+
+    if (clear)
+    {
+        m_stats.reset();
+    }
+}
 
 // For sorting group members by priority
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -165,6 +165,96 @@ class CUDTSocket;
     };
 #endif
 
+struct PacketMetric
+{
+    uint32_t pkts;
+    uint64_t bytes;
+
+    void update(uint64_t size)
+    {
+        ++pkts;
+        bytes += size;
+    }
+
+    void update(size_t mult, uint64_t value)
+    {
+        pkts += mult;
+        bytes += mult * value;
+    }
+
+    uint64_t fullBytes()
+    {
+        static const int PKT_HDR_SIZE = CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE;
+        return bytes + pkts * PKT_HDR_SIZE;
+    }
+};
+
+template <class METRIC_TYPE>
+struct MetricOp;
+
+template <class METRIC_TYPE>
+struct MetricUsage
+{
+    METRIC_TYPE local;
+    METRIC_TYPE total;
+
+    void Clear()
+    {
+        MetricOp<METRIC_TYPE>::Clear(local);
+    }
+
+    void Init()
+    {
+        MetricOp<METRIC_TYPE>::Clear(total);
+        Clear();
+    }
+
+    void Update(uint64_t value)
+    {
+        local += value;
+        total += value;
+    }
+
+    void UpdateTimes(size_t mult, uint64_t value)
+    {
+        local += mult * value;
+        total += mult * value;
+    }
+};
+
+template <>
+inline void MetricUsage<PacketMetric>::Update(uint64_t value)
+{
+    local.update(value);
+    total.update(value);
+}
+
+template <>
+inline void MetricUsage<PacketMetric>::UpdateTimes(size_t mult, uint64_t value)
+{
+    local.update(mult, value);
+    total.update(mult, value);
+}
+
+template <class METRIC_TYPE>
+struct MetricOp
+{
+    static void Clear(METRIC_TYPE& m)
+    {
+        m = 0;
+    }
+};
+
+template <>
+struct MetricOp<PacketMetric>
+{
+    static void Clear(PacketMetric& p)
+    {
+        p.pkts = 0;
+        p.bytes = 0;
+    }
+};
+
 class CUDTGroup
 {
     friend class CUDTUnited;
@@ -600,6 +690,7 @@ private:
 
     std::set<int> m_sPollID;                     // set of epoll ID to trigger
     int m_iMaxPayloadSize;
+    int m_iAvgPayloadSize;
     bool m_bSynRecving;
     bool m_bSynSending;
     bool m_bTsbPd;
@@ -654,8 +745,63 @@ private:
     srt::sync::Mutex m_RcvDataLock;
     volatile int32_t m_iLastSchedSeqNo; // represetnts the value of CUDT::m_iSndNextSeqNo for each running socket
     volatile int32_t m_iLastSchedMsgNo;
+    // Statistics
+
+    struct Stats
+    {
+        // Stats state
+        time_point tsActivateTime;             // Time when this group sent or received the first data packet
+        time_point tsLastSampleTime;           // Time reset when clearing stats
+
+        MetricUsage<PacketMetric> sent;        // number of packets sent from the application
+        MetricUsage<PacketMetric> recv;        // number of packets delivered from the group to the application
+        MetricUsage<PacketMetric> recvDrop;    // number of packets dropped by the group receiver (not received from any member)
+        MetricUsage<PacketMetric> recvDiscard; // number of packets discarded as already delivered
+
+        void init()
+        {
+            tsActivateTime = srt::sync::steady_clock::time_point();
+            sent.Init();
+            recv.Init();
+            recvDrop.Init();
+            recvDiscard.Init();
+
+            reset();
+        }
+
+        void reset()
+        {
+            sent.Clear();
+            recv.Clear();
+            recvDrop.Clear();
+            recvDiscard.Clear();
+
+            tsLastSampleTime = srt::sync::steady_clock::now();
+        }
+    } m_stats;
+
+    void updateAvgPayloadSize(int size)
+    {
+        if (m_iAvgPayloadSize == -1)
+            m_iAvgPayloadSize = size;
+        else
+            m_iAvgPayloadSize = avg_iir<4>(m_iAvgPayloadSize, size);
+    }
+
+    int avgRcvPacketSize()
+    {
+        // In case when no packet has been received yet, but already notified
+        // a dropped packet, its size will be SRT_LIVE_DEF_PLSIZE. It will be
+        // the value most matching in the typical uses, although no matter what
+        // value would be used here, each one would be wrong from some points
+        // of view. This one is simply the best choice for typical uses of groups
+        // provided that they are to be ued only for live mode.
+        return m_iAvgPayloadSize == -1 ? SRT_LIVE_DEF_PLSIZE : m_iAvgPayloadSize;
+    }
 
 public:
+    void bstatsSocket(CBytePerfMon *perf, bool clear);
+
     // Required after the call on newGroup on the listener side.
     // On the listener side the group is lazily created just before
     // accepting a new socket and therefore always open.
@@ -809,6 +955,7 @@ public: //API
     static int epoll_release(const int eid);
     static CUDTException& getlasterror();
     static int bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear = true, bool instantaneous = false);
+    static int groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear = true);
     static SRT_SOCKSTATUS getsockstate(SRTSOCKET u);
     static bool setstreamid(SRTSOCKET u, const std::string& sid);
     static std::string getstreamid(SRTSOCKET u);

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1950,6 +1950,7 @@ bytevector SrtSource::Read(size_t chunk)
         UpdateGroupStatus(mctrl.grpdata, mctrl.grpdata_size);
         if (transmit_stats_writer && (need_stats_report || need_bw_report))
         {
+            PrintSrtStats(m_sock, need_stats_report, need_bw_report, need_stats_report);
             for (size_t i = 0; i < mctrl.grpdata_size; ++i)
                 PrintSrtStats(mctrl.grpdata[i].id, need_stats_report, need_bw_report, need_stats_report);
         }
@@ -2035,6 +2036,7 @@ void SrtTarget::Write(const bytevector& data)
         UpdateGroupStatus(mctrl.grpdata, mctrl.grpdata_size);
         if (transmit_stats_writer && (need_stats_report || need_bw_report))
         {
+            PrintSrtStats(m_sock, need_stats_report, need_bw_report, need_stats_report);
             for (size_t i = 0; i < mctrl.grpdata_size; ++i)
                 PrintSrtStats(mctrl.grpdata[i].id, need_stats_report, need_bw_report, need_stats_report);
         }


### PR DESCRIPTION
The group support for `srt_bstats`.

The statistics structure gets filled with the following fields:

* `msTimeStamp` - updated just like normally, the time distance towards start time
* `pktSentUnique` (also `byte*` and `*Total`) - packets sent to the group by the application
* `pktRecvUnique` (also `byte*` and `*Total`) - packets received from the group by the application
* `pktRecvDrop` (also `byte*` [estimated from average] and `*Total`) - packets skipped in delivery to the application (dropped by all connections that were supposed to transmit it)

All other fields are set to 0.

There's also added an infrastructure that could allow for later rework of the internal statistics structure, and some fields (*Discard) that could be added to the report later.