### PR TITLE
[core] Added SRTO_ESTINPUTBW option to get estimated input bitrate

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1060,6 +1060,17 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         optlen = sizeof(int32_t);
         break;
 
+    case SRTO_ESTINPUTBW:
+        *(int64_t*)optval = 0LL;
+        if (m_pSndBuffer && m_pSndBuffer->getInRatePeriod() != 0)
+        {
+            // return sampled internally measured input bw
+            const int rate = m_pSndBuffer->getInputRate();
+            *(int64_t*)optval = rate;
+        }
+        optlen = sizeof(int64_t);
+        break;
+
     case SRTO_STATE:
         *(int32_t *)optval = s_UDTUnited.getStatus(m_SocketID);
         optlen             = sizeof(int32_t);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -770,6 +770,7 @@ private: // Identification
     int m_iPeerTsbPdDelay_ms;                       // Tx delay that the peer uses to absorb burst in milliseconds
     bool m_bTLPktDrop;                           // Enable Too-late Packet Drop
     int64_t m_llInputBW;                         // Input stream rate (bytes/sec)
+                                                 // 0: use internally estimated input bandwidth
     int m_iOverheadBW;                           // Percent above input stream rate (applies if m_llMaxBW == 0)
     bool m_bRcvNakReport;                        // Enable Receiver Periodic NAK Reports
     int m_iIpV6Only;                             // IPV6_V6ONLY option (-1 if not set)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -218,6 +218,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_PEERVERSION,         // Peer SRT Version (from SRT Handshake)
    SRTO_CONNTIMEO = 36,      // Connect timeout in msec. Caller default: 3000, rendezvous (x 10)
    SRTO_DRIFTTRACER = 37,    // Enable or disable drift tracer
+   SRTO_ESTINPUTBW = 38,     // Internally estimated input rate
    // (some space left)
    SRTO_SNDKMSTATE = 40,     // (GET) the current state of the encryption at the peer side
    SRTO_RCVKMSTATE,          // (GET) the current state of the encryption at the agent side


### PR DESCRIPTION
These changes are extracted from #1383.

Added readonly `SRTO_ESTINPUTBW` socket option available via `srt_getsockopt(..)` and `srt_getsockflag(..)`.