### PR TITLE
Added mutex protection and null check for removeFromGroup

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3042,18 +3042,18 @@ void CUDTSocket::removeFromGroup(bool broken)
     }
 
     // Another facility could have deleted it in the meantime.
-    if (pg)
+    if (!pg)
+        return;
+
+    pg->remove(m_SocketID);
+    if (broken)
     {
-        pg->remove(m_SocketID);
-        if (broken)
-        {
-            // Activate the SRT_EPOLL_UPDATE event on the group
-            // if it was because of a socket that was earlier connected
-            // and became broken. This is not to be sent in case when
-            // it is a failure during connection, or the socket was
-            // explicitly removed from the group.
-            pg->activateUpdateEvent();
-        }
+        // Activate the SRT_EPOLL_UPDATE event on the group
+        // if it was because of a socket that was earlier connected
+        // and became broken. This is not to be sent in case when
+        // it is a failure during connection, or the socket was
+        // explicitly removed from the group.
+        pg->activateUpdateEvent();
     }
 }
 


### PR DESCRIPTION
Fixes #1608 

The `removeFromGroup` could be called in the meantime or somewhere from inside `connectIn` call, possibly also in the receiver worker thread as a reaction on connection timeout. The call that has caused a crash was in the exception handler, which stated that the `m_IncludedGroup` field is still valid as set before. To prevent things like this from happening, this function now rewrites the `m_IncludedGroup` and reads it under protection. The following call to `CUDTGroup::remove` is also protected by a group mutex and can be called multiple times (the call on an already removed socket is ignored).