### PR TITLE
Readme: Fix cookbook link pointing to threads chapter instead of index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ As audio/video packets are streamed from a source to a destination device, SRT d
 # Guides
 * [Why SRT Was Created](docs/why-srt-was-created.md)
 * [SRT Protocol Technical Overview](https://github.com/Haivision/srt/files/2489142/SRT_Protocol_TechnicalOverview_DRAFT_2018-10-17.pdf)
-* SRT Cookbook: [website](https://srtlab.github.io/srt-cookbook/protocol/threads/), [GitHub](https://github.com/SRTLab/srt-cookbook)
+* SRT Cookbook: [website](https://srtlab.github.io/srt-cookbook), [GitHub](https://github.com/SRTLab/srt-cookbook)
 * SRT RFC: [txt](https://haivision.github.io/srt-rfc/draft-sharabayko-mops-srt.txt), [html](https://haivision.github.io/srt-rfc/draft-sharabayko-mops-srt.html), [GitHub](https://github.com/Haivision/srt-rfc)
 * [Using the `srt-live-transmit` App](docs/srt-live-transmit.md)
 * [Contributing](docs/Contributing.md)


### PR DESCRIPTION
Just a quick fix on the readme of a href-typo stumbled upon