### PR TITLE
[build] Reverted Ninja build from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
         - cmake
         - libssl-dev
         - build-essential
-        - ninja-build
     sonarcloud:
         organization: "haivision"
         token:
@@ -60,7 +59,7 @@ script:
         export CXX="x86_64-w64-mingw32-g++";
         cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON" -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
       elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
-        cmake . -G Ninja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
       elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
         export PKG_CONFIG_PATH=$(brew --prefix openssl)"/lib/pkgconfig";
         cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
@@ -73,10 +72,8 @@ script:
     - echo "RUN_SONARCUBE=$RUN_SONARCUBE"
     - if (( "$RUN_SONARCUBE" )); then
         build-wrapper-linux-x86-64 --out-dir bw-output make;
-      elif [ -f build.ninja ]; then
-        ninja -v;
       else
-        make;
+        make -j$(nproc);
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then ctest --extra-verbose; fi
     - if (( "$RUN_SONARCUBE" )); then source ./scripts/collect-gcov.sh; fi


### PR DESCRIPTION
Build time is reduced by Ninja, but no that much.
* Linux Debug build with Ninja: 50 sec -> 35 sec.
* Linux Debug build with `-j$(nproc)`: 50 sec -> 34 sec.
* Overall Linux debug job with Ninja: 125 sec -> 107 sec.

The MinGW build takes 4 minutes in both cases, so the overall CI process is anyway blocked.
The build config file becomes more complicated.

Trying `make -j$(nproc)` instead.