### PR TITLE
Removed triggerEvents from all cases but after readiness update

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -561,8 +561,6 @@ void CSndBuffer::ackData(int offset)
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
    updAvgBufSize(steady_clock::now());
 #endif
-
-   CGlobEvent::triggerEvent();
 }
 
 int CSndBuffer::getCurrBufSize() const
@@ -673,7 +671,6 @@ int CSndBuffer::dropLateData(int& w_bytes, int32_t& w_first_msgno, const steady_
    updAvgBufSize(steady_clock::now());
 #endif /* SRT_ENABLE_SNDBUFSZ_MAVG */
 
-// CTimer::triggerEvent();
    return(dpkts);
 }
 
@@ -996,8 +993,6 @@ int CRcvBuffer::ackData(int len)
    m_iMaxPos -= len;
    if (m_iMaxPos < 0)
       m_iMaxPos = 0;
-
-   CGlobEvent::triggerEvent();
 
    // Returned value is the distance towards the starting
    // position from m_iLastAckPos, which is in sync with CUDT::m_iRcvLastSkipAck.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7729,18 +7729,6 @@ int32_t CUDT::ackDataUpTo(int32_t ack)
     if (acksize > 0)
     {
         const int distance = m_pRcvBuffer->ackData(acksize);
-        /*
-           XXX example code - inform the group up to which packet
-           data are received so that it can be also acknowledged
-           in all others and false lossreport prevened
-           if (m_parent->m_IncludedGroup)
-           m_parent->m_IncludedGroup->readyPackets(this, ack);
-         */
-
-        // Signal threads waiting in CTimer::waitForEvent(),
-        // which are select(), selectEx() and epoll_wait().
-        CGlobEvent::triggerEvent();
-
         return CSeqNo::decseq(ack, distance);
     }
 
@@ -8143,6 +8131,7 @@ void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
 
         // acknowledde any waiting epolls to write
         s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_OUT, true);
+        CGlobEvent::triggerEvent();
     }
 
     // insert this socket to snd list if it is not on the list yet


### PR DESCRIPTION
Fixes #1192

This removes the call to `triggerEvent` when it's considered excessive - that is, the `triggerEvent` call is still present in every imaginable execution path that passes through these places where it is removed. The idea for `triggerEvent` is to forcefully release the waiting in `waitForEvent`, which releases the epoll waiting function, so it should be done only if it follows updates in the socket readiness bits.