### PR TITLE
[BUG] Fixed: SRTO_MINVERSION didn't cause rejection on too old version

### DIFF
--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -445,6 +445,22 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
         par.erase("groupconfig");
     }
 
+    // Fix Minversion, if specified as string
+    if (par.count("minversion"))
+    {
+        string v = par["minversion"];
+        if (v.find('.') != string::npos)
+        {
+            int version = SrtParseVersion(v.c_str());
+            if (version == 0)
+            {
+                throw std::runtime_error(Sprint("Value for 'minversion' doesn't specify a valid version: ", v));
+            }
+            par["minversion"] = Sprint(version);
+            Verb() << "\tFIXED: minversion = 0x" << std::hex << std::setfill('0') << std::setw(8) << version << std::dec;
+        }
+    }
+
     // Assign the others here.
     m_options = par;
     m_options["mode"] = m_mode;


### PR DESCRIPTION
Fixes #1577 

Changes:

1. Fixed lacking check in the HSRSP parsing (caller side) that didn't check the incoming peer version against the set up minimum version. Also fixing the rejection code that was unnecessarily overridden when it was set elsewhere already.

2. Fixed option fields derivation when deriving options from listener to the accepted socket - minversion wasn't derived and therefore the `minversion` option was ineffective on a listener

3. Added extra parsing possibility for the `minversion` option in the testing application so that it can also interpret a usual version string specification.