### PR TITLE
[devel] Fixed crash by having destructor but not copy rules in srt-test-live

### DIFF
--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -340,7 +340,7 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
                     cc.options = config;
                 }
 
-                m_group_nodes.push_back(cc);
+                m_group_nodes.push_back(move(cc));
             }
 
             par.erase("type");

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -49,16 +49,31 @@ class SrtCommon
 
 protected:
 
-    struct Connection
+    struct ConnectionBase
     {
         string host;
         int port;
         int weight = 0;
         SRTSOCKET socket = SRT_INVALID_SOCK;
         sockaddr_any source;
+        sockaddr_any target;
+
+        ConnectionBase(string h, int p): host(h), port(p), source(AF_INET) {}
+    };
+
+    struct Connection: ConnectionBase
+    {
         SRT_SOCKOPT_CONFIG* options = nullptr;
 
-        Connection(string h, int p): host(h), port(p), source(AF_INET) {}
+        Connection(string h, int p): ConnectionBase(h, p) {}
+        Connection(Connection&& old): ConnectionBase(old)
+        {
+            if (old.options)
+            {
+                options = old.options;
+                old.options = nullptr;
+            }
+        }
         ~Connection()
         {
             srt_delete_config(options);


### PR DESCRIPTION
This splits the `Connection` into a part that should contain copyable data and the part the contains only the real object state and pointed permanent object that should be uniquely pointed. For the right object, the move-only copying is the only allowed.