### PR TITLE
[BUG] Fixed: all-unstable situation responded with wait-for-ready link caused a hangup

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2960,7 +2960,7 @@ size_t CUDTGroup::sendBackup_CheckNeedActivate(const vector<gli_t>&          idl
           log << "grp/sendBackup: " << activate_reason << ", trying to activate an idle link (" << idlers.size()
               << " available)");
 
-    int nactive = 0;
+    size_t nactive = 0;
 
     for (vector<gli_t>::const_iterator i = idlers.begin(); i != idlers.end(); ++i)
     {
@@ -3247,7 +3247,7 @@ void CUDTGroup::sendBackup_CheckParallelLinks(const vector<gli_t>& unstable,
         {
             // wipeme wiped, pending sockets checked, it can only mean that
             // all sockets are broken.
-            LOGC(gslog.Debug, log << "grp/sendBackup: epolld empty - all sockets broken?");
+            HLOGC(gslog.Debug, log << "grp/sendBackup: epolld empty - all sockets broken?");
             throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
         }
 
@@ -3286,7 +3286,7 @@ RetryWaitBlocked:
             }
 
             InvertedLock ug(m_GroupLock);
-            LOGC(gslog.Debug,
+            HLOGC(gslog.Debug,
                     log << "grp/sendBackup: swait call to get at least one link alive up to " << m_iSndTimeOut << "us");
             THREAD_PAUSED();
             brdy = m_pGlobal->m_EPoll.swait(*m_SndEpolld, (sready), m_iSndTimeOut);
@@ -3323,7 +3323,7 @@ RetryWaitBlocked:
                     ++ndead;
                 }
             }
-            LOGC(gslog.Debug, log << "grp/sendBackup: swait/?close done, re-acquiring GroupLock");
+            HLOGC(gslog.Debug, log << "grp/sendBackup: swait/?close done, re-acquiring GroupLock");
         }
 
         if (brdy == -1 || ndead >= nlinks)
@@ -3399,7 +3399,7 @@ RetryWaitBlocked:
             d->ps->core().m_tsTmpActiveTime   = currtime;
             d->sndstate                       = SRT_GST_RUNNING;
             w_none_succeeded                  = false;
-            LOGC(gslog.Debug, log << "grp/sendBackup: after waiting, ACTIVATED link @" << d->id);
+            HLOGC(gslog.Debug, log << "grp/sendBackup: after waiting, ACTIVATED link @" << d->id);
 
             break;
         }
@@ -3841,7 +3841,7 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
     }
     else
     {
-        LOGC(gslog.Debug,
+        HLOGC(gslog.Debug,
               log << "grp/sendBackup: have sendable links, stable=" << (sendable.size() - unstable.size())
                   << " unstable=" << unstable.size());
     }

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -234,7 +234,7 @@ private:
                                     size_t&             w_nsuccessful,
                                     bool&               w_is_unstable);
     void sendBackup_Buffering(const char* buf, const int len, int32_t& curseq, SRT_MSGCTRL& w_mc);
-    void sendBackup_CheckNeedActivate(const std::vector<gli_t>& idlers,
+    size_t sendBackup_CheckNeedActivate(const std::vector<gli_t>& idlers,
                                       const char*               buf,
                                       const int                 len,
                                       bool&                     w_none_succeeded,
@@ -307,6 +307,7 @@ public:
 
     void syncWithSocket(const CUDT& core, const HandshakeSide side);
     int  getGroupData(SRT_SOCKGROUPDATA* pdata, size_t* psize);
+    int  getGroupDataIn(SRT_SOCKGROUPDATA* pdata, size_t* psize);
     int  configure(const char* str);
 
     /// Predicted to be called from the reading function to fill

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -111,9 +111,11 @@ void OnINT_ForceExit(int)
         throw ForcedExit("Requested exception interrupt");
 }
 
+std::string g_interrupt_reason;
+
 void OnAlarm_Interrupt(int)
 {
-    cerr << "\n---------- INTERRUPT ON TIMEOUT!\n";
+    cerr << "\n---------- INTERRUPT ON TIMEOUT: hang on " << g_interrupt_reason << "!\n";
     int_state = false; // JIC
     timer_state = true;
     throw AlarmExit("Watchdog bites hangup");
@@ -888,6 +890,7 @@ int main( int argc, char** argv )
                 alarm(0);
             }
             Verb() << " << ... " << VerbNoEOL;
+            g_interrupt_reason = "reading";
             const MediaPacket& data = src->Read(chunk);
             Verb() << " << " << data.payload.size() << "  ->  " << VerbNoEOL;
             if ( data.payload.empty() && src->End() )
@@ -895,6 +898,7 @@ int main( int argc, char** argv )
                 Verb() << "EOS";
                 break;
             }
+            g_interrupt_reason = "writing";
             tar->Write(data);
             if (stoptime == 0 && timeout != -1 )
             {


### PR DESCRIPTION
Main problem:

The problem was in the procedure that needed to make sure there are any links that could be used for sending a packet, in case when it wasn't sent over any stable links. The procedure was checking the links wrong way and was effectively waiting for another link to become ready to write except links that are running currently. In a situation when one and the only running link was considered unstable, it was effectively trying to find and activate another link and WAIT FOR IT by `swait` call until any was found, hence the hangup on the call to `srt_sendmsg2`.

Things fixed additionally:

1. The group characteristic data are also extracted in case when the function could end up with "again", as the group information is required in this case as well, and also it was lacking for a case when the available link should be found by waiting for write-readiness (in blocking mode).

2. The waiting for a ready link was involving the limitation set by the `SRTO_SNDTIMEO` option, but the procedure didn't react on the fact that there was no ready link in this time by an appropriate error.

Plus development support:
 - more logs around the process
 - the `srt-test-live` application displays which of the machines - input or output - has caused a hangup and therefore termination on timeout