### PR TITLE
WIP: Fixing synchronisation of the TSBPD thread

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7631,6 +7631,9 @@ void CUDT::releaseSynch()
     m_ReadyToReadEvent.lock_notify_one();
     CSync::lock_signal(m_RcvTsbPdCond, m_RecvLock);
 
+    SRT_ASSERT(m_bClosing);
+    CScopedResourceLock lockPrcRsrc(semIsProcessing());
+
     // TODO: [SYNC] Protect TBBPD Thread join
     //enterCS(m_NewDataReceivedLock);
     // ASSERT(m_bClosing)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9336,6 +9336,9 @@ bool CUDT::overrideSndSeqNo(int32_t seq)
 
 int CUDT::processData(CUnit* in_unit)
 {
+    // Before the state is checked mark this CUDT instance as "in process of receiving"
+    CScopedResourceLock processingLock(semIsProcessing());
+    
     if (m_bClosing)
         return -1;
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -490,6 +490,7 @@ public: // internal API
     SRTU_PROPERTY_RO(bool, isSynReceiving, m_bSynRecving);
     //SRTU_PROPERTY_RR(srt::sync::Condition*, recvDataCond, &m_NewDataReceivedCond);
     SRTU_PROPERTY_RR(srt::sync::Condition*, recvTsbPdCond, &m_RcvTsbPdCond);
+    SRTU_PROPERTY_RR(srt::sync::CSharedResource&, semIsProcessing, m_semIsProcessing);
 
     void ConnectSignal(ETransmissionEvent tev, EventSlot sl);
     void DisconnectSignal(ETransmissionEvent tev);
@@ -837,7 +838,7 @@ private:
     void EmitSignal(ETransmissionEvent tev, EventVariant var);
 
     // Internal state
-    volatile bool m_bListening;                  // If the UDT entit is listening to connection
+    volatile bool m_bListening;                  // If the UDT entity is listening to connection
     volatile bool m_bConnecting;                 // The short phase when connect() is called but not yet completed
     volatile bool m_bConnected;                  // Whether the connection is on or off
     volatile bool m_bClosing;                    // If the UDT entity is closing
@@ -847,6 +848,8 @@ private:
     volatile int m_RejectReason;
     bool m_bOpened;                              // If the UDT entity has been opened
     int m_iBrokenCounter;                        // a counter (number of GC checks) to let the GC tag this socket as disconnected
+    
+    srt::sync::CSharedResource m_semIsProcessing;// If the UDP entity is currently processing an incomming packet
 
     int m_iEXPCount;                             // Expiration counter
     int m_iBandwidth;                            // Estimated bandwidth, number of packets per second

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1397,9 +1397,6 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
         return CONN_AGAIN;
     }
 
-    // Before the state is checked mark this CUDT instance as "in process of receiving"
-    CScopedResourceLock processingLock(u->semIsProcessing());
-
     if (!u->m_bConnected || u->m_bBroken || u->m_bClosing)
     {
         u->m_RejectReason = SRT_REJ_CLOSE;

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -300,6 +300,8 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 {
     ScopedLock listguard(m_ListLock);
 
+	return -1;
+
     if (-1 == m_iLastEntry)
         return -1;
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1397,6 +1397,9 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
         return CONN_AGAIN;
     }
 
+    // Before the state is checked mark this CUDT instance as "in process of receiving"
+    CScopedResourceLock processingLock(u->semIsProcessing());
+
     if (!u->m_bConnected || u->m_bBroken || u->m_bClosing)
     {
         u->m_RejectReason = SRT_REJ_CLOSE;

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -137,6 +137,18 @@ void srt::sync::CEvent::notify_all()
     return m_cond.notify_all();
 }
 
+void srt::sync::CEvent::lock_notify_one()
+{
+    ScopedLock lock(m_lock);
+    return m_cond.notify_one();
+}
+
+void srt::sync::CEvent::lock_notify_all()
+{
+    ScopedLock lock(m_lock);
+    return m_cond.notify_all();
+}
+
 bool srt::sync::CEvent::lock_wait_for(const steady_clock::duration& rel_time)
 {
     UniqueLock lock(m_lock);

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -301,7 +301,7 @@ public:
     /// @return     true if the lock was acquired successfully, otherwise false
     bool try_lock();
 
-    // TODO: To be removed with introduction of the CEvent.
+    // TODO: [SYNC] To be removed with introduction of the CEvent.
     pthread_mutex_t& ref() { return m_mutex; }
 
 private:
@@ -594,6 +594,10 @@ public:
     void notify_one();
 
     void notify_all();
+
+    void lock_notify_one();
+
+    void lock_notify_all();
 
 private:
     Mutex      m_lock;

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -261,6 +261,8 @@ namespace sync
 
 Condition::Condition()
 #ifdef _WIN32
+    // If CV is used in the global scope, it must be initialized with PTHREAD_COND_INITIALIZER
+    // to avoid failures on Windows with with pthread wrapper library. See PR 1149.
     : m_cv(PTHREAD_COND_INITIALIZER)
 #endif
 {}
@@ -278,7 +280,7 @@ void Condition::init()
 #endif
     const int res = pthread_cond_init(&m_cv, attr);
     if (res != 0)
-        throw std::runtime_error("pthread_cond_init monotonic failed");
+        throw std::runtime_error("pthread_cond_init failed");
 }
 
 void Condition::destroy()


### PR DESCRIPTION
Issue: The `join()` operation on the TSBPD thread may be missed if `CUDT::releaseSynch()` finishes its execution while the receiving thread is still active and is about to create this thread.

### Changes

1.  The `CUDT::m_RecvDataCond` and `CUDT::m_RecvDataLock` mutex are replaced by `CUDT::m_ReadyToReadEvent` event (of type `CEvent` that combines CV and the corresponding mutex).



### TODO

- [ ] add description

Closes #1606

Includes unit test from #1619