### PR TITLE
[core] SRTO_RETRANSMITALGO becomes readable

### DIFF
--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -1216,7 +1216,7 @@ procedure of `srt_bind` and then `srt_connect` (or `srt_rendezvous`) to one anot
      bandwidth consumption.
 
 - This option is effective only on the sending side. It influences the decision
-as to whether a particular reported lost packets should be retransmitted at a
+as to whether a particular reported lost packet should be retransmitted at a
 certain time or not.
 
 - The reduced retransmission algorithm (`SRTO_RETRANSMITALGO=1`) is only operational when receiver sends
@@ -1521,5 +1521,4 @@ For example, version 1.4.2 is encoded as `0x010402`.
 
 
 [Return to list](#list-of-options)
-
 

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -239,7 +239,7 @@ The following table lists SRT socket options in alphabetical order. Option detai
 | [`SRTO_RCVSYN`](#SRTO_RCVSYN)                          |       | post    | `bool`    |         | true       |          | RW  | GSI   |
 | [`SRTO_RCVTIMEO`](#SRTO_RCVTIMEO)                      |       | post    | `int32_t` | ms      | -1         | -1, 0..  | RW  | GSI   |
 | [`SRTO_RENDEZVOUS`](#SRTO_RENDEZVOUS)                  |       | pre     | `bool`    |         | false      |          | RW  | S     |
-| [`SRTO_RETRANSMITALGO`](#SRTO_RETRANSMITALGO)          | 1.4.2 | pre     | `int32_t` |         | 0          | [0, 1]   | W   | GSD   |
+| [`SRTO_RETRANSMITALGO`](#SRTO_RETRANSMITALGO)          | 1.4.2 | pre     | `int32_t` |         | 0          | [0, 1]   | RW  | GSD   |
 | [`SRTO_REUSEADDR`](#SRTO_REUSEADDR)                    |       | pre     | `bool`    |         | true       |          | RW  | GSD   |
 | [`SRTO_SENDER`](#SRTO_SENDER)                          | 1.0.4 | pre     | `bool`    |         | false      |          | W   | S     |
 | [`SRTO_SNDBUF`](#SRTO_SNDBUF)                          |       | pre     | `int32_t` | bytes   | 8192 bufs  | *        | RW  | GSD+  |
@@ -1194,20 +1194,22 @@ procedure of `srt_bind` and then `srt_connect` (or `srt_rendezvous`) to one anot
 
 | OptName               | Since | Binding | Type      | Units  | Default | Range  | Dir | Entity |
 | --------------------- | ----- | ------- | --------- | ------ | ------- | ------ | --- | ------ |
-| `SRTO_RETRANSMITALGO` | 1.4.2 | pre     | `int32_t` |        | 0       | [0, 1] | W   | GSD    |
+| `SRTO_RETRANSMITALGO` | 1.4.2 | pre     | `int32_t` |        | 0       | [0, 1] | RW  | GSD    |
 
 - Retransmission algorithm to use (SENDER option):
-   - 0 - Default (retransmit on every loss report).
-   - 1 - Reduced retransmissions (not more often than once per RTT); reduced 
+  - 0 - Default (retransmit on every loss report).
+  - 1 - Reduced retransmissions (not more often than once per RTT); reduced
      bandwidth consumption.
 
-- This option is effective only on the sending side. It influences the decision 
-as to whether particular reported lost packets should be retransmitted at a 
+- This option is effective only on the sending side. It influences the decision
+as to whether a particular reported lost packets should be retransmitted at a
 certain time or not.
+
+- The reduced retransmission algorithm (`SRTO_RETRANSMITALGO=1`) is only operational when receiver sends
+  Periodic NAK reports. See [SRTO_NAKREPORT](#SRTO_NAKREPORT).
 
 
 [Return to list](#list-of-options)
-
 
 
 #### SRTO_REUSEADDR

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1309,6 +1309,11 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         optlen = m_OPT_PktFilterConfigString.size();
         break;
 
+    case SRTO_RETRANSMITALGO:
+        *(int32_t *)optval = m_iOPT_RetransmitAlgo;
+        optlen         = sizeof(int32_t);
+        break;
+
     default:
         throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
     }


### PR DESCRIPTION
The `SRTO_RETRANSMITALGO` was previously only writable, but not readable.
However, it is worth making it readable as well to verify that the setting was applied, especially on the accepted socket (inheriting from listener socket).
Updated the docs.