### PR TITLE
[apps] Test app fixed group parameter handling

### DIFF
--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -560,7 +560,6 @@ int main( int argc, char** argv )
             cerr << "    <area...> is a space-sep list of areas to turn on or ~areas to turn off.\n\n";
             cerr << "The list may include 'all' to turn all on or off, beside those selected.\n";
             cerr << "Example: `-lfa ~all cc` - turns off all FA, except cc\n";
-            cerr << "Areas: general bstats control data tsbpd rexmit haicrypt cc\n";
             cerr << "Default: all are on except haicrypt. NOTE: 'general' can't be off.\n\n";
             cerr << "List of functional areas:\n";
 

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -251,6 +251,25 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
             {
                 if (hostport == "")
                     continue;
+
+                // The attribute string, as it was embedded in another URI,
+                // must have had replaced the & character with another ?, so
+                // now all ? character, except the first one, must be now
+                // restored so that UriParser interprets them correctly.
+
+                size_t atq = hostport.find('?');
+                if (atq != string::npos)
+                {
+                    while (atq+1 < hostport.size())
+                    {
+                        size_t next = hostport.find('?', atq+1);
+                        if (next == string::npos)
+                            break;
+                        hostport[next] = '&';
+                        atq = next;
+                    }
+                }
+
                 UriParser check(hostport, UriParser::EXPECT_HOST);
                 if (check.host() == "" || check.port() == "")
                 {
@@ -270,8 +289,8 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
 
                 if (check.parameters().count("source"))
                 {
-                    UriParser hostport(check.queryValue("source"), UriParser::EXPECT_HOST);
-                    cc.source = CreateAddr(hostport.host(), hostport.portno());
+                    UriParser sourcehp(check.queryValue("source"), UriParser::EXPECT_HOST);
+                    cc.source = CreateAddr(sourcehp.host(), sourcehp.portno());
                 }
 
                 // Check if there's a key with 'srto.' prefix.
@@ -878,11 +897,25 @@ void SrtCommon::OpenGroupClient()
     for (Connection& c: m_group_nodes)
     {
         auto sa = CreateAddr(c.host, c.port);
-        Verb() << "\t[" << i << "] " << c.host << ":" << c.port
-            << "?weight=" << c.weight
-            << " ... " << VerbNoEOL;
+        Verb() << "\t[" << i << "] " << c.host << ":" << c.port << VerbNoEOL;
+        vector<string> extras;
+        if (c.weight)
+            extras.push_back(Sprint("weight=", c.weight));
+
+        if (!c.source.empty())
+            extras.push_back("source=" + c.source.str());
+
+        if (!extras.empty())
+        {
+            Verb() << "?" << extras[0] << VerbNoEOL;
+            for (size_t i = 1; i < extras.size(); ++i)
+                Verb() << "&" << extras[i] << VerbNoEOL;
+        }
+
+        Verb() << " ... " << VerbNoEOL;
         ++i;
-        SRT_SOCKGROUPCONFIG gd = srt_prepare_endpoint(NULL, sa.get(), namelen);
+        const sockaddr* source = c.source.empty() ? nullptr : c.source.get();
+        SRT_SOCKGROUPCONFIG gd = srt_prepare_endpoint(source, sa.get(), namelen);
         gd.weight = c.weight;
         gd.config = c.options;
         targets.push_back(gd);


### PR DESCRIPTION
1. Fixed "uri smuggling" from the node settings to the overall group URI and "recovering" before URI parsing for given node.

The idea for "URI smuggling" was that all `&` characters that separate the URI parameters are changed into `?`, then the list of nodes is joined with comma and set as `nodes` parameter in the group URI. The problem was that the `?` wasn't turned back to `&` after unpacking the "smuggled" URI and it was incorrectly interpreted later.

2. Fixed lacking `source` parameter specified address to `srt_prepare_endpoint`.

The `source` parameter after being correctly extracted from the "smuggled" node URI wasn't passed at all to `srt_prepare_endpoint`. After the fix it has been tested that the `srt_connect_group` function does effectively call `srt_bind` on the socket with the given source address.