### PR TITLE
Added fixes to prevent crash when close-and-pack

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -133,7 +133,7 @@ void CUDTSocket::makeShutdown()
     }
 
     HLOGC(mglog.Debug, log << "@" << m_SocketID << " CLOSING AS SOCKET");
-    m_pUDT->close();
+    m_pUDT->closeInternal();
 }
 
 void CUDTSocket::makeClosed()

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1171,8 +1171,8 @@ private:
     SRT_ATR_NODISCARD EConnectStatus processRendezvous(const CPacket &response, const sockaddr_any& serv_addr, bool synchro, EReadStatus,
             CPacket& reqpkt);
     SRT_ATR_NODISCARD bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
-    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro);
-    void applyResponseSettings();
+    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro) ATR_NOEXCEPT;
+    void applyResponseSettings() ATR_NOEXCEPT;
     SRT_ATR_NODISCARD EConnectStatus processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT;
     SRT_ATR_NODISCARD bool processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const CPacket& response, const sockaddr_any& serv_addr);
 
@@ -1223,7 +1223,7 @@ private:
 
     /// Close the opened UDT entity.
 
-    bool close();
+    bool closeInternal();
 
     /// Request UDT to send out a data block "data" with size of "len".
     /// @param data [in] The address of the application data to be sent.


### PR DESCRIPTION
Fixes #1182 
Closes PR #1193 

The problem was with `packData` that the internals (including mainly `m_pCryptoControl`) could be modified by the `CUDT::close` (now `closeInternal`) while `packData` was running in a separate thread (receiver worker). The `CUDT::close` acquires `m_ConnectionLock` for that purpose, which is used normally only during the connection process and not used afterwards. Obviously the processing cannot do data pack-and-send and connection attempt for the same socket, so this lock is for free use in the `packData` function and this lock will not interfere with any other process. The only part that will interact simultaneously with this lock is `CUDT::close` (now `closeInternal`), which locks this for the time of modifying the internal data.

Actually `closeInternal` applies a lock on about 4 mutexes and `m_ConnectionLock` is one of them. This lock should still be enough that the `packData` function either finish its job before the `closeInternal` function starts the total destruction, or it will learn just after locking that the destruction already happened, and therefore it should exit immediately.

This problem doesn't apply to `processData` because it's done under the lock of `m_RcvBufferLock`, which is also being locked in `closeInternal`.
