### PR TITLE
[core] Improved CRcvLossList protection from concurrent access

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7862,6 +7862,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam,
         }
         else
         {
+            ScopedLock lock(m_RcvLossLock);
             ack = m_pRcvLossList->getFirstLostSeq();
 #if ENABLE_HEAVY_LOGGING
             reason = "first lost";
@@ -8054,6 +8055,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam,
         // Call with no arguments - get loss list from internal data.
         else if (m_pRcvLossList->getLossLength() > 0)
         {
+            ScopedLock lock(m_RcvLossLock);
             // this is periodically NAK report; make sure NAK cannot be sent back too often
 
             // read loss list from the local receiver loss list


### PR DESCRIPTION
`CRcvLossList::remove()` is called in the `CUDT::tsbpd` thread, whereas the other `CRcvLossList` functions are performed in the `CRcvQueue::worker` thread.

As described in #1352:
`CRcvLossList::remove()` is called in the `CUDT::tsbpd` thread. While `remove(..)` modifies the list, `getFirstLostSeq(..)` is called from the `CRcvQueue::worker` thread. This could, while removing the last entry, result in `m_iLength` still being 1 but `m_iHead` being already -1 which would allow `m_caSeq[m_iHead]` to be accessed with a negative index.

This PR adds mutex protection to access `CRcvLossList::getFirstLostSeq(..)` and `CRcvLossList::getLossArray(..)`.

Fixes #1352