### PR TITLE
[core] Fixed cookie contest

### DIFF
--- a/docs/features/handshake.md
+++ b/docs/features/handshake.md
@@ -697,7 +697,26 @@ connection will not be made until new, unique cookies are generated (after a
 delay of up to one minute). In the case of an application "connecting to itself", 
 the cookies will always be identical, and so the connection will never be made.
 
-When one party's cookie value is greater than its peer's, it wins the cookie 
+```c++
+// Here m_ConnReq.m_iCookie is a local cookie value sent in connection request to the peer.
+// m_ConnRes.m_iCookie is a cookie value sent by the peer in its connection request.
+const int64_t contest = int64_t(m_ConnReq.m_iCookie) - int64_t(m_ConnRes.m_iCookie);
+
+if ((contest & 0xFFFFFFFF) == 0)
+{
+    return HSD_DRAW;
+}
+
+if (contest & 0x80000000)
+{
+    return HSD_RESPONDER;
+}
+
+return HSD_INITIATOR;
+```
+
+When one party's cookie value is greater than its peer's (based on 32-bit subtraction of both
+with potential overflow), it wins the cookie 
 contest and becomes Initiator (the other party becomes the Responder).
 
 At this point there are two "handshake flows" possible (at least theoretically):


### PR DESCRIPTION
The following condition in `CUDT::cookieContest()` can overflow the 32-bit signed integer:
```c++
int better_cookie = m_ConnReq.m_iCookie - m_ConnRes.m_iCookie;
```

The value of `better_cookie` is then checked against zero. A positive value is resolved to INITIATOR, a negative value is resolved to RESPONDER. Otherwise, DRAW and try again.

However, checking whether `better_cookie` has a negative or a positive value is not very reliable, as some compilers may optimize it just by comparing `m_ConnReq.m_iCookie` and `m_ConnRes.m_iCookie` instead.

The example input provided below results in HSD_DRAW when SRT is linked with -O3 and C++14 by clang.
A simplified example provided [in this comment](https://github.com/Haivision/srt/pull/1517#issuecomment-685745391) provides different results when built under Release or Debug configuration.

Probably further checks are optimized by the compiler somehow?

### Example Cookie Contest

In this example, the actual result of a cookie contest should be INITIATOR, but due to casting to int32 the actual result is RESPONDER. It is the most likely result of the cookie contest, however, due to compiler optimizations, other results are also possible. See a simplified example provided [in this comment](https://github.com/Haivision/srt/pull/1517#issuecomment-685745391).

```c++
m_ConnReq.m_iCookie = -1480577720;
m_ConnRes.m_iCookie = 811599203;

int64_t llBetterCookie = -1480577720 - 811599203 = -2292176923 (FFFF FFFF 7760 27E5);
int32_t iBetterCookie = 2002790373 (7760 27E5); // Used by SRT

if (iBetterCookie > 0)
{
    g_hs_side = HSD_INITIATOR;
    return;
}

if (iBetterCookie < 0)
{
    g_hs_side = HSD_RESPONDER;
    return;
}

g_hs_side = HSD_DRAW;
```

See also: #1267

### Proposed Change

Instead of relying on integer overflow, do 64-bit arithmetic and check the 31-st bit of the result.

```c++
const int64_t contest = int64_t(REQ) - int64_t(RSP);

if ((contest & 0xFFFFFFFF) == 0)
    return HSD_DRAW;

if (contest & 0x80000000) // was (contest > 0)
    return HSD_RESPONDER;

return HSD_INITIATOR;
```
Both 32-bit cast and checking the 31-st bit provide the same results:

| REQ               | RSP              | REQ - RSP | INT32 (REQ-RSP) | 31st bit |
| ------------- | ------------ | ------ | ---- | ---- |
| -1480577720 | 811599203 | -2292176923 (0xffffffff776027e5) | 2002790373 (0x776027e5) | 0 |
| 811599203 | -1480577720 | 2292176923 (0x889fd81b) | -2002790373 (0x889fd81b) | 1 |
| 2147483647 | -2147483648 | 4294967295 (0xffffffff) | -1 (0xffffffff) | 1 |
| -2147483648 | 2147483647 | -4294967295 (0xffffffff00000001) | 1 (0x1) | 0 |

### TODO:

- [x] Provide reliable cookie contest version (without integer overflow, backward compatible)
- [x] Update handshake.md
- [ ] Write unit tests