### PR TITLE
[build] add -h short option support

### DIFF
--- a/configure
+++ b/configure
@@ -102,7 +102,7 @@ foreach {o desc} $options {
 }
 
 
-if { $argv == "--help" } {
+if { $argv == "--help" || $argv == "-h" } {
 	puts stderr "Usage: ./configure \[options\]"
 	puts stderr "OPTIONS:"
 	foreach o [lsort [array names opt]] {


### PR DESCRIPTION
add -h short option support as common practice.

Signed-off-by: Jun Zhao <barryjzhao@tencent.com>