### PR TITLE
[build] Run codecov before sonar-scanner

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 40%
+        threshold: null
+    patch: false
+    changes: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,9 @@ script:
         ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6";
       fi
     - source ./scripts/collect-gcov.sh
-    - if (( "$RUN_SONARCUBE" )); then
-        sonar-scanner -D"sonar.cfamily.gcov.reportPath=.";
-      fi
     - if (( "$RUN_CODECOV" )); then
         bash <(curl -s https://codecov.io/bash);
+      fi
+    - if (( "$RUN_SONARCUBE" )); then
+        sonar-scanner -D"sonar.cfamily.gcov.reportPath=.";
       fi


### PR DESCRIPTION
Master build fail on uploading test coverage report to `codecov`, while PRs succeed.
The only difference is that PRs do not execute sonarcloud scan.
This P changes the order of codecov upload and sonarcloud scanning in case sonar scanner deletes reports.