### PR TITLE
[apps] Fixed stransmit processing a socket twice

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -599,6 +599,14 @@ int main(int argc, char** argv)
                     if (s == SRT_INVALID_SOCK)
                         continue;
 
+                    // Remove duplicated sockets
+                    for (size_t j = i + 1; j < sizeof(srtrwfds) / sizeof(SRTSOCKET); j++)
+                    {
+                        const SRTSOCKET next_s = srtrwfds[j];
+                        if (next_s == s)
+                            srtrwfds[j] = SRT_INVALID_SOCK;
+                    }
+
                     bool issource = false;
                     if (src && src->GetSRTSocket() == s)
                     {

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2272,7 +2272,7 @@ int CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
            return epoll_remove_entity(eid, s->m_pUDT);
    }
 
-   LOGC(ealog.Error, log << "IPE: remove_usock: @" << u
+   LOGC(ealog.Error, log << "remove_usock: @" << u
            << " not found as either socket or group. Removing only from epoll system.");
    int no_events = 0;
    return m_EPoll.update_usock(eid, u, &no_events);


### PR DESCRIPTION
Fixes issue #1568.
srt-live-transmit tries to process the same socket twice.
This PR is a bit hacky. It removes a socket ID that is to be processed from the array to process.

- Also changed the IPE message