### PR TITLE
Added length type wrapper in sockaddr_any for convenience.

### DIFF
--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -675,13 +675,11 @@ unique_ptr<Medium> SrtMedium::Accept()
 unique_ptr<Medium> TcpMedium::Accept()
 {
     sockaddr_any sa;
-    socklen_t salen = sizeof sa;
-    int s = ::accept(m_socket, (sa.get()), (&salen));
+    int s = ::accept(m_socket, (sa.get()), (&sa.syslen()));
     if (s == -1)
     {
         Error(errno, "accept");
     }
-    sa.len = salen;
 
     // Configure 1s timeout
     timeval timeout_1s { 1, 0 };

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -58,6 +58,29 @@ struct sockaddr_any
     // back here from the value of `syslen_t`.
     len_t len;
 
+    struct SysLenWrapper
+    {
+        syslen_t syslen;
+        len_t& backwriter;
+        syslen_t* operator&() { return &syslen; }
+
+        SysLenWrapper(len_t& source): syslen(source), backwriter(source)
+        {
+        }
+
+        ~SysLenWrapper()
+        {
+            backwriter = syslen;
+        }
+    };
+
+    // Usage:
+    //    ::accept(lsn_sock, sa.get(), &sa.syslen());
+    SysLenWrapper syslen()
+    {
+        return SysLenWrapper(len);
+    }
+
     static size_t storage_size()
     {
         typedef union

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -2517,16 +2517,14 @@ public:
     {
         bytevector data(chunk);
         sockaddr_any sa(sadr.family());
-        socklen_t si = sa.size();
         int64_t srctime = 0;
-        int stat = recvfrom(m_sock, data.data(), (int) chunk, 0, sa.get(), &si);
+        int stat = recvfrom(m_sock, data.data(), (int) chunk, 0, sa.get(), &sa.syslen());
         if (transmit_use_sourcetime)
         {
             srctime = srt_time_now();
         }
         if (stat == -1)
             Error(SysError(), "UDP Read/recvfrom");
-        sa.len = si;
 
         if (stat < 1)
         {


### PR DESCRIPTION
This adds a possibility to easily specify the forwarder for the `len` field in `sockaddr_any` usable with system functions.

The SRT API is using `int` type for length of the address specified by `sockaddr*`, whereas system functions use `socklen_t` on Linux (which resolves to various combinations) or `int` on Windows. To satisfy normal needs, the `len` field is of `int` type, but this way it can't be passed to system functions by pointer.

This makes it possible to pass a pointer to a system length type, as the system function require, and transparently bind it to the `len` field.