### PR TITLE
Added SRTO_DRIFTTRACER socket option

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -229,6 +229,7 @@ const SocketOption srt_options [] {
     { "snddropdelay", 0, SRTO_SNDDROPDELAY, SocketOption::POST, SocketOption::INT, nullptr},
     { "nakreport", 0, SRTO_NAKREPORT, SocketOption::PRE, SocketOption::BOOL, nullptr},
     { "conntimeo", 0, SRTO_CONNTIMEO, SocketOption::PRE, SocketOption::INT, nullptr},
+    { "drifttracer", 0, SRTO_DRIFTTRACER, SocketOption::POST, SocketOption::BOOL, nullptr},
     { "lossmaxttl", 0, SRTO_LOSSMAXTTL, SocketOption::PRE, SocketOption::INT, nullptr},
     { "rcvlatency", 0, SRTO_RCVLATENCY, SocketOption::PRE, SocketOption::INT, nullptr},
     { "peerlatency", 0, SRTO_PEERLATENCY, SocketOption::PRE, SocketOption::INT, nullptr},

--- a/docs/API.md
+++ b/docs/API.md
@@ -621,6 +621,14 @@ will be 10 times the value set with `SRTO_CONNTIMEO`.
 
 | OptName           | Since | Binding | Type      | Units  | Default  | Range  | Dir | Entity |
 | ----------------- | ----- | ------- | --------- | ------ | -------- | ------ | --- | ------ |
+| `SRTO_DRIFTTRACER`| 1.5.0 | post    | `bool`    |        | true     |        | RW  | GSD    |
+
+- Enables or disables time drift tracer (receiver).
+
+---
+
+| OptName           | Since | Binding | Type      | Units  | Default  | Range  | Dir | Entity |
+| ----------------- | ----- | ------- | --------- | ------ | -------- | ------ | --- | ------ |
 | `SRTO_EVENT`      |       |         | `int32_t` | flags  |          |        | R   | S      |
 
 - Returns bit flags set according to the current active events on the socket. 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -128,7 +128,7 @@ enum AckDataItem
 };
 const size_t ACKD_FIELD_SIZE = sizeof(int32_t);
 
-static const size_t SRT_SOCKOPT_NPOST = 11;
+static const size_t SRT_SOCKOPT_NPOST = 12;
 extern const SRT_SOCKOPT srt_post_opt_list [];
 
 enum GroupDataItem
@@ -1406,6 +1406,7 @@ private: // Identification
     bool m_bRendezvous;                          // Rendezvous connection mode
 
     duration m_tdConnTimeOut;    // connect timeout in milliseconds
+    bool m_bDriftTracer;
     int m_iSndTimeOut;                           // sending timeout in milliseconds
     int m_iRcvTimeOut;                           // receiving timeout in milliseconds
     bool m_bReuseAddr;                           // reuse an exiting port or not, for UDP multiplexer

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -217,6 +217,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_VERSION = 34,        // Local SRT Version
    SRTO_PEERVERSION,         // Peer SRT Version (from SRT Handshake)
    SRTO_CONNTIMEO = 36,      // Connect timeout in msec. Caller default: 3000, rendezvous (x 10)
+   SRTO_DRIFTTRACER = 37,    // Enable or disable drift tracer
    // (some space left)
    SRTO_SNDKMSTATE = 40,     // (GET) the current state of the encryption at the peer side
    SRTO_RCVKMSTATE,          // (GET) the current state of the encryption at the agent side


### PR DESCRIPTION
The intent of the `SRTO_DRIFTTRACER` socket option is to provide a way to enable or disable the time drift tracing module.

Addresses #753 and #984.