### PR TITLE
[core] Renamed SRTO_RETRANSMISSSION_ALGORITHM to SRTO_RETRANSMITALGO

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -245,7 +245,7 @@ const SocketOption srt_options [] {
     { "packetfilter", 0, SRTO_PACKETFILTER, SocketOption::PRE, SocketOption::STRING, nullptr },
     { "groupconnect", 0, SRTO_GROUPCONNECT, SocketOption::PRE, SocketOption::INT, nullptr},
     { "groupstabtimeo", 0, SRTO_GROUPSTABTIMEO, SocketOption::PRE, SocketOption::INT, nullptr},
-    { "rexmitalgo", 0, SRTO_RETRANSMISSION_ALGORITHM, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "rexmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
 };
 }
 

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -245,7 +245,7 @@ const SocketOption srt_options [] {
     { "packetfilter", 0, SRTO_PACKETFILTER, SocketOption::PRE, SocketOption::STRING, nullptr },
     { "groupconnect", 0, SRTO_GROUPCONNECT, SocketOption::PRE, SocketOption::INT, nullptr},
     { "groupstabtimeo", 0, SRTO_GROUPSTABTIMEO, SocketOption::PRE, SocketOption::INT, nullptr},
-    { "rexmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "retransmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
 };
 }
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1243,9 +1243,9 @@ procedure of `srt_bind` and then `srt_connect` (or `srt_rendezvous`) to one aoth
 
 ---
 
-| OptName                         | Since | Binding | Type   | Units  | Default | Range  | Dir | Entity |
-| ------------------------------- | ----- | ------- | ------ | ------ | ------- | ------ | --- | ------ |
-| `SRTO_RETRANSMISSION_ALGORITHM` | 1.5.0 | pre     | `int`  |        | 0       | [0, 1] | W   | GSD    |
+| OptName               | Since | Binding | Type   | Units  | Default | Range  | Dir | Entity |
+| --------------------- | ----- | ------- | ------ | ------ | ------- | ------ | --- | ------ |
+| `SRTO_RETRANSMITALGO` | 1.5.0 | pre     | `int`  |        | 0       | [0, 1] | W   | GSD    |
 
 - Retransmission algorithm to use (SENDER option):
    - 0 - Default (retranmsit on every loss report).

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -996,7 +996,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         }
         break;
 
-    case SRTO_RETRANSMISSION_ALGORITHM:
+    case SRTO_RETRANSMITALGO:
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -256,7 +256,7 @@ CUDT::CUDT(CUDTSocket* parent): m_parent(parent)
     m_uOPT_StabilityTimeout = 4*CUDT::COMM_SYN_INTERVAL_US;
     m_OPT_GroupConnect      = 0;
     m_HSGroupType           = SRT_GTYPE_UNDEFINED;
-    m_iOPT_RexmitAlgo       = 0;
+    m_iOPT_RetransmitAlgo       = 0;
     m_bTLPktDrop            = true; // Too-late Packet Drop
     m_bMessageAPI           = true;
     m_zOPT_ExpPayloadSize   = SRT_LIVE_DEF_PLSIZE;
@@ -314,7 +314,7 @@ CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
     m_bOPT_TLPktDrop        = ancestor.m_bOPT_TLPktDrop;
     m_iOPT_SndDropDelay     = ancestor.m_iOPT_SndDropDelay;
     m_bOPT_StrictEncryption = ancestor.m_bOPT_StrictEncryption;
-    m_iOPT_RexmitAlgo       = ancestor.m_iOPT_RexmitAlgo;
+    m_iOPT_RetransmitAlgo   = ancestor.m_iOPT_RetransmitAlgo;
     m_iOPT_PeerIdleTimeout  = ancestor.m_iOPT_PeerIdleTimeout;
     m_uOPT_StabilityTimeout = ancestor.m_uOPT_StabilityTimeout;
     m_OPT_GroupConnect      = ancestor.m_OPT_GroupConnect; // NOTE: on single accept set back to 0
@@ -1000,7 +1000,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         if (m_bConnected)
             throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-        m_iOPT_RexmitAlgo = cast_optval<int32_t>(optval, optlen);
+        m_iOPT_RetransmitAlgo = cast_optval<int32_t>(optval, optlen);
         break;
 
     default:
@@ -8978,7 +8978,7 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
             continue;
         }
 
-        if (m_bPeerNakReport && m_iOPT_RexmitAlgo != 0)
+        if (m_bPeerNakReport && m_iOPT_RetransmitAlgo != 0)
         {
             const steady_clock::time_point tsLastRexmit = m_pSndBuffer->getPacketRexmitTime(offset);
             if (tsLastRexmit >= time_nak)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1437,7 +1437,7 @@ private: // Identification
     std::string m_sStreamName;
     int m_iOPT_PeerIdleTimeout;      // Timeout for hearing anything from the peer.
     uint32_t m_uOPT_StabilityTimeout;
-    int m_iOPT_RexmitAlgo;
+    int m_iOPT_RetransmitAlgo;
 
     int m_iTsbPdDelay_ms;                           // Rx delay to absorb burst in milliseconds
     int m_iPeerTsbPdDelay_ms;                       // Tx delay that the peer uses to absorb burst in milliseconds

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -239,7 +239,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake
    // (some space left)
    SRTO_PACKETFILTER = 60,   // Add and configure a packet filter
-   SRTO_RETRANSMISSION_ALGORITHM = 61 // An option to select packet retransmission algorithm
+   SRTO_RETRANSMITALGO = 61  // An option to select packet retransmission algorithm
 } SRT_SOCKOPT;
 
 


### PR DESCRIPTION
Renamed `SRTO_RETRANSMISSSION_ALGORITHM` to a shorter version: `SRTO_RETRANSMITALGO`.
The shortened version is more consistent with the names of other socket options.
We can safely rename it as this option was only added recently and will first appear in not yet release v1.5.0.