### PR TITLE
[tests] Check IPv6 connection and socket address

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ build_script:
   - ps: if ($VSIMG -match '2013' -and $CNFG -eq "Debug")   { Exit-AppveyorBuild } # just skip 2013 debug build for speed
 
 test_script:
-  - ps: if ( $Env:RUN_UNIT_TESTS ) { cd ./_build; ctest --exclude-regex "--exclude-regex" --extra-verbose -C $Env:CONFIGURATION; cd ../ }
+  - ps: if ( $Env:RUN_UNIT_TESTS ) { cd ./_build; ctest -E "TestIPv6.v6_calls_v4" --extra-verbose -C $Env:CONFIGURATION; cd ../ }
   
 after_build:
 - cmd: >-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ build_script:
   - ps: if ($VSIMG -match '2013' -and $CNFG -eq "Debug")   { Exit-AppveyorBuild } # just skip 2013 debug build for speed
 
 test_script:
-  - ps: if ( $Env:RUN_UNIT_TESTS ) { cd ./_build; ctest --extra-verbose -C $Env:CONFIGURATION; cd ../ }
+  - ps: if ( $Env:RUN_UNIT_TESTS ) { cd ./_build; ctest --exclude-regex "--exclude-regex" --extra-verbose -C $Env:CONFIGURATION; cd ../ }
   
 after_build:
 - cmd: >-

--- a/.github/workflows/cxx11-macos.yaml
+++ b/.github/workflows/cxx11-macos.yaml
@@ -1,4 +1,4 @@
-name: cxx11_win
+name: cxx11
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: macos-cxx11
+    name: macos
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/cxx11-ubuntu.yaml
+++ b/.github/workflows/cxx11-ubuntu.yaml
@@ -1,4 +1,4 @@
-name: cxx11_win
+name: cxx11
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: ubuntu-cxx11
+    name: ubuntu
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/cxx11-win.yaml
+++ b/.github/workflows/cxx11-win.yaml
@@ -21,4 +21,4 @@ jobs:
     - name: build
       run: cd _build && cmake --build ./ --config Release
     - name: test
-      run: cd _build && ./test-srt --gtest_filter="-TestIPv6.v6_calls_v4"
+      run: cd _build && Release\test-srt --gtest_filter="-TestIPv6.v6_calls_v4"

--- a/.github/workflows/cxx11-win.yaml
+++ b/.github/workflows/cxx11-win.yaml
@@ -21,4 +21,4 @@ jobs:
     - name: build
       run: cd _build && cmake --build ./ --config Release
     - name: test
-      run: cd _build && ctest --extra-verbose -C Release
+      run: cd _build && ctest --extra-verbose -C Release --gtest_filter="-TestIPv6.v6_calls_v4"

--- a/.github/workflows/cxx11-win.yaml
+++ b/.github/workflows/cxx11-win.yaml
@@ -1,4 +1,4 @@
-name: cxx11_win
+name: cxx11
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    name: windows-cxx11
+    name: windows
     runs-on: windows-latest
 
     steps:
@@ -21,4 +21,4 @@ jobs:
     - name: build
       run: cd _build && cmake --build ./ --config Release
     - name: test
-      run: cd _build && ctest --extra-verbose -C Release --gtest_filter="-TestIPv6.v6_calls_v4"
+      run: cd _build && ./test-srt --gtest_filter="-TestIPv6.v6_calls_v4"

--- a/.github/workflows/cxx11-win.yaml
+++ b/.github/workflows/cxx11-win.yaml
@@ -21,4 +21,4 @@ jobs:
     - name: build
       run: cd _build && cmake --build ./ --config Release
     - name: test
-      run: cd _build && Release\test-srt --gtest_filter="-TestIPv6.v6_calls_v4"
+      run: cd _build && ctest -E "TestIPv6.v6_calls_v4" --extra-verbose -C Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
         make -j$(nproc);
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
-        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6";
+        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6*";
       fi
     - source ./scripts/collect-gcov.sh
     - if (( "$RUN_CODECOV" )); then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
         make -j$(nproc);
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
-        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6";
+        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6_mapped";
       fi
     - source ./scripts/collect-gcov.sh
     - if (( "$RUN_CODECOV" )); then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
         make -j$(nproc);
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
-        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6_mapped";
+        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6*";
       fi
     - source ./scripts/collect-gcov.sh
     - if (( "$RUN_CODECOV" )); then

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
         make -j$(nproc);
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
-        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6*";
+        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6";
       fi
     - source ./scripts/collect-gcov.sh
     - if (( "$RUN_CODECOV" )); then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1211,12 +1211,16 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 		${PTHREAD_LIBRARY}
 		)
 
-	add_test(
-		NAME
-			test-srt
-		COMMAND
-			${CMAKE_BINARY_DIR}/test-srt
-	)
+	if(${CMAKE_VERSION} VERSION_LESS "3.9.0") 
+		add_test(
+			NAME
+				test-srt
+			COMMAND
+				${CMAKE_BINARY_DIR}/test-srt
+		)
+	else()
+		gtest_add_tests(test-srt .withArgs AUTO)
+	endif()
 
 	enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1212,6 +1212,7 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 		)
 
 	if(${CMAKE_VERSION} VERSION_LESS "3.9.0") 
+		cmake_policy(SET CMP0057 NEW) # Support the new IN_LIST operator.
 		add_test(
 			NAME	test-srt
 			COMMAND	${CMAKE_BINARY_DIR}/test-srt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1213,13 +1213,15 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 
 	if(${CMAKE_VERSION} VERSION_LESS "3.9.0") 
 		add_test(
-			NAME
-				test-srt
-			COMMAND
-				${CMAKE_BINARY_DIR}/test-srt
+			NAME	test-srt
+			COMMAND	${CMAKE_BINARY_DIR}/test-srt
 		)
 	else()
-		gtest_add_tests(test-srt .withArgs AUTO)
+		gtest_add_tests(
+			test-srt
+			""
+			AUTO
+		)
 	endif()
 
 	enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1211,13 +1211,13 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 		${PTHREAD_LIBRARY}
 		)
 
-	if(${CMAKE_VERSION} VERSION_LESS "3.9.0") 
-		cmake_policy(SET CMP0057 NEW) # Support the new IN_LIST operator.
-		add_test(
-			NAME	test-srt
-			COMMAND	${CMAKE_BINARY_DIR}/test-srt
+	if(${CMAKE_VERSION} VERSION_LESS "3.10.0") 
+	add_test(
+		NAME	test-srt
+		COMMAND	${CMAKE_BINARY_DIR}/test-srt
 		)
 	else()
+		cmake_policy(SET CMP0057 NEW) # Support the new IN_LIST operator.
 		gtest_add_tests(
 			test-srt
 			""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1211,10 +1211,10 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 		${PTHREAD_LIBRARY}
 		)
 
-	if(${CMAKE_VERSION} VERSION_LESS "3.10.0") 
-	add_test(
-		NAME	test-srt
-		COMMAND	${CMAKE_BINARY_DIR}/test-srt
+	if (${CMAKE_VERSION} VERSION_LESS "3.10.0") 
+		add_test(
+			NAME	test-srt
+			COMMAND	${CMAKE_BINARY_DIR}/test-srt
 		)
 	else()
 		cmake_policy(SET CMP0057 NEW) # Support the new IN_LIST operator.

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -10,6 +10,7 @@ test_enforced_encryption.cpp
 test_epoll.cpp
 test_fec_rebuilding.cpp
 test_file_transmission.cpp
+test_ipv6.cpp
 test_list.cpp
 test_listen_callback.cpp
 test_muxer.cpp

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -611,7 +611,7 @@ static const char* const socket_state_array[] = {
 const char* const* TestEnforcedEncryption::m_socket_state = socket_state_array+1;
 
 /** 
- * @fn TEST_F(TestEnforcedEncryption, PasswordLength)
+ * @fn TestEnforcedEncryption.PasswordLength
  * @brief The password length should belong to the interval of [10; 80]
  */
 TEST_F(TestEnforcedEncryption, PasswordLength)
@@ -646,7 +646,7 @@ TEST_F(TestEnforcedEncryption, PasswordLength)
 
 
 /**
- * @fn TEST_F(TestEnforcedEncryption, SetGetDefault)
+ * @fn TestEnforcedEncryption.SetGetDefault
  * @brief The default value for the enforced encryption should be ON
  */
 TEST_F(TestEnforcedEncryption, SetGetDefault)

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -348,9 +348,9 @@ TEST(CEPoll, NotifyConnectionBreak)
 
     // The caller will close connection after 1 second
     auto close_res = std::async(std::launch::async, [&client_sock]() {
-        cout << "TEST(async call): WILL CLOSE client connection in 3s\n";
+        cout << "(async call): WILL CLOSE client connection in 3s\n";
         this_thread::sleep_for(chrono::seconds(1));
-        cout << "TEST(async call): Closing client connection\n";
+        cout << "(async call): Closing client connection\n";
         return srt_close(client_sock);
         });
 

--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -68,9 +68,10 @@ public:
     {
         ASSERT_NE(fam.count(w.family()), 0) << "INVALID FAMILY";
 
-        char out[INET6_ADDRSTRLEN];
-        ASSERT_NE(inet_ntop(w.family(), w.get_addr(), out, sizeof out), nullptr);
-        std::cout << src << ": " << out << " (" << fam[w.family()] << ")" << std::endl;
+        //char out[INET6_ADDRSTRLEN];
+        //ASSERT_NE(inet_ntop(w.family(), w.get_addr(), out, sizeof out), nullptr);
+        //std::cout << src << ": " << out << " (" << fam[w.family()] << ")" << std::endl;
+        std::cout << src << ": " << w.str() << " (" << fam[w.family()] << ")" << std::endl;
     }
 
     void DoAccept()

--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -1,0 +1,189 @@
+#include "gtest/gtest.h"
+#include <thread>
+#include <string>
+#include "srt.h"
+#include "netinet_any.h"
+
+inline std::string operator "" _S(const char* src, std::size_t)
+{
+    return std::string(src);
+}
+
+class TestIPv6
+    : public ::testing::Test
+{
+protected:
+    int yes = 1;
+    int no = 0;
+
+    TestIPv6()
+    {
+        // initialization code here
+    }
+
+    ~TestIPv6()
+    {
+        // cleanup any pending stuff, but no exceptions allowed
+    }
+
+protected:
+    // SetUp() is run immediately before a test starts.
+    void SetUp()
+    {
+        ASSERT_GE(srt_startup(), 0);
+
+        m_caller_sock = srt_create_socket();
+        ASSERT_NE(m_caller_sock, SRT_ERROR);
+
+        m_listener_sock = srt_create_socket();
+        ASSERT_NE(m_listener_sock, SRT_ERROR);
+    }
+
+    void TearDown()
+    {
+        // Code here will be called just after the test completes.
+        // OK to throw exceptions from here if needed.
+        srt_close(m_listener_sock);
+        srt_close(m_caller_sock);
+        srt_cleanup();
+    }
+
+public:
+    void ClientThread(int family, const std::string& address)
+    {
+        sockaddr_any sa (family);
+        sa.hport(m_listen_port);
+        ASSERT_EQ(inet_pton(family, address.c_str(), sa.get_addr()), 1);
+
+        std::cout << "Calling: " << address << "(" << fam[family] << ")\n";
+
+        ASSERT_NE(srt_connect(m_caller_sock, (sockaddr*)&sa, sizeof sa), SRT_ERROR);
+
+        PrintAddresses(m_caller_sock, "CALLER");
+    }
+
+    std::map<int, std::string> fam = { {AF_INET, "IPv4"}, {AF_INET6, "IPv6"} };
+
+    void ShowAddress(std::string src, const sockaddr_any& w)
+    {
+        ASSERT_NE(fam.count(w.family()), 0) << "INVALID FAMILY";
+
+        char out[INET6_ADDRSTRLEN];
+        ASSERT_NE(inet_ntop(w.family(), w.get_addr(), out, sizeof out), nullptr);
+        std::cout << src << ": " << out << " (" << fam[w.family()] << ")" << std::endl;
+    }
+
+    void DoAccept()
+    {
+        sockaddr_any sc1;
+
+        SRTSOCKET accepted_sock = srt_accept(m_listener_sock, sc1.get(), &sc1.len);
+        ASSERT_NE(accepted_sock, SRT_INVALID_SOCK);
+
+        PrintAddresses(accepted_sock, "ACCEPTED");
+
+        //ShowAddress("Accepted", sc1);
+
+        sockaddr_any sn;
+        ASSERT_NE(srt_getsockname(accepted_sock, sn.get(), &sn.len), SRT_ERROR);
+
+        //ShowAddress("srt_getsockname", sn);
+
+        int32_t ipv6_zero [] = {0, 0, 0, 0};
+        ASSERT_NE(memcmp(ipv6_zero, sn.get_addr(), sizeof ipv6_zero), 0)
+            << "EMPTY address in srt_getsockname";
+
+        srt_close(accepted_sock);
+    }
+
+private:
+    void PrintAddresses(SRTSOCKET sock, const char* who)
+    {
+        sockaddr_any sa;
+        int sa_len = sa.storage_size();
+        srt_getsockname(sock, sa.get(), &sa_len);
+        ShowAddress(std::string(who) + " Sock name: ", sa);
+        //std::cout << who << " Sock name: " << << sa.str() << std::endl;
+
+        sa_len = sa.storage_size();
+        srt_getpeername(sock, sa.get(), &sa_len);
+        //std::cout << who << " Peer name: " << << sa.str() << std::endl;
+        ShowAddress(std::string(who) + " Peer name: ", sa);
+    }
+
+protected:
+    SRTSOCKET m_caller_sock;
+    SRTSOCKET m_listener_sock;
+    const int m_listen_port = 4200;
+};
+
+
+TEST_F(TestIPv6, v4_calls_v6_mapped)
+{
+    sockaddr_any sa (AF_INET6);
+    sa.hport(m_listen_port);
+
+    ASSERT_EQ(srt_setsockflag(m_listener_sock, SRTO_IPV6ONLY, &no, sizeof no), 0);
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    std::thread client(&TestIPv6::ClientThread, this, AF_INET, "127.0.0.1"_S);
+
+    DoAccept();
+
+    client.join();
+}
+
+TEST_F(TestIPv6, v6_calls_v6_mapped)
+{
+    sockaddr_any sa (AF_INET6);
+    sa.hport(m_listen_port);
+
+    ASSERT_EQ(srt_setsockflag(m_listener_sock, SRTO_IPV6ONLY, &no, sizeof no), 0);
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "::1"_S);
+
+    DoAccept();
+
+    client.join();
+}
+
+TEST_F(TestIPv6, v6_calls_v6)
+{
+    sockaddr_any sa (AF_INET6);
+    sa.hport(m_listen_port);
+
+    // This time bind the socket exclusively to IPv6.
+    ASSERT_EQ(srt_setsockflag(m_listener_sock, SRTO_IPV6ONLY, &yes, sizeof yes), 0);
+    ASSERT_EQ(inet_pton(AF_INET6, "::1", sa.get_addr()), 1);
+
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "::1"_S);
+
+    DoAccept();
+
+    client.join();
+}
+
+TEST_F(TestIPv6, v6_calls_v4)
+{
+    sockaddr_any sa (AF_INET);
+    sa.hport(m_listen_port);
+
+    // This time bind the socket exclusively to IPv4.
+    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", sa.get_addr()), 1);
+
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "0::FFFF:127.0.0.1"_S);
+
+    DoAccept();
+
+    client.join();
+}
+


### PR DESCRIPTION
Extracted from #1664 due to CI failures on IPv6 tests. More time is required to configure CI tests for it.

### Excluded CI Tests

IPv6 tests failing on AppVeyor due to platform-specific reasons:
- `TestIPv6.v6_calls_v4`

Travis Linux
- `TestIPv6.v6_calls_v6_mapped`
- `TestIPv6.v6_calls_v6`

### TODO

- [x] `TestIPv6` don't check the actual socket name (IP) returned. Just checks on emptiness.