### PR TITLE
[core] Using sockaddr_any::str()

### DIFF
--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -99,7 +99,7 @@ protected:
     template <class DerivedMedium, class SocketType>
     static Medium* CreateAcceptor(DerivedMedium* self, const sockaddr_any& sa, SocketType sock, size_t chunk)
     {
-        string addr = SockaddrToString(sockaddr_any(sa.get(), sizeof sa));
+        string addr = sockaddr_any(sa.get(), sizeof sa).str();
         DerivedMedium* m = new DerivedMedium(UriParser(self->type() + string("://") + addr), chunk);
         m->m_socket = sock;
         return m;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -601,7 +601,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
        // the SRT Handshake message would fail.
        HLOGF(mglog.Debug,
                "newConnection: incoming %s, mapping socket %d",
-               SockaddrToString(peer).c_str(), ns->m_SocketID);
+               peer.str().c_str(), ns->m_SocketID);
        {
            ScopedLock cg(m_GlobControlLock);
            m_Sockets[ns->m_SocketID] = ns;
@@ -1250,7 +1250,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         SRTSOCKET& sid_rloc = targets[tii].id;
         int& erc_rloc = targets[tii].errorcode;
         erc_rloc = SRT_SUCCESS; // preinitialized
-        HLOGC(mglog.Debug, log << "groupConnect: taking on " << SockaddrToString(targets[tii].peeraddr));
+        HLOGC(mglog.Debug, log << "groupConnect: taking on " << sockaddr_any(targets[tii].peeraddr).str());
 
         CUDTSocket* ns = 0;
 

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -378,30 +378,4 @@ private:
    CUDTUnited& operator=(const CUDTUnited&);
 };
 
-// Debug support
-inline std::string SockaddrToString(const sockaddr_any& sadr)
-{
-    if (sadr.family() != AF_INET && sadr.family() != AF_INET6)
-        return "unknown:0";
-
-    std::ostringstream output;
-    char hostbuf[1024];
-    int flags;
-
-#if ENABLE_GETNAMEINFO
-    flags = NI_NAMEREQD;
-#else
-    flags = NI_NUMERICHOST | NI_NUMERICSERV;
-#endif
-
-    if (!getnameinfo(sadr.get(), sadr.size(), hostbuf, 1024, NULL, 0, flags))
-    {
-        output << hostbuf;
-    }
-
-    output << ":" << sadr.hport();
-    return output.str();
-}
-
-
 #endif

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -58,8 +58,8 @@ modified by
 #include <csignal>
 
 #include "channel.h"
+#include "core.h" // srt_logging:mglog
 #include "packet.h"
-#include "api.h" // SockaddrToString - possibly move it to somewhere else
 #include "logging.h"
 #include "netinet_any.h"
 #include "utilities.h"
@@ -122,7 +122,7 @@ void CChannel::open(const sockaddr_any& addr)
         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 
     m_BindAddr = addr;
-    LOGC(mglog.Debug, log << "CHANNEL: Bound to local address: " << SockaddrToString(m_BindAddr));
+    LOGC(mglog.Debug, log << "CHANNEL: Bound to local address: " << m_BindAddr.str());
 
     setUDPSockOpt();
 }
@@ -164,7 +164,7 @@ void CChannel::open(int family)
 
     ::freeaddrinfo(res);
 
-    HLOGC(mglog.Debug, log << "CHANNEL: Bound to local address: " << SockaddrToString(m_BindAddr));
+    HLOGC(mglog.Debug, log << "CHANNEL: Bound to local address: " << m_BindAddr.str());
 
     setUDPSockOpt();
 }
@@ -419,7 +419,7 @@ void CChannel::getPeerAddr(sockaddr_any& w_addr) const
 
 int CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
 {
-    HLOGC(mglog.Debug, log << "CChannel::sendto: SENDING NOW DST=" << SockaddrToString(addr)
+    HLOGC(mglog.Debug, log << "CChannel::sendto: SENDING NOW DST=" << addr.str()
         << " target=@" << packet.m_iID
         << " size=" << packet.getLength()
         << " pkt.ts=" << packet.m_iTimeStamp

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3936,7 +3936,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 {
     ScopedLock cg (m_ConnectionLock);
 
-    HLOGC(mglog.Debug, log << CONID() << "startConnect: -> " << SockaddrToString(serv_addr)
+    HLOGC(mglog.Debug, log << CONID() << "startConnect: -> " << serv_addr.str()
             << (m_bSynRecving ? " (SYNCHRONOUS)" : " (ASYNCHRONOUS)") << "...");
 
     if (!m_bOpened)
@@ -5193,7 +5193,7 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
         }
     }
 
-    LOGC(mglog.Note, log << CONID() << "Connection established to: " << SockaddrToString(m_PeerAddr));
+    LOGC(mglog.Note, log << CONID() << "Connection established to: " << m_PeerAddr.str());
 
     return CONN_ACCEPT;
 }

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -16,7 +16,9 @@ written by
 #ifndef INC_SRT_NETINET_ANY_H
 #define INC_SRT_NETINET_ANY_H
 
-#include <cstring>
+#include <cstring> // memcmp
+#include <string>
+#include <sstream>
 #include "platform_sys.h"
 
 // This structure should replace every use of sockaddr and its currently
@@ -350,6 +352,31 @@ struct sockaddr_any
             return memcmp(&sin6.sin6_addr, &in6addr_any, sizeof in6addr_any) == 0;
 
         return false;
+    }
+
+    // Debug support
+    std::string str() const
+    {
+        if (family() != AF_INET && family() != AF_INET6)
+            return "unknown:0";
+
+        std::ostringstream output;
+        char hostbuf[1024];
+        int flags;
+
+    #if ENABLE_GETNAMEINFO
+        flags = NI_NAMEREQD;
+    #else
+        flags = NI_NUMERICHOST | NI_NUMERICSERV;
+    #endif
+
+        if (!getnameinfo(get(), size(), hostbuf, 1024, NULL, 0, flags))
+        {
+            output << hostbuf;
+        }
+
+        output << ":" << hport();
+        return output.str();
     }
 
     bool operator==(const sockaddr_any& other) const

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -823,7 +823,7 @@ void CRendezvousQueue::insert(
     r.m_tsTTL = ttl;
 
     m_lRendezvousID.push_back(r);
-    HLOGC(mglog.Debug, log << "RID: adding socket @" << id << " for address: " << SockaddrToString(addr)
+    HLOGC(mglog.Debug, log << "RID: adding socket @" << id << " for address: " << addr.str()
             << " expires: " << FormatTime(ttl)
             << " (total connectors: " << m_lRendezvousID.size() << ")");
 }
@@ -857,7 +857,7 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
         {
             HLOGC(mglog.Debug, log << "RID: found id @" << i->m_iID << " while looking for "
                     << (w_id ? "THIS ID FROM " : "A NEW CONNECTION FROM ")
-                    << SockaddrToString(i->m_PeerAddr));
+                    << i->m_PeerAddr.str());
             w_id = i->m_iID;
             return i->m_pUDT;
         }
@@ -869,7 +869,7 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
        spec << "A NEW CONNECTION REQUEST";
    else
        spec << " AGENT @" << w_id;
-   HLOGC(mglog.Debug, log << "RID: NO CONNECTOR FOR ADR:" << SockaddrToString(addr)
+   HLOGC(mglog.Debug, log << "RID: NO CONNECTOR FOR ADR:" << addr.str()
            << " while looking for " << spec.str() << " (" << m_lRendezvousID.size() << " connectors total)");
 #endif
 
@@ -1288,8 +1288,8 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
     if (rst == RST_OK)
     {
         w_id = w_unit->m_Packet.m_iID;
-        HLOGC(mglog.Debug, log << "INCOMING PACKET: FROM=" << SockaddrToString(w_addr)
-                << " BOUND=" << SockaddrToString(m_pChannel->bindAddressAny())
+        HLOGC(mglog.Debug, log << "INCOMING PACKET: FROM=" << w_addr.str()
+                << " BOUND=" << m_pChannel->bindAddressAny().str()
                 << " " << w_unit->m_Packet.Info());
     }
     return rst;
@@ -1298,7 +1298,7 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
 EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
 {
     HLOGC(mglog.Debug,
-          log << "Got sockID=0 from " << SockaddrToString(addr)
+          log << "Got sockID=0 from " << addr.str()
               << " - trying to resolve it as a connection request...");
     // Introduced protection because it may potentially happen
     // that another thread could have closed the socket at
@@ -1311,7 +1311,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
         if (m_pListener)
         {
             LOGC(mglog.Note,
-                 log << "PASSING request from: " << SockaddrToString(addr) << " to agent:" << m_pListener->socketID());
+                 log << "PASSING request from: " << addr.str() << " to agent:" << m_pListener->socketID());
             listener_ret = m_pListener->processConnectRequest(addr, unit->m_Packet);
 
             // This function does return a code, but it's hard to say as to whether
@@ -1331,7 +1331,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     if (have_listener) // That is, the above block with m_pListener->processConnectRequest was executed
     {
         LOGC(mglog.Note,
-             log << CONID() << "Listener managed the connection request from: " << SockaddrToString(addr)
+             log << CONID() << "Listener managed the connection request from: " << addr.str()
                  << " result:" << RequestTypeStr(UDTRequestType(listener_ret)));
         return listener_ret == SRT_REJ_UNKNOWN ? CONN_CONTINUE : CONN_REJECT;
     }
@@ -1356,8 +1356,8 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
     if (addr != u->m_PeerAddr)
     {
         HLOGC(mglog.Debug,
-              log << CONID() << "Packet for SID=" << id << " asoc with " << SockaddrToString(u->m_PeerAddr)
-                  << " received from " << SockaddrToString(addr) << " (CONSIDERED ATTACK ATTEMPT)");
+              log << CONID() << "Packet for SID=" << id << " asoc with " << u->m_PeerAddr.str()
+                  << " received from " << addr.str() << " (CONSIDERED ATTACK ATTEMPT)");
         // This came not from the address that is the peer associated
         // with the socket. Ignore it.
         return CONN_AGAIN;
@@ -1416,13 +1416,13 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
         if (id == 0)
         {
             HLOGC(mglog.Debug,
-                  log << CONID() << "AsyncOrRND: no sockets expect connection from " << SockaddrToString(addr)
+                  log << CONID() << "AsyncOrRND: no sockets expect connection from " << addr.str()
                       << " - POSSIBLE ATTACK, ignore packet");
         }
         else
         {
             HLOGC(mglog.Debug,
-                  log << CONID() << "AsyncOrRND: no sockets expect socket " << id << " from " << SockaddrToString(addr)
+                  log << CONID() << "AsyncOrRND: no sockets expect socket " << id << " from " << addr.str()
                       << " - POSSIBLE ATTACK, ignore packet");
         }
         return CONN_AGAIN; // This means that the packet should be ignored.
@@ -1613,7 +1613,7 @@ void CRcvQueue::removeListener(const CUDT *u)
 void CRcvQueue::registerConnector(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const steady_clock::time_point& ttl)
 {
     HLOGC(mglog.Debug,
-          log << "registerConnector: adding @" << id << " addr=" << SockaddrToString(addr) << " TTL=" << FormatTime(ttl));
+          log << "registerConnector: adding @" << id << " addr=" << addr.str() << " TTL=" << FormatTime(ttl));
     m_pRendezvousQueue->insert(id, u, addr, ttl);
 }
 

--- a/test/test_many_connections.cpp
+++ b/test/test_many_connections.cpp
@@ -149,9 +149,8 @@ TEST_F(TestConnection, Multiple)
         int conntimeo = 60;
         srt_setsockflag(srt_socket_list[i], SRTO_CONNTIMEO, &conntimeo, sizeof conntimeo);
 
-        //cout << "Connecting #" << i << " to " << SockaddrToString(sockaddr_any(psa)) << "...\n";
-
-        //cerr << "Connecting to: " << SockaddrToString(sockaddr_any(psa)) << endl;
+        //cerr << "Connecting #" << i << " to " << sockaddr_any(psa).str() << "...\n";
+        //cerr << "Connecting to: " << sockaddr_any(psa).str() << endl;
         ASSERT_NE(srt_connect(srt_socket_list[i], psa, sizeof lsa), SRT_ERROR);
 
         // Set now async sending so that sending isn't blocked

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -541,14 +541,14 @@ void SrtCommon::AcceptNewClient()
         string peer = "<?PEER?>";
         if (-1 != srt_getpeername(m_sock, (peeraddr.get()), (&peeraddr.len)))
         {
-            peer = SockaddrToString(peeraddr);
+            peer = peeraddr.str();
         }
 
         sockaddr_any agentaddr(AF_INET6);
         string agent = "<?AGENT?>";
         if (-1 != srt_getsockname(m_sock, (agentaddr.get()), (&agentaddr.len)))
         {
-            agent = SockaddrToString(agentaddr);
+            agent = agentaddr.str();
         }
 
         Verb() << " connected [" << agent << "] <-- " << peer;
@@ -937,7 +937,7 @@ void SrtCommon::OpenGroupClient()
         SRTSOCKET insock = m_group_nodes[i].socket;
         if (insock == -1)
         {
-            Verb() << "TARGET '" << SockaddrToString(targets[i].peeraddr) << "' connection failed.";
+            Verb() << "TARGET '" << targets[i].peeraddr.str() << "' connection failed.";
             continue;
         }
 
@@ -971,7 +971,7 @@ void SrtCommon::OpenGroupClient()
     {
         // id, status, result, peeraddr
         Verb() << "@" << d.id << " <" << SockStatusStr(d.sockstate) << "> (=" << d.result << ") PEER:"
-            << SockaddrToString(sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr));
+            << sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr).str());
     }
 
     /*
@@ -1229,7 +1229,7 @@ void SrtCommon::UpdateGroupStatus(const SRT_SOCKGROUPDATA* grpdata, size_t grpda
         }
         // id, status, result, peeraddr
         Verb() << "\n\tG@" << id << " <" << SockStatusStr(status) << "/" << MemberStatusStr(mstatus) << "> (=" << result << ") PEER:"
-            << SockaddrToString(sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr)) << VerbNoEOL;
+            << sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr).str() << VerbNoEOL;
 
         if (status >= SRTS_BROKEN)
         {
@@ -1394,7 +1394,7 @@ RETRY_READING:
             if (d.status != SRTS_CONNECTED)
                 // id, status, result, peeraddr
                 Verb() << "@" << d.id << " <" << SockStatusStr(d.status) << "> (=" << d.result << ") PEER:"
-                    << SockaddrToString(sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr));
+                    << sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr).str();
         }
     }
 


### PR DESCRIPTION
Using `sockaddr_any::str()` instead of `SockaddrToString(sockaddr_any&)`.

To consider:
Printing the address of `sockaddr` or `sockaddr_storage` now can't be done implicitely.