### PR TITLE
Fixed  getting next available unit from CUnitQueue

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -164,7 +164,7 @@ int CUnitQueue::increase()
     char *   tempb = NULL;
 
     // all queues have the same size
-    int size = m_pQEntry->m_iSize;
+    const int size = m_pQEntry->m_iSize;
 
     try
     {

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -216,24 +216,21 @@ CUnit *CUnitQueue::getNextAvailUnit()
     if (m_iCount >= m_iSize)
         return NULL;
 
-    CQEntry *entrance = m_pCurrQueue;
-
+    int units_checked = 0;
     do
     {
-        for (CUnit *sentinel = m_pCurrQueue->m_pUnit + m_pCurrQueue->m_iSize - 1; m_pAvailUnit != sentinel;
-             ++m_pAvailUnit)
-            if (m_pAvailUnit->m_iFlag == CUnit::FREE)
-                return m_pAvailUnit;
-
-        if (m_pCurrQueue->m_pUnit->m_iFlag == CUnit::FREE)
+        const CUnit *end = m_pCurrQueue->m_pUnit + m_pCurrQueue->m_iSize;
+        for (; m_pAvailUnit != end; ++m_pAvailUnit, ++units_checked)
         {
-            m_pAvailUnit = m_pCurrQueue->m_pUnit;
-            return m_pAvailUnit;
+            if (m_pAvailUnit->m_iFlag == CUnit::FREE)
+            {
+                return m_pAvailUnit;
+            }
         }
 
         m_pCurrQueue = m_pCurrQueue->m_pNext;
         m_pAvailUnit = m_pCurrQueue->m_pUnit;
-    } while (m_pCurrQueue != entrance);
+    } while (units_checked < m_iSize);
 
     increase();
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -101,6 +101,10 @@ public:     // Storage size operations
 
    int shrink();
 
+public:
+   int size() const     { return m_iSize - m_iCount; }
+   int capacity() const { return m_iSize; }
+
 public:     // Operations on units
 
       /// find an available unit for incoming packet.
@@ -118,23 +122,23 @@ public:
 private:
    struct CQEntry
    {
-      CUnit* m_pUnit;		// unit queue
-      char* m_pBuffer;		// data buffer
-      int m_iSize;		// size of each queue
+      CUnit* m_pUnit;   // unit queue
+      char* m_pBuffer;  // data buffer
+      int m_iSize;      // size of each queue
 
       CQEntry* m_pNext;
    }
-   *m_pQEntry,			// pointer to the first unit queue
-   *m_pCurrQueue,		// pointer to the current available queue
-   *m_pLastQueue;		// pointer to the last unit queue
+   *m_pQEntry,          // pointer to the first unit queue
+   *m_pCurrQueue,       // pointer to the current available queue
+   *m_pLastQueue;       // pointer to the last unit queue
 
-   CUnit* m_pAvailUnit;         // recent available unit
+   CUnit* m_pAvailUnit; // recent available unit
 
-   int m_iSize;			// total size of the unit queue, in number of packets
-   int m_iCount;		// total number of valid packets in the queue
+   int m_iSize;         // total size of the unit queue, in number of packets
+   int m_iCount;        // total number of valid (occupied) packets in the queue
 
-   int m_iMSS;			// unit buffer size
-   int m_iIPversion;		// IP version
+   int m_iMSS;          // unit buffer size
+   int m_iIPversion;    // IP version
 
 private:
    CUnitQueue(const CUnitQueue&);

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -13,4 +13,5 @@ test_seqno.cpp
 test_socket_options.cpp
 test_sync.cpp
 test_timer.cpp
+test_unitqueue.cpp
 test_utilities.cpp

--- a/test/test_unitqueue.cpp
+++ b/test/test_unitqueue.cpp
@@ -1,0 +1,88 @@
+#include <array>
+#include <vector>
+#include "gtest/gtest.h"
+#include "queue.h"
+
+
+using namespace std;
+
+
+/// Create CUnitQueue with queue size of 4 units.
+/// The size of 4 is chosen on purpose, because 
+/// CUnitQueue::getNextAvailUnit(..) has the following
+/// condition `if (m_iCount * 10 > m_iSize * 9)`. With m_iSize = 4
+/// it will be false up until m_iCount becomes 4.
+/// And there was an issue in getNextAvailUnit(..) in taking
+/// the very last element of the queue (it was skipped).
+TEST(CUnitQueue, Increase)
+{
+    const int buffer_size_pkts = 4;
+    CUnitQueue unit_queue;
+    unit_queue.init(buffer_size_pkts, 1500, AF_INET);
+
+    vector<CUnit*> taken_units;
+    for (int i = 0; i < 5 * buffer_size_pkts; ++i)
+    {
+        CUnit* unit = unit_queue.getNextAvailUnit();
+        ASSERT_NE(unit, nullptr);
+        unit_queue.makeUnitGood(unit);
+        taken_units.push_back(unit);
+    }
+}
+
+/// Create CUnitQueue with queue size of 4 units.
+/// Then after requesting the 5th unit, free the previous
+/// four units. This makes the previous queue completely free.
+/// Requesting the 5th unit, there would be 3 units available in the
+/// beginning of the same queue.
+TEST(CUnitQueue, IncreaseAndFree)
+{
+    const int buffer_size_pkts = 4;
+    CUnitQueue unit_queue;
+    unit_queue.init(buffer_size_pkts, 1500, AF_INET);
+
+    CUnit* taken_unit = nullptr;
+    for (int i = 0; i < 5 * buffer_size_pkts; ++i)
+    {
+        CUnit* unit = unit_queue.getNextAvailUnit();
+        ASSERT_NE(unit, nullptr);
+        unit_queue.makeUnitGood(unit);
+
+        if (taken_unit)
+            unit_queue.makeUnitFree(taken_unit);
+
+        taken_unit = unit;
+    }
+}
+
+/// Create CUnitQueue with queue size of 4 units.
+/// Then after requesting the 5th unit, free the previous
+/// four units. This makes the previous queue completely free.
+/// Requesting the 9th unit, there would be 4 units available in the
+/// Thus the test checks if 
+TEST(CUnitQueue, IncreaseAndFreeGrouped)
+{
+    const int buffer_size_pkts = 4;
+    CUnitQueue unit_queue;
+    unit_queue.init(buffer_size_pkts, 1500, AF_INET);
+
+    vector<CUnit*> taken_units;
+    for (int i = 0; i < 5 * buffer_size_pkts; ++i)
+    {
+        CUnit* unit = unit_queue.getNextAvailUnit();
+        ASSERT_NE(unit, nullptr);
+        unit_queue.makeUnitGood(unit);
+
+        if (taken_units.size() >= buffer_size_pkts)
+        {
+            for_each(taken_units.begin(), taken_units.end(),
+                [&unit_queue](CUnit* u) { unit_queue.makeUnitFree(u); });
+
+            taken_units.clear();
+        }
+
+        taken_units.push_back(unit);
+        EXPECT_LE(unit_queue.capacity(), 2 * buffer_size_pkts)
+            << "Buffer capacity should not exceed two queues of 4 units";
+    }
+}


### PR DESCRIPTION
This is one set of bugs related to #486 

`CUnitQueue::getNextAvailUnit()` has several issues. They are described in the review comments to the code.

This PR consists of three commits:
1. Minor chage: add `size()` and `capacity()` getters to `CUnitQueue`. Needed for unit tests.
2. Added three unit tests describing issues with the current implementation of `CUnitQueue`.
3. Fix of `CUnitQueue::getNextAvailUnit()`