### PR TITLE
 [core] CUDTException is no longer exported in DLL

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -94,7 +94,7 @@ modified by
 // is predicted to NEVER LET ANY EXCEPTION out of implementation,
 // so it's useless to catch this exception anyway.
 
-class SRT_API CUDTException: public std::exception
+class CUDTException: public std::exception
 {
 public:
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8276,10 +8276,10 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 
 void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
 {
+#if ENABLE_EXPERIMENTAL_BONDING
     // This is for the call of CSndBuffer::getMsgNoAt that returns
     // this value as a notfound-trap.
     int32_t msgno_at_last_acked_seq = SRT_MSGNO_CONTROL;
-#if ENABLE_EXPERIMENTAL_BONDING
     bool is_group = m_parent->m_IncludedGroup;
 #endif
 


### PR DESCRIPTION
Fixes 19 warnings C4275 - DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'.
See #1646

In particular,
> Warning	C4275	non dll-interface class 'std::exception' used as base for dll-interface class 'CUDTException'	srt_virtual	srtcore\common.h	98	
