### PR TITLE
Changed generation of the SRT header file FA section

### DIFF
--- a/scripts/generate-logging-defs.tcl
+++ b/scripts/generate-logging-defs.tcl
@@ -75,10 +75,74 @@ set special {
 	}
 }
 
+proc GenerateModelForSrtH {} {
+
+	# `path` will be set to the git top path
+	global path
+
+	set fd [open [file join $path srtcore/srt.h] r]
+
+	set contents ""
+
+	set state read
+	set pass looking
+
+	while { [gets $fd line] != -1 } {
+		if { $state == "read" } {
+
+			if { $pass != "passed" } {
+				set re [regexp {^\#define SRT_LOGFA_} $line]
+				if {$re} {
+					set state skip
+					set pass found
+					continue
+				}
+
+			}
+
+			append contents "$line\n"
+			continue
+		}
+
+		if {$state == "skip"} {
+			if { [string trim $line] == "" } {
+				# Empty line, continue skipping
+				continue
+			}
+
+			if {[regexp {^\#define SRT_LOGFA_} $line]} {
+				# Still SRT_LOGFA definitions
+				continue
+			}
+
+			# End of generated section. Switch back to pass-thru.
+
+			# First fill the gap
+			append contents "\$entries\n\n"
+
+			append contents "$line\n"
+			set state read
+			set pass passed
+		}
+	}
+
+	close $fd
+
+	# Sanity check
+	if {$pass != "passed"} {
+		error "Invalid contents of `srt.h` file, can't find '#define SRT_LOGFA_' phrase"
+	}
+
+	return $contents
+}
+
 # COMMENTS NOT ALLOWED HERE! Only as C++ comments inside C++ model code.
+# Note: The syntax %<command> is a high-level command execution. This declares
+# a command that must be executed to GENERATE the model. Then, [subst] is executed
+# on the results.
 set generation {
-	srt.inc.h {
-		{}
+	srtcore/srt.h {
+		{%GenerateModelForSrtH}
 		{#define [format "%-20s %d" SRT_LOGFA_${longname} $id] // ${shortname}log}
 		{#define [format "%-20s %d" SRT_LOGFA_${longname} $id] // ${shortname}log}
 	}
@@ -212,6 +276,11 @@ proc generate_file {od target} {
 
     set ptabprefix ""
 
+	if {[string index $format_model 0] == "%"} {
+		set command [string range $format_model 1 end]
+		set format_model [eval $command]
+	}
+
 	if {$format_model != ""} {
 		set beginindex 0
 		while { [string index $format_model $beginindex] == "\n" } {
@@ -313,15 +382,16 @@ foreach f $entryfiles {
 		set filepath [file join $path $f] 
 	}
 
+    puts stderr "Generating '$filepath'"
+	set od [open $filepath.tmp w]
+	generate_file $od $f
+	close $od
 	if { [file exists $filepath] } {
 		puts "WARNING: will overwrite exiting '$f'. Hit ENTER to confirm, or Control-C to stop"
 		gets stdin
 	}
 
-    puts stderr "Generating '$filepath'"
-	set od [open $filepath w]
-	generate_file $od $f
-	close $od
+	file rename -force $filepath.tmp $filepath
 }
 
 puts stderr Done.

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -583,7 +583,6 @@ enum SRT_REJECT_REASON
 #define SRT_LOGFA_CONGEST    7 // cclog
 #define SRT_LOGFA_HAICRYPT   6 // hclog
 
-
 // To make a typical int32_t size, although still use std::bitset.
 // C API will carry it over.
 #define SRT_LOGFA_LASTNONE 31


### PR DESCRIPTION
This improves the logging FA generation for `srt.h` file. Instead of generation a fragment, now the whole file is generated basing on existing contents, with only the interesting fragment with FA definitions replaced.

Also added "safe generation" - the generated is first temporary file, and then renamed to the target file, if there were no errors in the meantime.