### PR TITLE
Fixed wrong definition of enum operator that lead to misinterpreting the result and mistaken edge update

### DIFF
--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -776,7 +776,7 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
                     st[i->fd] = i->events;
                     IF_HEAVY_LOGGING(singles << "@" << i->fd << ":");
                     IF_HEAVY_LOGGING(PrintEpollEvent(singles, i->events, i->parent->edgeOnly()));
-                    bool edged ATR_UNUSED = d.checkEdge(i++); // NOTE: potentially deletes `i`
+                    const bool edged ATR_UNUSED = d.checkEdge(i++); // NOTE: potentially deletes `i`
                     IF_HEAVY_LOGGING(singles << (edged ? "<^> " : " "));
                 }
 
@@ -964,4 +964,3 @@ string CEPollDesc::DisplayEpollWatch()
 }
 
 #endif
-

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -68,7 +68,7 @@ using namespace std;
 using namespace srt::sync;
 
 #if ENABLE_HEAVY_LOGGING
-static void PrintEpollEvent(ostream& os, int events);
+static ostream& PrintEpollEvent(ostream& os, int events, int et_events = 0);
 #endif
 
 namespace srt_logging
@@ -304,7 +304,13 @@ int CEPoll::update_usock(const int eid, const SRTSOCKET& u, const int* events)
     int32_t evts = events ? *events : uint32_t(SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR);
     bool edgeTriggered = evts & SRT_EPOLL_ET;
     evts &= ~SRT_EPOLL_ET;
+
+    // et_evts = all events, if SRT_EPOLL_ET, or only those that are always ET otherwise.
     int32_t et_evts = edgeTriggered ? evts : evts & SRT_EPOLL_ETONLY;
+
+    IF_HEAVY_LOGGING(ostringstream evos);
+    IF_HEAVY_LOGGING(PrintEpollEvent(evos, evts, et_evts));
+    HLOGC(dlog.Debug, log << "srt_epoll_update_usock: TO UPDATE: " << evos.str());
     if (evts)
     {
         pair<CEPollDesc::ewatch_t::iterator, bool> iter_new = d.addWatch(u, evts, et_evts);
@@ -762,6 +768,7 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
 
             if (!empty || msTimeOut == 0)
             {
+                IF_HEAVY_LOGGING(ostringstream singles);
                 // If msTimeOut == 0, it means that we need the information
                 // immediately, we don't want to wait. Therefore in this case
                 // report also when none is ready.
@@ -771,11 +778,16 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
                 {
                     ++total;
                     st[i->fd] = i->events;
-                    d.checkEdge(i++); // NOTE: potentially deletes `i`
+                    IF_HEAVY_LOGGING(singles << "@" << i->fd << ":");
+                    IF_HEAVY_LOGGING(PrintEpollEvent(singles, i->events, i->parent->edgeOnly()));
+                    bool edged ATR_UNUSED = d.checkEdge(i++); // NOTE: potentially deletes `i`
+                    IF_HEAVY_LOGGING(singles << (edged ? "<^> " : " "));
                 }
 
+                // Logging into 'singles' because it notifies as to whether
+                // the edge-triggered event has been cleared
                 HLOGC(dlog.Debug, log << "EID " << d.m_iID << " rdy=" << total << ": "
-                        << DisplayEpollResults(st)
+                        << singles.str()
                         << " TRACKED: " << d.DisplayEpollWatch());
                 return total;
             }
@@ -903,13 +915,13 @@ int CEPoll::update_events(const SRTSOCKET& uid, std::set<int>& eids, const int e
 
 // Debug use only.
 #if ENABLE_HEAVY_LOGGING
-static void PrintEpollEvent(ostream& os, int events)
+static ostream& PrintEpollEvent(ostream& os, int events, int et_events)
 {
     static pair<int, const char*> const namemap [] = {
-        make_pair(SRT_EPOLL_IN, "[R]"),
-        make_pair(SRT_EPOLL_OUT, "[W]"),
-        make_pair(SRT_EPOLL_ERR, "[E]"),
-        make_pair(SRT_EPOLL_UPDATE, "[U]")
+        make_pair(SRT_EPOLL_IN, "R"),
+        make_pair(SRT_EPOLL_OUT, "W"),
+        make_pair(SRT_EPOLL_ERR, "E"),
+        make_pair(SRT_EPOLL_UPDATE, "U")
     };
 
     int N = Size(namemap);
@@ -917,8 +929,15 @@ static void PrintEpollEvent(ostream& os, int events)
     for (int i = 0; i < N; ++i)
     {
         if (events & namemap[i].first)
-            os << namemap[i].second;
+        {
+            os << "[";
+            if (et_events & namemap[i].first)
+                os << "^";
+            os << namemap[i].second << "]";
+        }
     }
+
+    return os;
 }
 
 string DisplayEpollResults(const std::map<SRTSOCKET, int>& sockset)
@@ -941,7 +960,7 @@ string CEPollDesc::DisplayEpollWatch()
     for (ewatch_t::const_iterator i = m_USockWatchState.begin(); i != m_USockWatchState.end(); ++i)
     {
         os << "@" << i->first << ":";
-        PrintEpollEvent(os, i->second.watch);
+        PrintEpollEvent(os, i->second.watch, i->second.edge);
         os << " ";
     }
 

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -307,10 +307,6 @@ int CEPoll::update_usock(const int eid, const SRTSOCKET& u, const int* events)
 
     // et_evts = all events, if SRT_EPOLL_ET, or only those that are always ET otherwise.
     int32_t et_evts = edgeTriggered ? evts : evts & SRT_EPOLL_ETONLY;
-
-    IF_HEAVY_LOGGING(ostringstream evos);
-    IF_HEAVY_LOGGING(PrintEpollEvent(evos, evts, et_evts));
-    HLOGC(dlog.Debug, log << "srt_epoll_update_usock: TO UPDATE: " << evos.str());
     if (evts)
     {
         pair<CEPollDesc::ewatch_t::iterator, bool> iter_new = d.addWatch(u, evts, et_evts);

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -328,8 +328,7 @@ int CEPoll::update_usock(const int eid, const SRTSOCKET& u, const int* events)
 
             // Update the watch configuration, including edge
             wait.watch = evts;
-            if (edgeTriggered)
-                wait.edge = evts;
+            wait.edge = et_evts;
 
             // Now it should look exactly like newly added
             // and the state is also updated

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -662,7 +662,7 @@ typedef int32_t SRT_EPOLL_T;
 
 // Define which epoll flags determine events. All others are special flags.
 #define SRT_EPOLL_EVENTTYPES (SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_UPDATE | SRT_EPOLL_ERR)
-#define SRT_EPOLL_ETONLY (SRT_EPOLL_UPDATE)
+#define SRT_EPOLL_ETONLY (SRT_EPOLL_UPDATE) // XXX weird bug found without this "0 |", workaround.
 
 enum SRT_EPOLL_FLAGS
 {
@@ -686,13 +686,6 @@ inline SRT_EPOLL_OPT operator|(SRT_EPOLL_OPT a1, SRT_EPOLL_OPT a2)
     return SRT_EPOLL_OPT( (int)a1 | (int)a2 );
 }
 
-inline bool operator&(int flags, SRT_EPOLL_OPT eflg)
-{
-    // Using an enum prevents treating int automatically as enum,
-    // requires explicit enum to be passed here, and minimizes the
-    // risk that the right side value will contain multiple flags.
-    return (flags & int(eflg)) != 0;
-}
 #endif
 
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -662,7 +662,7 @@ typedef int32_t SRT_EPOLL_T;
 
 // Define which epoll flags determine events. All others are special flags.
 #define SRT_EPOLL_EVENTTYPES (SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_UPDATE | SRT_EPOLL_ERR)
-#define SRT_EPOLL_ETONLY (SRT_EPOLL_UPDATE) // XXX weird bug found without this "0 |", workaround.
+#define SRT_EPOLL_ETONLY (SRT_EPOLL_UPDATE)
 
 enum SRT_EPOLL_FLAGS
 {


### PR DESCRIPTION
Fixes #1405

Two bugfixes:

1. Subscription wasn't taking into account that some flags passed together with the others are always edge-triggered, while edge-triggered version for those that support both wasn't requested. This made an unwanted situation when an always-edge-triggered event was subscribed in level-trigger mode.

2. The operator & was defined incorrectly and actually it didn't do the job it was intended to do, instead caused a bug that resolved the flag & operation into a boolean, then interpreted as 1.