### PR TITLE
[core] Added source time check in sender

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1182,7 +1182,7 @@ when you are allowed to send or retrieve a part of the message.
 (specified as 0), the current system time (absolute microseconds since epoch) is 
 used.
    * [OUT] Receiver only. Specifies the time when the packet was intended to be
-delivered to the receiver.
+delivered to the receiver (microseconds since SRT clock epoch).
 
 * `pktseq`: Receiver only. Reports the sequence number for the packet carrying
 out the payload being returned. If the payload is carried out by more than one
@@ -1256,6 +1256,7 @@ with the rest of the buffer next time to send it completely. In both
   * `SRT_ECONNLOST`: Socket `u` used for the operation has lost its connection.
   * `SRT_EINVALMSGAPI`: Incorrect API usage in **message mode**:
     * **live mode**: trying to send more bytes at once than `SRTO_PAYLOADSIZE`
+    or wrong source time was provided.
   * `SRT_EINVALBUFFERAPI`: Incorrect API usage in **stream mode**:
     * Reserved for future use. The congestion controller object
       used for this mode doesn't use any restrictions on this call for now,

--- a/docs/API.md
+++ b/docs/API.md
@@ -214,7 +214,7 @@ to be dropped before sending (so -1 should be passed here).
 The `srctime` parameter is an SRT addition for applications (i.e. gateways)
 forwarding SRT streams. It permits pulling and pushing of the sender's original time
 stamp, converted to local time and drift adjusted. The srctime parameter is the
-number of usec (since epoch) in local time. If the connection is not between
+number of usec (since epoch) in local SRT clock time. If the connection is not between
 SRT peers or if Timestamp-Based Packet Delivery mode (TSBPDMODE) is not enabled
 (see Options), the extracted srctime will be 0. Passing srctime = 0 in sendmsg
 is like using the API without srctime and the local send time will be used (if

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -98,7 +98,7 @@ void AvgBufSize::update(const steady_clock::time_point& now, int pkts, int bytes
     m_dTimespanMAvg   = avg_iir_w<1000, double>(m_dTimespanMAvg, timespan_ms, elapsed_ms);
 }
 
-const int round_val(double val)
+int round_val(double val)
 {
     return static_cast<int>(round(val));
 }
@@ -195,12 +195,7 @@ void CSndBuffer::addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl)
     }
 
     const steady_clock::time_point time = steady_clock::now();
-    if (w_srctime == 0)
-    {
-        HLOGC(dlog.Debug, log << CONID() << "addBuffer: DEFAULT SRCTIME - overriding with current time.");
-        w_srctime = count_microseconds(time.time_since_epoch());
-    }
-    int32_t inorder = w_mctrl.inorder ? MSGNO_PACKET_INORDER::mask : 0;
+    const int32_t inorder = w_mctrl.inorder ? MSGNO_PACKET_INORDER::mask : 0;
 
     HLOGC(dlog.Debug,
           log << CONID() << "addBuffer: adding " << size << " packets (" << len << " bytes) to send, msgno="
@@ -397,6 +392,18 @@ int CSndBuffer::addBufferFromFile(fstream& ifs, int len)
     return total;
 }
 
+steady_clock::time_point CSndBuffer::getSourceTime(const CSndBuffer::Block& block)
+{
+    if (block.m_ullSourceTime_us)
+    {
+        const steady_clock::duration since_epoch = block.m_tsOriginTime.time_since_epoch();
+        const steady_clock::duration delta       = microseconds_from(block.m_ullSourceTime_us) - since_epoch;
+        return block.m_tsOriginTime + delta;
+    }
+
+    return block.m_tsOriginTime;
+}
+
 int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime, int kflgs)
 {
     // No data to read
@@ -442,15 +449,10 @@ int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime,
     {
         m_pCurrBlock->m_iMsgNoBitset |= MSGNO_ENCKEYSPEC::wrap(kflgs);
     }
+
     w_packet.m_iMsgNo = m_pCurrBlock->m_iMsgNoBitset;
-
-    // TODO: FR #930. Use source time if it is provided.
-    w_srctime = m_pCurrBlock->m_tsOriginTime;
-    /* *srctime =
-       m_pCurrBlock->m_ullSourceTime_us ? m_pCurrBlock->m_ullSourceTime_us :
-       m_pCurrBlock->m_tsOriginTime;*/
-
-    m_pCurrBlock = m_pCurrBlock->m_pNext;
+    w_srctime         = getSourceTime(*m_pCurrBlock);
+    m_pCurrBlock      = m_pCurrBlock->m_pNext;
 
     HLOGC(dlog.Debug, log << CONID() << "CSndBuffer: extracting packet size=" << readlen << " to send");
 
@@ -569,10 +571,7 @@ int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time
     w_packet.m_iMsgNo = p->m_iMsgNoBitset;
 
     // TODO: FR #930. Use source time if it is provided.
-    w_srctime = p->m_tsOriginTime;
-    /*w_srctime =
-       p->m_ullSourceTime_us ? p->m_ullSourceTime_us :
-       p->m_tsOriginTime;*/
+    w_srctime = getSourceTime(*p);
 
     HLOGC(dlog.Debug,
           log << CONID() << "CSndBuffer: getting packet %" << p->m_iSeqNo << " as per %" << w_packet.m_iSeqNo

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -105,6 +105,9 @@ private:
 
 class CSndBuffer
 {
+   typedef srt::sync::steady_clock::time_point time_point;
+   typedef srt::sync::steady_clock::duration duration;
+
 public:
 
    // XXX There's currently no way to access the socket ID set for
@@ -191,7 +194,7 @@ public:
    /// @param [in] bytes  number of payload bytes in those newly added packets
    ///
    /// @return Current size of the data in the sending list.
-   void updateInputRate(const srt::sync::steady_clock::time_point& time, int pkts = 0, int bytes = 0);
+   void updateInputRate(const time_point& time, int pkts = 0, int bytes = 0);
 
 
    void resetInputRateSmpPeriod(bool disable = false)
@@ -199,11 +202,12 @@ public:
        setInputRateSmpPeriod(disable ? 0 : INPUTRATE_FAST_START_US);
    }
 
-
 private:
-
    void increase();
    void setInputRateSmpPeriod(int period);
+
+   struct Block; // Defined below
+   static time_point getSourceTime(const CSndBuffer::Block& block);
 
 private:    // Constants
 
@@ -221,8 +225,8 @@ private:
       int m_iLength;                    // length of the block
 
       int32_t m_iMsgNoBitset;           // message number
-      int32_t m_iSeqNo;                       // sequence number for scheduling
-      srt::sync::steady_clock::time_point m_tsOriginTime;            // original request time
+      int32_t m_iSeqNo;                 // sequence number for scheduling
+      time_point m_tsOriginTime;        // original request time
       uint64_t m_ullSourceTime_us;
       int m_iTTL;                       // time to live (milliseconds)
 
@@ -259,7 +263,7 @@ private:
    int m_iCount;                        // number of used blocks
 
    int m_iBytesCount;                   // number of payload bytes in queue
-   srt::sync::steady_clock::time_point m_tsLastOriginTime;
+   time_point m_tsLastOriginTime;
 
 #ifdef SRT_ENABLE_SNDBUFSZ_MAVG
    AvgBufSize m_mavg;
@@ -267,7 +271,7 @@ private:
 
    int m_iInRatePktsCount;  // number of payload bytes added since InRateStartTime
    int m_iInRateBytesCount;  // number of payload bytes added since InRateStartTime
-   srt::sync::steady_clock::time_point m_tsInRateStartTime;
+   time_point m_tsInRateStartTime;
    uint64_t m_InRatePeriod; // usec
    int m_iInRateBps;        // Input Rate in Bytes/sec
    int m_iAvgPayloadSz;     // Average packet payload size

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6805,9 +6805,24 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
 
         // Now seqno is the sequence to which it was scheduled
         // XXX Conversion from w_mctrl.srctime -> steady_clock::time_point need not be accurrate.
-        HLOGC(dlog.Debug, log << CONID() << "buf:SENDING (BEFORE) srctime:" << FormatTime(ts_srctime)
+        HLOGC(dlog.Debug, log << CONID() << "buf:SENDING (BEFORE) srctime:"
+                << (w_mctrl.srctime ? FormatTime(ts_srctime) : "none")
                 << " DATA SIZE: " << size << " sched-SEQUENCE: " << seqno
                 << " STAMP: " << BufferStamp(data, size));
+
+        if (w_mctrl.srctime && w_mctrl.srctime < count_microseconds(m_stats.tsStartTime.time_since_epoch()))
+        {
+            LOGC(mglog.Error,
+                log << "Wrong source time was provided. Sending is rejected.");
+            throw CUDTException(MJ_NOTSUP, MN_INVALMSGAPI);
+        }
+
+        if (w_mctrl.srctime && (!m_bMessageAPI || !m_bTsbPd))
+        {
+            HLOGC(dlog.Warn,
+                log << "Source time can only be used with TSBPD and Message API enabled. Using default time instead.");
+            w_mctrl.srctime = 0;
+        }
 
         // w_mctrl.seqno is INPUT-OUTPUT value:
         // - INPUT: the current sequence number to be placed for the next scheduled packet

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -829,7 +829,6 @@ SRT_API       int srt_setsockopt   (SRTSOCKET u, int level /*ignored*/, SRT_SOCK
 SRT_API       int srt_getsockflag  (SRTSOCKET u, SRT_SOCKOPT opt, void* optval, int* optlen);
 SRT_API       int srt_setsockflag  (SRTSOCKET u, SRT_SOCKOPT opt, const void* optval, int optlen);
 
-// XXX Note that the srctime functionality doesn't work yet and needs fixing.
 typedef struct SRT_MsgCtrl_
 {
    int flags;            // Left for future


### PR DESCRIPTION
Added source time extraction in SRT sender.

`SRT_MSGCTRL::srctime` represents the time since epoch in microseconds of the internally used steady clock.

It allows to pass the time from the receiver to the sender.

```c++
// Receive
SRT_MSGCTRL ctrl_rcv;
srt_recvmsg2(srt_sock_rcv, (char*) data, (int) len, &ctrl_rcv);
// Send
SRT_MSGCTRL ctrl_snd = srt_msgctrl_default;
// Take time from the source
ctrl_snd.srctime = ctrl_rcv.srctime;
srt_sendmsg2(srt_sock_snd, (char*) data, (int) len, &ctrl_snd);
```

### TODO

- [x] Validate `srctime` in `srt_sendmsg2(..)`. If it is less than the connection start time, print a warning.
- [x] Update API docs.


Addresses #930