### PR TITLE
Fixed bug: listener callback was changing SRTO_GROUPCONNECT option.

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -547,6 +547,7 @@ std::string MessageTypeStr(UDTMessageType mt, uint32_t extt)
         "EXT:kmrsp",
         "EXT:sid",
         "EXT:congctl",
+        "EXT:filter",
         "EXT:group"
     };
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11386,6 +11386,11 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs
                 break;
         }
     }
+    if (have_group && acore->m_OPT_GroupConnect == 0)
+    {
+        HLOGC(mglog.Debug, log << "runAcceptHook: REJECTING connection WITHOUT calling the hook - groups not allowed");
+        return false;
+    }
 
     // Update the groupconnect flag
     acore->m_OPT_GroupConnect = have_group ? 1 : 0;


### PR DESCRIPTION
Fixes #1490 

Problem: the SRTO_GROUPCIBBECT option was changed in the listener callback wrapper function basing on the found group extension. This was overwriting the value derived from the listener, and the group interpreter was relying on that value.

Solution: before setting the option, first check if you have group extension, but groupconnect=0. If this is found, reject the connection prematurely, without calling the listener callback.