### PR TITLE
[docs] Fixing the android build script

### DIFF
--- a/docs/Android/Compiling.md
+++ b/docs/Android/Compiling.md
@@ -1,6 +1,12 @@
 # Establishing a Build Environment
 ## Installing the Android NDK
 The Android NDK is required to build native modules for Android.
+I had to install the latest version of cmake onto my computer. 
+May require removing the package manager version from your distro and building from source. 
+The higher version of cmake the better. As of writing the current version of cmake is 3.18.4
+You can download Cmake from the follwing site:
+[Download the latest cmake](https://cmake.org/download/)
+
 Download the NDK r19 or newer archive from the following site:
 [Download the Android NDK on developer.android.com](https://developer.android.com/ndk/downloads/index.html)
 To install the Android NDK, simply expand the archive in the folder where you want to install it.

--- a/docs/Android/Compiling.md
+++ b/docs/Android/Compiling.md
@@ -1,11 +1,9 @@
 # Establishing a Build Environment
 ## Installing the Android NDK
 The Android NDK is required to build native modules for Android.
-I had to install the latest version of cmake onto my computer. 
-May require removing the package manager version from your distro and building from source. 
-The higher version of cmake the better. As of writing the current version of cmake is 3.18.4
-You can download Cmake from the follwing site:
-[Download the latest cmake](https://cmake.org/download/)
+Consider installing the latest version of cmake. The higher version of cmake the better. As of writing the current version of CMake is 3.18.4
+You can download Cmake from the following website:
+[https://cmake.org/download](https://cmake.org/download/)
 
 Download the NDK r19 or newer archive from the following site:
 [Download the Android NDK on developer.android.com](https://developer.android.com/ndk/downloads/index.html)

--- a/docs/Android/mkall
+++ b/docs/Android/mkall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NDK=/home/nathan/srt/android-ndk-r19c
+NDK=/opt/android-ndk-r19c
 
 openssl_ver=1.1.1h
 #srt_version=1.4.2

--- a/docs/Android/mkall
+++ b/docs/Android/mkall
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-NDK=/opt/android-ndk-r19
+NDK=/home/nathan/srt/android-ndk-r19c
 
-openssl_ver=1.0.2q
-srt_version=1.3.1
+openssl_ver=1.1.1h
+#srt_version=1.4.2
 #srt_branch=dev
 
+API_LEVEL=28
 # Determine the path of the executing script
 BASE_DIR=$(readlink -f $0 | xargs dirname)
 
-wget -N https://www.openssl.org/source/openssl-$openssl_ver.tar.gz
+#wget -N https://www.openssl.org/source/openssl-$openssl_ver.tar.gz
 
 if [ ! -d $BASE_DIR/srt ]; then
  git clone https://github.com/Haivision/srt srt
@@ -23,6 +24,7 @@ toolchain=$NDK/toolchains/llvm/prebuilt/linux-x86_64
 # Cross-compiler tool prefix
 declare -A target_hosts
 target_hosts=(
+ [armeabi]=arm-linux-androideabi
  [arm]=arm-linux-androideabi
  [arm64]=aarch64-linux-android
  [x86]=i686-linux-android
@@ -32,6 +34,7 @@ target_hosts=(
 # Cross-compiler prefix for -clang and -clang++ has api version
 declare -A target_api
 target_api=(
+ [armeabi]=armv5te-linux-androideabi16
  [arm]=armv7a-linux-androideabi16
  [arm64]=aarch64-linux-android21
  [x86]=i686-linux-android16
@@ -40,17 +43,29 @@ target_api=(
 
 declare -A sysroots
 sysroots=(
+ [armeabi]=$BASE_DIR/armeabi
  [arm]=$BASE_DIR/armeabi-v7a
  [arm64]=$BASE_DIR/arm64-v8a
  [x86]=$BASE_DIR/x86
  [x86_64]=$BASE_DIR/x86_64
 )
 
-for arch in arm arm64 x86 x86_64; do
- rm -rf $BASE_DIR/openssl-$openssl_ver
- tar xf $BASE_DIR/openssl-$openssl_ver.tar.gz
- $BASE_DIR/mkssl -t $toolchain -h ${target_hosts[$arch]} -a ${target_api[$arch]} -s $BASE_DIR/openssl-$openssl_ver -i ${sysroots[$arch]}
+declare -A archabi
+archabi=(
+ [armeabi]=armeabi
+ [arm]=armeabi-v7a
+ [arm64]=arm64-v8a
+ [x86]=x86
+ [x86_64]=x86_64
+)
+
+$BASE_DIR/mkssl -n $NDK -o $openssl_ver -a $API_LEVEL
+
+for arch in armeabi arm arm64 x86 x86_64; do
+ #rm -rf $BASE_DIR/openssl-$openssl_ver
+ #tar xf $BASE_DIR/openssl-$openssl_ver.tar.gz
+ #$BASE_DIR/mkssl -t $toolchain -h ${target_hosts[$arch]} -a ${target_api[$arch]} -s $BASE_DIR/openssl-$openssl_ver -i ${sysroots[$arch]}
 
  git -C $BASE_DIR/srt clean -fd
- $BASE_DIR/mksrt -t $toolchain -h ${target_hosts[$arch]} -a ${target_api[$arch]} -s $BASE_DIR/srt -i ${sysroots[$arch]}
+ $BASE_DIR/mksrt -t $toolchain -h ${target_hosts[$arch]} -a ${target_api[$arch]} -s $BASE_DIR/srt -i ${sysroots[$arch]} -b ${archabi[$arch]} -n  $NDK -l $API_LEVEL 
 done

--- a/docs/Android/mksrt
+++ b/docs/Android/mksrt
@@ -2,6 +2,6 @@
 
 source prepare_build
 
-./configure --use-openssl-pc=OFF --CMAKE_PREFIX_PATH=$install_dir --CMAKE_INSTALL_PREFIX=$install_dir
+./configure --use-openssl-pc=OFF --CMAKE_PREFIX_PATH=$install_dir --CMAKE_INSTALL_PREFIX=$install_dir --CMAKE_SYSTEM_NAME=Android --CMAKE_SYSTEM_VERSION=$api_lev  --CMAKE_ANDROID_NDK=$NDK_HOME --CMAKE_ANDROID_ARCH_ABI=$arch_abi
 make
 make install

--- a/docs/Android/mkssl
+++ b/docs/Android/mkssl
@@ -7,6 +7,7 @@ do
  n) ndk_home=${OPTARG};;
  o) ssl_ver=${OPTARG};;
  a) api_lev=${OPTARG};;
+ *) twentytwo=${OPTARG};;
  esac
 done
 

--- a/docs/Android/mkssl
+++ b/docs/Android/mkssl
@@ -1,9 +1,135 @@
-#!/bin/bash
+#!/bin/sh
 
-source prepare_build
+while getopts n:o:a: option
+do
+ case "${option}"
+ in
+ n) ndk_home=${OPTARG};;
+ o) ssl_ver=${OPTARG};;
+ a) api_lev=${OPTARG};;
+ esac
+done
 
-./Configure android --openssldir=$install_dir -fPIC
-# OpenSSL (1.0.2) adds -mandroid to the compile flags. This flag is not recognized by clang.
-sed -i 's/-mandroid//g' Makefile
-make
-make install
+
+ANDROID_NDK=$ndk_home
+OPENSSL_VERSION=$ssl_ver
+
+API_LEVEL=$api_lev
+
+BUILD_DIR=/tmp/openssl_android_build
+OUT_DIR=$(pwd)
+
+BUILD_TARGETS="armeabi armeabi-v7a arm64-v8a x86 x86_64"
+
+if [ ! -d openssl-${OPENSSL_VERSION} ]
+then
+    if [ ! -f openssl-${OPENSSL_VERSION}.tar.gz ]
+    then
+        wget https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz || exit 128
+    fi
+    tar xzf openssl-${OPENSSL_VERSION}.tar.gz || exit 128
+fi
+
+cd openssl-${OPENSSL_VERSION} || exit 128
+
+
+##### Prepare Files #####
+sed -i 's/.*-mandroid.*//' Configurations/15-android.conf
+patch -p1 -N <<EOP
+--- old/Configurations/unix-Makefile.tmpl   2018-09-11 14:48:19.000000000 +0200
++++ new/Configurations/unix-Makefile.tmpl   2018-10-18 09:06:27.282007245 +0200
+@@ -43,12 +43,17 @@
+      # will return the name from shlib(\$libname) with any SO version number
+      # removed.  On some systems, they may therefore return the exact same
+      # string.
+-     sub shlib {
++     sub shlib_simple {
+          my \$lib = shift;
+          return () if \$disabled{shared} || \$lib =~ /\\.a$/;
+-         return \$unified_info{sharednames}->{\$lib}. \$shlibvariant. '\$(SHLIB_EXT)';
++
++         if (windowsdll()) {
++             return \$lib . '\$(SHLIB_EXT_IMPORT)';
++         }
++         return \$lib .  '\$(SHLIB_EXT_SIMPLE)';
+      }
+-     sub shlib_simple {
++     
++   sub shlib {
+          my \$lib = shift;
+          return () if \$disabled{shared} || \$lib =~ /\\.a$/;
+
+EOP
+
+##### remove output-directory #####
+#rm -rf $OUT_DIR
+
+##### export ndk directory. Required by openssl-build-scripts #####
+export ANDROID_NDK
+
+##### build-function #####
+build_the_thing() {
+    TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    export PATH=$TOOLCHAIN/$TRIBLE/bin:$TOOLCHAIN/bin:"$PATH"
+echo $PATH
+    make clean
+    #./Configure $SSL_TARGET $OPTIONS -fuse-ld="$TOOLCHAIN/$TRIBLE/bin/ld" "-gcc-toolchain $TOOLCHAIN" && \
+    ./Configure $SSL_TARGET $OPTIONS -fuse-ld="$TOOLCHAIN/$TRIBLE/bin/ld" && \
+    make && \
+    make install DESTDIR=$DESTDIR || exit 128
+}
+
+##### set variables according to build-tagret #####
+for build_target in $BUILD_TARGETS
+do
+    case $build_target in
+    armeabi)
+        TRIBLE="arm-linux-androideabi"
+        TC_NAME="arm-linux-androideabi-4.9"
+        #OPTIONS="--target=armv5te-linux-androideabi -mthumb -fPIC -latomic -D__ANDROID_API__=$API_LEVEL"
+        OPTIONS="--target=armv5te-linux-androideabi -mthumb -fPIC -latomic -D__ANDROID_API__=$API_LEVEL"
+        DESTDIR="$BUILD_DIR/armeabi"
+        SSL_TARGET="android-arm"
+    ;;
+    armeabi-v7a)
+        TRIBLE="arm-linux-androideabi"
+        TC_NAME="arm-linux-androideabi-4.9"
+        OPTIONS="--target=armv7a-linux-androideabi -Wl,--fix-cortex-a8 -fPIC -D__ANDROID_API__=$API_LEVEL"
+        DESTDIR="$BUILD_DIR/armeabi-v7a"
+        SSL_TARGET="android-arm"
+    ;;
+    x86)
+        TRIBLE="i686-linux-android"
+        TC_NAME="x86-4.9"
+        OPTIONS="-fPIC -D__ANDROID_API__=${API_LEVEL}"
+        DESTDIR="$BUILD_DIR/x86"
+        SSL_TARGET="android-x86"
+    ;;
+    x86_64)
+        TRIBLE="x86_64-linux-android"
+        TC_NAME="x86_64-4.9"
+        OPTIONS="-fPIC -D__ANDROID_API__=${API_LEVEL}"
+        DESTDIR="$BUILD_DIR/x86_64"
+        SSL_TARGET="android-x86_64"
+    ;;
+    arm64-v8a)
+        TRIBLE="aarch64-linux-android"
+        TC_NAME="aarch64-linux-android-4.9"
+        OPTIONS="-fPIC -D__ANDROID_API__=${API_LEVEL}"
+        DESTDIR="$BUILD_DIR/arm64-v8a"
+        SSL_TARGET="android-arm64"
+    ;;
+    esac
+
+    rm -rf $DESTDIR
+    build_the_thing
+#### copy libraries and includes to output-directory #####
+    mkdir -p $OUT_DIR/$build_target/include
+    cp -R $DESTDIR/usr/local/include/* $OUT_DIR/$build_target/include
+    cp -R $DESTDIR/usr/local/ssl/* $OUT_DIR/$build_target/
+    mkdir -p $OUT_DIR/$build_target/lib
+    cp -R $DESTDIR/usr/local/lib/*.so $OUT_DIR/$build_target/lib
+    cp -R $DESTDIR/usr/local/lib/*.a $OUT_DIR/$build_target/lib
+done
+
+echo Success

--- a/docs/Android/packjni
+++ b/docs/Android/packjni
@@ -4,17 +4,19 @@ BASE_DIR=$(readlink -f $0 | xargs dirname)
 
 declare -A sysroots
 sysroots=(
+ [armeabi]=$BASE_DIR/armeabi
  [arm]=$BASE_DIR/armeabi-v7a
  [arm64]=$BASE_DIR/arm64-v8a
  [x86]=$BASE_DIR/x86
  [x86_64]=$BASE_DIR/x86_64
 )
 
-srt_version=1.3.1
+srt_version=1.4.2
 jni_dir=$BASE_DIR/jniLibs
 
 declare -A jnilibs
 jnilibs=(
+ [armeabi=$jni_dir/armeabi
  [arm]=$jni_dir/armeabi-v7a
  [arm64]=$jni_dir/arm64-v8a
  [x86]=$jni_dir/x86
@@ -26,9 +28,9 @@ jni_dir=$BASE_DIR/jniLibs
 # Android < 6.0 has an issue with loading versioned libraries
 # The issue is because of library so-name libsrt.so.1
 
-for arch in arm arm64 x86 x86_64; do
+for arch in armeabi arm arm64 x86 x86_64; do
  mkdir -p ${jnilibs[$arch]}
- cp ${sysroots[$arch]}/lib/libsrt.so.${srt_version} ${jnilibs[$arch]}/libsrt.so
+ cp ${sysroots[$arch]}/lib/libsrt.so ${jnilibs[$arch]}/libsrt.so
  /usr/local/bin/patchelf --set-soname libsrt.so ${jnilibs[$arch]}/libsrt.so
  objdump -p ${jnilibs[$arch]}/libsrt.so | grep libsrt.so 
 done

--- a/docs/Android/prepare_build
+++ b/docs/Android/prepare_build
@@ -12,6 +12,7 @@ do
  b) arch_abi=${OPTARG};;
  n) NDK_HOME=${OPTARG};;
  l) api_lev=${OPTARG};;
+ *) twentytwo=${OPTARG};;
  esac
 done
 

--- a/docs/Android/prepare_build
+++ b/docs/Android/prepare_build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts t:h:a:s:i: option
+while getopts t:h:a:s:i:b:n:l: option
 do
  case "${option}"
  in
@@ -9,6 +9,9 @@ do
  a) target_host_api=${OPTARG};;
  s) src_dir=${OPTARG};;
  i) install_dir=$OPTARG;;
+ b) arch_abi=${OPTARG};;
+ n) NDK_HOME=${OPTARG};;
+ l) api_lev=${OPTARG};;
  esac
 done
 


### PR DESCRIPTION
Now builds .so files into jniLibs/[target-architecture] folders.

Updated instructions in case the issues that I faced are experienced. specifically using ndk-19 and latest cmake seemed to work for me. 