### PR TITLE
[core] Removed SRTO_ESTINPUTBW

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1060,17 +1060,6 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         optlen = sizeof(int32_t);
         break;
 
-    case SRTO_ESTINPUTBW:
-        *(int64_t*)optval = 0LL;
-        if (m_pSndBuffer && m_pSndBuffer->getInRatePeriod() != 0)
-        {
-            // return sampled internally measured input bw
-            const int rate = m_pSndBuffer->getInputRate();
-            *(int64_t*)optval = rate;
-        }
-        optlen = sizeof(int64_t);
-        break;
-
     case SRTO_STATE:
         *(int32_t *)optval = s_UDTUnited.getStatus(m_SocketID);
         optlen             = sizeof(int32_t);

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -218,7 +218,6 @@ typedef enum SRT_SOCKOPT {
    SRTO_PEERVERSION,         // Peer SRT Version (from SRT Handshake)
    SRTO_CONNTIMEO = 36,      // Connect timeout in msec. Caller default: 3000, rendezvous (x 10)
    SRTO_DRIFTTRACER = 37,    // Enable or disable drift tracer
-   SRTO_ESTINPUTBW = 38,     // Internally estimated input rate
    // (some space left)
    SRTO_SNDKMSTATE = 40,     // (GET) the current state of the encryption at the peer side
    SRTO_RCVKMSTATE,          // (GET) the current state of the encryption at the agent side


### PR DESCRIPTION
The socket option was introduced in PR #1537 recently to allow getting the estimated input bitrate value.
However, it should not be a socket option, but more a statistics entry.
Furthermore, there is already the [mbpsMaxBW](https://github.com/Haivision/srt/blob/master/docs/statistics.md#mbpsMaxBW) statistic that depicts the estimated input bitrate value (when the corresponding mode is used `SRTO_INPUTBW=0` and `SRTO_MAXBW=0`) as estimated value multiplied by (100% + `SRT_OHEADBW`).

Therefore removing the option.