### PR TITLE
[build] Added ENABLE_SOCK_CLOEXEC build option enabled by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,7 @@ option(ENABLE_STDCXX_SYNC "Use C++11 chrono and threads for timing instead of pt
 option(USE_OPENSSL_PC "Use pkg-config to find OpenSSL libraries" ON)
 option(USE_BUSY_WAITING "Enable more accurate sending times at a cost of potentially higher CPU load" OFF)
 option(USE_GNUSTL "Get c++ library/headers from the gnustl.pc" OFF)
+option(ENABLE_SOCK_CLOEXEC "Enable setting SOCK_CLOEXEC on a socket" OFF)
 
 set(TARGET_srt "srt" CACHE STRING "The name for the SRT library")
 
@@ -424,6 +425,10 @@ elseif (ENABLE_STDCXX_SYNC)
 endif()
 
 message(STATUS "STDCXX_SYNC: ${ENABLE_STDCXX_SYNC}")
+
+if (ENABLE_SOCK_CLOEXEC)
+	add_definitions(-DENABLE_SOCK_CLOEXEC=1)
+endif()
 
 if (CMAKE_MAJOR_VERSION LESS 3)
 	set (FORCE_CXX_STANDARD_GNUONLY 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ option(ENABLE_STDCXX_SYNC "Use C++11 chrono and threads for timing instead of pt
 option(USE_OPENSSL_PC "Use pkg-config to find OpenSSL libraries" ON)
 option(USE_BUSY_WAITING "Enable more accurate sending times at a cost of potentially higher CPU load" OFF)
 option(USE_GNUSTL "Get c++ library/headers from the gnustl.pc" OFF)
-option(ENABLE_SOCK_CLOEXEC "Enable setting SOCK_CLOEXEC on a socket" OFF)
+option(ENABLE_SOCK_CLOEXEC "Enable setting SOCK_CLOEXEC on a socket" ON)
 
 set(TARGET_srt "srt" CACHE STRING "The name for the SRT library")
 

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -77,7 +77,9 @@ using namespace srt_logging;
     static const int INVALID_SOCKET = -1;
 #endif
 
+#if ENABLE_CLOEXEC
 #ifndef _WIN32
+
 #if defined(_AIX) || \
     defined(__APPLE__) || \
     defined(__DragonFly__) || \
@@ -90,6 +92,7 @@ using namespace srt_logging;
 #else
 #define set_cloexec set_cloexec_fcntl
 #endif
+
 #if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__HAIKU__)
 static int set_cloexec_ioctl(int fd, int set) {
     int r;
@@ -104,6 +107,7 @@ static int set_cloexec_ioctl(int fd, int set) {
     return 0;
 }
 #endif
+
 static int set_cloexec_fcntl(int fd, int set) {
     int flags;
     int r;
@@ -134,6 +138,7 @@ static int set_cloexec_fcntl(int fd, int set) {
     return 0;
 }
 #endif
+#endif //ENABLE_CLOEXEC
 
 CChannel::CChannel():
 m_iSocket(INVALID_SOCKET),
@@ -151,6 +156,7 @@ CChannel::~CChannel()
 
 void CChannel::createSocket(int family)
 {
+#if ENABLE_CLOEXEC
     bool cloexec_flag = false;
     // construct an socket
 #if defined(SOCK_CLOEXEC)
@@ -164,10 +170,14 @@ void CChannel::createSocket(int family)
     m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
     cloexec_flag = true;
 #endif
+#else // ENABLE_CLOEXEC
+    m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
+#endif // ENABLE_CLOEXEC
 
     if (m_iSocket == INVALID_SOCKET)
         throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
 
+#if ENABLE_CLOEXEC
 #ifdef _WIN32
     // XXX ::SetHandleInformation(hInputWrite, HANDLE_FLAG_INHERIT, 0)
 #else
@@ -177,6 +187,8 @@ void CChannel::createSocket(int family)
         }
     }
 #endif
+#endif // ENABLE_CLOEXEC
+
     if ((m_iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {
         int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)(&m_iIpV6Only), sizeof(m_iIpV6Only));

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -88,13 +88,9 @@ using namespace srt_logging;
     defined(__linux__) || \
     defined(__OpenBSD__) || \
     defined(__NetBSD__)
-#define set_cloexec set_cloexec_ioctl
-#else
-#define set_cloexec set_cloexec_fcntl
-#endif
 
-#if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__HAIKU__)
-static int set_cloexec_ioctl(int fd, int set) {
+// Set the CLOEXEC flag using ioctl() function
+static int set_cloexec(int fd, int set) {
     int r;
 
     do
@@ -106,9 +102,9 @@ static int set_cloexec_ioctl(int fd, int set) {
 
     return 0;
 }
-#endif
-
-static int set_cloexec_fcntl(int fd, int set) {
+#else
+// Set the CLOEXEC flag using fcntl() function
+static int set_cloexec(int fd, int set) {
     int flags;
     int r;
 
@@ -137,8 +133,9 @@ static int set_cloexec_fcntl(int fd, int set) {
 
     return 0;
 }
-#endif
-#endif //ENABLE_CLOEXEC
+#endif // if defined(_AIX) ...
+#endif // ifndef _WIN32
+#endif // if ENABLE_CLOEXEC
 
 CChannel::CChannel():
 m_iSocket(INVALID_SOCKET),

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -77,7 +77,7 @@ using namespace srt_logging;
     static const int INVALID_SOCKET = -1;
 #endif
 
-#if ENABLE_CLOEXEC
+#if ENABLE_SOCK_CLOEXEC
 #ifndef _WIN32
 
 #if defined(_AIX) || \
@@ -153,7 +153,7 @@ CChannel::~CChannel()
 
 void CChannel::createSocket(int family)
 {
-#if ENABLE_CLOEXEC
+#if ENABLE_SOCK_CLOEXEC
     bool cloexec_flag = false;
     // construct an socket
 #if defined(SOCK_CLOEXEC)
@@ -167,14 +167,14 @@ void CChannel::createSocket(int family)
     m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
     cloexec_flag = true;
 #endif
-#else // ENABLE_CLOEXEC
+#else // ENABLE_SOCK_CLOEXEC
     m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
-#endif // ENABLE_CLOEXEC
+#endif // ENABLE_SOCK_CLOEXEC
 
     if (m_iSocket == INVALID_SOCKET)
         throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
 
-#if ENABLE_CLOEXEC
+#if ENABLE_SOCK_CLOEXEC
 #ifdef _WIN32
     // XXX ::SetHandleInformation(hInputWrite, HANDLE_FLAG_INHERIT, 0)
 #else
@@ -184,7 +184,7 @@ void CChannel::createSocket(int family)
         }
     }
 #endif
-#endif // ENABLE_CLOEXEC
+#endif // ENABLE_SOCK_CLOEXEC
 
     if ((m_iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -973,6 +973,7 @@ void FECFilterBuiltin::CollectIrrecoverRow(RcvGroup& g, loss_seqs_t& irrecover) 
     g.dismissed = true;
 }
 
+#if ENABLE_HEAVY_LOGGING
 static inline char CellMark(const std::deque<bool>& cells, int index)
 {
     if (index >= int(cells.size()))
@@ -981,7 +982,6 @@ static inline char CellMark(const std::deque<bool>& cells, int index)
     return cells[index] ? '#' : '.';
 }
 
-#if ENABLE_HEAVY_LOGGING
 static void DebugPrintCells(int32_t base, const std::deque<bool>& cells, int row_size)
 {
     int i = 0;


### PR DESCRIPTION
The changes introduced in PR #1465 might require more feedback regarding building on different platforms.

This PR adds the `ENABLE_SOCK_CLOEXEC` to allow to use the proposed changes, and at the same time to allow to disable the usage if a platform has issues using the `SOCK_CLOEXEC` or related flags (`FD_CLOEXEC`, `FIOCLEX`).

Enabled by default.

- Enabled the `ENABLE_SOCK_CLOEXEC` build option by default.
- Changed the `set_cloexec` definition to fix the build warning (fixes #1532).
- Fixed build warning regarding the unused `CellMark` function.