### PR TITLE
[apps] Fixed TCP ::connect for macOS

### DIFF
--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -732,7 +732,7 @@ void TcpMedium::Connect()
 {
     sockaddr_any sa = CreateAddr(m_uri.host(), m_uri.portno());
 
-    int st = ::connect(m_socket, sa.get(), sizeof sa);
+    int st = ::connect(m_socket, sa.get(), sa.size());
     if (st == -1)
         Error(errno, "connect");
 


### PR DESCRIPTION
Hi, I found and fixed a problem about TCP ::connect failure for 'srt-tunnel' on macOS. The reason is that the size of 'sockaddr_any' may be incorrect when using '::connect'. 
I have tested the fix on macOS and CentOS, and it worked well.