### PR TITLE
[docs] Access control guidelines: reserve single-character keys

### DIFF
--- a/docs/AccessControl.md
+++ b/docs/AccessControl.md
@@ -2,29 +2,30 @@
 
 ## Motivation
 
-One type of information that can be interchanged when a connection is being 
-established in SRT is "Stream ID", which can be used in a caller-listener 
-connection layout. This is a string of maximum 512 characters set on the caller 
-side. It can be retrieved at the listener side on the newly accepted socket 
+One type of information that can be interchanged when a connection is being
+established in SRT is "Stream ID", which can be used in a caller-listener
+connection layout. This is a string of maximum 512 characters set on the caller
+side. It can be retrieved at the listener side on the newly accepted socket
 through a socket option (see `SRTO_STREAMID` in [API.md](API.md)).
 
-As of SRT version 1.3.3 a callback can be registered on the listener socket for 
-an application to make decisions on incoming caller connections. This callback, 
-among others, is provided with the value of Stream ID from the incoming 
-connection. Based on this information, the application can accept or reject the 
-connection, select the desired data stream, or set an appropriate passphrase for 
+As of SRT version 1.3.3 a callback can be registered on the listener socket for
+an application to make decisions on incoming caller connections. This callback,
+among others, is provided with the value of Stream ID from the incoming
+connection. Based on this information, the application can accept or reject the
+connection, select the desired data stream, or set an appropriate passphrase for
 the connection.
 
 ## Purpose
 
-The Stream ID value can be used as free-form, but there is a recommended 
-convention so that all SRT users speak the same language. The intent of the 
+The Stream ID value can be used as free-form, but there is a recommended
+convention so that all SRT users speak the same language. The intent of the
 convention is to:
 
 - promote readability and consistency among free-form names
 - interpret some typical data in the key-value style
 
 In short,
+
 1. `SRTO_STREAMID` is designed for a caller (client) to be able to identify itself, and state what it wants.
 2. `srt_listen_callback(...)` function is used by a listener (server) to check what a caller (client) has provided in `SRTO_STREAMID` **before** the connection is established.
 For example, the listener (server) can check if it knows the user and set the corresponding passphrase for a connection to be accepted.
@@ -34,7 +35,6 @@ If a correct passphrase is not provided by the client (caller), the request from
 **Note!** `srt_listen_callback(...)` can't check the passphrase directly for security reasons. 
 The only way to make the app check the passphrase is to set the passphrase on the socket by using the `SRTO_PASSPHRASE` option. This lets SRT to reject connection on mismatch.
 
-
 ## Character Encoding
 
 The Stream ID uses UTF-8 encoding.
@@ -42,16 +42,14 @@ The Stream ID uses UTF-8 encoding.
 ## General Syntax
 
 This recommended syntax starts with the characters known as an executable
-specification in POSIX: 
-
-`#!` 
+specification in POSIX: `#!`.
 
 The next two characters are:
 
 - `:` - this marks the YAML format, the only one currently used
 - The content format, which is either:
-   - `:` - the comma-separated keys with no nesting
-   - `{` - like above, but nesting is allowed and must end with `}`
+  - `:` - the comma-separated keys with no nesting
+  - `{` - like above, but nesting is allowed and must end with `}`
 
 (Nesting means that you can have multiple level brace-enclosed parts inside.)
 
@@ -61,61 +59,60 @@ The form of the key-value pair is:
 
 ## Standard Keys
 
-Beside the general syntax, there are several top-level keys treated as standard 
+Beside the general syntax, there are several top-level keys treated as standard
 keys. Other keys can be used as needed.
 
 The following keys are standard:
 
-- `u`: **User Name**, or authorization name, that is expected to control which 
-password should be used for the connection. The application should interpret 
-it to distinguish which user should be used by the listener party to set up the 
+- `u`: **User Name**, or authorization name, that is expected to control which
+password should be used for the connection. The application should interpret
+it to distinguish which user should be used by the listener party to set up the
 password.
 - `r`: **Resource Name** identifies the name of the resource and facilitates
 selection should the listener party be able to serve multiple resources.
-- `h`: **Host Name** identifies the hostname of the resource. For example, 
-to request a stream with the URI `somehost.com/videos/querry.php?vid=366` the 
-`hostname` field should have “somehost.com”, and the resource name can have 
-“videos/querry.php?vid=366” or simply "366". Note that this is still a key to be 
-specified explicitly. Support tools that apply simplifications and URI extraction 
+- `h`: **Host Name** identifies the hostname of the resource. For example,
+to request a stream with the URI `somehost.com/videos/querry.php?vid=366` the
+`hostname` field should have “somehost.com”, and the resource name can have
+“videos/querry.php?vid=366” or simply "366". Note that this is still a key to be
+specified explicitly. Support tools that apply simplifications and URI extraction
 are expected to insert only the host portion of the URI here.
-- `s`: **Session ID** is a temporary resource identifier negotiated with 
-the server, used just for verification. This is a one-shot identifier, invalidated 
-after the first use. The expected usage is when details for the resource and 
-authorization are negotiated over a separate connection first, and then the 
+- `s`: **Session ID** is a temporary resource identifier negotiated with
+the server, used just for verification. This is a one-shot identifier, invalidated
+after the first use. The expected usage is when details for the resource and
+authorization are negotiated over a separate connection first, and then the
 session ID is used here alone.
-- `t`: **Type** specifies the purpose of the connection. Several standard 
+- `t`: **Type** specifies the purpose of the connection. Several standard
 types are defined, but users may extend the use:
-   - `stream` (default, if not specified): for exchanging the user-specified 
-   payload for an application-defined purpose
-   - `file`: for transmitting a file, where `r` is the filename
-   - `auth`: for exchanging sensible data. The `r` value states its purpose. 
-   No specific possible values for that are known so far (FUTURE USE]
+  - `stream` (default, if not specified): for exchanging the user-specified
+  payload for an application-defined purpose
+  - `file`: for transmitting a file, where `r` is the filename
+  - `auth`: for exchanging sensible data. The `r` value states its purpose.
+  No specific possible values for that are known so far (FUTURE USE]
 - `m`: **Mode** expected for this connection:
-   - `request` (default): the caller wants to receive the stream
-   - `publish`: the caller wants to send the stream data
-   - `bidirectional`:  bidirectional data exchange is expected
+  - `request` (default): the caller wants to receive the stream
+  - `publish`: the caller wants to send the stream data
+  - `bidirectional`:  bidirectional data exchange is expected
 
-Note that `m` is not required in the case where you don't use `streamid` to 
-distinguish authorization or resources, and your caller is expected to send the 
-data. This is only for cases where the listener can handle various purposes of the 
+Note that `m` is not required in the case where you don't use `streamid` to
+distinguish authorization or resources, and your caller is expected to send the
+data. This is only for cases where the listener can handle various purposes of the
 connection and is therefore required to know what the caller is attempting to do.
 
 Examples:
 
-```
+```js
 #!::u=admin,r=bluesbrothers1_hi
 ```
 
-This specifies the username and the resource name of the stream to be served 
+This specifies the username and the resource name of the stream to be served
 to the caller.
 
-```
+```js
 #!::u=johnny,t=file,m=publish,r=results.csv
 ```
 
-This specifies that the file is expected to be transmitted from the caller to 
+This specifies that the file is expected to be transmitted from the caller to
 the listener and its name is `results.csv`.
-
 
 ### Rejection codes
 
@@ -125,13 +122,13 @@ as `SRT_REJ_RESOURCE`. The handler can, however, set its own rejection
 code. There are two number spaces intended for this purpose (as the range
 below `SRT_REJC_PREDEFINED` is reserved for internal codes):
 
-* `SRT_REJC_PREDEFINED` and above: predefined errors. Errors from this range
+- `SRT_REJC_PREDEFINED` and above: predefined errors. Errors from this range
 (that is, below `SRT_REJC_USERDEFINED`) have their definitions provided in
 the `access_control.h` public header file. The intention is that applications
 using these codes understand the situation described by these codes standard
 way.
 
-* `SRT_REJC_USERDEFINED` and above: to be freely defined by the application.
+- `SRT_REJC_USERDEFINED` and above: to be freely defined by the application.
 Codes from this range can be only understood if each application knows the
 code definitions of the other. These codes should be used only after making
 sure that both applications understood them.
@@ -139,10 +136,10 @@ sure that both applications understood them.
 The intention for the predefined codes is to be consistent with the HTTP
 standard codes. Therefore the following sub-ranges are used:
 
-* 0 - 99: Reserved for unique SRT-specific codes (unused by HTTP)
-* 100 - 399: Info, Success and Redirection in HTTP, unused in SRT
-* 400 - 599: Client and server errors in HTTP, adopted by SRT
-* 600 - 999: unused in SRT
+- 0 - 99: Reserved for unique SRT-specific codes (unused by HTTP)
+- 100 - 399: Info, Success and Redirection in HTTP, unused in SRT
+- 400 - 599: Client and server errors in HTTP, adopted by SRT
+- 600 - 999: unused in SRT
 
 Such a code can be set by using the `srt_setrejectreason` function.
 
@@ -150,7 +147,7 @@ The SRT-specific codes are:
 
 #### SRT_REJX_FALLBACK
 
-This code should be set by the callback handler in the beginning in case 
+This code should be set by the callback handler in the beginning in case
 the application needs to be informed that the callback handler
 actually has interpreted the incoming connection, but hasn't set a
 more appropriate code describing the situation.
@@ -189,14 +186,12 @@ recognized services by host name to some predefined names and not
 handle the others, even if this is properly resolved by DNS. In this
 case it should report this error.
 
-
 The other error codes are HTTP codes adopted for SRT:
 
 #### SRT_REJX_BAD_REQUEST
 
 General syntax error. This can be reported in any case when parsing
 the StreamID contents failed, or it cannot be properly interpreted.
-
 
 #### SRT_REJX_UNAUTHORIZED
 
@@ -211,25 +206,23 @@ process has generated some valid session ID, but then the session
 connection has specified a resource that is not within the frames
 of that authentication.
 
-
 #### SRT_REJX_OVERLOAD
 
 The server is too heavily loaded to process your request, or you
 have exceeded credits for accessing the service and the resource.
 In HTTP the description mentions payment for a service, but
 it is also used by some services for general "credit" management
-for a client. In SRT it should be used when your service is doing 
-any kind of credit management to limit access to selected clients 
-that "have" enough credit, even if the credit is something the client 
-can recharge itself, or that can be granted depending on available 
+for a client. In SRT it should be used when your service is doing
+any kind of credit management to limit access to selected clients
+that "have" enough credit, even if the credit is something the client
+can recharge itself, or that can be granted depending on available
 service resources.
-
 
 #### SRT_REJX_FORBIDDEN
 
 Access denied to the resource for any reason. This error is
 independent of an authorization or authentication error (as reported
-by `SRT_REJX_UNAUTHORIZED`). The application can decide which 
+by `SRT_REJX_UNAUTHORIZED`). The application can decide which
 is more appropriate. This error is usually intended for
 a resource that should only be accessed after a successful
 authorization over a separate auth-only connection, where the query
@@ -237,7 +230,6 @@ in StreamID has correctly specified the resource identity and mode,
 but the session ID (in the `s` key) is either (a) not specified, or (b) does
 specify a valid session, but the authorization region for this
 session does not embrace the specified resource.
-
 
 #### SRT_REJX_NOTFOUND
 
@@ -247,13 +239,11 @@ information about resource accessibility is allowed to be publicly
 visible. Otherwise the application might report authorization
 errors.
 
-
 #### SRT_REJX_BAD_MODE
 
 The mode specified in the `m` key in StreamID is not supported for this request.
-This may apply to read-only or write-only resources, as well for when interactive 
+This may apply to read-only or write-only resources, as well for when interactive
 (bidirectional) access is not valid for a resource.
-
 
 #### SRT_REJX_UNACCEPTABLE
 
@@ -264,7 +254,6 @@ be wrong when sending, or a restriction on the data format (as specified in the
 details of the resource specification) such that it cannot be provided 
 when receiving.
 
-
 #### SRT_REJX_CONFLICT
 
 The resource being accessed (as specified by `r` and `h` keys) is locked for
@@ -272,12 +261,11 @@ modification. This error should only be reported for `m=publish` when the
 resource being accessed is read-only because another client (not necessarily
 connected through SRT):
 
-* is currently publishing into this resource
-* has reserved this resource ID for publishing
+- is currently publishing into this resource
+- has reserved this resource ID for publishing
 
 Note that this error should be reported when there is no other reason for
 having a problem accessing the resource.
-
 
 #### SRT_REJX_NOTSUP_MEDIA
 
@@ -286,7 +274,6 @@ specified in the `t` key. The currently standard types are
 `stream`, `file` and `auth`. An application may extend this list, and
 is not obliged to support all of the standard types.
 
-
 #### SRT_REJX_LOCKED
 
 The resource being accessed is locked against any access. This is similar to
@@ -294,21 +281,18 @@ The resource being accessed is locked against any access. This is similar to
 and writing. This is for when the resource should be shown as existing and 
 available to the client, but access is temporarily blocked.
 
-
-#### SRT_REJX_FAILED_DEPEND 
+#### SRT_REJX_FAILED_DEPEND
 
 The dependent entity for the request is not present. In this case the
 dependent entity is the session, which should be specified in the `s`
 key. This means that the specified session ID is nonexistent or it
 has already expired.
 
-
 #### SRT_REJX_ISE
 
 Internal server error. This is for a general case when a request has
-been correctly verified, with no related problems found, but an 
+been correctly verified, with no related problems found, but an
 unexpected error occurs after the processing of the request has started.
-
 
 #### SRT_REJX_UNIMPLEMENTED
 
@@ -322,30 +306,26 @@ temporarily blocked. This shouldn't be reported for existing features that are
 being deprecated, or older features that are no longer supported
 (for this case the general `SRT_REJX_BAD_REQUEST` is more appropriate).
 
-
 #### SRT_REJX_GW
 
 The server acts as a gateway and the target endpoint rejected the
-connection. The reason the connection was rejected is unspecified. 
-The gateway cannot forward the original rejection code from the 
-target endpoint because this would suggest the error was on the 
-gateway itself. Use this error with some other mechanism to report 
+connection. The reason the connection was rejected is unspecified.
+The gateway cannot forward the original rejection code from the
+target endpoint because this would suggest the error was on the
+gateway itself. Use this error with some other mechanism to report
 the original target error, if possible.
-
 
 #### SRT_REJX_DOWN
 
-The service is down for maintenance. This can only be reported 
+The service is down for maintenance. This can only be reported
 when the service has been temporarily replaced by a stub that is only
 reporting this error, while the real service is down for maintenance.
 
-
 #### SRT_REJX_VERSION
 
-Application version not supported. This can refer to an application feature 
-that is unsupported (possibly from an older SRT version), or to a feature 
+Application version not supported. This can refer to an application feature
+that is unsupported (possibly from an older SRT version), or to a feature
 that is no longer supported because of backward compatibility requirements.
-
 
 #### SRT_REJX_NOROOM
 
@@ -356,30 +336,29 @@ pre-declared, so this error can be reported early. It can also be reported when
 the stream is of undefined length, and there is no more storage space
 available.
 
-
 ## Example
 
-An example of Stream ID functionality and the listener callback can be 
+An example of Stream ID functionality and the listener callback can be
 found under `tests/test_listen_callback.cpp`.
 
-A listener can register a callback to be called in the middle of accepting a 
+A listener can register a callback to be called in the middle of accepting a
 new socket connection:
 
-```
+```c++
 srt_listen(server_sock, 5);
 srt_listen_callback(server_sock, &SrtTestListenCallback, NULL);
 ```
 
-A callback function has to be implemented by the upstream application. In the 
-example below, the function tries to interpret the Stream ID value first according 
+A callback function has to be implemented by the upstream application. In the
+example below, the function tries to interpret the Stream ID value first according
 to the Access Control guidelines and to extract the username from the `u` key.
-Otherwise it falls back to a free-form specified username. Depending on the user, 
-it sets the appropriate password for the expected connection so that it can be 
-rejected if the password isn't correct. If the user isn't found in the 
-database (`passwd` map) the function itself rejects the connection. Note that 
+Otherwise it falls back to a free-form specified username. Depending on the user,
+it sets the appropriate password for the expected connection so that it can be
+rejected if the password isn't correct. If the user isn't found in the
+database (`passwd` map) the function itself rejects the connection. Note that
 this can be done by both returning -1 and by throwing an exception.
 
-```
+```c++
 int SrtTestListenCallback(void* opaq, SRTSOCKET ns, int hsversion,
     const struct sockaddr* peeraddr, const char* streamid)
 {

--- a/docs/AccessControl.md
+++ b/docs/AccessControl.md
@@ -55,12 +55,19 @@ The next two characters are:
 
 The form of the key-value pair is:
 
-- `key1=value1,key2=value2`...
+```js
+key1=value1,key2=value2...
+```
 
 ## Standard Keys
 
 Beside the general syntax, there are several top-level keys treated as standard
-keys. Other keys can be used as needed.
+keys. All single letter key definitions, including those not listed in this section,
+are reserved for future use. Users can additionally use custom key definitions
+with `user_*` or `companyname_*` prefixes, where `user` and `companyname` are
+to be replaced with an actual user or company name.
+
+The existing key values must not be extended, and must not differ from those described in this section.
 
 The following keys are standard:
 
@@ -72,8 +79,8 @@ password.
 selection should the listener party be able to serve multiple resources.
 - `h`: **Host Name** identifies the hostname of the resource. For example,
 to request a stream with the URI `somehost.com/videos/querry.php?vid=366` the
-`hostname` field should have “somehost.com”, and the resource name can have
-“videos/querry.php?vid=366” or simply "366". Note that this is still a key to be
+`hostname` field should have `somehost.com`, and the resource name can have
+`videos/querry.php?vid=366` or simply `366`. Note that this is still a key to be
 specified explicitly. Support tools that apply simplifications and URI extraction
 are expected to insert only the host portion of the URI here.
 - `s`: **Session ID** is a temporary resource identifier negotiated with


### PR DESCRIPTION
The first commit fixes document formatting.

The second commit adds the following changes:
- All single-letter key definitions are reserved for future use.
- Users can add their keys with `user_*` or `companyname_*` prefixes.
- Users are not allowed to extend existing values.

Addresses #1342