### PR TITLE
[core] Shared moving average calc for RCV and SND buffers

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -98,6 +98,11 @@ void AvgBufSize::update(const steady_clock::time_point& now, int pkts, int bytes
     m_dTimespanMAvg   = avg_iir_w<1000, double>(m_dTimespanMAvg, timespan_ms, elapsed_ms);
 }
 
+const int round_val(double val)
+{
+    return static_cast<int>(round(val));
+}
+
 CSndBuffer::CSndBuffer(int size, int mss)
     : m_BufLock()
     , m_pBlock(NULL)
@@ -616,9 +621,9 @@ int CSndBuffer::getAvgBufSize(int& w_bytes, int& w_tsp)
     // so rounding is beneficial, while for the number of
     // bytes in the buffer is a higher value, so rounding can be omitted,
     // but probably better to round all three values.
-    w_bytes = static_cast<int>(round(m_mavg.bytes()));
-    w_tsp   = static_cast<int>(round(m_mavg.timespan_ms()));
-    return static_cast<int>(round(m_mavg.pkts()));
+    w_bytes = round_val(m_mavg.bytes());
+    w_tsp   = round_val(m_mavg.timespan_ms());
+    return round_val(m_mavg.pkts());
 }
 
 void CSndBuffer::updAvgBufSize(const steady_clock::time_point& now)
@@ -1583,9 +1588,9 @@ int CRcvBuffer::getRcvAvgDataSize(int& bytes, int& timespan)
     // so rounding is beneficial, while for the number of
     // bytes in the buffer is a higher value, so rounding can be omitted,
     // but probably better to round all three values.
-    timespan = static_cast<int>(round(m_mavg.timespan_ms()));
-    bytes    = static_cast<int>(round(m_mavg.bytes()));
-    return static_cast<int>(round(m_mavg.pkts()));
+    timespan = round_val(m_mavg.timespan_ms());
+    bytes    = round_val(m_mavg.bytes());
+    return round_val(m_mavg.pkts());
 }
 
 /* Update moving average of acked data pkts, bytes, and timespan (ms) of the receive buffer */

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -72,6 +72,37 @@ modified by
 // a +% b : shift a by b
 // a == b : equality is same as for just numbers
 
+#if defined(SRT_ENABLE_SNDBUFSZ_MAVG) || defined(SRT_ENABLE_RCVBUFSZ_MAVG)
+/// The AvgBufSize class is used to calculate moving average of the buffer (RCV or SND)
+class AvgBufSize
+{
+    typedef srt::sync::steady_clock::time_point time_point;
+
+public:
+    AvgBufSize()
+        : m_iBytesCountMAvg(0)
+        , m_iCountMAvg(0)
+        , m_iTimespanMAvg(0)
+    {
+    }
+
+public:
+    bool isTimeToUpdate(const time_point& now) const;
+    void update(const time_point& now, int pkts, int bytes, int timespan_ms);
+
+public:
+    inline int pkts() const { return m_iCountMAvg; }
+    inline int timespan_ms() const { return m_iTimespanMAvg; }
+    inline int bytes() const { return m_iBytesCountMAvg; }
+
+private:
+    time_point m_tsLastSamplingTime;
+    int        m_iBytesCountMAvg;
+    int        m_iCountMAvg;
+    int        m_iTimespanMAvg;
+};
+#endif // SRT_ENABLE_SNDBUFSZ_MAVG || SRT_ENABLE_RCVBUFSZ_MAVG
+
 
 class CSndBuffer
 {
@@ -232,10 +263,7 @@ private:
    srt::sync::steady_clock::time_point m_tsLastOriginTime;
 
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
-   srt::sync::steady_clock::time_point m_tsLastSamplingTime;
-   int m_iCountMAvg;
-   int m_iBytesCountMAvg;
-   int m_TimespanMAvg;
+   AvgBufSize m_mavg;
 #endif /* SRT_ENABLE_SNDBUFSZ_MAVG */
 
    int m_iInRatePktsCount;  // number of payload bytes added since InRateStartTime
@@ -585,10 +613,7 @@ private:
    static const int TSBPD_DRIFT_MAX_SAMPLES = 1000;
    DriftTracer<TSBPD_DRIFT_MAX_SAMPLES, TSBPD_DRIFT_MAX_VALUE> m_DriftTracer;
 #ifdef SRT_ENABLE_RCVBUFSZ_MAVG
-   time_point m_tsLastSamplingTime;
-   int m_TimespanMAvg;
-   int m_iCountMAvg;
-   int m_iBytesCountMAvg;
+   AvgBufSize m_mavg;
 #endif /* SRT_ENABLE_RCVBUFSZ_MAVG */
 #ifdef SRT_DEBUG_TSBPD_DRIFT
    int m_TsbPdDriftHisto100us[22];              // Histogram of 100us TsbPD drift (-1.0 .. +1.0 ms in 0.1ms increment)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -80,26 +80,25 @@ class AvgBufSize
 
 public:
     AvgBufSize()
-        : m_iBytesCountMAvg(0)
-        , m_iCountMAvg(0)
-        , m_iTimespanMAvg(0)
-    {
-    }
+        : m_dBytesCountMAvg(0.0)
+        , m_dCountMAvg(0.0)
+        , m_dTimespanMAvg(0.0)
+    { }
 
 public:
     bool isTimeToUpdate(const time_point& now) const;
     void update(const time_point& now, int pkts, int bytes, int timespan_ms);
 
 public:
-    inline int pkts() const { return m_iCountMAvg; }
-    inline int timespan_ms() const { return m_iTimespanMAvg; }
-    inline int bytes() const { return m_iBytesCountMAvg; }
+    inline double pkts() const { return m_dCountMAvg; }
+    inline double timespan_ms() const { return m_dTimespanMAvg; }
+    inline double bytes() const { return m_dBytesCountMAvg; }
 
 private:
     time_point m_tsLastSamplingTime;
-    int        m_iBytesCountMAvg;
-    int        m_iCountMAvg;
-    int        m_iTimespanMAvg;
+    double     m_dBytesCountMAvg;
+    double     m_dCountMAvg;
+    double     m_dTimespanMAvg;
 };
 #endif // SRT_ENABLE_SNDBUFSZ_MAVG || SRT_ENABLE_RCVBUFSZ_MAVG
 


### PR DESCRIPTION
Both Receiver and Sender buffers share the same logic of the moving average calculation of the buffer state (packets, bytes, timespan).
This PR moves this logic into a separate class, which is used as aggregation by both buffers.

Didn't use inheritance to avoid virtual tables.

Fixes #1272