### PR TITLE
Fixed some problems in group code found during review

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1559,7 +1559,9 @@ parties.
 #### SRT_REJ_GROUP
 
 The group type or some group settings are incompatible for both connection
-parties.
+parties. This includes the possibility that the currently performed connection
+within the bonding group connection does not designate the same endpoint as
+those already established connections.
 
 #### SRT_REJ_TIMEOUT
 

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -1558,10 +1558,12 @@ parties.
 
 #### SRT_REJ_GROUP
 
-The group type or some group settings are incompatible for both connection
-parties. This includes the possibility that the currently performed connection
-within the bonding group connection does not designate the same endpoint as
-those already established connections.
+The group type or some group settings are incompatible for both connection parties. 
+While every connection within a bonding group may have different target addresses, 
+they should all designate the same endpoint and the same SRT application. If this 
+condition isn't satisfied, then the peer will respond with a different peer group 
+ID for the connection that is trying to contact a machine/application that is 
+completely different from the existing connections in the bonding group.
 
 #### SRT_REJ_TIMEOUT
 

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1244,6 +1244,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
     // connection is going to later succeed or fail (this will be
     // known in the group state information).
     bool block_new_opened = !g.m_bOpened && g.m_bSynRecving;
+    bool was_empty = g.empty();
     SRTSOCKET retval = -1;
 
     int eid = -1;
@@ -1363,7 +1364,6 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
             isn = -1;
         }
 
-
         // Set it the groupconnect option, as all in-group sockets should have.
         ns->m_pUDT->m_OPT_GroupConnect = 1;
 
@@ -1439,9 +1439,9 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         {
             ScopedLock grd (g.m_GroupLock);
 
-            if (isn == 0)
+            if (was_empty)
             {
-                g.syncWithSocket(ns->core());
+                g.syncWithSocket(ns->core(), HSD_INITIATOR);
             }
 
             HLOGC(aclog.Debug, log << "groupConnect: @" << sid << " connection successful, setting group OPEN (was "
@@ -1488,7 +1488,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
     if (retval == -1)
     {
         HLOGC(aclog.Debug, log << "groupConnect: none succeeded as background-spawn, exit with error");
-        block_new_opened = false;
+        block_new_opened = false; // Avoid executing further while loop
     }
 
     vector<SRTSOCKET> broken;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1244,7 +1244,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
     // connection is going to later succeed or fail (this will be
     // known in the group state information).
     bool block_new_opened = !g.m_bOpened && g.m_bSynRecving;
-    bool was_empty = g.empty();
+    const bool was_empty = g.empty();
     SRTSOCKET retval = -1;
 
     int eid = -1;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1862,30 +1862,32 @@ size_t CUDT::fillHsExtGroup(uint32_t* pcmdspec)
     if (m_parent->m_IncludedGroup->synconmsgno())
         flags |= SRT_GFLAG_SYNCONMSG;
 
+    // NOTE: this code remains as is for historical reasons.
+    // The initial implementation stated that the peer id be
+    // extracted so that it can be reported and possibly the
+    // start time somehow encoded and written into the group
+    // extension, but it was later seen not necessary. Therefore
+    // this code remains, but now it's informational only.
 #if ENABLE_HEAVY_LOGGING
-
     SRTSOCKET master_peerid;
-    steady_clock::duration master_tdiff;
     steady_clock::time_point master_st;
 
     // "Master" is the first found running connection. Will be false, if
     // there's no other connection yet. When any connection is found, specify this
     // as a determined master connection, and extract its id.
-    if ( !m_parent->m_IncludedGroup->getMasterData(m_SocketID, (master_peerid), (master_st)) )
+    if ( !m_parent->m_IncludedGroup->debugMasterData(m_SocketID, (master_peerid), (master_st)) )
     {
         master_peerid = -1;
-        IF_HEAVY_LOGGING(master_tdiff = steady_clock::duration());
-        HLOGC(cnlog.Debug, log << CONID() << "NO GROUP MASTER LINK found for group: $" << m_parent->m_IncludedGroup->id());
+        LOGC(cnlog.Debug, log << CONID() << "NO GROUP MASTER LINK found for group: $" << m_parent->m_IncludedGroup->id());
     }
     else
     {
         // The returned master_st is the master's start time. Calculate the
         // differene time.
-        IF_HEAVY_LOGGING(master_tdiff = m_stats.tsStartTime - master_st);
-        HLOGC(cnlog.Debug, log << CONID() << "FOUND GROUP MASTER LINK: peer=$" << master_peerid
+        steady_clock::duration master_tdiff = m_stats.tsStartTime - master_st;
+        LOGC(cnlog.Debug, log << CONID() << "FOUND GROUP MASTER LINK: peer=$" << master_peerid
                 << " - start time diff: " << FormatDuration<DUNIT_S>(master_tdiff));
     }
-
 #endif
 
     // See CUDT::interpretGroup()

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1869,25 +1869,7 @@ size_t CUDT::fillHsExtGroup(uint32_t* pcmdspec)
     // extension, but it was later seen not necessary. Therefore
     // this code remains, but now it's informational only.
 #if ENABLE_HEAVY_LOGGING
-    SRTSOCKET master_peerid;
-    steady_clock::time_point master_st;
-
-    // "Master" is the first found running connection. Will be false, if
-    // there's no other connection yet. When any connection is found, specify this
-    // as a determined master connection, and extract its id.
-    if ( !m_parent->m_IncludedGroup->debugMasterData(m_SocketID, (master_peerid), (master_st)) )
-    {
-        master_peerid = -1;
-        LOGC(cnlog.Debug, log << CONID() << "NO GROUP MASTER LINK found for group: $" << m_parent->m_IncludedGroup->id());
-    }
-    else
-    {
-        // The returned master_st is the master's start time. Calculate the
-        // differene time.
-        steady_clock::duration master_tdiff = m_stats.tsStartTime - master_st;
-        LOGC(cnlog.Debug, log << CONID() << "FOUND GROUP MASTER LINK: peer=$" << master_peerid
-                << " - start time diff: " << FormatDuration<DUNIT_S>(master_tdiff));
-    }
+    m_parent->m_IncludedGroup->debugMasterData(m_SocketID);
 #endif
 
     // See CUDT::interpretGroup()

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -135,13 +135,18 @@ bool CUDTGroup::applyGroupSequences(SRTSOCKET target, int32_t& w_snd_isn, int32_
 
 // NOTE: This function is now for DEBUG PURPOSES ONLY.
 // Except for presenting the extracted data in the logs, there's no use of it now.
-bool CUDTGroup::debugMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, steady_clock::time_point& w_st)
+void CUDTGroup::debugMasterData(SRTSOCKET slave)
 {
     // Find at least one connection, which is running. Note that this function is called
     // from within a handshake process, so the socket that undergoes this process is at best
     // currently in SRT_GST_PENDING state and it's going to be in SRT_GST_IDLE state at the
     // time when the connection process is done, until the first reading/writing happens.
     ScopedLock cg(m_GroupLock);
+
+    SRTSOCKET mpeer;
+    steady_clock::time_point start_time;
+
+    bool found = false;
 
     for (gli_t gi = m_Group.begin(); gi != m_Group.end(); ++gi)
     {
@@ -150,39 +155,54 @@ bool CUDTGroup::debugMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, steady_cloc
             // Found it. Get the socket's peer's ID and this socket's
             // Start Time. Once it's delivered, this can be used to calculate
             // the Master-to-Slave start time difference.
-            w_mpeer = gi->ps->m_PeerID;
-            w_st    = gi->ps->core().socketStartTime();
+            mpeer = gi->ps->m_PeerID;
+            start_time    = gi->ps->core().socketStartTime();
             HLOGC(gmlog.Debug,
-                  log << "getMasterData: found RUNNING master @" << gi->id << " - reporting master's peer $" << w_mpeer
-                      << " starting at " << FormatTime(w_st));
-            return true;
+                  log << "getMasterData: found RUNNING master @" << gi->id << " - reporting master's peer $" << mpeer
+                      << " starting at " << FormatTime(start_time));
+            found = true;
+            break;
         }
     }
 
-    // If no running one found, then take the first socket in any other
-    // state than broken, except the slave. This is for a case when a user
-    // has prepared one link already, but hasn't sent anything through it yet.
-    for (gli_t gi = m_Group.begin(); gi != m_Group.end(); ++gi)
+    if (!found)
     {
-        if (gi->sndstate == SRT_GST_BROKEN)
-            continue;
+        // If no running one found, then take the first socket in any other
+        // state than broken, except the slave. This is for a case when a user
+        // has prepared one link already, but hasn't sent anything through it yet.
+        for (gli_t gi = m_Group.begin(); gi != m_Group.end(); ++gi)
+        {
+            if (gi->sndstate == SRT_GST_BROKEN)
+                continue;
 
-        if (gi->id == slave)
-            continue;
+            if (gi->id == slave)
+                continue;
 
-        // Found it. Get the socket's peer's ID and this socket's
-        // Start Time. Once it's delivered, this can be used to calculate
-        // the Master-to-Slave start time difference.
-        w_mpeer = gi->ps->core().m_PeerID;
-        w_st    = gi->ps->core().socketStartTime();
-        HLOGC(gmlog.Debug,
-              log << "getMasterData: found IDLE/PENDING master @" << gi->id << " - reporting master's peer $" << w_mpeer
-                  << " starting at " << FormatTime(w_st));
-        return true;
+            // Found it. Get the socket's peer's ID and this socket's
+            // Start Time. Once it's delivered, this can be used to calculate
+            // the Master-to-Slave start time difference.
+            mpeer = gi->ps->core().m_PeerID;
+            start_time    = gi->ps->core().socketStartTime();
+            HLOGC(gmlog.Debug,
+                    log << "getMasterData: found IDLE/PENDING master @" << gi->id << " - reporting master's peer $" << mpeer
+                    << " starting at " << FormatTime(start_time));
+            found = true;
+            break;
+        }
     }
 
-    HLOGC(gmlog.Debug, log << "getMasterData: no link found suitable as master for @" << slave);
-    return false;
+    if (!found)
+    {
+        LOGC(cnlog.Debug, log << CONID() << "NO GROUP MASTER LINK found for group: $" << id());
+    }
+    else
+    {
+        // The returned master_st is the master's start time. Calculate the
+        // differene time.
+        steady_clock::duration master_tdiff = m_tsStartTime - start_time;
+        LOGC(cnlog.Debug, log << CONID() << "FOUND GROUP MASTER LINK: peer=$" << mpeer
+                << " - start time diff: " << FormatDuration<DUNIT_S>(master_tdiff));
+    }
 }
 
 // GROUP

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -133,6 +133,8 @@ bool CUDTGroup::applyGroupSequences(SRTSOCKET target, int32_t& w_snd_isn, int32_
     return true;
 }
 
+// NOTE: This function is now for DEBUG PURPOSES ONLY.
+// Except for presenting the extracted data in the logs, there's no use of it now.
 bool CUDTGroup::getMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, steady_clock::time_point& w_st)
 {
     // Find at least one connection, which is running. Note that this function is called
@@ -862,11 +864,18 @@ SRT_SOCKSTATUS CUDTGroup::getStatus()
     return SRTS_BROKEN;
 }
 
-void CUDTGroup::syncWithSocket(const CUDT& core)
+void CUDTGroup::syncWithSocket(const CUDT& core, const HandshakeSide side)
 {
     // [[using locked(m_GroupLock)]];
 
-    set_currentSchedSequence(core.ISN());
+    if (side == HSD_RESPONDER)
+    {
+        // On the listener side you should synchronize ISN with the incoming
+        // socket, which is done immediately after creating the socket and
+        // adding it to the group. On the caller side the ISN is defined in
+        // the group directly, before any member socket is created.
+        set_currentSchedSequence(core.ISN());
+    }
 
     // XXX
     // Might need further investigation as to whether this isn't

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -135,7 +135,7 @@ bool CUDTGroup::applyGroupSequences(SRTSOCKET target, int32_t& w_snd_isn, int32_
 
 // NOTE: This function is now for DEBUG PURPOSES ONLY.
 // Except for presenting the extracted data in the logs, there's no use of it now.
-bool CUDTGroup::getMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, steady_clock::time_point& w_st)
+bool CUDTGroup::debugMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, steady_clock::time_point& w_st)
 {
     // Find at least one connection, which is running. Note that this function is called
     // from within a handshake process, so the socket that undergoes this process is at best

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -263,7 +263,7 @@ public:
 
     SRT_SOCKSTATUS getStatus();
 
-    bool getMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, time_point& w_st);
+    bool debugMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, time_point& w_st);
 
     bool isGroupReceiver()
     {

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -299,7 +299,7 @@ public:
     /// @param ack The past-the-last-received ACK sequence number
     void readyPackets(CUDT* core, int32_t ack);
 
-    void syncWithSocket(const CUDT& core);
+    void syncWithSocket(const CUDT& core, const HandshakeSide side);
     int  getGroupData(SRT_SOCKGROUPDATA* pdata, size_t* psize);
     int  configure(const char* str);
 

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -263,7 +263,7 @@ public:
 
     SRT_SOCKSTATUS getStatus();
 
-    bool debugMasterData(SRTSOCKET slave, SRTSOCKET& w_mpeer, time_point& w_st);
+    void debugMasterData(SRTSOCKET slave);
 
     bool isGroupReceiver()
     {


### PR DESCRIPTION
Things found during the review:

1. Synchronization group data with the socket data at the caller side:
* wrong reaction on isn == 0 (0 is a perfectly legal sequence value), which likely was remaining after the fact that a freshly created group has recorded scheduling sequence undefined
* the right "undefined sequence" value is -1, but this no longer makes sense because the group is now always initialized the schedule sequence number due to another bugfix
* the intention was to synchronize the latency value for the group from the value taken from the first socket in case when the group didn't get this information yet. The condition to do it was then changed to simply checking if the group is empty. Also the synchronization done at the caller side has been changed to not perform the sequence number derivation, as it doesn't make sense here - now the ISN is created in the group and it's the socket deriving this value from group, not the other way around

2. The use of `getMasterData` has proven to be now informative only - therefore the whole call is put under ENABLE_HEAVY_LOGGING condition for clarity.

3. Comparison of the expected peer id in case when the group is not empty should result in rejection. This is a probable situation if the user has mistakenly made two connections within a group, but these endpoints do not designate the same application at the peer side. In this case the returned peer group ID will be different for the second member socket, and this means that the address of the second connection is wrong, stating that the first was right.

