### PR TITLE
Fixed error handling in group connect

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1146,7 +1146,7 @@ int CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* ta
 
         // When connecting to exactly one target, only this very target
         // can be returned as a socket, so rewritten back array can be ignored.
-        return groupConnect(g, gd, 1);
+        return singleMemberConnect(g, gd);
     }
 
     CUDTSocket* s = locateSocket(u);
@@ -1176,7 +1176,7 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
         // it's generated anew for the very first socket, and then
         // derived by all sockets in the group.
         SRT_SOCKGROUPCONFIG gd[1] = { srt_prepare_endpoint(NULL, name, namelen) };
-        return groupConnect(g, gd, 1);
+        return singleMemberConnect(g, gd);
     }
 
     CUDTSocket* s = locateSocket(u);
@@ -1184,6 +1184,25 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
         throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
     return connectIn(s, target_addr, forced_isn);
+}
+
+int CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* gd)
+{
+    int gstat = groupConnect(pg, gd, 1);
+    if (gstat == -1)
+    {
+        // We have only one element here, so refer to it.
+        // Sanity check
+        if (gd->errorcode == SRT_SUCCESS)
+            gd->errorcode = SRT_EINVPARAM;
+
+        CodeMajor mj = CodeMajor(gd->errorcode / 1000);
+        CodeMinor mn = CodeMinor(gd->errorcode % 1000);
+
+        return CUDT::APIError(mj, mn);
+    }
+
+    return gstat;
 }
 
 int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int arraysize)
@@ -1300,6 +1319,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         {
             ScopedLock cs(m_GlobControlLock);
             SRTSOCKET id = ns->m_SocketID;
+            targets[tii].id = CUDT::INVALID_SOCK;
             delete ns;
             m_Sockets.erase(id);
 
@@ -1372,6 +1392,8 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
             // to avoid locking more than one mutex at a time.
             ns->removeFromGroup();
             erc_rloc = e.getErrorCode();
+            targets[tii].errorcode = e.getErrorCode();
+            targets[tii].id = CUDT::INVALID_SOCK;
 
             ScopedLock cl (m_GlobControlLock);
             m_Sockets.erase(ns->m_SocketID);
@@ -1383,13 +1405,15 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         {
             LOGC(mglog.Fatal, log << "groupConnect: IPE: UNKNOWN EXCEPTION from connectIn");
             ns->removeFromGroup();
+            targets[tii].errorcode = SRT_ESYSOBJ;
+            targets[tii].id = CUDT::INVALID_SOCK;
             ScopedLock cl (m_GlobControlLock);
             m_Sockets.erase(ns->m_SocketID);
             // Intercept to delete the socket on failure.
             delete ns;
 
             // Do not use original exception, it may crash off a C API.
-            throw CUDTException(MJ_SYSTEMRES, MN_NONE);
+            throw CUDTException(MJ_SYSTEMRES, MN_OBJECT);
         }
 
         SRT_SOCKSTATUS st;

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -227,6 +227,7 @@ public:
    int connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
    int connectIn(CUDTSocket* s, const sockaddr_any& target, int32_t forced_isn);
    int groupConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG targets [], int arraysize);
+   int singleMemberConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG* target);
    int close(const SRTSOCKET u);
    int close(CUDTSocket* s);
    void getpeername(const SRTSOCKET u, sockaddr* name, int* namelen);


### PR DESCRIPTION
1. Complete the error-sensitive data in the SOCKGROUPCONFIG structure. Report the early error in `errorcode` correctly.
2. Introduced translation for a single member connection. Now `srt_connect` call can be checked for early errors on a single connection.