### PR TITLE
Fixed: srt-file-transmit fails when address binding happens

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -664,6 +664,9 @@ bool Download(UriParser& srt_source_uri, UriParser& fileuri,
     ExtractPath(path, (directory), (filename));
     Verb() << "Extract path '" << path << "': directory=" << directory << " filename=" << filename;
 
+    // Add some extra parameters.
+    srt_source_uri["transtype"] = "file";
+
     return DoDownload(srt_source_uri, directory, filename, cfg, out_stats);
 }
 

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -28,6 +28,7 @@ written by
 #include <sys/stat.h>
 #include <srt.h>
 #include <udt.h>
+#include <common.h>
 
 #include "apputil.hpp"
 #include "uriparser.hpp"
@@ -305,17 +306,12 @@ bool DoUpload(UriParser& ut, string path, string filename,
     {
         if (!tar.get())
         {
-            int sockopt = SRTT_FILE;
-
-            tar = Target::Create(ut.uri());
+            tar = Target::Create(ut.makeUri());
             if (!tar.get())
             {
                 cerr << "Unsupported target type: " << ut.uri() << endl;
                 goto exit;
             }
-
-            srt_setsockflag(tar->GetSRTSocket(), SRTO_TRANSTYPE,
-                &sockopt, sizeof sockopt);
 
             int events = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
             if (srt_epoll_add_usock(pollid,
@@ -344,7 +340,7 @@ bool DoUpload(UriParser& ut, string path, string filename,
         assert(efdlen == 1);
 
         SRT_SOCKSTATUS status = srt_getsockstate(s);
-        Verb() << "Event with status " << status << "\n";
+        Verb() << "Socket status: " << srt_logging::SockStatusStr(status) << "\n";
 
         switch (status)
         {
@@ -492,17 +488,12 @@ bool DoDownload(UriParser& us, string directory, string filename,
     {
         if (!src.get())
         {
-            int sockopt = SRTT_FILE;
-
-            src = Source::Create(us.uri());
+            src = Source::Create(us.makeUri());
             if (!src.get())
             {
                 cerr << "Unsupported source type: " << us.uri() << endl;
                 goto exit;
             }
-
-            srt_setsockflag(src->GetSRTSocket(), SRTO_TRANSTYPE,
-                &sockopt, sizeof sockopt);
 
             int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
             if (srt_epoll_add_usock(pollid,

--- a/apps/uriparser.hpp
+++ b/apps/uriparser.hpp
@@ -52,6 +52,7 @@ public:
     std::string hostport() const { return host() + ":" + port(); }
     std::string path() const;
     std::string queryValue(const std::string& strKey) const;
+    std::string makeUri();
     ParamProxy operator[](const std::string& key) { return ParamProxy(m_mapQuery, key); }
     const std::map<std::string, std::string>& parameters() const { return m_mapQuery; }
     typedef std::map<std::string, std::string>::const_iterator query_it;
@@ -73,6 +74,7 @@ private:
     std::string m_port;
     std::string m_path;
     Type m_uriType;
+    DefaultExpect m_expect;
 
     std::map<std::string, std::string> m_mapQuery;
 };

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -603,33 +603,38 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_TSBPDMODE:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
+
         m_bOPT_TsbPd = cast_optval<bool>(optval, optlen);
         break;
 
     case SRTO_LATENCY:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
+
         m_iOPT_TsbPdDelay     = cast_optval<int>(optval, optlen);
         m_iOPT_PeerTsbPdDelay = cast_optval<int>(optval);
         break;
 
     case SRTO_RCVLATENCY:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
+
         m_iOPT_TsbPdDelay = cast_optval<int>(optval, optlen);
         break;
 
     case SRTO_PEERLATENCY:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
+
         m_iOPT_PeerTsbPdDelay = cast_optval<int>(optval, optlen);
         break;
 
     case SRTO_TLPKTDROP:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
+
         m_bOPT_TLPktDrop = cast_optval<bool>(optval, optlen);
         break;
 
@@ -725,8 +730,9 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_NAKREPORT:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
+
         m_bRcvNakReport = cast_optval<bool>(optval, optlen);
         break;
 
@@ -829,8 +835,8 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         break;
 
     case SRTO_TRANSTYPE:
-        if (m_bConnected)
-            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_ISBOUND, 0);
 
         // XXX Note that here the configuration for SRTT_LIVE
         // is the same as DEFAULT VALUES for these fields set


### PR DESCRIPTION
Fixes #1301 

The problem: the `transtype` option sets up flags (this concerns then also `tsbpdmode` `rcvlatency` `peerlatency` `tlpktdrop` and `nakreport`) that are written into the state in `CUDT::clearData` as a part of `CUDT::open` that is called either at the time of self-binding (when you do `srt_connect`) or directly in `srt_bind`. Therefore this option cannot be altered after binding.

The application was trying to set the `transtype=file` parameter on the socket after the creation function (`Source::Create` or `Target::Create`) has already been called, and pre-options already set, and also does the binding. Therefore setting the `transtype` option couldn't happen neither before nor after this call.

The only way to enforce the `transtype` setting was to add this to the list of socket options as specified by the user so that it's set together with all other options. This was done, too, however the function has received the original URI to parse.

Therefore there was needed an extension for UriParser class, which is now able to add new parameters. In order to be able to pass the URI to be correctly parsed by `Create` call, the URI has to be reassembled. This functionality has been added as `UriParser::makeUri()`.

Also these options that couldn't be set after binding have changed the entry condition that was that the socket shouldn't be connected, now the socket shouldn't even be bound (note that connecting involves binding, at least as self-binding).