### PR TITLE
[core] Fixed some compiler warnings.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2966,7 +2966,7 @@ void CUDTUnited::updateMux(
        s->m_pUDT->m_pRcvQueue = m.m_pRcvQueue;
        s->m_iMuxID = m.m_iID;
    }
-   catch (CUDTException&)
+   catch (const CUDTException&)
    {
        m.destroy();
        throw;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -574,7 +574,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
    {
        ns->m_SocketID = generateSocketID();
    }
-   catch (const CUDTException& e)
+   catch (const CUDTException&)
    {
        LOGF(cnlog.Fatal, "newConnection: IPE: all sockets occupied? Last gen=%d", m_SocketIDGenerator);
        // generateSocketID throws exception, which can be naturally handled
@@ -2966,7 +2966,7 @@ void CUDTUnited::updateMux(
        s->m_pUDT->m_pRcvQueue = m.m_pRcvQueue;
        s->m_iMuxID = m.m_iID;
    }
-   catch (CUDTException& e)
+   catch (CUDTException&)
    {
        m.destroy();
        throw;

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -498,7 +498,7 @@ private:
         HLOGC(cclog.Debug, log << "FileCC: LOSS: "
             << "sent=" << CSeqNo::seqlen(m_iLastAck, m_parent->sndSeqNo()) << ", inFlight=" << pktsInFlight
             << ", lost=" << numPktsLost << " ("
-            << lost_pcent_x10 / 10 << "." << lost_pcent_x10 % 10 << "\%)");
+            << lost_pcent_x10 / 10 << "." << lost_pcent_x10 % 10 << "%%)");
         if (lost_pcent_x10 < 20)    // 2.0%
         {
             HLOGC(cclog.Debug, log << "FileCC: LOSS: m_dLastDecPeriod=" << m_dLastDecPeriod << "->" << m_dPktSndPeriod);

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -498,7 +498,7 @@ private:
         HLOGC(cclog.Debug, log << "FileCC: LOSS: "
             << "sent=" << CSeqNo::seqlen(m_iLastAck, m_parent->sndSeqNo()) << ", inFlight=" << pktsInFlight
             << ", lost=" << numPktsLost << " ("
-            << lost_pcent_x10 / 10 << "." << lost_pcent_x10 % 10 << "%%)");
+            << lost_pcent_x10 / 10 << "." << lost_pcent_x10 % 10 << "%)");
         if (lost_pcent_x10 < 20)    // 2.0%
         {
             HLOGC(cclog.Debug, log << "FileCC: LOSS: m_dLastDecPeriod=" << m_dLastDecPeriod << "->" << m_dPktSndPeriod);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11184,9 +11184,9 @@ void CUDT::updateBrokenConnection()
 void CUDT::completeBrokenConnectionDependencies(int errorcode)
 {
     int token = -1;
-    bool pending_broken = false;
 
 #if ENABLE_EXPERIMENTAL_BONDING
+    bool pending_broken = false;
     {
         ScopedLock guard_group_existence (s_UDTUnited.m_GlobControlLock);
         if (m_parent->m_IncludedGroup)

--- a/test/test_listen_callback.cpp
+++ b/test/test_listen_callback.cpp
@@ -145,7 +145,7 @@ int SrtTestListenCallback(void* opaq, SRTSOCKET ns, int hsversion, const struct 
 
     static const char stdhdr [] = "#!::";
     uint32_t* pattern = (uint32_t*)stdhdr;
-    bool found = -1;
+    bool found = false;
 
     if (strlen(streamid) > 4 && *(uint32_t*)streamid == *pattern)
     {


### PR DESCRIPTION
- C4101 - local variable never used (2).
- C4129- 'character' : unrecognized character escape sequence (1).
- C4305 - truncation from 'type1' to 'type2' (1).

Related to #1646