### PR TITLE
[test] Added a standard ability to turn off IPv6-related tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ script:
         make -j$(nproc);
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
-        ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6";
+        SRT_TEST_DISABLE_IPv6=1 ./test-srt;
       fi
     - source ./scripts/collect-gcov.sh
     - if (( "$RUN_CODECOV" )); then

--- a/test/test_muxer.cpp
+++ b/test/test_muxer.cpp
@@ -100,6 +100,14 @@ protected:
 
 TEST_F(TestMuxer, IPv4_and_IPv6)
 {
+    char* venv = getenv("SRT_TEST_DISABLE_IPv6");
+    if (venv && venv[0] == '1')
+    {
+        std::cout << "TEST DISABLED DUE TO no IPv6 support\n";
+        //GTEST_SKIP(); <-- use when available
+        return;
+    }
+
     int yes = 1;
     int no = 0;
 


### PR DESCRIPTION
Simply define an env: `SRT_TEST_DISABLE_IPv6=1` and the test will be forcefully exit and will show itself as passed.

There's a pending feature in gtest - `GTEST_SKIP()` - which would look better here, but it's not in release yet.