### PR TITLE
[apps] Added buffering command-line option to srt-live-transmit

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -283,7 +283,11 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
     cfg.chunk_size   = Option<OutNumber>(params, "-1", o_chunk);
     cfg.srctime      = Option<OutBool>(params, cfg.srctime, o_srctime);
     cfg.buffering    = Option<OutNumber>(params, o_buffering);
-    cfg.buffering    = cfg.buffering > 0 ? cfg.buffering : 10;
+    if (cfg.buffering <= 0)
+    {
+        cerr << "ERROR: Buffering value should be positive. Value provided: " << cfg.buffering << "." << endl;
+        return 1;
+    }
     cfg.bw_report    = Option<OutNumber>(params, o_bwreport);
     cfg.stats_report = Option<OutNumber>(params, o_statsrep);
     cfg.stats_out    = Option<OutString>(params, o_statsout);

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -282,13 +282,13 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
     cfg.timeout_mode = Option<OutNumber>(params, o_timeout_mode);
     cfg.chunk_size   = Option<OutNumber>(params, "-1", o_chunk);
     cfg.srctime      = Option<OutBool>(params, cfg.srctime, o_srctime);
-    const int buffering = Option<OutNumber>(params, o_buffering);
-    if (buffering < 0)
+    const int buffering = Option<OutNumber>(params, "10", o_buffering);
+    if (buffering <= 0)
     {
         cerr << "ERROR: Buffering value should be positive. Value provided: " << buffering << "." << endl;
         return 1;
     }
-    else if (buffering > 0)
+    else
     {
         cfg.buffering = (size_t) buffering;
     }

--- a/docs/srt-live-transmit.md
+++ b/docs/srt-live-transmit.md
@@ -267,7 +267,7 @@ shell (using **"** **"** quotes or backslash).
     - **The timeout mechanism doesn't work on Windows at all.** It behaves as if the timeout was set to **-1** and it's not modifiable.
 - **-timeout-mode, -tm** - Timeout mode used. Default is 0 - timeout will happen after the specified time. Mode 1 cancels the timeout if the connection was established.
 - **-st, -srctime, -sourcetime** - Enable source time passthrough. Default: disabled. It is recommended to build SRT with monotonic (`-DENABLE_MONOTONIC_CLOCK=ON`) or C++ 11 steady (`-DENABLE_STDCXX_SYNC=ON`) clock to use this feature.
-- **-buffering** - Enable source buffering up to the specified number of packets. Default: 10. Minimum: 1.
+- **-buffering** - Enable source buffering up to the specified number of packets. Default: 10. Minimum: 1 (no buffering).
 - **-chunk, -c** - use given size of the buffer. The default size is 1456 bytes, which is the maximum payload size for a single SRT packet.
 - **-verbose, -v** - Display additional information on the standard output. Note that it's not allowed to be combined with output specified as **file://con**.
 - **-statsout** - SRT statistics output: filename. Without this option specified, the statistics will be printed to the standard output.

--- a/docs/srt-live-transmit.md
+++ b/docs/srt-live-transmit.md
@@ -267,6 +267,7 @@ shell (using **"** **"** quotes or backslash).
     - **The timeout mechanism doesn't work on Windows at all.** It behaves as if the timeout was set to **-1** and it's not modifiable.
 - **-timeout-mode, -tm** - Timeout mode used. Default is 0 - timeout will happen after the specified time. Mode 1 cancels the timeout if the connection was established.
 - **-st, -srctime, -sourcetime** - Enable source time passthrough. Default: disabled. It is recommended to build SRT with monotonic (`-DENABLE_MONOTONIC_CLOCK=ON`) or C++ 11 steady (`-DENABLE_STDCXX_SYNC=ON`) clock to use this feature.
+- **-buffering** - Enable source buffering up to the specified number of packets. Default: 10. Minimum: 1.
 - **-chunk, -c** - use given size of the buffer. The default size is 1456 bytes, which is the maximum payload size for a single SRT packet.
 - **-verbose, -v** - Display additional information on the standard output. Note that it's not allowed to be combined with output specified as **file://con**.
 - **-statsout** - SRT statistics output: filename. Without this option specified, the statistics will be printed to the standard output.


### PR DESCRIPTION
Add buffering config command-line option to `srt-live-transmit`.

Fixes #1350 