### PR TITLE
Improved broken member link detection

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -12116,6 +12116,19 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
     // This simply requires the payload to be sent through every socket in the group
     for (gli_t d = m_Group.begin(); d != m_Group.end(); ++d)
     {
+        // Check the socket state prematurely in order not to uselessly
+        // send over a socket that is broken.
+        CUDT* pu = 0;
+        if (d->ps)
+            pu = &d->ps->core();
+
+        if (!pu || pu->m_bBroken)
+        {
+            HLOGC(dlog.Debug, log << "grp/sendBroadcast: socket @" << d->id << " detected +Broken - transit to BROKEN");
+            d->sndstate = SRT_GST_BROKEN;
+            d->rcvstate = SRT_GST_BROKEN;
+        }
+
         // Check socket sndstate before sending
         if (d->sndstate == SRT_GST_BROKEN)
         {
@@ -14459,6 +14472,19 @@ int CUDTGroup::sendBackup(const char *buf, int len, SRT_MSGCTRL& w_mc)
     // First, check status of every link - no matter if idle or active.
     for (gli_t d = m_Group.begin(); d != m_Group.end(); ++d)
     {
+        // Check the socket state prematurely in order not to uselessly
+        // send over a socket that is broken.
+        CUDT* pu = 0;
+        if (d->ps)
+            pu = &d->ps->core();
+
+        if (!pu || pu->m_bBroken)
+        {
+            HLOGC(dlog.Debug, log << "grp/sendBackup: socket @" << d->id << " detected +Broken - transit to BROKEN");
+            d->sndstate = SRT_GST_BROKEN;
+            d->rcvstate = SRT_GST_BROKEN;
+        }
+
         // Check socket sndstate before sending
         if (d->sndstate == SRT_GST_BROKEN)
         {


### PR DESCRIPTION
This adds a detection as to whether a member socket is in the broken state, before doing battle-test on it by trying to send a packet over it. Such a link is prematurely qualified as broken, just as if the operation was done on it and it failed.