### PR TITLE
[FR] Added retrieving weight setting in group data

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -685,6 +685,7 @@ typedef struct SRT_SocketGroupData_
     SRTSOCKET id;
     struct sockaddr_storage peeraddr;
     SRT_SOCKSTATUS sockstate;
+	int weight;
     SRT_MEMBERSTATUS memberstate;
     int result;
 
@@ -696,6 +697,7 @@ where:
 * `id`: member socket ID
 * `peeraddr`: address to which `id` should be connected
 * `sockstate`: current connection status (see [`srt_getsockstate`](#srt_getsockstate))
+* `weight`: current weight value set on the link
 * `memberstate`: current state of the member (see below)
 * `result`: result of the operation (if this operation recently updated this structure)
 

--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -685,7 +685,7 @@ typedef struct SRT_SocketGroupData_
     SRTSOCKET id;
     struct sockaddr_storage peeraddr;
     SRT_SOCKSTATUS sockstate;
-	int weight;
+    int weight;
     SRT_MEMBERSTATUS memberstate;
     int result;
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -1653,6 +1653,8 @@ int CUDTGroup::getGroupData(SRT_SOCKGROUPDATA* pdata, size_t* psize)
             pdata[i].result      = 0;
             pdata[i].memberstate = d->sndstate;
         }
+
+        pdata[i].weight = d->weight;
     }
 
     return m_Group.size();

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -786,6 +786,7 @@ typedef struct SRT_SocketGroupData_
     SRTSOCKET id;
     struct sockaddr_storage peeraddr; // Don't want to expose sockaddr_any to public API
     SRT_SOCKSTATUS sockstate;
+    int weight;
     SRT_MEMBERSTATUS memberstate;
     int result;
 } SRT_SOCKGROUPDATA;


### PR DESCRIPTION
This adds the `weight` value to the `SRT_GROUPDATA` structure and retrieval of this value from the internal member data.

As on the caller side it shouldn't be a problem because the weight is set by the caller requester and the application should have this value in its connection table, on the listener side there's no way otherwise to know this value, as the listener keeps such connections that are reporting in, together with their settings decided at caller side.