### PR TITLE
[test] Test apps improvements + build break fixes with logging off

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -199,7 +199,17 @@ options_t ProcessOptions(char* const* argv, int argc, std::vector<OptionScheme> 
     {
         const char* a = *p;
         // cout << "*D ARG: '" << a << "'\n";
-        if (moreoptions && a[0] == '-')
+        bool isoption = false;
+        if (a[0] == '-')
+        {
+            isoption = true;
+            // If a[0] isn't NUL - because it is dash - then
+            // we can safely check a[1].
+            if (a[1] && isdigit(a[1]))
+                isoption = false;
+        }
+
+        if (moreoptions && isoption)
         {
             bool arg_specified = false;
             size_t seppos; // (see goto, it would jump over initialization)

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -661,12 +661,11 @@ uint64_t PacketMetric::fullBytes()
 }
 
 
-// Some logging imps
-#if ENABLE_LOGGING
-
 namespace srt_logging
 {
 
+// Value display utilities
+// (also useful for applications)
 
 std::string SockStatusStr(SRT_SOCKSTATUS s)
 {
@@ -721,6 +720,10 @@ std::string MemberStatusStr(SRT_MEMBERSTATUS s)
     return names.names[int(s)];
 }
 #endif
+
+// Logging system implementation
+
+#if ENABLE_LOGGING
 
 LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabled(that.CheckEnabled())
 {
@@ -834,7 +837,7 @@ std::string LogDispatcher::Proxy::ExtractName(std::string pretty_function)
 
     return pretty_function.substr(pos+2);
 }
+#endif
 
 } // (end namespace srt_logging)
 
-#endif

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -44,7 +44,8 @@ using namespace srt_logging;
 // 10* HAICRYPT_DEF_KM_PRE_ANNOUNCE
 const int SRT_CRYPT_KM_PRE_ANNOUNCE = 0x10000;
 
-#if ENABLE_LOGGING
+namespace srt_logging
+{
 std::string KmStateStr(SRT_KM_STATE state)
 {
     switch (state)
@@ -64,8 +65,11 @@ std::string KmStateStr(SRT_KM_STATE state)
         }
     }
 }
+} // namespace
 
+using srt_logging::KmStateStr;
 
+#if ENABLE_LOGGING
 std::string CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srtlen)
 {
     std::ostringstream os;

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -28,16 +28,16 @@ written by
 #include <haicrypt.h>
 #include <hcrypt_msg.h>
 
-#if ENABLE_LOGGING
 
-std::string KmStateStr(SRT_KM_STATE state);
 
 namespace srt_logging
 {
+std::string KmStateStr(SRT_KM_STATE state);
+#if ENABLE_LOGGING
 extern Logger cnlog;
+#endif
 }
 
-#endif
 
 // For KMREQ/KMRSP. Only one field is used.
 const size_t SRT_KMR_KMSTATE = 0;

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -451,6 +451,7 @@ int main( int argc, char** argv )
         o_group     ((optargs), "<URIs...> Using multiple SRT connections as redundancy group", "g"),
 #endif
         o_stime     ((optargs), " Pass source time explicitly to SRT output", "st", "srctime", "sourcetime"),
+        o_retry     ((optargs), "<N=-1,0,+N> Retry connection N times if failed on timeout", "rc", "retry"),
         o_help      ((optargs), "[special=logging] This help", "?",   "help", "-help")
             ;
 
@@ -761,6 +762,17 @@ int main( int argc, char** argv )
         }
     }
 
+    string retryphrase = Option<OutString>(params, "", o_retry);
+    if (retryphrase != "")
+    {
+        if (retryphrase[retryphrase.size()-1] == 'a')
+        {
+            transmit_retry_always = true;
+            retryphrase = retryphrase.substr(0, retryphrase.size()-1);
+        }
+
+        transmit_retry_connect = stoi(retryphrase);
+    }
 
 #ifdef _WIN32
 #define alarm(argument) (void)0

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -40,6 +40,7 @@
 #define signal_alarm(fn) signal(SIGALRM, fn)
 #endif
 
+srt_logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-mpbond");
 
 volatile bool mpbond_int_state = false;
 void OnINT_SetIntState(int)

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -18,6 +18,8 @@
 #include <stdexcept>
 #include <iterator>
 #include <map>
+#include <chrono>
+#include <thread>
 #include <srt.h>
 #if !defined(_WIN32)
 #include <sys/ioctl.h>
@@ -40,6 +42,7 @@
 
 using namespace std;
 
+using srt_logging::KmStateStr;
 using srt_logging::SockStatusStr;
 #if ENABLE_EXPERIMENTAL_BONDING
 using srt_logging::MemberStatusStr;
@@ -53,6 +56,8 @@ bool transmit_printformat_json = false;
 srt_listen_callback_fn* transmit_accept_hook_fn = nullptr;
 void* transmit_accept_hook_op = nullptr;
 bool transmit_use_sourcetime = false;
+int transmit_retry_connect = 0;
+bool transmit_retry_always = false;
 
 // Do not unblock. Copy this to an app that uses applog and set appropriate name.
 //srt_logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-test");
@@ -140,7 +145,6 @@ public:
     {
         ofile.write(data.payload.data(), data.payload.size());
 #ifdef PLEASE_LOG
-        extern srt_logging::Logger applog;
         applog.Debug() << "FileTarget::Write: " << data.size() << " written to a file";
 #endif
     }
@@ -151,7 +155,6 @@ public:
     void Close() override
     {
 #ifdef PLEASE_LOG
-        extern srt_logging::Logger applog;
         applog.Debug() << "FileTarget::Close";
 #endif
         ofile.close();
@@ -696,9 +699,6 @@ void SrtCommon::Init(string host, int port, string path, map<string,string> par,
     srt_getsockflag(m_sock, SRTO_SNDKMSTATE, &snd_kmstate, &len);
     srt_getsockflag(m_sock, SRTO_RCVKMSTATE, &rcv_kmstate, &len);
 
-    // Bring this declaration temporarily, this is only for testing
-    std::string KmStateStr(SRT_KM_STATE state);
-
     Verb() << "ENCRYPTION status: " << KmStateStr(kmstate)
         << " (SND:" << KmStateStr(snd_kmstate) << " RCV:" << KmStateStr(rcv_kmstate)
         << ") PBKEYLEN=" << pbkeylen;
@@ -899,6 +899,10 @@ void TransmitGroupSocketConnect(void* srtcommon, SRTSOCKET sock, int error, cons
         return; // nothing to do for a successful socket
     }
 
+#ifdef PLEASE_LOG
+    applog.Debug("connect callback: error on @", sock, " erc=", error, " token=", token);
+#endif
+
     /* Example: identify by target address
     sockaddr_any peersa = peer;
     sockaddr_any agentsa;
@@ -1024,26 +1028,48 @@ void SrtCommon::OpenGroupClient()
         targets.push_back(gd);
     }
 
-    Verb() << "Waiting for group connection... " << VerbNoEOL;
-
-    int fisock = srt_connect_group(m_sock, targets.data(), targets.size());
-
-    if (fisock == SRT_ERROR)
+    ::transmit_throw_on_interrupt = true;
+    for (;;) // REPEATABLE BLOCK
     {
-        // Complete the error information for every member
+Connect_Again:
+        Verb() << "Waiting for group connection... " << VerbNoEOL;
 
-        ostringstream out;
-        for (Connection& c: m_group_nodes)
+        int fisock = srt_connect_group(m_sock, targets.data(), targets.size());
+
+        if (fisock == SRT_ERROR)
         {
-            if (c.error != SRT_SUCCESS)
+            // Complete the error information for every member
+            ostringstream out;
+            set<int> reasons;
+            for (Connection& c: m_group_nodes)
             {
-                out << "[" << c.token << "] " << c.host << ":" << c.port;
-                if (!c.source.empty())
-                    out << "[[" << c.source.str() << "]]";
-                out << ": " << srt_strerror(c.error, 0) << ": " << srt_rejectreason_str(c.reason) << endl;
+                if (c.error != SRT_SUCCESS)
+                {
+                    out << "[" << c.token << "] " << c.host << ":" << c.port;
+                    if (!c.source.empty())
+                        out << "[[" << c.source.str() << "]]";
+                    out << ": " << srt_strerror(c.error, 0) << ": " << srt_rejectreason_str(c.reason) << endl;
+                }
+                reasons.insert(c.reason);
             }
+
+            if (transmit_retry_connect && (transmit_retry_always || (reasons.size() == 1 && *reasons.begin() == SRT_REJ_TIMEOUT)))
+            {
+                if (transmit_retry_connect != -1)
+                    --transmit_retry_connect;
+
+                Verb() << "...all links timeout, retrying (" << transmit_retry_connect << ")...";
+                continue;
+            }
+
+            Error("srt_connect_group, nodes:\n" + out.str());
         }
-        Error("srt_connect_group, nodes:\n" + out.str());
+        else
+        {
+            Verb() << "[ASYNC] will wait..." << VerbNoEOL;
+        }
+
+        break;
     }
 
     if (m_blocking_mode)
@@ -1127,7 +1153,33 @@ void SrtCommon::OpenGroupClient()
             if (find(ready_err, ready_err+len2, m_sock) != ready_err+len2)
             {
                 Verb() << "[EPOLL: " << len2 << " entities FAILED]";
-                Error("All group connections failed", SRT_REJ_UNKNOWN, SRT_ENOCONN);
+                // Complete the error information for every member
+                ostringstream out;
+                set<int> reasons;
+                for (Connection& c: m_group_nodes)
+                {
+                    if (c.error != SRT_SUCCESS)
+                    {
+                        out << "[" << c.token << "] " << c.host << ":" << c.port;
+                        if (!c.source.empty())
+                            out << "[[" << c.source.str() << "]]";
+                        out << ": " << srt_strerror(c.error, 0) << ": " << srt_rejectreason_str(c.reason) << endl;
+                    }
+                    reasons.insert(c.reason);
+                }
+
+                if (transmit_retry_connect && (transmit_retry_always || (reasons.size() == 1 && *reasons.begin() == SRT_REJ_TIMEOUT)))
+                {
+                    if (transmit_retry_connect != -1)
+                        --transmit_retry_connect;
+
+
+                    Verb() << "...all links timeout, retrying in 250ms (" << transmit_retry_connect << ")...";
+                    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+                    goto Connect_Again;
+                }
+
+                Error("srt_connect_group, nodes:\n" + out.str());
             }
             else if (find(ready_conn, ready_conn+len1, m_sock) != ready_conn+len1)
             {
@@ -1153,6 +1205,7 @@ void SrtCommon::OpenGroupClient()
         Error("ConfigurePost");
     }
 
+    ::transmit_throw_on_interrupt = false;
 
     Verb() << "Group connection report:";
     for (auto& d: m_group_data)
@@ -1220,16 +1273,31 @@ void SrtCommon::ConnectClient(string host, int port)
         srt_connect_callback(m_sock, &TransmitConnectCallback, 0);
     }
 
-    int stat = srt_connect(m_sock, sa.get(), sizeof sa);
-    if (stat == SRT_ERROR)
+    int stat = -1;
+    for (;;)
     {
-        int reason = srt_getrejectreason(m_sock);
+        ::transmit_throw_on_interrupt = true;
+        stat = srt_connect(m_sock, sa.get(), sizeof sa);
+        ::transmit_throw_on_interrupt = false;
+        if (stat == SRT_ERROR)
+        {
+            int reason = srt_getrejectreason(m_sock);
 #if PLEASE_LOG
-        extern srt_logging::Logger applog;
-        LOGP(applog.Error, "ERROR reported by srt_connect - closing socket @", m_sock);
+            LOGP(applog.Error, "ERROR reported by srt_connect - closing socket @", m_sock);
 #endif
-        srt_close(m_sock);
-        Error("srt_connect", reason);
+            if (transmit_retry_connect && (transmit_retry_always || reason == SRT_REJ_TIMEOUT))
+            {
+                if (transmit_retry_connect != -1)
+                    --transmit_retry_connect;
+
+                Verb() << "...timeout, retrying (" << transmit_retry_connect << ")...";
+                continue;
+            }
+
+            srt_close(m_sock);
+            Error("srt_connect", reason);
+        }
+        break;
     }
 
     // Wait for REAL connected state if nonblocking mode

--- a/testing/testmediabase.hpp
+++ b/testing/testmediabase.hpp
@@ -24,6 +24,8 @@ extern unsigned transmit_stats_report;
 extern size_t transmit_chunk_size;
 extern bool transmit_printformat_json;
 extern bool transmit_use_sourcetime;
+extern int transmit_retry_connect;
+extern bool transmit_retry_always;
 
 struct MediaPacket
 {


### PR DESCRIPTION
Changes summary:

1. Fixes for compiling with ENABLE_LOGGING=OFF that got a build break (some may additionally follow in the application files):
* srtcore/common.cpp
* srtcore/crypto.cpp
* srtcore/crypto.h

2. Small bugfixes and improvements in the test application, mainly connected with ability to test with unusual scenarios:
* apps/apputil.cpp  -- Bugfix for correct handling -1 numbers in option arguments
* testing/srt-test-live.cpp  -- Added retry option
* testing/srt-test-mpbond.cpp  -- Fixed build break when logging is on
* testing/testmedia.cpp -- Fix for proper handling async group connection; handler for retry
