### PR TITLE
Added UPDATE event raised when a member connection broken

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -154,7 +154,7 @@ public:
    /// operation, but continues to be responsive in the connection in order
    /// to finish sending the data that were scheduled for sending so far.
    void makeShutdown();
-   void removeFromGroup();
+   void removeFromGroup(bool broken);
 
    // Instrumentally used by select() and also required for non-blocking
    // mode check in groups

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -4145,6 +4145,11 @@ void CUDTGroup::updateLatestRcv(CUDTGroup::gli_t current)
     }
 }
 
+void CUDTGroup::activateUpdateEvent()
+{
+    m_pGlobal->m_EPoll.update_events(id(), m_sPollID, SRT_EPOLL_UPDATE, true);
+}
+
 void CUDTGroup::addEPoll(int eid)
 {
     enterCS(m_pGlobal->m_EPoll.m_EPollLock);

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -278,6 +278,7 @@ public:
     void              removeEPollID(const int eid);
     void              updateReadState(SRTSOCKET sock, int32_t sequence);
     void              updateWriteState();
+    void              activateUpdateEvent();
 
     /// Update the in-group array of packet providers per sequence number.
     /// Also basing on the information already provided by possibly other sockets,

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -876,7 +876,7 @@ void SrtCommon::OpenGroupClient()
     if ( stat == SRT_ERROR )
         Error("ConfigurePre");
 
-    if ( !m_blocking_mode )
+    if (!m_blocking_mode)
     {
         // Note: here the GROUP is added to the poller.
         srt_conn_epoll = AddPoller(m_sock, SRT_EPOLL_CONNECT | SRT_EPOLL_ERR);
@@ -918,6 +918,7 @@ void SrtCommon::OpenGroupClient()
         gd.config = c.options;
         targets.push_back(gd);
     }
+
 
     int fisock = srt_connect_group(m_sock, targets.data(), targets.size());
 
@@ -1005,10 +1006,7 @@ void SrtCommon::OpenGroupClient()
             << sockaddr_any((sockaddr*)&d.peeraddr, sizeof d.peeraddr).str();
     }
 
-    /*
-
-       XXX Temporarily disabled, until the nonblocking mode
-       is added to groups.
+    //*
 
     // Wait for REAL connected state if nonblocking mode, for AT LEAST one node.
     if ( !m_blocking_mode )
@@ -1035,7 +1033,7 @@ void SrtCommon::OpenGroupClient()
             Error("srt_epoll_wait");
         }
     }
-    */
+    // */
 
     if (!any_node)
     {


### PR DESCRIPTION
Fixes #1506

Changes:

Removal from group of a socket is given a separate parameter that confirms that it was so because the socket was broken. If so, additionally the group will be set the UPDATE event.

Applications: changed the code for non-blocking mode case that tests also the case for the UPDATE event.