### PR TITLE
Replaced CreateAddrInet with CreateAddr that handles IPv6

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -77,30 +77,62 @@ int inet_pton(int af, const char * src, void * dst)
 }
 #endif // _WIN32 && !HAVE_INET_PTON
 
-sockaddr_in CreateAddrInet(const string& name, unsigned short port)
+sockaddr_any CreateAddr(const string& name, unsigned short port, int pref_family)
 {
-    sockaddr_in sa;
-    memset(&sa, 0, sizeof sa);
-    sa.sin_family = AF_INET;
-    sa.sin_port = htons(port);
-
-    if ( name != "" )
+    // Handle empty name.
+    // If family is specified, empty string resolves to ANY of that family.
+    // If not, it resolves to IPv4 ANY (to specify IPv6 any, use [::]).
+    if (name == "")
     {
-        if ( inet_pton(AF_INET, name.c_str(), &sa.sin_addr) == 1 )
-            return sa;
-
-        // XXX RACY!!! Use getaddrinfo() instead. Check portability.
-        // Windows/Linux declare it.
-        // See:
-        //  http://www.winsocketdotnetworkprogramming.com/winsock2programming/winsock2advancedInternet3b.html
-        hostent* he = gethostbyname(name.c_str());
-        if ( !he || he->h_addrtype != AF_INET )
-            throw invalid_argument("CreateAddrInet: host not found: " + name);
-
-        sa.sin_addr = *(in_addr*)he->h_addr_list[0];
+        sockaddr_any result(pref_family == AF_INET6 ? pref_family : AF_INET);
+        result.hport(port);
+        return result;
     }
 
-    return sa;
+    bool first6 = pref_family != AF_INET;
+    int families[2] = {AF_INET6, AF_INET};
+    if (!first6)
+    {
+        families[0] = AF_INET;
+        families[1] = AF_INET6;
+    }
+
+    for (int i = 0; i < 2; ++i)
+    {
+        int family = families[i];
+        sockaddr_any result (family);
+
+        // Try to resolve the name by pton first
+        if (inet_pton(family, name.c_str(), result.get_addr()) == 1)
+        {
+            result.hport(port); // same addr location in ipv4 and ipv6
+            return result;
+        }
+    }
+
+    // If not, try to resolve by getaddrinfo
+    // This time, use the exact value of pref_family
+
+    sockaddr_any result;
+    addrinfo fo = {
+        0,
+        pref_family,
+        0, 0,
+        0, 0,
+        NULL, NULL
+    };
+
+    addrinfo* val = nullptr;
+    int erc = getaddrinfo(name.c_str(), nullptr, &fo, &val);
+    if (erc == 0)
+    {
+        result.set(val->ai_addr);
+        result.len = result.size();
+        result.hport(port); // same addr location in ipv4 and ipv6
+    }
+    freeaddrinfo(val);
+
+    return result;
 }
 
 string Join(const vector<string>& in, string sep)

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -18,6 +18,8 @@
 #include <vector>
 #include <memory>
 
+#include "netinet_any.h"
+
 #if _WIN32
 
 // Keep this below commented out.
@@ -69,7 +71,7 @@ inline int SysError() { return ::GetLastError(); }
 inline int SysError() { return errno; }
 #endif
 
-sockaddr_in CreateAddrInet(const std::string& name, unsigned short port);
+sockaddr_any CreateAddr(const std::string& name, unsigned short port = 0, int pref_family = AF_UNSPEC);
 std::string Join(const std::vector<std::string>& in, std::string sep);
 
 

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -240,6 +240,7 @@ const SocketOption srt_options [] {
     { "kmrefreshrate", 0, SRTO_KMREFRESHRATE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "kmpreannounce", 0, SRTO_KMPREANNOUNCE, SocketOption::PRE, SocketOption::INT, nullptr },
     { "enforcedencryption", 0, SRTO_ENFORCEDENCRYPTION, SocketOption::PRE, SocketOption::BOOL, nullptr },
+    { "ipv6only", 0, SRTO_IPV6ONLY, SocketOption::PRE, SocketOption::INT, nullptr },
     { "peeridletimeo", 0, SRTO_PEERIDLETIMEO, SocketOption::PRE, SocketOption::INT, nullptr },
     { "packetfilter", 0, SRTO_PACKETFILTER, SocketOption::PRE, SocketOption::STRING, nullptr },
     { "groupconnect", 0, SRTO_GROUPCONNECT, SocketOption::PRE, SocketOption::INT, nullptr},

--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -97,9 +97,9 @@ protected:
     mutex access; // For closing
 
     template <class DerivedMedium, class SocketType>
-    static Medium* CreateAcceptor(DerivedMedium* self, const sockaddr_in& sa, SocketType sock, size_t chunk)
+    static Medium* CreateAcceptor(DerivedMedium* self, const sockaddr_any& sa, SocketType sock, size_t chunk)
     {
-        string addr = SockaddrToString(sockaddr_any((sockaddr*)&sa, sizeof sa));
+        string addr = SockaddrToString(sockaddr_any(sa.get(), sizeof sa));
         DerivedMedium* m = new DerivedMedium(UriParser(self->type() + string("://") + addr), chunk);
         m->m_socket = sock;
         return m;
@@ -603,9 +603,9 @@ void SrtMedium::CreateListener()
 
     ConfigurePre();
 
-    sockaddr_in sa = CreateAddrInet(m_uri.host(), m_uri.portno());
+    sockaddr_any sa = CreateAddr(m_uri.host(), m_uri.portno());
 
-    int stat = srt_bind(m_socket, (sockaddr*)&sa, sizeof sa);
+    int stat = srt_bind(m_socket, sa.get(), sizeof sa);
 
     if ( stat == SRT_ERROR )
     {
@@ -630,9 +630,9 @@ void TcpMedium::CreateListener()
     m_socket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     ConfigurePre();
 
-    sockaddr_in sa = CreateAddrInet(m_uri.host(), m_uri.portno());
+    sockaddr_any sa = CreateAddr(m_uri.host(), m_uri.portno());
 
-    int stat = ::bind(m_socket, (sockaddr*)&sa, sizeof sa);
+    int stat = ::bind(m_socket, sa.get(), sizeof sa);
 
     if (stat == -1)
     {
@@ -652,9 +652,8 @@ void TcpMedium::CreateListener()
 
 unique_ptr<Medium> SrtMedium::Accept()
 {
-    sockaddr_in sa;
-    int salen = sizeof sa;
-    SRTSOCKET s = srt_accept(m_socket, (sockaddr*)&sa, &salen);
+    sockaddr_any sa;
+    SRTSOCKET s = srt_accept(m_socket, (sa.get()), (&sa.len));
     if (s == SRT_ERROR)
     {
         Error(UDT::getlasterror(), "srt_accept");
@@ -674,13 +673,14 @@ unique_ptr<Medium> SrtMedium::Accept()
 
 unique_ptr<Medium> TcpMedium::Accept()
 {
-    sockaddr_in sa;
+    sockaddr_any sa;
     socklen_t salen = sizeof sa;
-    int s = ::accept(m_socket, (sockaddr*)&sa, &salen);
+    int s = ::accept(m_socket, (sa.get()), (&salen));
     if (s == -1)
     {
         Error(errno, "accept");
     }
+    sa.len = salen;
 
     // Configure 1s timeout
     timeval timeout_1s { 1, 0 };
@@ -714,9 +714,9 @@ void TcpMedium::CreateCaller()
 
 void SrtMedium::Connect()
 {
-    sockaddr_in sa = CreateAddrInet(m_uri.host(), m_uri.portno());
+    sockaddr_any sa = CreateAddr(m_uri.host(), m_uri.portno());
 
-    int st = srt_connect(m_socket, (sockaddr*)&sa, sizeof sa);
+    int st = srt_connect(m_socket, sa.get(), sizeof sa);
     if (st == SRT_ERROR)
         Error(UDT::getlasterror(), "srt_connect");
 
@@ -729,9 +729,9 @@ void SrtMedium::Connect()
 
 void TcpMedium::Connect()
 {
-    sockaddr_in sa = CreateAddrInet(m_uri.host(), m_uri.portno());
+    sockaddr_any sa = CreateAddr(m_uri.host(), m_uri.portno());
 
-    int st = ::connect(m_socket, (sockaddr*)&sa, sizeof sa);
+    int st = ::connect(m_socket, sa.get(), sizeof sa);
     if (st == -1)
         Error(errno, "connect");
 

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -192,8 +192,8 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
     if ( stat == SRT_ERROR )
         Error("ConfigurePre");
 
-    sockaddr_in sa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&sa;
+    sockaddr_any sa = CreateAddr(host, port);
+    sockaddr* psa = sa.get();
     Verb() << "Binding a server on " << host << ":" << port << " ...";
 
     stat = srt_bind(m_bindsock, psa, sizeof sa);
@@ -364,8 +364,8 @@ int SrtCommon::ConfigurePre(SRTSOCKET sock)
 
 void SrtCommon::SetupAdapter(const string& host, int port)
 {
-    sockaddr_in localsa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&localsa;
+    sockaddr_any localsa = CreateAddr(host, port);
+    sockaddr* psa = localsa.get();
     int stat = srt_bind(m_sock, psa, sizeof localsa);
     if ( stat == SRT_ERROR )
         Error("srt_bind");
@@ -398,8 +398,8 @@ void SrtCommon::PrepareClient()
 void SrtCommon::ConnectClient(string host, int port)
 {
 
-    sockaddr_in sa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&sa;
+    sockaddr_any sa = CreateAddr(host, port);
+	sockaddr* psa = sa.get();
 
     Verb() << "Connecting to " << host << ":" << port;
 
@@ -440,8 +440,8 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
 
     const int outport = m_outgoing_port ? m_outgoing_port : port;
 
-    sockaddr_in localsa = CreateAddrInet(adapter, outport);
-    sockaddr* plsa = (sockaddr*)&localsa;
+    sockaddr_any localsa = CreateAddr(adapter, outport);
+	sockaddr* plsa = localsa.get();
 
     Verb() << "Binding a server on " << adapter << ":" << outport;
 
@@ -452,8 +452,8 @@ void SrtCommon::OpenRendezvous(string adapter, string host, int port)
         Error("srt_bind");
     }
 
-    sockaddr_in sa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&sa;
+    sockaddr_any sa = CreateAddr(host, port);
+	sockaddr* psa = sa.get();
     Verb() << "Connecting to " << host << ":" << port;
 
     stat = srt_connect(m_sock, psa, sizeof sa);
@@ -768,7 +768,7 @@ class UdpCommon
 {
 protected:
     int m_sock = -1;
-    sockaddr_in sadr;
+    sockaddr_any sadr;
     string adapter;
     map<string, string> m_options;
 
@@ -792,19 +792,19 @@ protected:
             Error(SysError(), "UdpCommon::Setup: ioctl FIONBIO");
         }
 
-        sadr = CreateAddrInet(host, port);
+        sadr = CreateAddr(host, port);
 
         bool is_multicast = false;
 
         if ( attr.count("multicast") )
         {
-            if (!IsMulticast(sadr.sin_addr))
+            if (!IsMulticast(sadr.sin.sin_addr))
             {
                 throw std::runtime_error("UdpCommon: requested multicast for a non-multicast-type IP address");
             }
             is_multicast = true;
         }
-        else if (IsMulticast(sadr.sin_addr))
+        else if (IsMulticast(sadr.sin.sin_addr))
         {
             is_multicast = true;
         }
@@ -813,7 +813,7 @@ protected:
         {
             ip_mreq_source mreq_ssm;
             ip_mreq mreq;
-            sockaddr_in maddr;
+            sockaddr_any maddr (AF_INET);
             int opt_name;
             void* mreq_arg_ptr;
             socklen_t mreq_arg_size;
@@ -822,14 +822,14 @@ protected:
             if ( adapter == "" )
             {
                 Verb() << "Multicast: home address: INADDR_ANY:" << port;
-                maddr.sin_family = AF_INET;
-                maddr.sin_addr.s_addr = htonl(INADDR_ANY);
-                maddr.sin_port = htons(port); // necessary for temporary use
+                maddr.sin.sin_family = AF_INET;
+                maddr.sin.sin_addr.s_addr = htonl(INADDR_ANY);
+                maddr.sin.sin_port = htons(port); // necessary for temporary use
             }
             else
             {
                 Verb() << "Multicast: home address: " << adapter << ":" << port;
-                maddr = CreateAddrInet(adapter, port);
+                maddr = CreateAddr(adapter, port);
             }
 
             if (attr.count("source"))
@@ -837,8 +837,8 @@ protected:
 #ifdef IP_ADD_SOURCE_MEMBERSHIP
                 /* this is an ssm.  we need to use the right struct and opt */
                 opt_name = IP_ADD_SOURCE_MEMBERSHIP;
-                mreq_ssm.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
-                mreq_ssm.imr_interface.s_addr = maddr.sin_addr.s_addr;
+                mreq_ssm.imr_multiaddr.s_addr = sadr.sin.sin_addr.s_addr;
+                mreq_ssm.imr_interface.s_addr = maddr.sin.sin_addr.s_addr;
                 inet_pton(AF_INET, attr.at("source").c_str(), &mreq_ssm.imr_sourceaddr);
                 mreq_arg_size = sizeof(mreq_ssm);
                 mreq_arg_ptr = &mreq_ssm;
@@ -849,8 +849,8 @@ protected:
             else
             {
                 opt_name = IP_ADD_MEMBERSHIP;
-                mreq.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
-                mreq.imr_interface.s_addr = maddr.sin_addr.s_addr;
+                mreq.imr_multiaddr.s_addr = sadr.sin.sin_addr.s_addr;
+                mreq.imr_interface.s_addr = maddr.sin.sin_addr.s_addr;
                 mreq_arg_size = sizeof(mreq);
                 mreq_arg_ptr = &mreq;
             }
@@ -997,8 +997,13 @@ public:
         Setup(host, port, attr);
         if (adapter != "")
         {
-            sockaddr_in maddr = CreateAddrInet(adapter, 0);
-            in_addr addr = maddr.sin_addr;
+            sockaddr_any maddr = CreateAddr(adapter, 0);
+            if (maddr.family() != AF_INET)
+            {
+                Error(0, "UDP/target: IPv6 multicast not supported in the application");
+            }
+
+            in_addr addr = maddr.sin.sin_addr;
 
             int res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char*>(&addr), sizeof(addr));
             if (res == -1)

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -64,7 +64,7 @@
 #include <chrono>
 #include <thread>
 
-#include "apputil.hpp"  // CreateAddrInet
+#include "apputil.hpp"
 #include "uriparser.hpp"  // UriParser
 #include "socketoptions.hpp"
 #include "logsupport.hpp"

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -183,7 +183,7 @@ int main( int argc, char** argv )
     for (size_t i = 0; i < args.size(); ++i)
     {
         UriParser u(args[i], UriParser::EXPECT_HOST);
-        sockaddr_in sa = CreateAddrInet(u.host(), u.portno());
+        sockaddr_any sa = CreateAddr(u.host(), u.portno());
 
         SRTSOCKET s = srt_create_socket();
 
@@ -191,7 +191,7 @@ int main( int argc, char** argv )
         int gcon = 1;
         srt_setsockflag(s, SRTO_GROUPCONNECT, &gcon, sizeof gcon);
 
-        srt_bind(s, (sockaddr*)&sa, sizeof sa);
+        srt_bind(s, sa.get(), sizeof sa);
         srt_listen(s, 5);
 
         listeners.push_back(s);

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -269,8 +269,8 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
                 if (check.parameters().count("source"))
                 {
                     UriParser hostport(check.queryValue("source"), UriParser::EXPECT_HOST);
-                    sockaddr_in in = CreateAddrInet(hostport.host(), hostport.portno());
-                    cc.source.set(in);
+                    sockaddr_any adr = CreateAddr(hostport.host(), hostport.portno());
+                    cc.source = adr;
                 }
 
                 // Check if there's a key with 'srto.' prefix.
@@ -438,8 +438,8 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
         srt_conn_epoll = AddPoller(m_bindsock, SRT_EPOLL_OUT);
     }
 
-    sockaddr_in sa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&sa;
+    auto sa = CreateAddr(host, port);
+    sockaddr* psa = sa.get();
     Verb() << "Binding a server on " << host << ":" << port << " ...";
     stat = srt_bind(m_bindsock, psa, sizeof sa);
     if (stat == SRT_ERROR)
@@ -489,12 +489,11 @@ void SrtCommon::StealFrom(SrtCommon& src)
 
 void SrtCommon::AcceptNewClient()
 {
-    sockaddr_in scl;
-    int sclen = sizeof scl;
+    sockaddr_any scl;
 
     Verb() << " accept..." << VerbNoEOL;
 
-    m_sock = srt_accept(m_bindsock, (sockaddr*)&scl, &sclen);
+    m_sock = srt_accept(m_bindsock, (scl.get()), (&scl.len));
     if (m_sock == SRT_INVALID_SOCK)
     {
         srt_close(m_bindsock);
@@ -539,7 +538,25 @@ void SrtCommon::AcceptNewClient()
     }
     else
     {
-        Verb() << " connected.";
+        sockaddr_any peeraddr;
+        int len = sizeof peeraddr;
+        string peer = "<?PEER?>";
+        if (-1 != srt_getpeername(m_sock, peeraddr.get(), &len))
+        {
+            peeraddr.len = len;
+            peer = SockaddrToString(peeraddr);
+        }
+
+        sockaddr_any agentaddr;
+        len = sizeof agentaddr;
+        string agent = "<?AGENT?>";
+        if (-1 != srt_getsockname(m_sock, agentaddr.get(), &len))
+        {
+            agentaddr.len = len;
+            agent = SockaddrToString(agentaddr);
+        }
+
+        Verb() << " connected [" << agent << "] <-- " << peer;
     }
     ::transmit_throw_on_interrupt = false;
 
@@ -765,9 +782,8 @@ int SrtCommon::ConfigurePre(SRTSOCKET sock)
 
 void SrtCommon::SetupAdapter(const string& host, int port)
 {
-    sockaddr_in localsa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&localsa;
-    int stat = srt_bind(m_sock, psa, sizeof localsa);
+    auto lsa = CreateAddr(host, port);
+    int stat = srt_bind(m_sock, lsa.get(), sizeof lsa);
     if (stat == SRT_ERROR)
         Error("srt_bind");
 }
@@ -860,19 +876,18 @@ void SrtCommon::OpenGroupClient()
         m_group_data.resize(1);
 
     vector<SRT_SOCKGROUPCONFIG> targets;
-    int namelen = sizeof (sockaddr_in);
+    int namelen = sizeof (sockaddr_any);
 
     Verb() << "Connecting to nodes:";
     int i = 1;
     for (Connection& c: m_group_nodes)
     {
-        sockaddr_in sa = CreateAddrInet(c.host, c.port);
-        sockaddr* psa = (sockaddr*)&sa;
+        auto sa = CreateAddr(c.host, c.port);
         Verb() << "\t[" << i << "] " << c.host << ":" << c.port
             << "?weight=" << c.weight
             << " ... " << VerbNoEOL;
         ++i;
-        SRT_SOCKGROUPCONFIG gd = srt_prepare_endpoint(NULL, psa, namelen);
+        SRT_SOCKGROUPCONFIG gd = srt_prepare_endpoint(NULL, sa.get(), namelen);
         gd.weight = c.weight;
         gd.config = c.options;
         targets.push_back(gd);
@@ -1035,10 +1050,9 @@ void SrtCommon::OpenGroupClient()
 
 void SrtCommon::ConnectClient(string host, int port)
 {
-    sockaddr_in sa = CreateAddrInet(host, port);
-    sockaddr* psa = (sockaddr*)&sa;
+    auto sa = CreateAddr(host, port);
     Verb() << "Connecting to " << host << ":" << port << " ... " << VerbNoEOL;
-    int stat = srt_connect(m_sock, psa, sizeof sa);
+    int stat = srt_connect(m_sock, sa.get(), sizeof sa);
     if (stat == SRT_ERROR)
     {
         int reason = srt_getrejectreason(m_sock);
@@ -1122,10 +1136,9 @@ void SrtCommon::SetupRendezvous(string adapter, int port)
 
     const int outport = m_outgoing_port ? m_outgoing_port : port;
 
-    sockaddr_in localsa = CreateAddrInet(adapter, outport);
-    sockaddr* plsa = (sockaddr*)&localsa;
+    auto localsa = CreateAddr(adapter, outport);
     Verb() << "Binding a server on " << adapter << ":" << outport << " ...";
-    int stat = srt_bind(m_sock, plsa, sizeof localsa);
+    int stat = srt_bind(m_sock, localsa.get(), localsa.size());
     if (stat == SRT_ERROR)
     {
         srt_close(m_sock);
@@ -1227,12 +1240,11 @@ void SrtCommon::UpdateGroupStatus(const SRT_SOCKGROUPDATA* grpdata, size_t grpda
         if (n.socket != SRT_INVALID_SOCK)
             continue;
 
-        sockaddr_in sa = CreateAddrInet(n.host, n.port);
-        sockaddr* psa = (sockaddr*)&sa;
+        auto sa = CreateAddr(n.host, n.port);
         Verb() << "[" << i << "] RECONNECTING to node " << n.host << ":" << n.port << " ... " << VerbNoEOL;
         ++i;
 
-        int insock = srt_connect(m_sock, psa, sizeof sa);
+        int insock = srt_connect(m_sock, sa.get(), sa.size());
         if (insock == SRT_ERROR)
         {
             // Whatever. Skip the node.
@@ -2303,7 +2315,7 @@ class UdpCommon
 {
 protected:
     int m_sock = -1;
-    sockaddr_in sadr;
+    sockaddr_any sadr;
     string adapter;
     map<string, string> m_options;
 
@@ -2316,98 +2328,100 @@ protected:
         int yes = 1;
         ::setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&yes, sizeof yes);
 
-        sadr = CreateAddrInet(host, port);
+        sadr = CreateAddr(host, port);
 
         bool is_multicast = false;
-
-        if (attr.count("multicast"))
+        if (sadr.family() == AF_INET)
         {
-            if (!IsMulticast(sadr.sin_addr))
+            if (attr.count("multicast"))
             {
-                throw std::runtime_error("UdpCommon: requested multicast for a non-multicast-type IP address");
+                if (!IsMulticast(sadr.sin.sin_addr))
+                {
+                    throw std::runtime_error("UdpCommon: requested multicast for a non-multicast-type IP address");
+                }
+                is_multicast = true;
             }
-            is_multicast = true;
-        }
-        else if (IsMulticast(sadr.sin_addr))
-        {
-            is_multicast = true;
-        }
-
-        if (is_multicast)
-        {
-            ip_mreq_source mreq_ssm;
-            ip_mreq mreq;
-            sockaddr_in maddr;
-            int opt_name;
-            void* mreq_arg_ptr;
-            socklen_t mreq_arg_size;
-
-            adapter = attr.count("adapter") ? attr.at("adapter") : string();
-            if (adapter == "")
+            else if (IsMulticast(sadr.sin.sin_addr))
             {
-                Verb() << "Multicast: home address: INADDR_ANY:" << port;
-                maddr.sin_family = AF_INET;
-                maddr.sin_addr.s_addr = htonl(INADDR_ANY);
-                maddr.sin_port = htons(port); // necessary for temporary use
-            }
-            else
-            {
-                Verb() << "Multicast: home address: " << adapter << ":" << port;
-                maddr = CreateAddrInet(adapter, port);
+                is_multicast = true;
             }
 
-            if (attr.count("source"))
+            if (is_multicast)
             {
-                /* this is an ssm.  we need to use the right struct and opt */
-                opt_name = IP_ADD_SOURCE_MEMBERSHIP;
-                mreq_ssm.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
-                mreq_ssm.imr_interface.s_addr = maddr.sin_addr.s_addr;
-                inet_pton(AF_INET, attr.at("source").c_str(), &mreq_ssm.imr_sourceaddr);
-                mreq_arg_size = sizeof(mreq_ssm);
-                mreq_arg_ptr = &mreq_ssm;
-            }
-            else
-            {
-                opt_name = IP_ADD_MEMBERSHIP;
-                mreq.imr_multiaddr.s_addr = sadr.sin_addr.s_addr;
-                mreq.imr_interface.s_addr = maddr.sin_addr.s_addr;
-                mreq_arg_size = sizeof(mreq);
-                mreq_arg_ptr = &mreq;
-            }
+                ip_mreq_source mreq_ssm;
+                ip_mreq mreq;
+                sockaddr_any maddr;
+                int opt_name;
+                void* mreq_arg_ptr;
+                socklen_t mreq_arg_size;
+
+                adapter = attr.count("adapter") ? attr.at("adapter") : string();
+                if (adapter == "")
+                {
+                    Verb() << "Multicast: home address: INADDR_ANY:" << port;
+                    maddr.sin.sin_family = AF_INET;
+                    maddr.sin.sin_addr.s_addr = htonl(INADDR_ANY);
+                    maddr.sin.sin_port = htons(port); // necessary for temporary use
+                }
+                else
+                {
+                    Verb() << "Multicast: home address: " << adapter << ":" << port;
+                    maddr = CreateAddr(adapter, port);
+                }
+
+                if (attr.count("source"))
+                {
+                    /* this is an ssm.  we need to use the right struct and opt */
+                    opt_name = IP_ADD_SOURCE_MEMBERSHIP;
+                    mreq_ssm.imr_multiaddr.s_addr = sadr.sin.sin_addr.s_addr;
+                    mreq_ssm.imr_interface.s_addr = maddr.sin.sin_addr.s_addr;
+                    inet_pton(AF_INET, attr.at("source").c_str(), &mreq_ssm.imr_sourceaddr);
+                    mreq_arg_size = sizeof(mreq_ssm);
+                    mreq_arg_ptr = &mreq_ssm;
+                }
+                else
+                {
+                    opt_name = IP_ADD_MEMBERSHIP;
+                    mreq.imr_multiaddr.s_addr = sadr.sin.sin_addr.s_addr;
+                    mreq.imr_interface.s_addr = maddr.sin.sin_addr.s_addr;
+                    mreq_arg_size = sizeof(mreq);
+                    mreq_arg_ptr = &mreq;
+                }
 
 #ifdef _WIN32
-            const char* mreq_arg = (const char*)mreq_arg_ptr;
-            const auto status_error = SOCKET_ERROR;
+                const char* mreq_arg = (const char*)mreq_arg_ptr;
+                const auto status_error = SOCKET_ERROR;
 #else
-            const void* mreq_arg = mreq_arg_ptr;
-            const auto status_error = -1;
+                const void* mreq_arg = mreq_arg_ptr;
+                const auto status_error = -1;
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)
-            // On Windows it somehow doesn't work when bind()
-            // is called with multicast address. Write the address
-            // that designates the network device here.
-            // Also, sets port sharing when working with multicast
-            sadr = maddr;
-            int reuse = 1;
-            int shareAddrRes = setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse), sizeof(reuse));
-            if (shareAddrRes == status_error)
-            {
-                throw runtime_error("marking socket for shared use failed");
-            }
-            Verb() << "Multicast(Windows): will bind to home address";
+                // On Windows it somehow doesn't work when bind()
+                // is called with multicast address. Write the address
+                // that designates the network device here.
+                // Also, sets port sharing when working with multicast
+                sadr = maddr;
+                int reuse = 1;
+                int shareAddrRes = setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&reuse), sizeof(reuse));
+                if (shareAddrRes == status_error)
+                {
+                    throw runtime_error("marking socket for shared use failed");
+                }
+                Verb() << "Multicast(Windows): will bind to home address";
 #else
-            Verb() << "Multicast(POSIX): will bind to IGMP address: " << host;
+                Verb() << "Multicast(POSIX): will bind to IGMP address: " << host;
 #endif
-            int res = setsockopt(m_sock, IPPROTO_IP, opt_name, mreq_arg, mreq_arg_size);
+                int res = setsockopt(m_sock, IPPROTO_IP, opt_name, mreq_arg, mreq_arg_size);
 
-            if (res == status_error)
-            {
-                Error(errno, "adding to multicast membership failed");
+                if (res == status_error)
+                {
+                    Error(errno, "adding to multicast membership failed");
+                }
+
+                attr.erase("multicast");
+                attr.erase("adapter");
             }
-
-            attr.erase("multicast");
-            attr.erase("adapter");
         }
 
         // The "ttl" options is handled separately, it maps to both IP_TTL
@@ -2517,8 +2531,8 @@ public:
         Setup(host, port, attr);
         if (adapter != "")
         {
-            sockaddr_in maddr = CreateAddrInet(adapter, 0);
-            in_addr addr = maddr.sin_addr;
+            auto maddr = CreateAddr(adapter, 0);
+            in_addr addr = maddr.sin.sin_addr;
 
             int res = setsockopt(m_sock, IPPROTO_IP, IP_MULTICAST_IF, reinterpret_cast<const char*>(&addr), sizeof(addr));
             if (res == -1)

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -269,8 +269,7 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
                 if (check.parameters().count("source"))
                 {
                     UriParser hostport(check.queryValue("source"), UriParser::EXPECT_HOST);
-                    sockaddr_any adr = CreateAddr(hostport.host(), hostport.portno());
-                    cc.source = adr;
+                    cc.source = CreateAddr(hostport.host(), hostport.portno());
                 }
 
                 // Check if there's a key with 'srto.' prefix.
@@ -439,9 +438,8 @@ void SrtCommon::PrepareListener(string host, int port, int backlog)
     }
 
     auto sa = CreateAddr(host, port);
-    sockaddr* psa = sa.get();
     Verb() << "Binding a server on " << host << ":" << port << " ...";
-    stat = srt_bind(m_bindsock, psa, sizeof sa);
+    stat = srt_bind(m_bindsock, sa.get(), sizeof sa);
     if (stat == SRT_ERROR)
     {
         srt_close(m_bindsock);
@@ -538,21 +536,17 @@ void SrtCommon::AcceptNewClient()
     }
     else
     {
-        sockaddr_any peeraddr;
-        int len = sizeof peeraddr;
+        sockaddr_any peeraddr(AF_INET6);
         string peer = "<?PEER?>";
-        if (-1 != srt_getpeername(m_sock, peeraddr.get(), &len))
+        if (-1 != srt_getpeername(m_sock, (peeraddr.get()), (&peeraddr.len)))
         {
-            peeraddr.len = len;
             peer = SockaddrToString(peeraddr);
         }
 
-        sockaddr_any agentaddr;
-        len = sizeof agentaddr;
+        sockaddr_any agentaddr(AF_INET6);
         string agent = "<?AGENT?>";
-        if (-1 != srt_getsockname(m_sock, agentaddr.get(), &len))
+        if (-1 != srt_getsockname(m_sock, (agentaddr.get()), (&agentaddr.len)))
         {
-            agentaddr.len = len;
             agent = SockaddrToString(agentaddr);
         }
 


### PR DESCRIPTION
1. CreateAddrInet -> CreateAddr
2. Updated applications to use the new functions
3. Drop-in: added lacking ipv6only option handling in apps.