### PR TITLE
Fixed: prevent calling swait on an empty epoll

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -13858,6 +13858,10 @@ void CUDTGroup::send_CheckPendingSockets(const vector<gli_t>& pending, vector<gl
         }
         else
         {
+            // Some sockets could have been closed in the meantime.
+            if (m_SndEpolld->watch_empty())
+                throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
+
             {
                 InvertedLock ug (m_GroupLock);
                 m_pGlobal->m_EPoll.swait(*m_SndEpolld, sready, 0, false /*report by retval*/); // Just check if anything happened
@@ -13991,6 +13995,10 @@ void CUDTGroup::sendBackup_CheckParallelLinks(const size_t nunstable, vector<gli
 
 RetryWaitBlocked:
         {
+            // Some sockets could have been closed in the meantime.
+            if (m_SndEpolld->watch_empty())
+                throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
+
             InvertedLock ug (m_GroupLock);
             HLOGC(dlog.Debug, log << "grp/sendBackup: swait call to get at least one link alive up to "
                     << m_iSndTimeOut << "us");


### PR DESCRIPTION
This might lead to potential problems; although the result in the form of exception that interrupts the sending or receiving function prematurely, is still a fair enough reaction on the fact that the group got empty after closing all its member sockets, at least the error details could be misleading.

This fix adds a check if the epoll container is empty before calling `swait` and report the connection closed error in response.

Impact: Significant because: this changes the type of error reported to the application, although it fixes a problem of reporting the wrong code.