### PR TITLE
[core] fix race crash for m_RecvDataLock on shutdown

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9338,7 +9338,7 @@ bool CUDT::overrideSndSeqNo(int32_t seq)
 
 int CUDT::processData(CUnit* in_unit)
 {
-	ScopedLock scopedRecvDataLock(m_RecvDataLock);
+    ScopedLock recvdata_scope(m_RecvDataLock);
 
     if (m_bClosing)
         return -1;
@@ -11144,4 +11144,3 @@ void CUDT::handleKeepalive(const char* /*data*/, size_t /*size*/)
     }
 #endif
 }
-

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9338,6 +9338,8 @@ bool CUDT::overrideSndSeqNo(int32_t seq)
 
 int CUDT::processData(CUnit* in_unit)
 {
+	ScopedLock scopedRecvDataLock(m_RecvDataLock);
+
     if (m_bClosing)
         return -1;
 


### PR DESCRIPTION
We identified a problem in 1.4.2 on Windows (although likely topical on all platforms).

If a session does not establish before being stopped, then a crash can happen within the SRT library. This was identified internally as a race condition. Specifically, in the following function:

```c++
void CUDT::releaseSynch()
{
    // wake up user calls
    CSync::lock_signal(m_SendBlockCond, m_SendBlockLock);

    enterCS(m_SendLock);
    leaveCS(m_SendLock);

    CSync::lock_signal(m_RecvDataCond, m_RecvDataLock);
    CSync::lock_signal(m_RcvTsbPdCond, m_RecvLock);

    enterCS(m_RecvDataLock);
    if (m_RcvTsbPdThread.joinable())
    {
        m_RcvTsbPdThread.join();
    }
    leaveCS(m_RecvDataLock);

    enterCS(m_RecvLock);
    leaveCS(m_RecvLock);
}
```

Above, there is a join under m_RecvDataLock mutex, but when this thread is started in "int CUDT::processData(CUnit* in_unit)" there is no lock. 

This PR adds a fix to this problem by introducing a scoped lock within the call to CUDT::processData.

This may not be the perfect way to fix -- maybe it should be another mutex dedicated for this thread. There may be other race conditions, but we think this small change should not cause terrible problems and certainly does stop crashes when a client might connect and then abort before completing a session.

It should be noted, I'm acting as somewhat of a puppet for the engineer that analyzed and patched this - so my responses might be slower than normal.


