### PR TITLE
[core] Fixed undefined zero length array in epoll

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -151,7 +151,7 @@ public:
 
    static int64_t getPeerSpec(SRTSOCKET id, int32_t isn)
    {
-       return (id << 30) + isn;
+       return (int64_t(id) << 30) + isn;
    }
    int64_t getPeerSpec()
    {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -152,7 +152,8 @@ void CUDT::construct()
     m_bBroken             = false;
     m_bPeerHealth         = true;
     m_RejectReason        = SRT_REJ_UNKNOWN;
-    m_tsLastReqTime         = steady_clock::time_point();
+    m_tsLastReqTime       = steady_clock::time_point();
+    m_SrtHsSide           = HSD_DRAW;
 
     m_lSrtVersion            = SRT_DEF_VERSION;
     m_lPeerSrtVersion        = 0; // not defined until connected.

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -604,10 +604,11 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
             HLOGC(ealog.Debug, log << "CEPoll::wait: REPORTED " << total << "/" << total_noticed
                     << debug_sockets.str());
 
-            if (lrfds || lwfds)
+            if ((lrfds || lwfds) && !ed.m_sLocals.empty())
             {
 #ifdef LINUX
                 const int max_events = ed.m_sLocals.size();
+                SRT_ASSERT(max_event > 0);
                 epoll_event ev[max_events];
                 int nfds = ::epoll_wait(ed.m_iLocalID, ev, max_events, 0);
 
@@ -630,6 +631,7 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
 #elif defined(BSD) || defined(OSX) || (TARGET_OS_IOS == 1) || (TARGET_OS_TV == 1)
                 struct timespec tmout = {0, 0};
                 const int max_events = ed.m_sLocals.size();
+                SRT_ASSERT(max_event > 0);
                 struct kevent ke[max_events];
 
                 int nfds = kevent(ed.m_iLocalID, NULL, 0, ke, max_events, &tmout);


### PR DESCRIPTION
Three issues are fixed in this PR.

### 1. Zero array size

It is likely that there are no system sockets signaled in the event, which makes `ed.m_sLocals` empty.
Then the following becomes a declaration of a zero-length array

```c++
const int max_events = ed.m_sLocals.size();
struct kevent ke[max_events];
```
This PR adds a check for an empty `ed.m_sLocals`.

### 2. Fixed getPeerSpec() function

There was a right shift operation that was dropping bits due to the insufficient size of the `int32_t` type.

### 3. Initialization of CUDT::m_SrtHsSide

Initialization was missing from the constructor.
