### PR TITLE
[core] Replaced CGuard with corresponding lock: UniqueLock or ScopedLock

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -249,7 +249,7 @@ public:
 
    CUDTGroup& addGroup(SRTSOCKET id, SRT_GROUP_TYPE type)
    {
-       srt::sync::CGuard cg (m_GlobControlLock);
+       srt::sync::ScopedLock cg (m_GlobControlLock);
        // This only ensures that the element exists.
        // If the element was newly added, it will be NULL.
        CUDTGroup*& g = m_Groups[id];
@@ -270,7 +270,7 @@ public:
    {
        using srt_logging::mglog;
 
-       srt::sync::CGuard cg (m_GlobControlLock);
+       srt::sync::ScopedLock cg (m_GlobControlLock);
 
        CUDTGroup* pg = map_get(m_Groups, g->m_GroupID, NULL);
        if (pg)
@@ -293,7 +293,7 @@ public:
 
    CUDTGroup* findPeerGroup(SRTSOCKET peergroup)
    {
-       srt::sync::CGuard cg (m_GlobControlLock);
+       srt::sync::ScopedLock cg (m_GlobControlLock);
 
        for (groups_t::iterator i = m_Groups.begin();
                i != m_Groups.end(); ++i)

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -590,7 +590,7 @@ int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time
 
 srt::sync::steady_clock::time_point CSndBuffer::getPacketRexmitTime(const int offset)
 {
-    CGuard bufferguard(m_BufLock);
+    ScopedLock bufferguard(m_BufLock);
     const Block* p = m_pFirstBlock;
 
     // XXX Suboptimal procedure to keep the blocks identifiable

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -464,7 +464,7 @@ int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime,
 
 int32_t CSndBuffer::getMsgNoAt(const int offset)
 {
-    CGuard bufferguard(m_BufLock);
+    ScopedLock bufferguard(m_BufLock);
 
     Block* p = m_pFirstBlock;
 
@@ -512,7 +512,7 @@ int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time
 {
     int32_t& msgno_bitset = w_packet.m_iMsgNo;
 
-    CGuard bufferguard(m_BufLock);
+    ScopedLock bufferguard(m_BufLock);
 
     Block* p = m_pFirstBlock;
 
@@ -585,7 +585,7 @@ int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time
 
 void CSndBuffer::ackData(int offset)
 {
-    CGuard bufferguard(m_BufLock);
+    ScopedLock bufferguard(m_BufLock);
 
     bool move = false;
     for (int i = 0; i < offset; ++i)
@@ -610,7 +610,7 @@ int CSndBuffer::getCurrBufSize() const
 
 int CSndBuffer::getAvgBufSize(int& w_bytes, int& w_tsp)
 {
-    CGuard bufferguard(m_BufLock); /* Consistency of pkts vs. bytes vs. spantime */
+    ScopedLock bufferguard(m_BufLock); /* Consistency of pkts vs. bytes vs. spantime */
 
     /* update stats in case there was no add/ack activity lately */
     updAvgBufSize(steady_clock::now());
@@ -655,7 +655,7 @@ int CSndBuffer::dropLateData(int& w_bytes, int32_t& w_first_msgno, const steady_
     bool    move   = false;
     int32_t msgno  = 0;
 
-    CGuard bufferguard(m_BufLock);
+    ScopedLock bufferguard(m_BufLock);
     for (int i = 0; i < m_iCount && m_pFirstBlock->m_tsOriginTime < too_late_time; ++i)
     {
         dpkts++;
@@ -837,7 +837,7 @@ void CRcvBuffer::countBytes(int pkts, int bytes, bool acked)
      *  acked (bytes>0, acked=true),
      *  removed (bytes<0, acked=n/a)
      */
-    CGuard cg(m_BytesCountLock);
+    ScopedLock cg(m_BytesCountLock);
 
     if (!acked) // adding new pkt in RcvBuffer
     {

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -98,7 +98,7 @@ public:
 
    int lookup(T* data)
    {
-      srt::sync::CGuard cacheguard(m_Lock);
+      srt::sync::ScopedLock cacheguard(m_Lock);
 
       int key = data->getKey();
       if (key < 0)
@@ -126,7 +126,7 @@ public:
 
    int update(T* data)
    {
-      srt::sync::CGuard cacheguard(m_Lock);
+      srt::sync::ScopedLock cacheguard(m_Lock);
 
       int key = data->getKey();
       if (key < 0)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -389,7 +389,7 @@ public:
 
     gli_t find(SRTSOCKET id)
     {
-        srt::sync::CGuard g (m_GroupLock);
+        srt::sync::ScopedLock g (m_GroupLock);
         gli_t f = std::find_if(m_Group.begin(), m_Group.end(), HaveID(id));
         if (f == m_Group.end())
         {
@@ -408,7 +408,7 @@ public:
     bool remove(SRTSOCKET id)
     {
         bool s = false;
-        srt::sync::CGuard g (m_GroupLock);
+        srt::sync::ScopedLock g (m_GroupLock);
         gli_t f = std::find_if(m_Group.begin(), m_Group.end(), HaveID(id));
         if (f != m_Group.end())
         {
@@ -446,7 +446,7 @@ public:
 
     bool empty()
     {
-        srt::sync::CGuard g (m_GroupLock);
+        srt::sync::ScopedLock g (m_GroupLock);
         return m_Group.empty();
     }
 
@@ -1110,7 +1110,7 @@ public: // internal API
     // immediately to free the socket
     void notListening()
     {
-        srt::sync::CGuard cg(m_ConnectionLock);
+        srt::sync::ScopedLock cg(m_ConnectionLock);
         m_bListening = false;
         m_pRcvQueue->removeListener(this);
     }

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -109,7 +109,7 @@ void CSndLossList::traceState() const
 
 int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     if (m_iLength == 0)
     {
@@ -184,7 +184,7 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 
 void CSndLossList::removeUpTo(int32_t seqno)
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     if (0 == m_iLength)
         return;
@@ -296,14 +296,14 @@ void CSndLossList::removeUpTo(int32_t seqno)
 
 int CSndLossList::getLossLength() const
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     return m_iLength;
 }
 
 int32_t CSndLossList::popLostSeq()
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     if (0 == m_iLength)
     {

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -66,7 +66,7 @@ void PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_se
     else
     {
         // Packet not to be passthru, update stats
-        CGuard lg(m_parent->m_StatsLock);
+        ScopedLock lg(m_parent->m_StatsLock);
         ++m_parent->m_stats.rcvFilterExtra;
         ++m_parent->m_stats.rcvFilterExtraTotal;
     }
@@ -80,7 +80,7 @@ void PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_se
         int dist = CSeqNo::seqoff(i->first, i->second) + 1;
         if (dist > 0)
         {
-            CGuard lg(m_parent->m_StatsLock);
+            ScopedLock lg(m_parent->m_StatsLock);
             m_parent->m_stats.rcvFilterLoss += dist;
             m_parent->m_stats.rcvFilterLossTotal += dist;
         }
@@ -99,7 +99,7 @@ void PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_se
         size_t nsupply = m_provided.size();
         InsertRebuilt(w_incoming, m_unitq);
 
-        CGuard lg(m_parent->m_StatsLock);
+        ScopedLock lg(m_parent->m_StatsLock);
         m_parent->m_stats.rcvFilterSupply += nsupply;
         m_parent->m_stats.rcvFilterSupplyTotal += nsupply;
     }

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -272,7 +272,7 @@ CSndUList::~CSndUList()
 
 void CSndUList::update(const CUDT* u, EReschedule reschedule)
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     CSNode* n = u->m_pSNode;
 
@@ -298,7 +298,7 @@ void CSndUList::update(const CUDT* u, EReschedule reschedule)
 
 int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     if (-1 == m_iLastEntry)
         return -1;
@@ -339,14 +339,14 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 
 void CSndUList::remove(const CUDT *u)
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     remove_(u);
 }
 
 steady_clock::time_point CSndUList::getNextProcTime()
 {
-    CGuard listguard(m_ListLock);
+    ScopedLock listguard(m_ListLock);
 
     if (-1 == m_iLastEntry)
         return steady_clock::time_point();
@@ -547,7 +547,7 @@ void *CSndQueue::worker(void *param)
             self->m_WorkerStats.lNotReadyTs++;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
-            CGuard windlock (self->m_WindowLock);
+            UniqueLock windlock (self->m_WindowLock);
             CSync windsync  (self->m_WindowCond, windlock);
 
             // wait here if there is no sockets with data to be sent
@@ -814,7 +814,7 @@ CRendezvousQueue::~CRendezvousQueue()
 void CRendezvousQueue::insert(
     const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const steady_clock::time_point& ttl)
 {
-    CGuard vg(m_RIDVectorLock);
+    ScopedLock vg(m_RIDVectorLock);
 
     CRL r;
     r.m_iID        = id;
@@ -848,7 +848,7 @@ void CRendezvousQueue::remove(const SRTSOCKET &id, bool should_lock)
 
 CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
 {
-    CGuard     vg(m_RIDVectorLock);
+    ScopedLock     vg(m_RIDVectorLock);
 
     // TODO: optimize search
     for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
@@ -878,7 +878,7 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
 
 void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket &response)
 {
-    CGuard vg(m_RIDVectorLock);
+    ScopedLock vg(m_RIDVectorLock);
 
     if (m_lRendezvousID.empty())
         return;
@@ -1307,7 +1307,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     int listener_ret  = SRT_REJ_UNKNOWN;
     bool              have_listener = false;
     {
-        CGuard cg(m_LSLock);
+        ScopedLock cg(m_LSLock);
         if (m_pListener)
         {
             LOGC(mglog.Note,
@@ -1541,7 +1541,7 @@ void CRcvQueue::stopWorker()
 
 int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
 {
-    CGuard bufferlock (m_BufferLock);
+    UniqueLock bufferlock (m_BufferLock);
     CSync buffercond    (m_BufferCond, bufferlock);
 
     map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
@@ -1593,7 +1593,7 @@ int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
 
 int CRcvQueue::setListener(CUDT *u)
 {
-    CGuard lslock(m_LSLock);
+    ScopedLock lslock(m_LSLock);
 
     if (NULL != m_pListener)
         return -1;
@@ -1604,7 +1604,7 @@ int CRcvQueue::setListener(CUDT *u)
 
 void CRcvQueue::removeListener(const CUDT *u)
 {
-    CGuard lslock(m_LSLock);
+    ScopedLock lslock(m_LSLock);
 
     if (u == m_pListener)
         m_pListener = NULL;
@@ -1622,7 +1622,7 @@ void CRcvQueue::removeConnector(const SRTSOCKET &id, bool should_lock)
     HLOGC(mglog.Debug, log << "removeConnector: removing @" << id);
     m_pRendezvousQueue->remove(id, should_lock);
 
-    CGuard bufferlock(m_BufferLock);
+    ScopedLock bufferlock(m_BufferLock);
 
     map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
     if (i != m_mBuffer.end())
@@ -1642,7 +1642,7 @@ void CRcvQueue::removeConnector(const SRTSOCKET &id, bool should_lock)
 void CRcvQueue::setNewEntry(CUDT *u)
 {
     HLOGC(mglog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
-    CGuard listguard(m_IDLock);
+    ScopedLock listguard(m_IDLock);
     m_vNewEntry.push_back(u);
 }
 
@@ -1650,7 +1650,7 @@ bool CRcvQueue::ifNewEntry() { return !(m_vNewEntry.empty()); }
 
 CUDT *CRcvQueue::getNewEntry()
 {
-    CGuard listguard(m_IDLock);
+    ScopedLock listguard(m_IDLock);
 
     if (m_vNewEntry.empty())
         return NULL;
@@ -1663,7 +1663,7 @@ CUDT *CRcvQueue::getNewEntry()
 
 void CRcvQueue::storePkt(int32_t id, CPacket *pkt)
 {
-    CGuard bufferlock (m_BufferLock);
+    UniqueLock bufferlock (m_BufferLock);
     CSync passcond    (m_BufferCond, bufferlock);
 
     map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -457,7 +457,7 @@ class CSync
     UniqueLock* m_locker;
 
 public:
-    // Locked version: must be declared only after the declaration of ScopedLock,
+    // Locked version: must be declared only after the declaration of UniqueLock,
     // which has locked the mutex. On this delegate you should call only
     // signal_locked() and pass the ScopedLock variable that should remain locked.
     // Also wait() and wait_for() can be used only with this socket.
@@ -528,7 +528,7 @@ public:
     // when you don't care whether the associated mutex is locked or not (you
     // accept the case that a mutex isn't locked and the signal gets effectively
     // missed), or you somehow know that the mutex is locked, but you don't have
-    // access to the associated ScopedLock object. This function, although it does
+    // access to the associated UniqueLock object. This function, although it does
     // the same thing as signal_locked() and broadcast_locked(), is here for
     // the user to declare explicitly that the signal/broadcast is done without
     // being prematurely certain that the associated mutex is locked.

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -338,12 +338,6 @@ private:
 };
 #endif // ENABLE_STDCXX_SYNC
 
-/// The purpose of this typedef is to reduce the number of changes in the code (renamings)
-/// and produce less merge conflicts with some other parallel work done.
-/// TODO: Replace CGuard with ScopedLock. Use UniqueLock only when required.
-typedef UniqueLock CGuard;
-
-
 inline void enterCS(Mutex& m) { m.lock(); }
 inline bool tryEnterCS(Mutex& m) { return m.try_lock(); }
 inline void leaveCS(Mutex& m) { m.unlock(); }
@@ -460,14 +454,14 @@ inline void releaseCond(Condition& cv) { cv.destroy(); }
 class CSync
 {
     Condition* m_cond;
-    CGuard* m_locker;
+    UniqueLock* m_locker;
 
 public:
-    // Locked version: must be declared only after the declaration of CGuard,
+    // Locked version: must be declared only after the declaration of ScopedLock,
     // which has locked the mutex. On this delegate you should call only
-    // signal_locked() and pass the CGuard variable that should remain locked.
+    // signal_locked() and pass the ScopedLock variable that should remain locked.
     // Also wait() and wait_for() can be used only with this socket.
-    CSync(Condition& cond, CGuard& g)
+    CSync(Condition& cond, UniqueLock& g)
         : m_cond(&cond), m_locker(&g)
     {
         // XXX it would be nice to check whether the owner is also current thread
@@ -514,17 +508,17 @@ public:
     // Static ad-hoc version
     static void lock_signal(Condition& cond, Mutex& m)
     {
-        CGuard lk(m); // XXX with thread logging, don't use CGuard directly!
+        ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
         cond.notify_one();
     }
 
     static void lock_broadcast(Condition& cond, Mutex& m)
     {
-        CGuard lk(m); // XXX with thread logging, don't use CGuard directly!
+        ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
         cond.notify_all();
     }
 
-    void signal_locked(CGuard& lk ATR_UNUSED)
+    void signal_locked(UniqueLock& lk ATR_UNUSED)
     {
         // EXPECTED: lk.mutex() is LOCKED.
         m_cond->notify_one();
@@ -534,7 +528,7 @@ public:
     // when you don't care whether the associated mutex is locked or not (you
     // accept the case that a mutex isn't locked and the signal gets effectively
     // missed), or you somehow know that the mutex is locked, but you don't have
-    // access to the associated CGuard object. This function, although it does
+    // access to the associated ScopedLock object. This function, although it does
     // the same thing as signal_locked() and broadcast_locked(), is here for
     // the user to declare explicitly that the signal/broadcast is done without
     // being prematurely certain that the associated mutex is locked.

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -459,7 +459,7 @@ class CSync
 public:
     // Locked version: must be declared only after the declaration of UniqueLock,
     // which has locked the mutex. On this delegate you should call only
-    // signal_locked() and pass the ScopedLock variable that should remain locked.
+    // signal_locked() and pass the UniqueLock variable that should remain locked.
     // Also wait() and wait_for() can be used only with this socket.
     CSync(Condition& cond, UniqueLock& g)
         : m_cond(&cond), m_locker(&g)

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -169,7 +169,7 @@ public:
    int getPktRcvSpeed(int& w_bytesps) const
    {
        // Lock access to the packet Window
-       srt::sync::CGuard cg(m_lockPktWindow);
+       srt::sync::ScopedLock cg(m_lockPktWindow);
 
        int pktReplica[ASIZE];          // packet information window (inter-packet time)
        return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, (w_bytesps));
@@ -187,7 +187,7 @@ public:
    int getBandwidth() const
    {
        // Lock access to the packet Window
-       srt::sync::CGuard cg(m_lockProbeWindow);
+       srt::sync::ScopedLock cg(m_lockProbeWindow);
 
        int probeReplica[PSIZE];
        return getBandwidth_in(m_aProbeWindow, probeReplica, PSIZE);
@@ -210,7 +210,7 @@ public:
 
    void onPktArrival(int pktsz = 0)
    {
-       srt::sync::CGuard cg(m_lockPktWindow);
+       srt::sync::ScopedLock cg(m_lockPktWindow);
 
        m_tsCurrArrTime = srt::sync::steady_clock::now();
 
@@ -285,7 +285,7 @@ public:
        const srt::sync::steady_clock::time_point now = srt::sync::steady_clock::now();
 
        // Lock access to the packet Window
-       srt::sync::CGuard cg(m_lockProbeWindow);
+       srt::sync::ScopedLock cg(m_lockProbeWindow);
 
        m_tsCurrArrTime = now;
 


### PR DESCRIPTION
Addresses an item in #1103.
`CGuard` was used as a temporal solution to avoid too many merge conflicts with the bonding functionality.
Now most of that functionality is merged, so it is relatively safe to replace `CGuard` with the corresponding lock: `ScopedLock` or `UniqueLock`.