### PR TITLE
[core] Moved ACK sending to CUDT::sendCtrlAck

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1048,6 +1048,15 @@ private: // Common connection Congestion Control setup
 private: // Generation and processing of packets
     void sendCtrl(UDTMessageType pkttype, const int32_t* lparam = NULL, void* rparam = NULL, int size = 0);
 
+    /// Forms and sends ACK packet
+    /// @note Assumes @ctrlpkt already has a timestamp.
+    ///
+    /// @param ctrlpkt  A control packet structure to fill. It must have a timestemp already set.
+    /// @param size     Sends lite ACK if size is SEND_LITE_ACK, Full ACK otherwise
+    ///
+    /// @returns the nmber of packets sent.
+    int  sendCtrlAck(CPacket& ctrlpkt, int size);
+
     void processCtrl(const CPacket& ctrlpkt);
     void sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& losslist);
     void processCtrlAck(const CPacket& ctrlpkt, const time_point &currtime);

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -329,6 +329,7 @@ public:
     ~UniqueLock();
 
 public:
+    void lock();
     void unlock();
     Mutex* mutex(); // reflects C++11 unique_lock::mutex()
 

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -234,6 +234,12 @@ srt::sync::UniqueLock::~UniqueLock()
     unlock();
 }
 
+void srt::sync::UniqueLock::lock()
+{
+    if (m_iLocked == -1)
+        m_iLocked = m_Mutex.lock();
+}
+
 void srt::sync::UniqueLock::unlock()
 {
     if (m_iLocked == 0)

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -259,6 +259,38 @@ TEST(SyncTimePoint, OperatorMinusEqDuration)
 
 /*****************************************************************************/
 /*
+ * UniqueLock tests
+ */
+/*****************************************************************************/
+TEST(SyncUniqueLock, LockUnlock)
+{
+    Mutex mtx;
+    UniqueLock lock(mtx);
+    EXPECT_FALSE(mtx.try_lock());
+    
+    lock.unlock();
+    EXPECT_TRUE(mtx.try_lock());
+    
+    mtx.unlock();
+    lock.lock();
+    EXPECT_FALSE(mtx.try_lock());
+}
+
+TEST(SyncUniqueLock, Scope)
+{
+    Mutex mtx;
+
+    {
+        UniqueLock lock(mtx);
+        EXPECT_FALSE(mtx.try_lock());
+    }
+    
+    EXPECT_TRUE(mtx.try_lock());
+    mtx.unlock();
+}
+
+/*****************************************************************************/
+/*
  * SyncEvent tests
  */
 /*****************************************************************************/


### PR DESCRIPTION
As a part of the #1610 the ACK sending code was moved to a dedicated function `CUDT::sendCtrlAck(..)`.
The body of the function has no changes except for `break` statements that are replaced by `return`.