### PR TITLE
[apps] Added source time to sample apps

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -394,7 +394,7 @@ bool DoUpload(UriParser& ut, string path, string filename,
             size_t shift = 0;
             while (n > 0)
             {
-                int st = tar->Write(buf.data() + shift, n, out_stats);
+                int st = tar->Write(buf.data() + shift, n, 0, out_stats);
                 Verb() << "Upload: " << n << " --> " << st
                     << (!shift ? string() : "+" + Sprint(shift));
                 if (st == SRT_ERROR)
@@ -574,7 +574,7 @@ bool DoDownload(UriParser& us, string directory, string filename,
 
         if (connected)
         {
-            vector<char> buf(cfg.chunk_size);
+            MediaPacket packet(cfg.chunk_size);
 
             if (!ofile.is_open())
             {
@@ -591,7 +591,7 @@ bool DoDownload(UriParser& us, string directory, string filename,
                 cerr << "Writing output to [" << directory << "]" << endl;
             }
 
-            int n = src->Read(cfg.chunk_size, buf, out_stats);
+            int n = src->Read(cfg.chunk_size, packet, out_stats);
             if (n == SRT_ERROR)
             {
                 cerr << "Download: SRT error: " << srt_getlasterror_str() << endl;
@@ -607,7 +607,7 @@ bool DoDownload(UriParser& us, string directory, string filename,
 
             // Write to file any amount of data received
             Verb() << "Download: --> " << n;
-            ofile.write(buf.data(), n);
+            ofile.write(packet.payload.data(), n);
             if (!ofile.good())
             {
                 cerr << "Error writing file" << endl;

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -172,7 +172,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         o_autorecon     = { "a", "auto", "autoreconnect" },
         o_chunk         = { "c", "chunk" },
         o_bwreport      = { "r", "bwreport", "report", "bandwidth-report", "bitrate-report" },
-        o_srctime       = {"st", "stime", "sourcetime"},
+        o_srctime       = {"st", "srctime", "sourcetime"},
         o_statsrep      = { "s", "stats", "stats-report-frequency" },
         o_statsout      = { "statsout" },
         o_statspf       = { "pf", "statspf" },
@@ -745,13 +745,16 @@ int main(int argc, char** argv)
                 while (!dataqueue.empty())
                 {
                     std::shared_ptr<MediaPacket> pkt = dataqueue.front();
-                    if (!tar.get() || !tar->IsOpen()) {
+                    if (!tar.get() || !tar->IsOpen())
+                    {
                         lostBytes += pkt->payload.size();
                     }
-                    else if (!tar->Write(pkt->payload.data(), pkt->payload.size(), cfg.srctime ? pkt->time : 0, out_stats)) {
+                    else if (!tar->Write(pkt->payload.data(), pkt->payload.size(), cfg.srctime ? pkt->time : 0, out_stats))
+                    {
                         lostBytes += pkt->payload.size();
                     }
-                    else {
+                    else
+                    {
                         wroteBytes += pkt->payload.size();
                     }
 

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -136,6 +136,7 @@ struct LiveTransmitConfig
     bool log_internal;
     string logfile;
     int bw_report = 0;
+    bool srctime = true;
     int stats_report = 0;
     string stats_out;
     SrtStatsPrintFormat stats_pf = SRTSTATS_PROFMAT_2COLS;
@@ -171,6 +172,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         o_autorecon     = { "a", "auto", "autoreconnect" },
         o_chunk         = { "c", "chunk" },
         o_bwreport      = { "r", "bwreport", "report", "bandwidth-report", "bitrate-report" },
+        o_srctime       = {"st", "stime", "sourcetime"},
         o_statsrep      = { "s", "stats", "stats-report-frequency" },
         o_statsout      = { "statsout" },
         o_statspf       = { "pf", "statspf" },
@@ -190,6 +192,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         { o_autorecon,    OptionScheme::ARG_ONE },
         { o_chunk,        OptionScheme::ARG_ONE },
         { o_bwreport,     OptionScheme::ARG_ONE },
+        { o_srctime,      OptionScheme::ARG_ONE },
         { o_statsrep,     OptionScheme::ARG_ONE },
         { o_statsout,     OptionScheme::ARG_ONE },
         { o_statspf,      OptionScheme::ARG_ONE },
@@ -236,15 +239,16 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         PrintOptionHelp(o_timeout,   "<timeout=0>", "exit timer in seconds");
         PrintOptionHelp(o_timeout_mode, "<mode=0>", "timeout mode (0 - since app start; 1 - like 0, but cancel on connect");
 #endif
-        PrintOptionHelp(o_autorecon, "<enabled=yes>", "auto-reconnect mode [yes|no]");
+        PrintOptionHelp(o_autorecon, "<enabled=yes>", "auto-reconnect mode {yes, no}");
         PrintOptionHelp(o_chunk,     "<chunk=1456>", "max size of data read in one step, that can fit one SRT packet");
         PrintOptionHelp(o_bwreport,  "<every_n_packets=0>", "bandwidth report frequency");
+        PrintOptionHelp(o_srctime,   "<enabled=yes>", "Pass packet time from source to SRT output {yes, no}");
         PrintOptionHelp(o_statsrep,  "<every_n_packets=0>", "frequency of status report");
         PrintOptionHelp(o_statsout,  "<filename>", "output stats to file");
-        PrintOptionHelp(o_statspf,   "<format=default>", "stats printing format [json|csv|default]");
+        PrintOptionHelp(o_statspf,   "<format=default>", "stats printing format {json, csv, default}");
         PrintOptionHelp(o_statsfull, "", "full counters in stats-report (prints total statistics)");
-        PrintOptionHelp(o_loglevel,  "<level=error>", "log level [fatal,error,info,note,warning]");
-        PrintOptionHelp(o_logfa,     "<fas=general,...>", "log functional area [all,general,bstats,control,data,tsbpd,rexmit]");
+        PrintOptionHelp(o_loglevel,  "<level=error>", "log level {fatal,error,info,note,warning}");
+        PrintOptionHelp(o_logfa,     "<fas=general,...>", "log functional area {all,general,bstats,control,data,tsbpd,rexmit}");
         //PrintOptionHelp(o_log_internal, "", "use internal logger");
         PrintOptionHelp(o_logfile, "<filename="">", "write logs to file");
         PrintOptionHelp(o_quiet, "", "quiet mode (default off)");
@@ -273,6 +277,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
     cfg.timeout      = Option<OutNumber>(params, o_timeout);
     cfg.timeout_mode = Option<OutNumber>(params, o_timeout_mode);
     cfg.chunk_size   = Option<OutNumber>(params, "-1", o_chunk);
+    cfg.srctime      = Option<OutBool>(params, cfg.srctime, o_srctime);
     cfg.bw_report    = Option<OutNumber>(params, o_bwreport);
     cfg.stats_report = Option<OutNumber>(params, o_statsrep);
     cfg.stats_out    = Option<OutString>(params, o_statsout);
@@ -708,15 +713,13 @@ int main(int argc, char** argv)
                 // read buffers as much as possible on each read event
                 // note that this implies live streams and does not
                 // work for cached/file sources
-                std::list<std::shared_ptr<bytevector>> dataqueue;
+                std::list<std::shared_ptr<MediaPacket>> dataqueue;
                 if (src.get() && src->IsOpen() && (srtrfdslen || sysrfdslen))
                 {
                     while (dataqueue.size() < 10)
                     {
-                        std::shared_ptr<bytevector> pdata(
-                            new bytevector(transmit_chunk_size));
-
-                        const int res = src->Read(transmit_chunk_size, *pdata, out_stats);
+                        std::shared_ptr<MediaPacket> pkt(new MediaPacket(transmit_chunk_size));
+                        const int res = src->Read(transmit_chunk_size, *pkt, out_stats);
 
                         if (res == SRT_ERROR && src->uri.type() == UriParser::SRT)
                         {
@@ -728,28 +731,29 @@ int main(int argc, char** argv)
                             );
                         }
 
-                        if (res == 0 || pdata->empty())
+                        if (res == 0 || pkt->payload.empty())
                         {
                             break;
                         }
 
-                        dataqueue.push_back(pdata);
-                        receivedBytes += (*pdata).size();
+                        dataqueue.push_back(pkt);
+                        receivedBytes += pkt->payload.size();
                     }
                 }
 
-                // if no target, let received data fall to the floor
+                // if there is no target, let the received data be lost
                 while (!dataqueue.empty())
                 {
-                    std::shared_ptr<bytevector> pdata = dataqueue.front();
+                    std::shared_ptr<MediaPacket> pkt = dataqueue.front();
                     if (!tar.get() || !tar->IsOpen()) {
-                        lostBytes += (*pdata).size();
+                        lostBytes += pkt->payload.size();
                     }
-                    else if (!tar->Write(pdata->data(), pdata->size(), out_stats)) {
-                        lostBytes += (*pdata).size();
+                    else if (!tar->Write(pkt->payload.data(), pkt->payload.size(), cfg.srctime ? pkt->time : 0, out_stats)) {
+                        lostBytes += pkt->payload.size();
                     }
-                    else
-                        wroteBytes += (*pdata).size();
+                    else {
+                        wroteBytes += pkt->payload.size();
+                    }
 
                     dataqueue.pop_front();
                 }

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -136,7 +136,7 @@ struct LiveTransmitConfig
     bool log_internal;
     string logfile;
     int bw_report = 0;
-    bool srctime = true;
+    bool srctime = false;
     int stats_report = 0;
     string stats_out;
     SrtStatsPrintFormat stats_pf = SRTSTATS_PROFMAT_2COLS;

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -28,6 +28,20 @@ extern unsigned long transmit_bw_report;
 extern unsigned long transmit_stats_report;
 extern unsigned long transmit_chunk_size;
 
+struct MediaPacket
+{
+    bytevector payload;
+    int64_t time = 0;
+
+    MediaPacket(bytevector&& src) : payload(std::move(src)) {}
+    MediaPacket(bytevector&& src, int64_t stime) : payload(std::move(src)), time(stime) {}
+
+    MediaPacket(size_t payload_size) : payload(payload_size), time(0) {}
+    MediaPacket(const bytevector& src) : payload(src) {}
+    MediaPacket(const bytevector& src, int64_t stime) : payload(src), time(stime) {}
+    MediaPacket() {}
+};
+
 extern std::shared_ptr<SrtStatsWriter> transmit_stats_writer;
 
 class Location
@@ -40,7 +54,7 @@ public:
 class Source: public Location
 {
 public:
-    virtual int  Read(size_t chunk, bytevector& data, std::ostream &out_stats = std::cout) = 0;
+    virtual int  Read(size_t chunk, MediaPacket& pkt, std::ostream &out_stats = std::cout) = 0;
     virtual bool IsOpen() = 0;
     virtual bool End() = 0;
     static std::unique_ptr<Source> Create(const std::string& url);
@@ -63,7 +77,7 @@ public:
 class Target: public Location
 {
 public:
-    virtual int  Write(const char* data, size_t size, std::ostream &out_stats = std::cout) = 0;
+    virtual int  Write(const char* data, size_t size, int64_t src_time, std::ostream &out_stats = std::cout) = 0;
     virtual bool IsOpen() = 0;
     virtual bool Broken() = 0;
     virtual void Close() {}

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -54,17 +54,18 @@ public:
             throw std::runtime_error(path + ": Can't open file for reading");
     }
 
-    int Read(size_t chunk, bytevector& data, ostream & ignored SRT_ATR_UNUSED = cout) override
+    int Read(size_t chunk, MediaPacket& pkt, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
-        if (data.size() < chunk)
-            data.resize(chunk);
+        if (pkt.payload.size() < chunk)
+            pkt.payload.resize(chunk);
 
-        ifile.read(data.data(), chunk);
+        pkt.time = 0;
+        ifile.read(pkt.payload.data(), chunk);
         size_t nread = ifile.gcount();
-        if ( nread < data.size() )
-            data.resize(nread);
+        if (nread < pkt.payload.size())
+            pkt.payload.resize(nread);
 
-        if (data.empty())
+        if (pkt.payload.empty())
         {
             return 0;
         }
@@ -83,7 +84,7 @@ public:
 
     FileTarget(const string& path): ofile(path, ios::out | ios::trunc | ios::binary) {}
 
-    int Write(const char* data, size_t size, ostream & ignored SRT_ATR_UNUSED = cout) override
+    int Write(const char* data, size_t size, int64_t time SRT_ATR_UNUSED, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         ofile.write(data, size);
         return !(ofile.bad()) ? (int) size : 0;
@@ -499,23 +500,26 @@ SrtSource::SrtSource(string host, int port, const map<string,string>& par)
     hostport_copy = os.str();
 }
 
-int SrtSource::Read(size_t chunk, bytevector& data, ostream &out_stats)
+int SrtSource::Read(size_t chunk, MediaPacket& pkt, ostream &out_stats)
 {
     static unsigned long counter = 1;
 
-    if (data.size() < chunk)
-        data.resize(chunk);
+    if (pkt.payload.size() < chunk)
+        pkt.payload.resize(chunk);
 
-    const int stat = srt_recvmsg(m_sock, data.data(), (int) chunk);
+    SRT_MSGCTRL ctrl;
+    const int stat = srt_recvmsg2(m_sock, pkt.payload.data(), (int) chunk, &ctrl);
     if (stat <= 0)
     {
-        data.clear();
+        pkt.payload.clear();
         return stat;
     }
 
+    pkt.time = ctrl.srctime;
+
     chunk = size_t(stat);
-    if (chunk < data.size())
-        data.resize(chunk);
+    if (chunk < pkt.payload.size())
+        pkt.payload.resize(chunk);
 
     const bool need_bw_report = transmit_bw_report && (counter % transmit_bw_report) == transmit_bw_report - 1;
     const bool need_stats_report = transmit_stats_report && (counter % transmit_stats_report) == transmit_stats_report - 1;
@@ -554,11 +558,13 @@ int SrtTarget::ConfigurePre(SRTSOCKET sock)
     return 0;
 }
 
-int SrtTarget::Write(const char* data, size_t size, ostream &out_stats)
+int SrtTarget::Write(const char* data, size_t size, int64_t src_time, ostream &out_stats)
 {
     static unsigned long counter = 1;
 
-    int stat = srt_sendmsg2(m_sock, data, (int) size, nullptr);
+    SRT_MSGCTRL ctrl = srt_msgctrl_default;
+    ctrl.srctime = src_time;
+    int stat = srt_sendmsg2(m_sock, data, (int) size, &ctrl);
     if (stat == SRT_ERROR)
     {
         return stat;
@@ -684,21 +690,21 @@ public:
 #endif
     }
 
-    int Read(size_t chunk, bytevector& data, ostream & ignored SRT_ATR_UNUSED = cout) override
+    int Read(size_t chunk, MediaPacket& pkt, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
-        if (data.size() < chunk)
-            data.resize(chunk);
+        if (pkt.payload.size() < chunk)
+            pkt.payload.resize(chunk);
 
-        bool st = cin.read(data.data(), chunk).good();
+        bool st = cin.read(pkt.payload.data(), chunk).good();
         chunk = cin.gcount();
         if (chunk == 0 || !st)
         {
-            data.clear();
+            pkt.payload.clear();
             return 0;
         }
 
-        if (chunk < data.size())
-            data.resize(chunk);
+        if (chunk < pkt.payload.size())
+            pkt.payload.resize(chunk);
 
         return (int) chunk;
     }
@@ -726,7 +732,7 @@ public:
         cout.flush();
     }
 
-    int Write(const char* data, size_t len, ostream & ignored SRT_ATR_UNUSED = cout) override
+    int Write(const char* data, size_t len, int64_t src_time SRT_ATR_UNUSED, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         cout.write(data, len);
         return (int) len;
@@ -958,25 +964,27 @@ public:
         eof = false;
     }
 
-    int Read(size_t chunk, bytevector& data, ostream & ignored SRT_ATR_UNUSED = cout) override
+    int Read(size_t chunk, MediaPacket& pkt, ostream & ignored SRT_ATR_UNUSED = cout) override
     {
-        if (data.size() < chunk)
-            data.resize(chunk);
+        if (pkt.payload.size() < chunk)
+            pkt.payload.resize(chunk);
 
         sockaddr_in sa;
         socklen_t si = sizeof(sockaddr_in);
-        int stat = recvfrom(m_sock, data.data(), (int) chunk, 0, (sockaddr*)&sa, &si);
+        int stat = recvfrom(m_sock, pkt.payload.data(), (int) chunk, 0, (sockaddr*)&sa, &si);
         if (stat < 1)
         {
             if (SysError() != EWOULDBLOCK)
                 eof = true;
-            data.clear();
+            pkt.payload.clear();
             return stat;
         }
 
+        // Save this time to potentially use it for SRT target.
+        pkt.time = srt_time_now();
         chunk = size_t(stat);
-        if ( chunk < data.size() )
-            data.resize(chunk);
+        if (chunk < pkt.payload.size())
+            pkt.payload.resize(chunk);
 
         return stat;
     }
@@ -1012,7 +1020,7 @@ public:
 
     }
 
-    int Write(const char* data, size_t len, ostream & ignored SRT_ATR_UNUSED = cout) override
+    int Write(const char* data, size_t len, int64_t src_time SRT_ATR_UNUSED,  ostream & ignored SRT_ATR_UNUSED = cout) override
     {
         int stat = sendto(m_sock, data, (int) len, 0, (sockaddr*)&sadr, sizeof sadr);
         if ( stat == -1 )

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -703,6 +703,8 @@ public:
             return 0;
         }
 
+        // Save this time to potentially use it for SRT target.
+        pkt.time = srt_time_now();
         if (chunk < pkt.payload.size())
             pkt.payload.resize(chunk);
 

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -93,7 +93,7 @@ public:
         // Do nothing - create just to prepare for use
     }
 
-    int Read(size_t chunk, bytevector& data, ostream& out_stats = cout) override;
+    int Read(size_t chunk, MediaPacket& pkt, ostream& out_stats = cout) override;
 
     /*
        In this form this isn't needed.
@@ -134,7 +134,7 @@ public:
     SrtTarget() {}
 
     int ConfigurePre(SRTSOCKET sock) override;
-    int Write(const char* data, size_t size, ostream &out_stats = cout) override;
+    int Write(const char* data, size_t size, int64_t src_time, ostream &out_stats = cout) override;
     bool IsOpen() override { return IsUsable(); }
     bool Broken() override { return IsBroken(); }
     void Close() override { return SrtCommon::Close(); }

--- a/docs/srt-live-transmit.md
+++ b/docs/srt-live-transmit.md
@@ -266,6 +266,7 @@ shell (using **"** **"** quotes or backslash).
     - The alarm is set up after the reading loop has started, **not when the application has started**. That is, a caller will still wait the standard timeout to connect, and a listener may wait infinitely until some peer connects; only after the connection is established is the alarm counting started. 
     - **The timeout mechanism doesn't work on Windows at all.** It behaves as if the timeout was set to **-1** and it's not modifiable.
 - **-timeout-mode, -tm** - Timeout mode used. Default is 0 - timeout will happen after the specified time. Mode 1 cancels the timeout if the connection was established.
+- **-st, -stime, -sourcetime** - Enable source time passthrough. Default: enabled.
 - **-chunk, -c** - use given size of the buffer. The default size is 1456 bytes, which is the maximum payload size for a single SRT packet.
 - **-verbose, -v** - Display additional information on the standard output. Note that it's not allowed to be combined with output specified as **file://con**.
 - **-statsout** - SRT statistics output: filename. Without this option specified, the statistics will be printed to the standard output.

--- a/docs/srt-live-transmit.md
+++ b/docs/srt-live-transmit.md
@@ -266,7 +266,7 @@ shell (using **"** **"** quotes or backslash).
     - The alarm is set up after the reading loop has started, **not when the application has started**. That is, a caller will still wait the standard timeout to connect, and a listener may wait infinitely until some peer connects; only after the connection is established is the alarm counting started. 
     - **The timeout mechanism doesn't work on Windows at all.** It behaves as if the timeout was set to **-1** and it's not modifiable.
 - **-timeout-mode, -tm** - Timeout mode used. Default is 0 - timeout will happen after the specified time. Mode 1 cancels the timeout if the connection was established.
-- **-st, -srctime, -sourcetime** - Enable source time passthrough. Default: enabled.
+- **-st, -srctime, -sourcetime** - Enable source time passthrough. Default: disabled. It is recommended to build SRT with monotonic (`-DENABLE_MONOTONIC_CLOCK=ON`) or C++ 11 steady (`-DENABLE_STDCXX_SYNC=ON`) clock to use this feature.
 - **-chunk, -c** - use given size of the buffer. The default size is 1456 bytes, which is the maximum payload size for a single SRT packet.
 - **-verbose, -v** - Display additional information on the standard output. Note that it's not allowed to be combined with output specified as **file://con**.
 - **-statsout** - SRT statistics output: filename. Without this option specified, the statistics will be printed to the standard output.

--- a/docs/srt-live-transmit.md
+++ b/docs/srt-live-transmit.md
@@ -266,7 +266,7 @@ shell (using **"** **"** quotes or backslash).
     - The alarm is set up after the reading loop has started, **not when the application has started**. That is, a caller will still wait the standard timeout to connect, and a listener may wait infinitely until some peer connects; only after the connection is established is the alarm counting started. 
     - **The timeout mechanism doesn't work on Windows at all.** It behaves as if the timeout was set to **-1** and it's not modifiable.
 - **-timeout-mode, -tm** - Timeout mode used. Default is 0 - timeout will happen after the specified time. Mode 1 cancels the timeout if the connection was established.
-- **-st, -stime, -sourcetime** - Enable source time passthrough. Default: enabled.
+- **-st, -srctime, -sourcetime** - Enable source time passthrough. Default: enabled.
 - **-chunk, -c** - use given size of the buffer. The default size is 1456 bytes, which is the maximum payload size for a single SRT packet.
 - **-verbose, -v** - Display additional information on the standard output. Note that it's not allowed to be combined with output specified as **file://con**.
 - **-statsout** - SRT statistics output: filename. Without this option specified, the statistics will be printed to the standard output.

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -444,7 +444,7 @@ int main( int argc, char** argv )
         o_stoptime  ((optargs), "<time[s]=0[no timeout]> Time after which the application gets interrupted", "d", "stoptime"),
         o_hook      ((optargs), "<hookspec> Use listener callback of given specification (internally coded)", "hook"),
         o_group     ((optargs), "<URIs...> Using multiple SRT connections as redundancy group", "g"),
-        o_stime     ((optargs), " Pass source time explicitly to SRT output", "st", "stime", "sourcetime"),
+        o_stime     ((optargs), " Pass source time explicitly to SRT output", "st", "srctime", "sourcetime"),
         o_help      ((optargs), "[special=logging] This help", "?",   "help", "-help")
             ;
 


### PR DESCRIPTION
Add source time passthrough to srt-live-transmit.

Note also #1350.

Be in sync with `srt-test-live` CLI changes in 59f617f304d3e292913ab9b1e7c170886a88ee35.

See previous implementation in [this branch](https://github.com/Haivision/srt/compare/master...maxsharabayko:feature/source-time-app).