### PR TITLE
Renamed CSndLossList::remove to removeUpTo

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6547,7 +6547,7 @@ void CUDT::checkNeedDrop(bool& w_bCongestion)
             m_iSndLastDataAck = fakeack;
 
             int32_t minlastack = CSeqNo::decseq(m_iSndLastDataAck);
-            m_pSndLossList->remove(minlastack);
+            m_pSndLossList->removeUpTo(minlastack);
             /* If we dropped packets not yet sent, advance current position */
             // THIS MEANS: m_iSndCurrSeqNo = MAX(m_iSndCurrSeqNo, m_iSndLastDataAck-1)
             if (CSeqNo::seqcmp(m_iSndCurrSeqNo, minlastack) < 0)
@@ -8205,7 +8205,7 @@ void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
         }
 
         // remove any loss that predates 'ack' (not to be considered loss anymore)
-        m_pSndLossList->remove(CSeqNo::decseq(m_iSndLastDataAck));
+        m_pSndLossList->removeUpTo(CSeqNo::decseq(m_iSndLastDataAck));
 
         // acknowledge the sending buffer (remove data that predate 'ack')
         m_pSndBuffer->ackData(offset);
@@ -9007,7 +9007,7 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
             sendCtrl(UMSG_DROPREQ, &w_packet.m_iMsgNo, seqpair, sizeof(seqpair));
 
             // only one msg drop request is necessary
-            m_pSndLossList->remove(seqpair[1]);
+            m_pSndLossList->removeUpTo(seqpair[1]);
 
             // skip all dropped packets
             m_iSndCurrSeqNo = CSeqNo::maxseq(m_iSndCurrSeqNo, CSeqNo::incseq(seqpair[1]));

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -184,7 +184,7 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
     return m_iLength - origlen;
 }
 
-void CSndLossList::remove(int32_t seqno)
+void CSndLossList::removeUpTo(int32_t seqno)
 {
     CGuard listguard(m_ListLock);
 

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -148,9 +148,7 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
                 i = m_caSeq[i].inext;
 
             // 3. Check if seqno1 overlaps with (seqbegin, seqend)
-            const int seqend = m_caSeq[i].seqend == SRT_SEQNO_NONE
-                ? m_caSeq[i].seqstart
-                : m_caSeq[i].seqend;
+            const int seqend = m_caSeq[i].seqend == SRT_SEQNO_NONE ? m_caSeq[i].seqstart : m_caSeq[i].seqend;
 
             if (CSeqNo::seqcmp(seqend, seqno1) < 0 && CSeqNo::incseq(seqend) != seqno1)
             {

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -71,12 +71,12 @@ public:
 
    int insert(int32_t seqno1, int32_t seqno2);
 
-      /// Remove ALL the seq. no. that are not greater than the parameter.
+      /// Remove the given sequence number and all numbers that precede it.
       /// @param [in] seqno sequence number.
 
-   void remove(int32_t seqno);
+   void removeUpTo(int32_t seqno);
 
-      /// Read the loss length.
+      /// Read the loss length.∏
       /// @return The length of the list.
 
    int getLossLength() const;

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -53,78 +53,76 @@ modified by
 #ifndef INC_SRT_LIST_H
 #define INC_SRT_LIST_H
 
-
 #include "udt.h"
 #include "common.h"
-
 
 class CSndLossList
 {
 public:
-   CSndLossList(int size = 1024);
-   ~CSndLossList();
+    CSndLossList(int size = 1024);
+    ~CSndLossList();
 
-      /// Insert a seq. no. into the sender loss list.
-      /// @param [in] seqno1 sequence number starts.
-      /// @param [in] seqno2 sequence number ends.
-      /// @return number of packets that are not in the list previously.
+    /// Insert a seq. no. into the sender loss list.
+    /// @param [in] seqno1 sequence number starts.
+    /// @param [in] seqno2 sequence number ends.
+    /// @return number of packets that are not in the list previously.
 
-   int insert(int32_t seqno1, int32_t seqno2);
+    int insert(int32_t seqno1, int32_t seqno2);
 
-      /// Remove the given sequence number and all numbers that precede it.
-      /// @param [in] seqno sequence number.
+    /// Remove the given sequence number and all numbers that precede it.
+    /// @param [in] seqno sequence number.
 
-   void removeUpTo(int32_t seqno);
+    void removeUpTo(int32_t seqno);
 
-      /// Read the loss length.∏
-      /// @return The length of the list.
+    /// Read the loss length.∏
+    /// @return The length of the list.
 
-   int getLossLength() const;
+    int getLossLength() const;
 
-      /// Read the first (smallest) loss seq. no. in the list and remove it.
-      /// @return The seq. no. or -1 if the list is empty.
+    /// Read the first (smallest) loss seq. no. in the list and remove it.
+    /// @return The seq. no. or -1 if the list is empty.
 
-   int32_t popLostSeq();
+    int32_t popLostSeq();
 
-   void traceState() const;
-
-private:
-   struct Seq
-   {
-       int32_t seqstart;                // sequence number starts
-       int32_t seqend;                  // seqnence number ends
-       int inext;                       // index of the next node in the list
-   }* m_caSeq;
-
-   int m_iHead;                         // first node
-   int m_iLength;                       // loss length
-   const int m_iSize;                   // size of the static array
-   int m_iLastInsertPos;                // position of last insert node
-
-   mutable srt::sync::Mutex m_ListLock; // used to synchronize list operation
+    void traceState() const;
 
 private:
-   /// Inserts an element to the beginning and updates head pointer.
-   /// No lock.
-   void insertHead(int pos, int32_t seqno1, int32_t seqno2);
+    struct Seq
+    {
+        int32_t seqstart; // sequence number starts
+        int32_t seqend;   // seqnence number ends
+        int     inext;    // index of the next node in the list
+    } * m_caSeq;
 
-   /// Inserts an element after previous element.
-   /// No lock.
-   void insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2);
+    int       m_iHead;          // first node
+    int       m_iLength;        // loss length
+    const int m_iSize;          // size of the static array
+    int       m_iLastInsertPos; // position of last insert node
 
-   /// Check if it is possible to coalesce element at loc with further elements.
-   /// @param loc - last changed location
-   void coalesce(int loc);
-
-   /// Update existing element with the new range (increase only)
-   /// @param pos     position of the element being updated
-   /// @param seqno1  first seqnuence number in range
-   /// @param seqno2  last sequence number in range (SRT_SEQNO_NONE if no range)
-   bool updateElement(int pos, int32_t seqno1, int32_t seqno2);
+    mutable srt::sync::Mutex m_ListLock; // used to synchronize list operation
 
 private:
-   CSndLossList(const CSndLossList&);
-   CSndLossList& operator=(const CSndLossList&);
+    /// Inserts an element to the beginning and updates head pointer.
+    /// No lock.
+    void insertHead(int pos, int32_t seqno1, int32_t seqno2);
+
+    /// Inserts an element after previous element.
+    /// No lock.
+    void insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2);
+
+    /// Check if it is possible to coalesce element at loc with further elements.
+    /// @param loc - last changed location
+    void coalesce(int loc);
+
+    /// Update existing element with the new range (increase only)
+    /// @param pos     position of the element being updated
+    /// @param seqno1  first seqnuence number in range
+    /// @param seqno2  last sequence number in range (SRT_SEQNO_NONE if no range)
+    bool updateElement(int pos, int32_t seqno1, int32_t seqno2);
+
+private:
+    CSndLossList(const CSndLossList&);
+    CSndLossList& operator=(const CSndLossList&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -132,121 +130,122 @@ private:
 class CRcvLossList
 {
 public:
-   CRcvLossList(int size = 1024);
-   ~CRcvLossList();
+    CRcvLossList(int size = 1024);
+    ~CRcvLossList();
 
-      /// Insert a series of loss seq. no. between "seqno1" and "seqno2" into the receiver's loss list.
-      /// @param [in] seqno1 sequence number starts.
-      /// @param [in] seqno2 seqeunce number ends.
+    /// Insert a series of loss seq. no. between "seqno1" and "seqno2" into the receiver's loss list.
+    /// @param [in] seqno1 sequence number starts.
+    /// @param [in] seqno2 seqeunce number ends.
 
-   void insert(int32_t seqno1, int32_t seqno2);
+    void insert(int32_t seqno1, int32_t seqno2);
 
-      /// Remove a loss seq. no. from the receiver's loss list.
-      /// @param [in] seqno sequence number.
-      /// @return if the packet is removed (true) or no such lost packet is found (false).
+    /// Remove a loss seq. no. from the receiver's loss list.
+    /// @param [in] seqno sequence number.
+    /// @return if the packet is removed (true) or no such lost packet is found (false).
 
-   bool remove(int32_t seqno);
+    bool remove(int32_t seqno);
 
-      /// Remove all packets between seqno1 and seqno2.
-      /// @param [in] seqno1 start sequence number.
-      /// @param [in] seqno2 end sequence number.
-      /// @return if the packet is removed (true) or no such lost packet is found (false).
+    /// Remove all packets between seqno1 and seqno2.
+    /// @param [in] seqno1 start sequence number.
+    /// @param [in] seqno2 end sequence number.
+    /// @return if the packet is removed (true) or no such lost packet is found (false).
 
-   bool remove(int32_t seqno1, int32_t seqno2);
+    bool remove(int32_t seqno1, int32_t seqno2);
 
-      /// Find if there is any lost packets whose sequence number falling seqno1 and seqno2.
-      /// @param [in] seqno1 start sequence number.
-      /// @param [in] seqno2 end sequence number.
-      /// @return True if found; otherwise false.
+    /// Find if there is any lost packets whose sequence number falling seqno1 and seqno2.
+    /// @param [in] seqno1 start sequence number.
+    /// @param [in] seqno2 end sequence number.
+    /// @return True if found; otherwise false.
 
-   bool find(int32_t seqno1, int32_t seqno2) const;
+    bool find(int32_t seqno1, int32_t seqno2) const;
 
-      /// Read the loss length.
-      /// @return the length of the list.
+    /// Read the loss length.
+    /// @return the length of the list.
 
-   int getLossLength() const;
+    int getLossLength() const;
 
-      /// Read the first (smallest) seq. no. in the list.
-      /// @return the sequence number or -1 if the list is empty.
+    /// Read the first (smallest) seq. no. in the list.
+    /// @return the sequence number or -1 if the list is empty.
 
-   int32_t getFirstLostSeq() const;
+    int32_t getFirstLostSeq() const;
 
-      /// Get a encoded loss array for NAK report.
-      /// @param [out] array the result list of seq. no. to be included in NAK.
-      /// @param [out] len physical length of the result array.
-      /// @param [in] limit maximum length of the array.
+    /// Get a encoded loss array for NAK report.
+    /// @param [out] array the result list of seq. no. to be included in NAK.
+    /// @param [out] len physical length of the result array.
+    /// @param [in] limit maximum length of the array.
 
-   void getLossArray(int32_t* array, int& len, int limit);
-
-private:
-   struct Seq
-   {
-        int32_t seqstart;               // sequence number starts
-        int32_t seqend;                 // sequence number ends
-        int inext;                      // index of the next node in the list
-        int iprior;                     // index of the previous node in the list
-   }* m_caSeq;
-
-   int m_iHead;                         // first node in the list
-   int m_iTail;                         // last node in the list;
-   int m_iLength;                       // loss length
-   int m_iSize;                         // size of the static array
+    void getLossArray(int32_t* array, int& len, int limit);
 
 private:
-   CRcvLossList(const CRcvLossList&);
-   CRcvLossList& operator=(const CRcvLossList&);
+    struct Seq
+    {
+        int32_t seqstart; // sequence number starts
+        int32_t seqend;   // sequence number ends
+        int     inext;    // index of the next node in the list
+        int     iprior;   // index of the previous node in the list
+    } * m_caSeq;
+
+    int m_iHead;   // first node in the list
+    int m_iTail;   // last node in the list;
+    int m_iLength; // loss length
+    int m_iSize;   // size of the static array
+
+private:
+    CRcvLossList(const CRcvLossList&);
+    CRcvLossList& operator=(const CRcvLossList&);
 
 public:
-   struct iterator
-   {
-       int32_t head;
-       Seq* seq;
+    struct iterator
+    {
+        int32_t head;
+        Seq*    seq;
 
-       iterator(Seq* str, int32_t v): head(v), seq(str) {}
+        iterator(Seq* str, int32_t v)
+            : head(v)
+            , seq(str)
+        {
+        }
 
-       iterator next() const
-       {
-           if ( head == -1 )
-               return *this; // should report error, but we can only throw exception, so simply ignore it.
+        iterator next() const
+        {
+            if (head == -1)
+                return *this; // should report error, but we can only throw exception, so simply ignore it.
 
-           return iterator(seq, seq[head].inext);
-       }
+            return iterator(seq, seq[head].inext);
+        }
 
-       iterator& operator++()
-       {
-           *this = next();
-           return *this;
-       }
+        iterator& operator++()
+        {
+            *this = next();
+            return *this;
+        }
 
-       iterator operator++(int)
-       {
-           iterator old (seq, head);
-           *this = next();
-           return old;
-       }
+        iterator operator++(int)
+        {
+            iterator old(seq, head);
+            *this = next();
+            return old;
+        }
 
-       bool operator==(const iterator& second) const
-       {
-           // Ignore seq - should be the same and this is only a sanity check.
-           return head == second.head;
-       }
+        bool operator==(const iterator& second) const
+        {
+            // Ignore seq - should be the same and this is only a sanity check.
+            return head == second.head;
+        }
 
-       bool operator!=(const iterator& second) const { return !(*this == second); }
+        bool operator!=(const iterator& second) const { return !(*this == second); }
 
-       std::pair<int32_t, int32_t> operator*()
-       {
-           return std::make_pair(seq[head].seqstart, seq[head].seqend);
-       }
-   };
+        std::pair<int32_t, int32_t> operator*() { return std::make_pair(seq[head].seqstart, seq[head].seqend); }
+    };
 
-   iterator begin() { return iterator(m_caSeq, m_iHead); }
-   iterator end() { return iterator(m_caSeq, -1); }
+    iterator begin() { return iterator(m_caSeq, m_iHead); }
+    iterator end() { return iterator(m_caSeq, -1); }
 };
 
 struct CRcvFreshLoss
 {
-    int32_t seq[2];
-    int ttl;
+    int32_t                             seq[2];
+    int                                 ttl;
     srt::sync::steady_clock::time_point timestamp;
 
     CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_ttl);
@@ -256,11 +255,12 @@ struct CRcvFreshLoss
 #ifdef DELETE
 #undef DELETE
 #endif
-    enum Emod {
-        NONE, //< the given sequence was not found in this range
+    enum Emod
+    {
+        NONE,     //< the given sequence was not found in this range
         STRIPPED, //< it was equal to first or last, already taken care of
-        SPLIT, //< found in the middle, you have to split this range into two
-        DELETE //< This was a range of one element exactly equal to sequence. Simply delete it.
+        SPLIT,    //< found in the middle, you have to split this range into two
+        DELETE    //< This was a range of one element exactly equal to sequence. Simply delete it.
     };
 
     Emod revoke(int32_t sequence);

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -164,7 +164,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNodeHead01)
     EXPECT_EQ(m_lossList->insert(4, 4), 1);
     EXPECT_EQ(m_lossList->getLossLength(), 3);
     // Remove up to element 4
-    m_lossList->remove(4);
+    m_lossList->removeUpTo(4);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -175,7 +175,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNodeHead02)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(4, 5), 2);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(4);
+    m_lossList->removeUpTo(4);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->popLostSeq(), 5);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
@@ -188,7 +188,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNodeHead03)
     EXPECT_EQ(m_lossList->insert(4, 4), 1);
     EXPECT_EQ(m_lossList->insert(8, 8), 1);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(4);
+    m_lossList->removeUpTo(4);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->popLostSeq(), 8);
     CheckEmptyArray();
@@ -200,7 +200,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNodeHead04)
     EXPECT_EQ(m_lossList->insert(4, 6), 3);
     EXPECT_EQ(m_lossList->insert(8, 8), 1);
     EXPECT_EQ(m_lossList->getLossLength(), 6);
-    m_lossList->remove(4);
+    m_lossList->removeUpTo(4);
     EXPECT_EQ(m_lossList->getLossLength(), 3);
     EXPECT_EQ(m_lossList->popLostSeq(), 5);
     EXPECT_EQ(m_lossList->popLostSeq(), 6);
@@ -213,7 +213,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead01)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(4, 5), 2);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -225,7 +225,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead02)
     EXPECT_EQ(m_lossList->insert(4, 5), 2);
     EXPECT_EQ(m_lossList->insert(8, 8), 1);
     EXPECT_EQ(m_lossList->getLossLength(), 5);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->popLostSeq(), 8);
     CheckEmptyArray();
@@ -236,7 +236,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead03)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(4, 8), 5);
     EXPECT_EQ(m_lossList->getLossLength(), 7);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 3);
     EXPECT_EQ(m_lossList->popLostSeq(), 6);
     EXPECT_EQ(m_lossList->popLostSeq(), 7);
@@ -250,7 +250,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead04)
     EXPECT_EQ(m_lossList->insert(4, 8), 5);
     EXPECT_EQ(m_lossList->insert(10, 12), 3);
     EXPECT_EQ(m_lossList->getLossLength(), 10);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 6);
     EXPECT_EQ(m_lossList->popLostSeq(), 6);
     EXPECT_EQ(m_lossList->popLostSeq(), 7);
@@ -267,7 +267,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead05)
     EXPECT_EQ(m_lossList->insert(4, 8), 5);
     EXPECT_EQ(m_lossList->insert(10, 12), 3);
     EXPECT_EQ(m_lossList->getLossLength(), 10);
-    m_lossList->remove(9);
+    m_lossList->removeUpTo(9);
     EXPECT_EQ(m_lossList->getLossLength(), 3);
     EXPECT_EQ(m_lossList->popLostSeq(), 10);
     EXPECT_EQ(m_lossList->popLostSeq(), 11);
@@ -281,7 +281,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead06)
     EXPECT_EQ(m_lossList->insert(4, 8), 5);
     EXPECT_EQ(m_lossList->insert(10, 12), 3);
     EXPECT_EQ(m_lossList->getLossLength(), 10);
-    m_lossList->remove(50);
+    m_lossList->removeUpTo(50);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -293,7 +293,7 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead07)
     EXPECT_EQ(m_lossList->insert(4, 8), 5);
     EXPECT_EQ(m_lossList->insert(10, 12), 3);
     EXPECT_EQ(m_lossList->getLossLength(), 10);
-    m_lossList->remove(-50);
+    m_lossList->removeUpTo(-50);
     EXPECT_EQ(m_lossList->getLossLength(), 10);
     EXPECT_EQ(m_lossList->popLostSeq(), 1);
     EXPECT_EQ(m_lossList->popLostSeq(), 2);
@@ -313,9 +313,9 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead08)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(5, 6), 2);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
-    m_lossList->remove(6);
+    m_lossList->removeUpTo(6);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -326,10 +326,10 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead09)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(5, 6), 2);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
-    m_lossList->remove(6);
+    m_lossList->removeUpTo(6);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -341,10 +341,10 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead10)
     EXPECT_EQ(m_lossList->insert(5, 6), 2);
     EXPECT_EQ(m_lossList->insert(10, 10), 1);
     EXPECT_EQ(m_lossList->getLossLength(), 5);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 2);
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
-    m_lossList->remove(7);
+    m_lossList->removeUpTo(7);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->popLostSeq(), 10);
     CheckEmptyArray();
@@ -355,10 +355,10 @@ TEST_F(CSndLossListTest, BasicRemoveInListNotInNodeHead11)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(5, 6), 2);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
-    m_lossList->remove(7);
+    m_lossList->removeUpTo(7);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -371,10 +371,10 @@ TEST_F(CSndLossListTest, InsertRemoveInsert01)
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
     EXPECT_EQ(m_lossList->insert(5, 6), 2);
     EXPECT_EQ(m_lossList->getLossLength(), 4);
-    m_lossList->remove(5);
+    m_lossList->removeUpTo(5);
     EXPECT_EQ(m_lossList->getLossLength(), 1);
     EXPECT_EQ(m_lossList->insert(1, 2), 2);
-    m_lossList->remove(6);
+    m_lossList->removeUpTo(6);
     EXPECT_EQ(m_lossList->getLossLength(), 0);
     EXPECT_EQ(m_lossList->popLostSeq(), -1);
     CheckEmptyArray();
@@ -512,7 +512,7 @@ TEST_F(CSndLossListTest, InsertNoUpdateElement01)
 {
     EXPECT_EQ(m_lossList->insert(0, 1), 2);
     EXPECT_EQ(m_lossList->insert(3, 5), 3);
-    m_lossList->remove(3); // Remove all to seq no 3
+    m_lossList->removeUpTo(3); // Remove all to seq no 3
     EXPECT_EQ(m_lossList->insert(4, 5), 0); // Element not updated
     EXPECT_EQ(m_lossList->getLossLength(), 2);
     EXPECT_EQ(m_lossList->popLostSeq(), 4);


### PR DESCRIPTION
It also has changes from `clang-format` applied on `list.h` (in a separate commit).

Fixes #1093 