### PR TITLE
Fixed bug: wrong reject reason on async connect

### DIFF
--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1101,7 +1101,7 @@ void SrtCommon::Error(string src, int reason, int force_result)
         cerr << "\nERROR (app): " << src << endl;
         throw std::runtime_error(src);
     }
-    string message = srt_getlasterror_str();
+    string message = srt_strerror(result, errnov);
     if (result == SRT_ECONNREJ)
     {
         if ( Verbose::on )


### PR DESCRIPTION
1. The fix for the case when the connection process ended up in rejection, but it was running in background (async). In this case the SRT_REJ_TIMEOUT code was set forcefully, even though this execution path was due to a TTL timer reset to zero, which means that it wasn't an expired timeout, but forceful break due to rejection. The fix: for a case with zero TTL, the reject reason is set only in case when it wasn't set (unlikely, but just as a safety fallback), and in general it's believed that the correct rejection reason is set already.

2. A small fix in reporting the error by `srt-live-transmit`: as with introducing the forced error code (case of non-blocking mode connect), the `srt_getlasterror_str` call is also not correct. Instead the message for the possibly enforced error code should be displayed.