### PR TITLE
[apps] Added absolute time in CSV stats of srt-live-transmit

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -440,18 +440,20 @@ public:
 
             const auto   systime_now = system_clock::now();
             const time_t time_now    = system_clock::to_time_t(systime_now);
-            std::tm*     tm_now      = std::localtime(&time_now);
-            if (!tm_now)
-            {
-                cerr << "SrtStatsCsv: Failed to get current time for stats.";
-                return;
-            }
 
-            output << std::put_time(tm_now, "%d.%m.%Y %T.") << std::setfill('0') << std::setw(6);
+            // Ignore the error from localtime, as zeroed tm_now is acceptable.
+            tm tm_now = {};
+#ifdef _WIN32
+	        localtime_s(&time_now, &tm_now);
+#else
+            localtime_r(&time_now, &tm_now);
+#endif
+
+            output << std::put_time(&tm_now, "%d.%m.%Y %T.") << std::setfill('0') << std::setw(6);
             const auto    since_epoch = systime_now.time_since_epoch();
             const seconds s           = duration_cast<seconds>(since_epoch);
             output << duration_cast<microseconds>(since_epoch - s).count();
-            output << std::put_time(tm_now, " %z");
+            output << std::put_time(&tm_now, " %z");
             output << ",";
         };
 

--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -407,9 +407,9 @@ private:
 public: 
     SrtStatsCsv() : first_line_printed(false) {}
 
-    string WriteStats(int sid, const CBytePerfMon& mon) override 
-    { 
-	    // Note: std::put_time is supported only in GCC 5 and higher
+    string WriteStats(int sid, const CBytePerfMon& mon) override
+    {
+        // Note: std::put_time is supported only in GCC 5 and higher
 #if !defined(__GNUC__) || defined(__clang__) || (__GNUC__ >= 5)
 #define HAS_PUT_TIME
 #endif
@@ -417,7 +417,7 @@ public:
         if (!first_line_printed)
         {
 #ifdef HAS_PUT_TIME
-		    output << "Timepoint,";
+            output << "Timepoint,";
 #endif
             output << "Time,SocketID,pktFlowWindow,pktCongestionWindow,pktFlightSize,";
             output << "msRTT,mbpsBandwidth,mbpsMaxBW,pktSent,pktSndLoss,pktSndDrop,";
@@ -430,7 +430,7 @@ public:
             first_line_printed = true;
         }
         int rcv_latency = 0;
-        int int_len = sizeof rcv_latency;
+        int int_len     = sizeof rcv_latency;
         srt_getsockopt(sid, 0, SRTO_RCVLATENCY, &rcv_latency, &int_len);
 
 #ifdef HAS_PUT_TIME
@@ -438,9 +438,9 @@ public:
             using namespace std;
             using namespace std::chrono;
 
-            const auto systime_now = system_clock::now();
-            const time_t time_now = system_clock::to_time_t(systime_now);
-            std::tm*     tm_now   = std::localtime(&time_now);
+            const auto   systime_now = system_clock::now();
+            const time_t time_now    = system_clock::to_time_t(systime_now);
+            std::tm*     tm_now      = std::localtime(&time_now);
             if (!tm_now)
             {
                 cerr << "SrtStatsCsv: Failed to get current time for stats.";
@@ -448,8 +448,8 @@ public:
             }
 
             output << std::put_time(tm_now, "%d.%m.%Y %T.") << std::setfill('0') << std::setw(6);
-            const auto since_epoch = systime_now.time_since_epoch();
-            const seconds s = duration_cast<seconds>(since_epoch);
+            const auto    since_epoch = systime_now.time_since_epoch();
+            const seconds s           = duration_cast<seconds>(since_epoch);
             output << duration_cast<microseconds>(since_epoch - s).count();
             output << std::put_time(tm_now, " %z");
             output << ",";
@@ -493,7 +493,7 @@ public:
         return output.str();
     }
 
-    string WriteBandwidth(double mbpsBandwidth) override 
+    string WriteBandwidth(double mbpsBandwidth) override
     {
         std::ostringstream output;
         output << "+++/+++SRT BANDWIDTH: " << mbpsBandwidth << endl;

--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <cstring>
+#include <chrono>
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -18,6 +18,7 @@
 
 #include "apputil.hpp"
 #include "netinet_any.h"
+#include "srt_compat.h"
 
 using namespace std;
 
@@ -441,14 +442,8 @@ public:
             const auto   systime_now = system_clock::now();
             const time_t time_now    = system_clock::to_time_t(systime_now);
 
-            // Ignore the error from localtime, as zeroed tm_now is acceptable.
-            tm tm_now = {};
-#ifdef _WIN32
-	        localtime_s(&time_now, &tm_now);
-#else
-            localtime_r(&time_now, &tm_now);
-#endif
-
+            // SysLocalTime returns zeroed tm_now on failure, which is ok for put_time.
+            const tm tm_now = SysLocalTime(time_now);
             output << std::put_time(&tm_now, "%d.%m.%Y %T.") << std::setfill('0') << std::setw(6);
             const auto    since_epoch = systime_now.time_since_epoch();
             const seconds s           = duration_cast<seconds>(since_epoch);


### PR DESCRIPTION
Added absolute time in CSV stats of `srt-live-transmit`.
The first column of CSV stats:
```
Timepoint
--
19.08.2020 09:40:10.619482 +0200
19.08.2020 09:40:10.724653 +0200
```
Example CLI:
```shell
./srt-live-transmit srt://:4200 udp://127.0.0.1:4201 -pf csv -statsout rcvstats.csv -s 100
```

Note: GCC before v5.0 is not supported.

Fixes #1218 