### PR TITLE
[core] Fixed getFlighSpan function and rexmit bug

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -575,8 +575,6 @@ int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time
     // the packet originally (the other overload of this function) must set these
     // flags.
     w_packet.m_iMsgNo = p->m_iMsgNoBitset;
-
-    // TODO: FR #930. Use source time if it is provided.
     w_srctime = getSourceTime(*p);
 
     // This function is called when packet retransmission is triggered.

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -620,6 +620,7 @@ public:
    {return (abs(seq1 - seq2) < m_iSeqNoTH) ? (seq1 - seq2) : (seq2 - seq1);}
 
    /// This function measures a length of the range from seq1 to seq2,
+   /// including endpoints (seqlen(a, a) = 1; seqlen(a, a + 1) = 2),
    /// WITH A PRECONDITION that certainly @a seq1 is earlier than @a seq2.
    /// This can also include an enormously large distance between them,
    /// that is, exceeding the m_iSeqNoTH value (can be also used to test

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -395,31 +395,39 @@ public: // internal API
     sockaddr_any peerAddr() const { return m_PeerAddr; }
 
     /// Returns the number of packets in flight (sent, but not yet acknowledged).
+    /// @param lastack is the sequence number of the first unacknowledged packet.
+    /// @param curseq is the sequence number of the latest original packet sent
+    ///
+    /// @note When there are no packets in flight, lastack = incseq(curseq).
+    ///
     /// @returns The number of packets in flight belonging to the interval [0; ...)
-    int32_t getFlightSpan() const
+    static int32_t getFlightSpan(int32_t lastack, int32_t curseq)
     {
-        // m_iSndCurrSeqNo is the sequence number of the latest original packet sent.
-        // m_iSndLastAck is the sequence number of the first unacknowledged packet.
-        // When there are no packets in flight, m_iSndLastAck = incseq(m_iSndCurrSeqNo).
-
         // Packets sent:
         // | 1 | 2 | 3 | 4 | 5 |
         //   ^               ^
         //   |               |
-        // m_iSndLastAck     |
-        //               m_iSndCurrSeqNo
+        // lastack           |
+        //                curseq
         //
-        // In Flight: [m_iSndLastAck; m_iSndCurrSeqNo]
+        // In Flight: [lastack; curseq]
         //
-        // Normally m_iSndLastAck should be PAST the m_iSndCurrSeqNo,
+        // Normally 'lastack' should be PAST the 'curseq',
         // however in a case when the sending stopped and all packets were
-        // ACKed, the m_iSndLastAck is one sequence ahead of m_iSndCurrSeqNo.
-        // Therefore we increase m_iSndCurrSeqNo by 1 forward and then
+        // ACKed, the 'lastack' is one sequence ahead of 'curseq'.
+        // Therefore we increase 'curseq' by 1 forward and then
         // get the distance towards the last ACK. This way this value may
         // be only positive as seqlen() includes endpoints.
         // Finally, we subtract 1 to exclude the increment added earlier.
 
-        return CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
+        return CSeqNo::seqlen(lastack, CSeqNo::incseq(curseq)) - 1;
+    }
+
+    /// Returns the number of packets in flight (sent, but not yet acknowledged).
+    /// @returns The number of packets in flight belonging to the interval [0; ...)
+    int32_t getFlightSpan() const
+    {
+        return getFlightSpan(m_iSndLastAck, m_iSndCurrSeqNo);
     }
 
     int minSndSize(int len = 0) const

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -111,6 +111,7 @@ void CSndLossList::traceState() const
 
 int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 {
+    SRT_ASSERT(CSeqNo::seqlen(seqno1, seqno2) > 0);
     ScopedLock listguard(m_ListLock);
 
     if (m_iLength == 0)

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -54,7 +54,7 @@ TEST(CUDT, getFlightSpan)
         // lastack  curseq  span
         {      125,    124,   0 },
         {      125,    125,   1 },
-        {      125,    130,   5 }
+        {      125,    130,   6 }
     };
 
     for (auto val : test_values)

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -41,6 +41,12 @@ TEST(CSeqNo, seqoff)
     EXPECT_EQ(CSeqNo::seqoff(0x7FFFFFFF, 1),    2);
 }
 
+TEST(CSeqNo, seqlen)
+{
+    EXPECT_EQ(CSeqNo::seqlen(125, 125), 1);
+    EXPECT_EQ(CSeqNo::seqlen(125, 126), 2);
+}
+
 
 TEST(CSeqNo, incseq)
 {

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -52,7 +52,7 @@ TEST(CUDT, getFlightSpan)
 {
     const int test_values[3][3] = {
         // lastack  curseq  span
-        {      125,    124,   0 },
+        {      125,    124,   0 }, // all sent packets are acknowledged
         {      125,    125,   1 },
         {      125,    130,   6 }
     };

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "common.h"
+#include "core.h"
 
 
 const int32_t CSeqNo::m_iSeqNoTH;
@@ -47,6 +48,20 @@ TEST(CSeqNo, seqlen)
     EXPECT_EQ(CSeqNo::seqlen(125, 126), 2);
 }
 
+TEST(CUDT, getFlightSpan)
+{
+    const int test_values[3][3] = {
+        // lastack  curseq  span
+        {      125,    124,   0 },
+        {      125,    125,   1 },
+        {      125,    130,   5 }
+    };
+
+    for (auto val : test_values)
+    {
+        EXPECT_EQ(CUDT::getFlightSpan(val[0], val[1]), val[2]) << "Span(" << val[0] << ", " << val[1] << ")";
+    }
+}
 
 TEST(CSeqNo, incseq)
 {


### PR DESCRIPTION
### Scope

In short, SRT sender may hang up under certain conditions if the receiver does not send loss reports periodically.
It means the receiver is either SRT version prior to v1.3.0 (didn’t have PeriodicNAK) or disables Periodic NAK explicitly (SRTO_NAKREPORTS option).

The issue found by @CommonsNat in #1000 was introduced in PR #1181 (Mar 17, 2020) with the new `getFlightSpan()` utility function. The function was later modified in #1190.

Only SRT v1.4.2 is affected by the bug which this PR fixes.

### TODO:

- [x] Resolve inline comments that are left in the code to help with the review.
- [x] Should there be any difference in LATE_REXMIT and FAST_REXMIT logic except for periodic NAK?

### Fixing the getFlighSpan()

The lowest value returned by the `getFlightSpan()` was `1`, while `0` is expected if there are no packets in flight.
The fixed version:

```c++
/// Returns the number of packets in flight (sent, but not yet acknowledged).
/// @returns The number of packets in flight belonging to the interval [0; ...)
int32_t getFlightSpan() const
{
    // m_iSndCurrSeqNo is the sequence number of the latest original packet sent.
    // m_iSndLastAck is the sequence number of the first unacknowledged packet.
    // When there are no packets in flight, m_iSndLastAck = incseq(m_iSndCurrSeqNo).

    // Packets sent:
    // | 1 | 2 | 3 | 4 | 5 |
    //   ^               ^
    //   |               |
    // m_iSndLastAck     |
    //               m_iSndCurrSeqNo
    //
    // In Flight: [m_iSndLastAck; m_iSndCurrSeqNo]
    //
    // Normally m_iSndLastAck should be PAST the m_iSndCurrSeqNo,
    // however in a case when the sending stopped and all packets were
    // ACKed, the m_iSndLastAck is one sequence ahead of m_iSndCurrSeqNo.
    // Therefore we increase m_iSndCurrSeqNo by 1 forward and then
    // get the distance towards the last ACK. This way this value may
    // be only positive as seqlen() includes endpoints.
    // Finally, we subtract 1 to exclude the increment added earlier.

    return CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) - 1;
}
```

### About the Breaking Change in PR 1181

The condition in `CUDT::checkRexmitTimer(..)`:
```c++
if (is_fastrexmit && (CSeqNo::seqoff(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo)) > 0))
```

in #1181 was replaced by:
```c++
if (is_fastrexmit && getFlightSpan() != 0)
```
essentially identical to
```c++
CSeqNo::seqlen(m_iSndLastAck, CSeqNo::incseq(m_iSndCurrSeqNo));
```

```c++
CSeqNo::seqoff(A, A) = 0;
CSeqNo::seqlen(A, A) = 1;
CSeqNo::seqoff(A, A) != CSeqNo::seqlen(A, A);
```