### PR TITLE
Fix BSD builds.

### DIFF
--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -66,6 +66,15 @@
 
 #endif
 
+#ifdef BSD
+#ifdef SRT_IMPORT_EVENT
+   #include <sys/types.h>
+   #include <sys/event.h>
+   #include <sys/time.h>
+   #include <unistd.h>
+#endif
+#endif
+
 #ifdef LINUX
 
 #ifdef SRT_IMPORT_EVENT


### PR DESCRIPTION
This fixes SRT build for BSD targets. Tested with FreeBSD, TrueOS, and OpenBSD.