### PR TITLE
Fix the activation and stability check criteria

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -465,10 +465,10 @@ private:
     // Support functions for sendBackup and sendBroadcast
     bool send_CheckIdle(const gli_t d, std::vector<gli_t>& w_wipeme, std::vector<gli_t>& w_pending);
     void sendBackup_CheckIdleTime(gli_t w_d);
-    void sendBackup_CheckRunningStability(const gli_t d, const time_point currtime, size_t& w_nunstable);
+    bool sendBackup_CheckRunningStability(const gli_t d, const time_point currtime);
     bool sendBackup_CheckSendStatus(const gli_t d, const time_point& currtime, const int stat, const int erc, const int32_t lastseq,
             const int32_t pktseq, CUDT& w_u, int32_t& w_curseq, std::vector<gli_t>& w_parallel,
-            int& w_final_stat, std::set<int>& w_sendable_pri, size_t& w_nsuccessful, size_t& w_nunstable);
+            int& w_final_stat, std::set<int>& w_sendable_pri, size_t& w_nsuccessful, bool& w_is_unstable);
     void sendBackup_Buffering(const char* buf, const int len, int32_t& curseq, SRT_MSGCTRL& w_mc);
     void sendBackup_CheckNeedActivate(const std::vector<gli_t>& idlers, const char *buf, const int len,
             bool& w_none_succeeded, SRT_MSGCTRL& w_mc, int32_t& w_curseq, int32_t& w_final_stat,
@@ -477,7 +477,7 @@ private:
             const std::string& activate_reason);
     void send_CheckPendingSockets(const std::vector<gli_t>& pending, std::vector<gli_t>& w_wipeme);
     void send_CloseBrokenSockets(std::vector<gli_t>& w_wipeme);
-    void sendBackup_CheckParallelLinks(const size_t nunstable, std::vector<gli_t>& w_parallel,
+    void sendBackup_CheckParallelLinks(const std::vector<gli_t>& unstable, std::vector<gli_t>& w_parallel,
             int& w_final_stat, bool& w_none_succeeded, SRT_MSGCTRL& w_mc, CUDTException& w_cx);
 
 public:

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -103,6 +103,7 @@ written by
 #include <algorithm>
 #include <bitset>
 #include <map>
+#include <vector>
 #include <functional>
 #include <memory>
 #include <iomanip>
@@ -676,7 +677,7 @@ std::string PrintableMod(const Container& in, const std::string& prefix)
 }
 
 template<typename InputIterator, typename OutputIterator, typename TransFunction>
-void FilterIf(InputIterator bg, InputIterator nd,
+inline void FilterIf(InputIterator bg, InputIterator nd,
         OutputIterator out, TransFunction fn)
 {
     for (InputIterator i = bg; i != nd; ++i)
@@ -686,6 +687,16 @@ void FilterIf(InputIterator bg, InputIterator nd,
             continue;
         *out++ = result.first;
     }
+}
+
+template <class Value, class ArgValue>
+inline void insert_uniq(std::vector<Value>& v, const ArgValue& val)
+{
+    typename std::vector<Value>::iterator i = std::find(v.begin(), v.end(), val);
+    if (i != v.end())
+        return;
+
+    v.push_back(val);
 }
 
 template <class Signature>


### PR DESCRIPTION
This fix make the stability criteria take into account the problems that arise while stopping transmission and prevents flipping instability that was seen too soon.

The new criteria make it clear that during the "temporary activation" time no check for the stability is being made, as well as the ACK last time is taken into account in order to clear the situation when the ACK hasn't yet come at all. Even though the ACK timer is initialized to "now" at the open time and also it's being updated beside the ACK reception in one place, it is considered that it's enough to state that ACK predates activation time to confirm that we are speaking about a stopped and restarted transmission (or not yet started after connection). If this is detected, the stability check will not be done at all.  This state obviously will only last up to the next ACK reception.