### PR TITLE
Fixed bug: write back actual sending time if no source time supplied

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -255,6 +255,10 @@ void CSndBuffer::addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl)
         s->m_tsOriginTime = time;
         s->m_tsRexmitTime = time_point();
         s->m_iTTL = w_ttl;
+        // Rewrite the actual sending time back into w_srctime
+        // so that the calling facilities can reuse it
+        if (!w_srctime)
+            w_srctime = count_microseconds(s->m_tsOriginTime.time_since_epoch());
 
         // XXX unchecked condition: s->m_pNext == NULL.
         // Should never happen, as the call to increase() should ensure enough buffers.
@@ -400,9 +404,7 @@ steady_clock::time_point CSndBuffer::getSourceTime(const CSndBuffer::Block& bloc
 {
     if (block.m_llSourceTime_us)
     {
-        const steady_clock::duration since_epoch = block.m_tsOriginTime.time_since_epoch();
-        const steady_clock::duration delta       = microseconds_from(block.m_llSourceTime_us) - since_epoch;
-        return block.m_tsOriginTime + delta;
+        return steady_clock::time_point() + microseconds_from(block.m_llSourceTime_us);
     }
 
     return block.m_tsOriginTime;

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -120,19 +120,20 @@ public:
 public:
 
       /// Insert a user buffer into the sending list.
-      /// For Message control data the following data are used:
+      /// For @a w_mctrl the following fields are used:
       /// INPUT:
-      /// - msgttl: timeout for scheduling the messsage for sending
+      /// - msgttl: timeout for retransmitting the message, if lost
       /// - inorder: request to deliver the message in order of sending
       /// - srctime: local time as a base for packet's timestamp (0 if unused)
-      /// - pktseq: sequence number to be stamped on the packet (0 if unused)
+      /// - pktseq: sequence number to be stamped on the packet (-1 if unused)
+      /// - msgno: message number to be stamped on the packet (-1 if unused)
       /// OUTPUT:
-      /// - srctime: local time that was used to stamp the packet
+      /// - srctime: local time stamped on the packet (same as input, if input wasn't 0)
       /// - pktseq: sequence number to be stamped on the next packet
       /// - msgno: message number stamped on the packet
       /// @param [in] data pointer to the user data block.
       /// @param [in] len size of the block.
-      /// @param [inout] r_mctrl Message control data
+      /// @param [inout] w_mctrl Message control data
    void addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl);
 
       /// Read a block of data from file and insert it into the sending list.


### PR DESCRIPTION
1. Fixed: the actual sending time is available back after calling `sendmsg2`. If no source time supplied, this field will be written with the value of "origin time" (time when the packet was scheduled for sending). This way the next call in the group sender will pick up the time rewritten by the previous call and supply identical time for the same packet sent over a different link.

2. Formula fixed for `getSourceTime`: the `m_tsOriginTime` was actually reduced in this equation making false impression that this value participates in the equation.