### PR TITLE
[core] Added snd loss rexmit time check

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -244,7 +244,8 @@ const SocketOption srt_options [] {
     { "peeridletimeo", 0, SRTO_PEERIDLETIMEO, SocketOption::PRE, SocketOption::INT, nullptr },
     { "packetfilter", 0, SRTO_PACKETFILTER, SocketOption::PRE, SocketOption::STRING, nullptr },
     { "groupconnect", 0, SRTO_GROUPCONNECT, SocketOption::PRE, SocketOption::INT, nullptr},
-    { "groupstabtimeo", 0, SRTO_GROUPSTABTIMEO, SocketOption::PRE, SocketOption::INT, nullptr}
+    { "groupstabtimeo", 0, SRTO_GROUPSTABTIMEO, SocketOption::PRE, SocketOption::INT, nullptr},
+    { "rexmitalgo", 0, SRTO_RETRANSMISSION_ALGORITHM, SocketOption::PRE, SocketOption::INT, nullptr }
 };
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1070,6 +1070,17 @@ and both must use bind/connect to one another.
 
 ---
 
+| OptName                         | Since | Binding | Type   | Units  | Default | Range  |
+| ------------------------------- | ----- | ------- | ------ | ------ | ------- | ------ |
+| `SRTO_RETRANSMISSION_ALGORITHM` | 1.5.0 | pre     | `int`  |        | 0       | [0, 1] |
+
+* **[GET or SET]** - Retransmission algorithm to use (SENDER option).
+
+* 0 - Default (retranmsit on every loss report).
+* 1 - Reduced retransmissions (not more often than once per RTT) - reduced bandwidth consumption.
+
+---
+
 | OptName               | Since | Binding | Type  | Units  | Default  | Range       |
 | --------------------- | ----- | ------- | ----- | ------ | -------- | ----------- |
 | `SRTO_REUSEADDR`      |       | pre     |       |        | true     | true, false |

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -149,7 +149,7 @@ public:
       /// @param [in] kflags Odd|Even crypto key flag
       /// @return Actual length of data read.
 
-   int readData(CPacket& w_packet, srt::sync::steady_clock::time_point& w_origintime, int kflgs);
+   int readData(CPacket& w_packet, time_point& w_origintime, int kflgs);
 
       /// Find data position to pack a DATA packet for a retransmission.
       /// @param [out] data the pointer to the data position.
@@ -159,7 +159,14 @@ public:
       /// @param [out] msglen length of the message
       /// @return Actual length of data read.
 
-   int readData(const int offset, CPacket& w_packet, srt::sync::steady_clock::time_point& w_origintime, int& w_msglen);
+   int readData(const int offset, CPacket& w_packet, time_point& w_origintime, int& w_msglen);
+
+      /// Get the time of the last retransmission (if any) of the DATA packet.
+      /// @param [in] offset offset from the last ACK point (backward sequence number difference)
+      ///
+      /// @return Last time of the last retransmission event for the corresponding DATA packet.
+
+   time_point getPacketRexmitTime(const int offset);
 
       /// Update the ACK point and may release/unmap/return the user data according to the flag.
       /// @param [in] offset number of packets acknowledged.
@@ -173,9 +180,9 @@ public:
 
    int getCurrBufSize() const;
 
-   int dropLateData(int& bytes, int32_t& w_first_msgno, const srt::sync::steady_clock::time_point& too_late_time);
+   int dropLateData(int& bytes, int32_t& w_first_msgno, const time_point& too_late_time);
 
-   void updAvgBufSize(const srt::sync::steady_clock::time_point& time);
+   void updAvgBufSize(const time_point& time);
    int getAvgBufSize(int& bytes, int& timespan);
    int getCurrBufSize(int& bytes, int& timespan);
 
@@ -223,7 +230,8 @@ private:
       int32_t m_iMsgNoBitset;           // message number
       int32_t m_iSeqNo;                 // sequence number for scheduling
       time_point m_tsOriginTime;        // original request time
-      int64_t m_llSourceTime_us;
+      time_point m_tsRexmitTime;        // packet retransmission time
+      uint64_t m_llSourceTime_us;
       int m_iTTL;                       // time to live (milliseconds)
 
       Block* m_pNext;                   // next block

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1439,6 +1439,7 @@ private: // Identification
     std::string m_sStreamName;
     int m_iOPT_PeerIdleTimeout;      // Timeout for hearing anything from the peer.
     uint32_t m_uOPT_StabilityTimeout;
+    int m_iOPT_RexmitAlgo;
 
     int m_iTsbPdDelay_ms;                           // Rx delay to absorb burst in milliseconds
     int m_iPeerTsbPdDelay_ms;                       // Tx delay that the peer uses to absorb burst in milliseconds

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -238,7 +238,8 @@ typedef enum SRT_SOCKOPT {
    SRTO_GROUPSTABTIMEO,      // Stability timeout (backup groups) in [us]
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake
    // (some space left)
-   SRTO_PACKETFILTER = 60          // Add and configure a packet filter
+   SRTO_PACKETFILTER = 60,   // Add and configure a packet filter
+   SRTO_RETRANSMISSION_ALGORITHM = 61 // An option to select packet retransmission algorithm
 } SRT_SOCKOPT;
 
 


### PR DESCRIPTION
Fixes #701

Improve periodic NAK handling by the sender.

Each unit of the sender buffer now has a retransmission timestamp. It allows tracking the time elapsed since the last retransmission of a certain packet. If a packet is retransmitted, the sender will not get ACK earlier than after 1xRTT from the retransmission time, therefore sender can ignore periodic NAK of those packet retransmissions that are still in flight.

### This PR
- [x] Adds new socket option `SRTO_RETRANSMISSION_ALGORITHM` to swith between the old and new algorithms.
- [x] Adds packet retransmission timestamp tracking to the sender.
- [x] Updated docs