### PR TITLE
[core] Moved loggers into separate files

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -58,6 +58,7 @@ modified by
 #include "packet.h"
 #include "core.h" // provides some constants
 #include "logging.h"
+#include "loggers.h"
 
 using namespace std;
 using namespace srt_logging;

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -32,6 +32,7 @@
 #include "packet.h"
 #include "congctl.h"
 #include "logging.h"
+#include "loggers.h"
 
 using namespace std;
 using namespace srt::sync;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -68,6 +68,7 @@ modified by
 #include "logging.h"
 #include "crypto.h"
 #include "logging_api.h" // Required due to containing extern srt_logger_config
+#include "loggers.h"
 
 // Again, just in case when some "smart guy" provided such a global macro
 #ifdef min
@@ -79,48 +80,6 @@ modified by
 
 using namespace std;
 using namespace srt::sync;
-
-namespace srt_logging
-{
-
-struct AllFaOn
-{
-    LogConfig::fa_bitset_t allfa;
-
-    AllFaOn()
-    {
-        //        allfa.set(SRT_LOGFA_BSTATS, true);
-        allfa.set(SRT_LOGFA_CONTROL, true);
-        allfa.set(SRT_LOGFA_DATA, true);
-        allfa.set(SRT_LOGFA_TSBPD, true);
-        allfa.set(SRT_LOGFA_REXMIT, true);
-        allfa.set(SRT_LOGFA_CONGEST, true);
-#if ENABLE_HAICRYPT_LOGGING
-        allfa.set(SRT_LOGFA_HAICRYPT, true);
-#endif
-    }
-} logger_fa_all;
-
-} // namespace srt_logging
-
-// We need it outside the namespace to preserve the global name.
-// It's a part of "hidden API" (used by applications)
-SRT_API srt_logging::LogConfig srt_logger_config(srt_logging::logger_fa_all.allfa);
-
-namespace srt_logging
-{
-
-Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
-// Unused. If not found useful, maybe reuse for another FA.
-// Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
-Logger mglog(SRT_LOGFA_CONTROL, srt_logger_config, "SRT.c");
-Logger dlog(SRT_LOGFA_DATA, srt_logger_config, "SRT.d");
-Logger tslog(SRT_LOGFA_TSBPD, srt_logger_config, "SRT.t");
-Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
-Logger cclog(SRT_LOGFA_CONGEST, srt_logger_config, "SRT.cc");
-
-} // namespace srt_logging
-
 using namespace srt_logging;
 
 CUDTUnited CUDT::s_UDTUnited;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -73,21 +73,6 @@ modified by
 
 #include <haicrypt.h>
 
-namespace srt_logging
-{
-
-extern Logger
-    glog,
-//    blog,
-    mglog,
-    dlog,
-    tslog,
-    rxlog,
-    cclog;
-
-}
-
-
 // XXX Utility function - to be moved to utilities.h?
 template <class T>
 inline T CountIIR(T base, T newval, double factor)

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -12,6 +12,7 @@ epoll.cpp
 fec.cpp
 handshake.cpp
 list.cpp
+loggers.cpp
 md5.cpp
 packet.cpp
 packetfilter.cpp
@@ -52,6 +53,7 @@ epoll.h
 handshake.h
 list.h
 logging.h
+loggers.h
 md5.h
 netinet_any.h
 packet.h

--- a/srtcore/loggers.cpp
+++ b/srtcore/loggers.cpp
@@ -1,0 +1,42 @@
+#include "logging.h"
+
+namespace srt_logging
+{
+
+struct AllFaOn
+{
+    LogConfig::fa_bitset_t allfa;
+
+    AllFaOn()
+    {
+        //        allfa.set(SRT_LOGFA_BSTATS, true);
+        allfa.set(SRT_LOGFA_CONTROL, true);
+        allfa.set(SRT_LOGFA_DATA, true);
+        allfa.set(SRT_LOGFA_TSBPD, true);
+        allfa.set(SRT_LOGFA_REXMIT, true);
+        allfa.set(SRT_LOGFA_CONGEST, true);
+#if ENABLE_HAICRYPT_LOGGING
+        allfa.set(SRT_LOGFA_HAICRYPT, true);
+#endif
+    }
+} logger_fa_all;
+
+} // namespace srt_logging
+
+// We need it outside the namespace to preserve the global name.
+// It's a part of "hidden API" (used by applications)
+SRT_API srt_logging::LogConfig srt_logger_config(srt_logging::logger_fa_all.allfa);
+
+namespace srt_logging
+{
+
+Logger glog(SRT_LOGFA_GENERAL, srt_logger_config, "SRT.g");
+// Unused. If not found useful, maybe reuse for another FA.
+// Logger blog(SRT_LOGFA_BSTATS, srt_logger_config, "SRT.b");
+Logger mglog(SRT_LOGFA_CONTROL, srt_logger_config, "SRT.c");
+Logger dlog(SRT_LOGFA_DATA, srt_logger_config, "SRT.d");
+Logger tslog(SRT_LOGFA_TSBPD, srt_logger_config, "SRT.t");
+Logger rxlog(SRT_LOGFA_REXMIT, srt_logger_config, "SRT.r");
+Logger cclog(SRT_LOGFA_CONGEST, srt_logger_config, "SRT.cc");
+
+} // namespace srt_logging

--- a/srtcore/loggers.h
+++ b/srtcore/loggers.h
@@ -1,0 +1,15 @@
+#include "logging.h"
+
+namespace srt_logging
+{
+
+extern Logger
+    glog,
+//    blog,
+    mglog,
+    dlog,
+    tslog,
+    rxlog,
+    cclog;
+
+}


### PR DESCRIPTION
Moved loggers into separate files `loggers.h` and `loggers.cpp`.

Related PR #1440 uses the `LOGGER` macro to provide declarations and definitions. But it might worsen the code readability. Here we discuss the alternative approach.