### PR TITLE
Add #include <iterator> to compile on Windows VS 14 2015

### DIFF
--- a/apps/logsupport.cpp
+++ b/apps/logsupport.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <iterator>
 #include <algorithm>
 #include <cctype>
 #include "logsupport.hpp"


### PR DESCRIPTION
Resolve the following compilation error on Windows 10 with VS 14 2015 :
`'back_inserter': identifier not found`