### PR TITLE
[apps] CSV stats timepoint now follows ISO 8601 format

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -435,6 +435,7 @@ public:
         srt_getsockopt(sid, 0, SRTO_RCVLATENCY, &rcv_latency, &int_len);
 
 #ifdef HAS_PUT_TIME
+        // Follows ISO 8601
         auto print_timestamp = [&output]() {
             using namespace std;
             using namespace std::chrono;
@@ -444,11 +445,11 @@ public:
 
             // SysLocalTime returns zeroed tm_now on failure, which is ok for put_time.
             const tm tm_now = SysLocalTime(time_now);
-            output << std::put_time(&tm_now, "%d.%m.%Y %T.") << std::setfill('0') << std::setw(6);
+            output << std::put_time(&tm_now, "%FT%T.") << std::setfill('0') << std::setw(6);
             const auto    since_epoch = systime_now.time_since_epoch();
             const seconds s           = duration_cast<seconds>(since_epoch);
             output << duration_cast<microseconds>(since_epoch - s).count();
-            output << std::put_time(&tm_now, " %z");
+            output << std::put_time(&tm_now, "%z");
             output << ",";
         };
 


### PR DESCRIPTION
Fixes #1618.

New format:
```
2020-11-06T13:11:13.532194+0100
```

Old format:
```
06.11.2020 13:11:13.532194 +0200
```

Checked Python parsing:
```python
df = pd.read_csv("./gen-snd.csv")
df['Timepoint']= pd.to_datetime(df['Timepoint'])
print(type(df.Timepoint[0]))
print(df.Timepoint[0])
print(df.Timepoint[1])
print(df.Timepoint[1] > df.Timepoint[0])
```

Output:

```shell
<class 'pandas._libs.tslibs.timestamps.Timestamp'>
2020-11-06 13:11:02.522656+01:00
2020-11-06 13:11:03.522864+01:00
True
```