### PR TITLE
Fixed removing sockets from group members' rolled list after parallelly closed.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1466,7 +1466,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         HLOGC(mglog.Debug, log << "groupConnect: first connection, applying EPOLL WAITING.");
         int len = spawned.size();
         vector<SRTSOCKET> ready(spawned.size());
-        int estat = srt_epoll_wait(eid,
+        const int estat = srt_epoll_wait(eid,
                     NULL, NULL,  // IN/ACCEPT
                     &ready[0], &len, // OUT/CONNECT
                     -1, // indefinitely (FIXME Check if it needs to REGARD CONNECTION TIMEOUT!)


### PR DESCRIPTION
Problem: the sockets weren't removed from the roll list and could make the EID empty without noticing it. Two fixes:

1. Checking if all sockets from the list after applying a lock for group if they exist and are not broken. If not pass this test, remove them ALSO from the list of sockets to review. If this makes the container empty, the loop will interrupt at the next iteration.

2. Checking the return code from `srt_epoll_wait` call. It could have happened that it returns error in case when EID container is empty, which should be handled. No other error than that is predicted to happen; the error log is displayed in case when it would happen.

3. Removal from the EID container immediately when found out that the socket is broken so that this doesn't get probed again in this loop.