### PR TITLE
Reworked the structures for config and status for groups

### DIFF
--- a/examples/test-c-client-bonding.c
+++ b/examples/test-c-client-bonding.c
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
 
     nmemb /= 2;
 
-    SRT_SOCKGROUPDATA* grpdata = calloc(nmemb, sizeof (SRT_SOCKGROUPDATA));
+    SRT_SOCKGROUPCONFIG* grpconfig = calloc(nmemb, sizeof (SRT_SOCKGROUPCONFIG));
 
     printf("srt group\n");
     ss = srt_create_group(gtype);
@@ -97,7 +97,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        grpdata[i] = srt_prepare_endpoint(NULL, (struct sockaddr*)&sa, sizeof sa);
+        grpconfig[i] = srt_prepare_endpoint(NULL, (struct sockaddr*)&sa, sizeof sa);
     }
 
     printf("srt connect (group)\n");
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
     // Note: this function unblocks at the moment when at least one connection
     // from the array is established (no matter which one); the others will
     // continue in background.
-    st = srt_connect_group(ss, grpdata, nmemb);
+    st = srt_connect_group(ss, grpconfig, nmemb);
     if (st == SRT_ERROR)
     {
         fprintf(stderr, "srt_connect: %s\n", srt_getlasterror_str());
@@ -122,6 +122,8 @@ int main(int argc, char** argv)
     // SRT_EPOLL_UPDATE signal.
     printf("sleeping 1s to make it probable all links are established\n");
     sleep(1);
+
+    SRT_SOCKGROUPDATA* grpdata = calloc(nmemb, sizeof (SRT_SOCKGROUPDATA));
 
     for (i = 0; i < 100; i++)
     {
@@ -151,8 +153,8 @@ int main(int argc, char** argv)
             for (i = 0; i < mc.grpdata_size; ++i)
             {
                 printf( "[%zd] result=%d state=%s ", i, mc.grpdata[i].result,
-                        mc.grpdata[i].status <= SRTS_CONNECTING ? "pending" :
-                        mc.grpdata[i].status == SRTS_CONNECTED ? "connected" : "broken");
+                        mc.grpdata[i].sockstate <= SRTS_CONNECTING ? "pending" :
+                        mc.grpdata[i].sockstate == SRTS_CONNECTED ? "connected" : "broken");
             }
             printf("\n");
         }
@@ -170,6 +172,7 @@ int main(int argc, char** argv)
     }
 
     free(grpdata);
+    free(grpconfig);
 
     printf("srt cleanup\n");
     srt_cleanup();

--- a/examples/test-c-server-bonding.c
+++ b/examples/test-c-server-bonding.c
@@ -138,8 +138,8 @@ int main(int argc, char** argv)
             for (z = 0; z < mc.grpdata_size; ++z)
             {
                 printf( "[%zd] result=%d state=%s ", z, mc.grpdata[z].result,
-                        mc.grpdata[z].status <= SRTS_CONNECTING ? "pending" :
-                        mc.grpdata[z].status == SRTS_CONNECTED ? "connected" : "broken");
+                        mc.grpdata[z].sockstate <= SRTS_CONNECTING ? "pending" :
+                        mc.grpdata[z].sockstate == SRTS_CONNECTED ? "connected" : "broken");
             }
             printf("\n");
         }

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -676,8 +676,8 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
 
       HLOGC(mglog.Debug, log << "newConnection(GROUP): Socket @" << ns->m_SocketID << " BELONGS TO $" << g->id()
             << " - will " << (should_submit_to_accept? "" : "NOT ") << "report in accept");
-      gi->sndstate = CUDTGroup::GST_IDLE;
-      gi->rcvstate = CUDTGroup::GST_IDLE;
+      gi->sndstate = SRT_GST_IDLE;
+      gi->rcvstate = SRT_GST_IDLE;
       gi->laststatus = SRTS_CONNECTED;
 
       if (!g->m_bConnected)
@@ -1136,7 +1136,7 @@ int CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* ta
         // The group manages the ISN by itself ALWAYS, that is,
         // it's generated anew for the very first socket, and then
         // derived by all sockets in the group.
-        SRT_SOCKGROUPDATA gd[1] = { srt_prepare_endpoint(srcname, tarname, namelen) };
+        SRT_SOCKGROUPCONFIG gd[1] = { srt_prepare_endpoint(srcname, tarname, namelen) };
 
         // When connecting to exactly one target, only this very target
         // can be returned as a socket, so rewritten back array can be ignored.
@@ -1169,7 +1169,7 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
         // The group manages the ISN by itself ALWAYS, that is,
         // it's generated anew for the very first socket, and then
         // derived by all sockets in the group.
-        SRT_SOCKGROUPDATA gd[1] = { srt_prepare_endpoint(NULL, name, namelen) };
+        SRT_SOCKGROUPCONFIG gd[1] = { srt_prepare_endpoint(NULL, name, namelen) };
         return groupConnect(g, gd, 1);
     }
 
@@ -1180,7 +1180,7 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
     return connectIn(s, target_addr, forced_isn);
 }
 
-int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPDATA* targets, int arraysize)
+int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int arraysize)
 {
     CUDTGroup& g = *pg;
     // The group must be managed to use srt_connect on it,
@@ -1232,12 +1232,9 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPDATA* targets, int arra
         sockaddr_any target_addr(targets[tii].peeraddr);
         sockaddr_any source_addr(targets[tii].srcaddr);
         SRTSOCKET& sid_rloc = targets[tii].id;
-        int &erc_rloc = targets[tii].result;
+        int& erc_rloc = targets[tii].errorcode;
+        erc_rloc = SRT_SUCCESS; // preinitialized
         HLOGC(mglog.Debug, log << "groupConnect: taking on " << SockaddrToString(targets[tii].peeraddr));
-
-        // Preset this to every state, when there is any notifying
-        // the change, this will be changed.
-        targets[tii].status = SRTS_CONNECTING;
 
         CUDTSocket* ns = 0;
 
@@ -1400,15 +1397,15 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPDATA* targets, int arra
 
             if (st >= SRTS_BROKEN)
             {
-                f->sndstate = CUDTGroup::GST_BROKEN;
-                f->rcvstate = CUDTGroup::GST_BROKEN;
+                f->sndstate = SRT_GST_BROKEN;
+                f->rcvstate = SRT_GST_BROKEN;
                 srt_epoll_remove_usock(g.m_SndEID, sid);
                 srt_epoll_remove_usock(g.m_RcvEID, sid);
             }
             else
             {
-                f->sndstate = CUDTGroup::GST_PENDING;
-                f->rcvstate = CUDTGroup::GST_PENDING;
+                f->sndstate = SRT_GST_PENDING;
+                f->rcvstate = SRT_GST_PENDING;
                 spawned[sid] = ns;
 
                 sid_rloc = sid;
@@ -1464,12 +1461,6 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPDATA* targets, int arra
             // Check status. If failed, remove from spawned
             // and try again.
             SRT_SOCKSTATUS st = s->getStatus();
-            // Find this socket in targets, as it's filled already, and mark the state.
-            for (int y = 0; y < arraysize; ++y)
-            {
-                if (targets[y].id == sid)
-                    targets[y].status = st;
-            }
             if (st >= SRTS_BROKEN)
             {
                 HLOGC(mglog.Debug, log << "groupConnect: Socket @" << sid << " got BROKEN during background connect, remove & TRY AGAIN");
@@ -1530,9 +1521,16 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPDATA* targets, int arra
         close(s);
     }
 
-    // XXX This is wrong code probably, get that better.
+    // There's no possibility to report a problem on every connection
+    // separately in case when every single connection has failed. What
+    // is more interesting, it's only a matter of luck that all connections
+    // fail at exactly the same time. OTOH if all are to fail, this
+    // function will still be polling sockets to determine the last man
+    // standing. Each one could, however, break by a different reason,
+    // for example, one by timeout, another by wrong passphrase. Check
+    // the `errorcode` field to determine the reaon for particular link.
     if (retval == -1)
-        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+        throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
     return retval;
 }
@@ -3029,7 +3027,7 @@ int CUDT::connect(
 }
 
 int CUDT::connectLinks(SRTSOCKET grp,
-        SRT_SOCKGROUPDATA targets [], int arraysize)
+        SRT_SOCKGROUPCONFIG targets [], int arraysize)
 {
     if (arraysize <= 0)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -226,7 +226,7 @@ public:
    int connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int tarlen);
    int connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
    int connectIn(CUDTSocket* s, const sockaddr_any& target, int32_t forced_isn);
-   int groupConnect(CUDTGroup* g, SRT_SOCKGROUPDATA targets [], int arraysize);
+   int groupConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG targets [], int arraysize);
    int close(const SRTSOCKET u);
    int close(CUDTSocket* s);
    void getpeername(const SRTSOCKET u, sockaddr* name, int* namelen);

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -619,6 +619,29 @@ std::string SockStatusStr(SRT_SOCKSTATUS s)
     return names.names[int(s)-1];
 }
 
+std::string MemberStatusStr(SRT_MEMBERSTATUS s)
+{
+    if (int(s) < int(SRT_GST_PENDING) || int(s) > int(SRT_GST_BROKEN))
+        return "???";
+
+    static struct AutoMap
+    {
+        std::string names[int(SRT_GST_BROKEN)+1];
+
+        AutoMap()
+        {
+#define SINI(statename) names[SRT_GST_##statename] = #statename
+            SINI(PENDING);
+            SINI(IDLE);
+            SINI(RUNNING);
+            SINI(BROKEN);
+#undef SINI
+        }
+    } names;
+
+    return names.names[int(s)];
+}
+
 LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabled(that.CheckEnabled())
 {
     if (that_enabled)

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -1361,6 +1361,7 @@ public:
 namespace srt_logging
 {
 std::string SockStatusStr(SRT_SOCKSTATUS s);
+std::string MemberStatusStr(SRT_MEMBERSTATUS s);
 }
 
 // Version parsing

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -264,13 +264,8 @@ class CUDTGroup
     typedef srt::sync::steady_clock steady_clock;
 
 public:
-    enum GroupState
-    {
-        GST_PENDING,  // The socket is created correctly, but not yet ready for getting data.
-        GST_IDLE,     // The socket is ready to be activated
-        GST_RUNNING,  // The socket was already activated and is in use
-        GST_BROKEN    // The last operation broke the socket, it should be closed.
-    };
+
+    typedef SRT_MEMBERSTATUS GroupState;
 
     // Note that the use of states may differ in particular group types:
     //
@@ -534,7 +529,6 @@ private:
     // Check if there's at least one connected socket.
     // If so, grab the status of all member sockets.
     void getGroupCount(size_t& w_size, bool& w_still_alive);
-    void getMemberStatus(std::vector<SRT_SOCKGROUPDATA>& w_gd, SRTSOCKET wasread, int result, bool again);
 
     class CUDTUnited* m_pGlobal;
     srt::sync::Mutex m_GroupLock;
@@ -677,7 +671,6 @@ public:
     //typedef StaticBuffer<BufferedMessage, 1000> senderBuffer_t;
 
 private:
-
     // Fields required for SRT_GTYPE_BACKUP groups.
     senderBuffer_t m_SenderBuffer;
     int32_t m_iSndOldestMsgNo; // oldest position in the sender buffer
@@ -924,7 +917,7 @@ public: //API
     static SRTSOCKET accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut);
     static int connect(SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
     static int connect(SRTSOCKET u, const sockaddr* name, const sockaddr* tname, int namelen);
-    static int connectLinks(SRTSOCKET grp, SRT_SOCKGROUPDATA links [], int arraysize);
+    static int connectLinks(SRTSOCKET grp, SRT_SOCKGROUPCONFIG links [], int arraysize);
     static int close(SRTSOCKET u);
     static int getpeername(SRTSOCKET u, sockaddr* name, int* namelen);
     static int getsockname(SRTSOCKET u, sockaddr* name, int* namelen);

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -129,6 +129,18 @@ struct sockaddr_any
         }
     }
 
+    void set(const sockaddr_in& in4)
+    {
+        memcpy((&sin), &in4, sizeof in4);
+        len = sizeof in4;
+    }
+
+    void set(const sockaddr_in6& in6)
+    {
+        memcpy((&sin6), &in6, sizeof in6);
+        len = sizeof in6;
+    }
+
     sockaddr_any(const in_addr& i4_adr, uint16_t port)
     {
         // Some cases require separately IPv4 address passed as in_addr,

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -757,15 +757,37 @@ SRT_ATR_DEPRECATED_PX SRT_API SRTSOCKET srt_socket(int, int, int) SRT_ATR_DEPREC
 SRT_API       SRTSOCKET srt_create_socket();
 
 // Group management
+
+
+typedef enum SRT_MemberStatus
+{
+    SRT_GST_PENDING,  // The socket is created correctly, but not yet ready for getting data.
+    SRT_GST_IDLE,     // The socket is ready to be activated
+    SRT_GST_RUNNING,  // The socket was already activated and is in use
+    SRT_GST_BROKEN    // The last operation broke the socket, it should be closed.
+} SRT_MEMBERSTATUS;
+
+
 typedef struct SRT_SocketGroupData_
 {
     SRTSOCKET id;
-    SRT_SOCKSTATUS status;
+    struct sockaddr_storage peeraddr; // Don't want to expose sockaddr_any to public API
+    SRT_SOCKSTATUS sockstate;
+    SRT_MEMBERSTATUS memberstate;
     int result;
+} SRT_SOCKGROUPDATA;
+
+typedef struct SRT_SocketOptionObject SRT_SOCKOPT_CONFIG;
+
+typedef struct SRT_GroupMemberConfig_
+{
+    SRTSOCKET id;
     struct sockaddr_storage srcaddr;
     struct sockaddr_storage peeraddr; // Don't want to expose sockaddr_any to public API
     int weight;
-} SRT_SOCKGROUPDATA;
+    SRT_SOCKOPT_CONFIG* config;
+    int errorcode;
+} SRT_SOCKGROUPCONFIG;
 
 SRT_API SRTSOCKET srt_create_group (SRT_GROUP_TYPE);
 SRT_API       int srt_include      (SRTSOCKET socket, SRTSOCKET group);
@@ -791,8 +813,8 @@ SRT_API       int srt_connect_bind (SRTSOCKET u, const struct sockaddr* source,
 SRT_API       int srt_rendezvous   (SRTSOCKET u, const struct sockaddr* local_name, int local_namelen,
                                     const struct sockaddr* remote_name, int remote_namelen);
 
-SRT_API SRT_SOCKGROUPDATA srt_prepare_endpoint(const struct sockaddr* src /*nullable*/, const struct sockaddr* adr, int namelen);
-SRT_API       int srt_connect_group(SRTSOCKET group, SRT_SOCKGROUPDATA name [], int arraysize);
+SRT_API SRT_SOCKGROUPCONFIG srt_prepare_endpoint(const struct sockaddr* src /*nullable*/, const struct sockaddr* adr, int namelen);
+SRT_API       int srt_connect_group(SRTSOCKET group, SRT_SOCKGROUPCONFIG name [], int arraysize);
 
 
 SRT_API       int srt_close        (SRTSOCKET u);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -65,13 +65,13 @@ int srt_connect_bind(SRTSOCKET u,
     return CUDT::connect(u, source, target, target_len);
 }
 
-SRT_SOCKGROUPDATA srt_prepare_endpoint(const struct sockaddr* src, const struct sockaddr* adr, int namelen)
+SRT_SOCKGROUPCONFIG srt_prepare_endpoint(const struct sockaddr* src, const struct sockaddr* adr, int namelen)
 {
-    SRT_SOCKGROUPDATA data;
-    data.result = 0;
-    data.status = SRTS_INIT;
+    SRT_SOCKGROUPCONFIG data;
+    data.errorcode = SRT_SUCCESS;
     data.id = -1;
     data.weight = 0;
+    data.config = NULL;
     if (src)
         memcpy(&data.srcaddr, src, namelen);
     else
@@ -85,7 +85,7 @@ SRT_SOCKGROUPDATA srt_prepare_endpoint(const struct sockaddr* src, const struct 
 }
 
 int srt_connect_group(SRTSOCKET group,
-        SRT_SOCKGROUPDATA name [], int arraysize)
+        SRT_SOCKGROUPCONFIG name [], int arraysize)
 {
     return CUDT::connectLinks(group, name, arraysize);
 }

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -18,6 +18,7 @@
 
 #include "testmediabase.hpp"
 #include <udt.h> // Needs access to CUDTException
+#include <netinet_any.h>
 
 extern srt_listen_callback_fn* transmit_accept_hook_fn;
 extern void* transmit_accept_hook_op;
@@ -54,8 +55,9 @@ protected:
         int port;
         int weight = 0;
         SRTSOCKET socket = SRT_INVALID_SOCK;
+        sockaddr_any source;
 
-        Connection(string h, int p): host(h), port(p) {}
+        Connection(string h, int p): host(h), port(p), source(AF_INET) {}
     };
 
     int srt_epoll = -1;


### PR DESCRIPTION
Changes:

1. Structures for configuring group connection and getting group status have been separated. Common fields are only the socket and target address.

2. For the status structure, there's renamed `status` into `sockstate` and added `memberstate`.

3. The `memberstate` type has been exposed to the API.