### PR TITLE
[core] Protecting RCV buffer access

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6930,7 +6930,6 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
             throw CUDTException(MJ_AGAIN, MN_RDAVAIL, 0);
         }
 
-        enterCS(m_RcvBufferLock);
         if (!m_pRcvBuffer->isRcvDataReady())
         {
             // Kick TsbPd thread to schedule next wakeup (if running)
@@ -6953,7 +6952,6 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
             HLOGC(mglog.Debug, log << CONID() << "CURRENT BANDWIDTH: " << bw << "Mbps (" << m_iBandwidth << " buffers per second)");
 #endif
         }
-        leaveCS(m_RcvBufferLock);
         return res;
     }
 
@@ -6970,7 +6968,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
     {
         steady_clock::time_point tstime SRT_ATR_UNUSED;
         int32_t seqno;
-        if (stillConnected() && !timeout && !m_pRcvBuffer->isRcvDataReady((tstime), (seqno), seqdistance))
+        if (stillConnected() && !timeout && !(m_pRcvBuffer->isRcvDataReady((tstime), (seqno), seqdistance)))
         {
             /* Kick TsbPd thread to schedule next wakeup (if running) */
             if (m_bTsbPd)
@@ -7014,7 +7012,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
 
             HLOGC(tslog.Debug,
                   log << CONID() << "receiveMessage: lock-waiting loop exited: stillConntected=" << stillConnected()
-                      << " timeout=" << timeout << " data-ready=" << m_pRcvBuffer->isRcvDataReady();
+                      << " timeout=" << timeout << " data-ready=" << m_pRcvBuffer->isRcvDataReady());
         }
 
         /* XXX DEBUG STUFF - enable when required

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6968,7 +6968,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
     {
         steady_clock::time_point tstime SRT_ATR_UNUSED;
         int32_t seqno;
-        if (stillConnected() && !timeout && !(m_pRcvBuffer->isRcvDataReady((tstime), (seqno), seqdistance)))
+        if (stillConnected() && !timeout && !m_pRcvBuffer->isRcvDataReady((tstime), (seqno), seqdistance))
         {
             /* Kick TsbPd thread to schedule next wakeup (if running) */
             if (m_bTsbPd)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1617,7 +1617,7 @@ private: // synchronization: mutexes and conditions
     srt::sync::Mutex m_RecvDataLock;             // lock associated to m_RecvDataCond
 
     srt::sync::Mutex m_SendLock;                 // used to synchronize "send" call
-    srt::sync::Mutex m_RecvLock;                 // used to synchronize "recv" call
+    srt::sync::Mutex m_RecvLock;                 // used to synchronize "recv" call, protects TSBPD drift updates (CRcvBuffer::isRcvDataReady())
     srt::sync::Mutex m_RcvLossLock;              // Protects the receiver loss list (access: CRcvQueue::worker, CUDT::tsbpd)
     srt::sync::Mutex m_StatsLock;                // used to synchronize access to trace statistics
 


### PR DESCRIPTION
This PR protects access to `CRcvBuffer::readMsg(..)` with `m_RcvBufferLock`.
Together with #1333 fixes #486

In case of the receiver, there are two threads accessing `CUnitQueue`.
Both of these threads were protecting access to `CRcvBuffer` and eventually to `CUnitQueue` with **different** mutexes, meaning there was **no protection from simultaneous writing** via `makeUnit*(..)` functions. 

The thread that receives packets from the network has the following call stack:
- `CUDT::processData(CUnit* in_unit)`
   locks `m_RcvBufferLock`
- `CRcvBuffer::addData(CUnit* unit, int offset)`
- `m_pUnitQueue->makeUnitGood(unit, "addData")`

Another thread is the application thread that reads data from the buffer.
Call stack:

- `CUDT::receiveMessage(..)`
   locks `m_RecvLock`
- `CRcvBuffer::readMsg(..)`
- `CRcvBuffer::extractData(..)`
- `freeUnitAt(..)`
- `m_pUnitQueue->makeUnitFree(..)`