### PR TITLE
Added support for conditionals in MAF syntax

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,6 +735,12 @@ set(OBJECT_LIB_SUPPORT "${PROJECT_SOURCE_DIR}/cmake_object_lib_support.c")
 # ---
 # Target: srt. DEFINITION ONLY. Haicrypt flag settings follow.
 # ---
+
+if (ENABLE_SHARED AND MICROSOFT)
+	#add resource files to shared library, to set DLL metadata on Windows DLLs
+	set (EXTRA_WIN32_SHARED 1)
+endif()
+
 MafReadDir(srtcore filelist.maf
 	SOURCES SOURCES_srt
 	PUBLIC_HEADERS HEADERS_srt
@@ -759,15 +765,6 @@ add_library(srt_virtual OBJECT ${SOURCES_srt} ${SOURCES_srt_extra} ${HEADERS_srt
 if (ENABLE_SHARED)
 	# Set this to sources as well, as it won't be automatically handled
 	set_target_properties(srt_virtual PROPERTIES POSITION_INDEPENDENT_CODE 1)
-
-	#add resource files to shared library, to set DLL metadata on Windows DLLs
-	if (MICROSOFT)
-		MafReadDir(srtcore filelist.maf
-			SOURCES_WIN32_SHARED SOURCES_srt_shared_win32
-		)
-		
-		message(STATUS "WINDOWS detected: Adding sources to SRT shared project: ${SOURCES_srt_shared_win32}")
-	endif()
 endif()
 
 macro(srt_set_stdcxx targetname spec)
@@ -791,7 +788,7 @@ srt_set_stdcxx(srt_virtual "${USE_CXX_STD_LIB}")
 set (VIRTUAL_srt $<TARGET_OBJECTS:srt_virtual>)
 
 if (srt_libspec_shared)
-	add_library(${TARGET_srt}_shared SHARED ${OBJECT_LIB_SUPPORT} ${VIRTUAL_srt} ${SOURCES_srt_shared_win32} ${HEADERS_srt_shared_win32})
+	add_library(${TARGET_srt}_shared SHARED ${OBJECT_LIB_SUPPORT} ${VIRTUAL_srt})
 	# shared libraries need PIC
 	set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 	set_property(TARGET ${TARGET_srt}_shared PROPERTY OUTPUT_NAME ${TARGET_srt})

--- a/scripts/haiUtil.cmake
+++ b/scripts/haiUtil.cmake
@@ -49,83 +49,8 @@ FUNCTION(join_arguments outvar)
 	set (${outvar} ${output} PARENT_SCOPE)
 ENDFUNCTION()
 
-# LEGACY. PLEASE DON'T USE ANYMORE.
-MACRO(MafRead maffile)
-	message(WARNING "MafRead is deprecated. Please use MafReadDir instead")
-	# ARGN contains the extra "section-variable" pairs
-	# If empty, return nothing
-	set (MAFREAD_TAGS
-		SOURCES            # source files
-		PUBLIC_HEADERS     # installable headers for include
-		PROTECTED_HEADERS  # installable headers used by other headers
-		PRIVATE_HEADERS    # non-installable headers
-	)
-	cmake_parse_arguments(MAFREAD_VAR "" "${MAFREAD_TAGS}" "" ${ARGN})
-	# Arguments for these tags are variables to be filled
-	# with the contents of particular section.
-	# While reading the file, extract the section.
-	# Section is recognized by either first uppercase character or space.
-
-	# @c http://cmake.org/pipermail/cmake/2007-May/014222.html
-	FILE(READ ${maffile} MAFREAD_CONTENTS)
-	STRING(REGEX REPLACE ";" "\\\\;" MAFREAD_CONTENTS "${MAFREAD_CONTENTS}")
-	STRING(REGEX REPLACE "\n" ";" MAFREAD_CONTENTS "${MAFREAD_CONTENTS}")
-
-    #message("DEBUG: MAF FILE CONTENTS: ${MAFREAD_CONTENTS}")
-    #message("DEBUG: PASSED VARIABLES:")
-    #foreach(DEBUG_VAR ${MAFREAD_TAGS})
-    #	message("DEBUG: ${DEBUG_VAR}=${MAFREAD_VAR_${DEBUG_VAR}}")
-    #endforeach()
-
-	# The unnamed section becomes SOURCES
-	set (MAFREAD_VARIABLE ${MAFREAD_VAR_SOURCES})
-	set (MAFREAD_UNASSIGNED "")
-
-	FOREACH(MAFREAD_LINE ${MAFREAD_CONTENTS})
-		# Test what this line is
-		string(STRIP ${MAFREAD_LINE} MAFREAD_OLINE)
-		string(SUBSTRING ${MAFREAD_OLINE} 0 1 MAFREAD_FIRST)
-		#message("DEBUG: LINE='${MAFREAD_LINE}' FIRST='${MAFREAD_FIRST}'")
-
-		# The 'continue' command is cmake 3.2 - very late discovery
-		if (MAFREAD_FIRST STREQUAL "")
-			#message("DEBUG: ... skipped: empty")
-		elseif (MAFREAD_FIRST STREQUAL "#")
-			#message("DEBUG: ... skipped: comment")
-		else()
-			# Will be skipped if the line was a comment/empty
-			string(REGEX MATCH "[ A-Z]" MAFREAD_SECMARK ${MAFREAD_FIRST})
-			if (MAFREAD_SECMARK STREQUAL "")
-				# This isn't a section, it's a list element.
-				#message("DEBUG: ITEM: ${MAFREAD_OLINE} --> ${MAFREAD_VARIABLE}")
-				LIST(APPEND ${MAFREAD_VARIABLE} ${MAFREAD_OLINE})
-			else()
-				# It's a section - change the running variable
-				# Make it section name
-				STRING(REPLACE  " " "_" MAFREAD_SECNAME ${MAFREAD_OLINE})
-				set(MAFREAD_VARIABLE ${MAFREAD_VAR_${MAFREAD_SECNAME}})
-				if (MAFREAD_VARIABLE STREQUAL "")
-					set(MAFREAD_VARIABLE MAFREAD_UNASSIGNED)
-				endif()
-				#message("DEBUG: NEW SECTION: '${MAFREAD_SECNAME}' --> VARIABLE: '${MAFREAD_VARIABLE}'")
-			endif()
-		endif()
-	ENDFOREACH()
-	
-	# Final debug report
-    #set (ALL_VARS "")
-    #message("DEBUG: extracted variables:")
-    #foreach(DEBUG_VAR ${MAFREAD_TAGS})
-    #	list(APPEND ALL_VARS ${MAFREAD_VAR_${DEBUG_VAR}})
-    #endforeach()
-    #list(REMOVE_DUPLICATES ALL_VARS)
-    #foreach(DEBUG_VAR ${ALL_VARS})
-    #	message("DEBUG: --> ${DEBUG_VAR} = ${${DEBUG_VAR}}")
-    #endforeach()
-ENDMACRO(MafRead)
-
-# New version of MafRead macro, which automatically adds directory
-# prefix. This should also resolve each relative path.
+# The directory specifies the location of maffile and
+# all files specified in the list.
 MACRO(MafReadDir directory maffile)
 	# ARGN contains the extra "section-variable" pairs
 	# If empty, return nothing
@@ -188,11 +113,60 @@ MACRO(MafReadDir directory maffile)
 				if (${MAFREAD_SECTION_TYPE} STREQUAL file)
 					get_filename_component(MAFREAD_OLINE ${directory}/${MAFREAD_OLINE} ABSOLUTE)
 				endif()
-				LIST(APPEND ${MAFREAD_VARIABLE} ${MAFREAD_OLINE})
+
+				set (MAFREAD_CONDITION_OK 1)
+				if (DEFINED MAFREAD_CONDITION_LIST)
+					FOREACH(MFITEM IN ITEMS ${MAFREAD_CONDITION_LIST})
+						separate_arguments(MFITEM)
+						FOREACH(MFVAR IN ITEMS ${MFITEM})
+							STRING(SUBSTRING ${MFVAR} 0 1 MFPREFIX)
+							if (MFPREFIX STREQUAL "!")
+								STRING(SUBSTRING ${MFVAR} 1 -1 MFVAR)
+								if (${MFVAR})
+									set (MFCONDITION_RESULT 0)
+								else()
+									set (MFCONDITION_RESULT 1)
+								endif()
+							else()
+								if (${MFVAR})
+									set (MFCONDITION_RESULT 1)
+								else()
+									set (MFCONDITION_RESULT 0)
+								endif()
+							endif()
+							#message("CONDITION: ${MFPREFIX} ${MFVAR} -> ${MFCONDITION_RESULT}")
+
+							MATH(EXPR MAFREAD_CONDITION_OK "${MAFREAD_CONDITION_OK} & (${MFCONDITION_RESULT})")
+						ENDFOREACH()
+					ENDFOREACH()
+				endif()
+
+				if (MAFREAD_CONDITION_OK)
+					LIST(APPEND ${MAFREAD_VARIABLE} ${MAFREAD_OLINE})
+				else()
+					#message("... NOT ADDED ITEM: ${MAFREAD_OLINE}")
+				endif()
 			else()
-				# It's a section - change the running variable
+				# It's a section
+				# Check for conditionals (clear current conditions first)
+				unset(MAFREAD_CONDITION_LIST)
+
+				STRING(FIND ${MAFREAD_OLINE} " -" MAFREAD_HAVE_CONDITION)
+				if (NOT MAFREAD_HAVE_CONDITION EQUAL -1)
+					# Cut off conditional specification, and 
+					# grab the section name and condition list
+					STRING(REPLACE " -" ";" MAFREAD_CONDITION_LIST ${MAFREAD_OLINE})
+
+					#message("CONDITION READ: ${MAFREAD_CONDITION_LIST}")
+
+					LIST(GET MAFREAD_CONDITION_LIST 0 MAFREAD_OLINE)
+					LIST(REMOVE_AT MAFREAD_CONDITION_LIST 0)
+					#message("EXTRACTING SECTION=${MAFREAD_OLINE} CONDITIONS=${MAFREAD_CONDITION_LIST}")
+				endif()
+				# change the running variable
 				# Make it section name
 				STRING(REPLACE  " " "_" MAFREAD_SECNAME ${MAFREAD_OLINE})
+				#message("MAF SECTION: ${MAFREAD_SECNAME}")
 
 				# The cmake's version of 'if (MAFREAD_SECNAME[0] == '-')' - sigh...
 				string(SUBSTRING ${MAFREAD_SECNAME} 0 1 MAFREAD_SECNAME0)

--- a/scripts/maf.vim
+++ b/scripts/maf.vim
@@ -1,0 +1,38 @@
+"
+" SRT - Secure, Reliable, Transport
+" Copyright (c) 2018 Haivision Systems Inc.
+"
+" This Source Code Form is subject to the terms of the Mozilla Public
+" License, v. 2.0. If a copy of the MPL was not distributed with this
+" file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"
+" This file describes MAF ("manifest") file syntax used by
+" SRT project.
+"
+
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" conditionals
+syn match mafCondition  contained " - [!A-Za-z].*"hs=s+2
+
+" section
+syn match mafSection "^[A-Z][0-9A-Za-z_].*$" contains=mafCondition
+syn match mafsection "^ .*$" contains=mafCondition
+
+" comments
+syn match  mafComment		"^\s*\zs#.*$"
+syn match  mafComment		"\s\zs#.*$"
+syn match  mafComment	contained	"#.*$"
+
+
+" hilites
+
+hi def link mafComment Comment
+hi def link mafSection Statement
+hi def link mafCondition Number
+
+
+let b:current_syntax = "maf"

--- a/scripts/maf.vim
+++ b/scripts/maf.vim
@@ -1,6 +1,6 @@
 "
 " SRT - Secure, Reliable, Transport
-" Copyright (c) 2018 Haivision Systems Inc.
+" Copyright (c) 2020 Haivision Systems Inc.
 "
 " This Source Code Form is subject to the terms of the Mozilla Public
 " License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -21,7 +21,16 @@ srt_c_api.cpp
 window.cpp
 srt_compat.c
 sync.cpp
+
+# Add when created
+# SOURCES - !ENABLE_STDCXX_SYNC
+# sync_posix.cpp
+
+SOURCES - ENABLE_STDCXX_SYNC
 sync_cxx11.cpp
+
+SOURCES - EXTRA_WIN32_SHARED
+srt_shared.rc
 
 PUBLIC HEADERS
 srt.h
@@ -56,6 +65,3 @@ srt_compat.h
 threadname.h
 utilities.h
 window.h
-
-SOURCES WIN32 SHARED
-srt_shared.rc


### PR DESCRIPTION
Fixes #920

Changes:

1. Added support for conditional MAF.

Sections can be defined multiple times (can be merged) and condition can be added by adding ` - ` after the name, followed by an expression, currently possible as a variable, possibly with `!` at the end. The variable needs to "resolve to true" (the way how the interpreter defines it - in cmake case it's the reaction on `if()` condition), `!` inverts the condition.

2. Added conditionally C++11 sync and the windows resource file in MAF.

3. Removed old and obsolete `MafRead` function.