### PR TITLE
[core] Moved post-hs-update locking code out of mutex; untangled lock order around RIDVector

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1896,13 +1896,8 @@ int CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_
    */
    try
    {
-       // InvertedGuard unlocks in the constructor, then locks in the
-       // destructor, no matter if an exception has fired.
-       InvertedLock l_unlocker (s->m_pUDT->m_bSynRecving ? &s->m_ControlLock : 0);
-
        // record peer address
        s->m_PeerAddr = target_addr;
-
        s->m_pUDT->startConnect(target_addr, forced_isn);
    }
    catch (CUDTException& e) // Interceptor, just to change the state.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4074,7 +4074,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
         if (m_pRcvQueue->recvfrom(m_SocketID, (response)) > 0)
         {
             HLOGC(cnlog.Debug, log << CONID() << "startConnect: got response for connect request");
-            cst = processConnectResponse(response, &e, COM_SYNCHRO);
+            cst = processConnectResponse(response, &e);
 
             HLOGC(cnlog.Debug, log << CONID() << "startConnect: response processing result: " << ConnectStatusStr(cst));
 
@@ -4107,7 +4107,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
                 // it means that it has done all that was required, however none of the below
                 // things has to be done (this function will do it by itself if needed).
                 // Otherwise the handshake rolling can be interrupted and considered complete.
-                cst = processRendezvous(response, serv_addr, true /*synchro*/, RST_OK, (reqpkt));
+                cst = processRendezvous(response, serv_addr, RST_OK, (reqpkt));
                 if (cst == CONN_CONTINUE)
                     continue;
                 break;
@@ -4239,7 +4239,7 @@ EConnectStatus CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEP
 
     ScopedLock cg(m_ConnectionLock); // FIX
     HLOGC(cnlog.Debug, log << CONID() << "processAsyncConnectResponse: got response for connect request, processing");
-    cst = processConnectResponse(pkt, &e, COM_ASYNCHRO);
+    cst = processConnectResponse(pkt, &e);
 
     HLOGC(cnlog.Debug,
           log << CONID() << "processAsyncConnectResponse: response processing result: " << ConnectStatusStr(cst)
@@ -4275,10 +4275,12 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
 
     bool status = true;
 
+    ScopedLock cg(m_ConnectionLock); // FIX
+
     if (cst == CONN_RENDEZVOUS)
     {
         HLOGC(cnlog.Debug, log << "processAsyncConnectRequest: passing to processRendezvous");
-        cst = processRendezvous(response, serv_addr, false /*asynchro*/, rst, (request));
+        cst = processRendezvous(response, serv_addr, rst, (request));
         if (cst == CONN_ACCEPT)
         {
             HLOGC(cnlog.Debug,
@@ -4389,7 +4391,7 @@ void CUDT::cookieContest()
 
 EConnectStatus CUDT::processRendezvous(
     const CPacket& response, const sockaddr_any& serv_addr,
-    bool synchro, EReadStatus rst, CPacket& w_reqpkt)
+    EReadStatus rst, CPacket& w_reqpkt)
 {
     if (m_RdvState == CHandShake::RDV_CONNECTED)
     {
@@ -4638,7 +4640,7 @@ EConnectStatus CUDT::processRendezvous(
         // When synchro=false, don't lock a mutex for rendezvous queue.
         // This is required when this function is called in the
         // receive queue worker thread - it would lock itself.
-        int cst = postConnect(response, true, 0, synchro);
+        int cst = postConnect(response, true, 0);
         if (cst == CONN_REJECT)
         {
             // m_RejectReason already set
@@ -4714,7 +4716,8 @@ EConnectStatus CUDT::processRendezvous(
     return CONN_CONTINUE;
 }
 
-EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTException* eout, EConnectMethod synchro) ATR_NOEXCEPT
+// [[using locked(m_ConnectionLock)]];
+EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTException* eout) ATR_NOEXCEPT
 {
     // NOTE: ASSUMED LOCK ON: m_ConnectionLock.
 
@@ -4773,7 +4776,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
             m_RdvState = CHandShake::RDV_CONNECTED;
         }
 
-        return postConnect(response, hsv5, eout, synchro);
+        return postConnect(response, hsv5, eout);
     }
 
     if (!response.isControl(UMSG_HANDSHAKE))
@@ -4943,7 +4946,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
         }
     }
 
-    return postConnect(response, false, eout, synchro);
+    return postConnect(response, false, eout);
 }
 
 void CUDT::applyResponseSettings() ATR_NOEXCEPT
@@ -4967,7 +4970,7 @@ void CUDT::applyResponseSettings() ATR_NOEXCEPT
               << " peerID=" << m_ConnRes.m_iID);
 }
 
-EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTException *eout, bool synchro) ATR_NOEXCEPT
+EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTException *eout) ATR_NOEXCEPT
 {
     if (m_ConnRes.m_iVersion < HS_VERSION_SRT1)
         m_tsRcvPeerStartTime = steady_clock::time_point(); // will be set correctly in SRT HS.
@@ -5088,7 +5091,7 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
     // because otherwise the packets that are coming for this socket before the
     // connection process is complete will be rejected as "attack", instead of
     // being enqueued for later pickup from the queue.
-    m_pRcvQueue->removeConnector(m_SocketID, synchro);
+    m_pRcvQueue->removeConnector(m_SocketID);
 
     // Ok, no more things to be done as per "clear connecting state"
     if (!s)
@@ -8100,7 +8103,7 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
     if (CSeqNo::seqcmp(ack, m_iRcvLastAck) > 0)
     {
         const int32_t first_seq ATR_UNUSED = ackDataUpTo(ack);
-        bufflock.unlock();
+        InvertedLock un_bufflock (m_RcvBufferLock);
 
 #if ENABLE_EXPERIMENTAL_BONDING
         // This actually should be done immediately after the ACK pointers were
@@ -8178,7 +8181,6 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 #endif
             CGlobEvent::triggerEvent();
         }
-        bufflock.lock();
     }
     else if (ack == m_iRcvLastAck)
     {
@@ -10608,6 +10610,8 @@ int32_t CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int correct
 //
 // XXX Make this function return EConnectStatus enum type (extend if needed),
 // and this will be directly passed to the caller.
+
+// [[using locked(m_pRcvQueue->m_LSLock)]];
 int CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
 {
     // XXX ASSUMPTIONS:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4237,7 +4237,7 @@ EConnectStatus CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEP
     EConnectStatus cst = CONN_CONTINUE;
     CUDTException  e;
 
-    ScopedLock cg(m_ConnectionLock); // FIX
+    ScopedLock cg(m_ConnectionLock);
     HLOGC(cnlog.Debug, log << CONID() << "processAsyncConnectResponse: got response for connect request, processing");
     cst = processConnectResponse(pkt, &e);
 
@@ -4275,7 +4275,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
 
     bool status = true;
 
-    ScopedLock cg(m_ConnectionLock); // FIX
+    ScopedLock cg(m_ConnectionLock);
 
     if (cst == CONN_RENDEZVOUS)
     {

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -524,7 +524,7 @@ private:
     /// @retval 1 Connection in progress (m_ConnReq turned into RESPONSE)
     /// @retval -1 Connection failed
 
-    SRT_ATR_NODISCARD EConnectStatus processConnectResponse(const CPacket& pkt, CUDTException* eout, EConnectMethod synchro) ATR_NOEXCEPT;
+    SRT_ATR_NODISCARD EConnectStatus processConnectResponse(const CPacket& pkt, CUDTException* eout) ATR_NOEXCEPT;
 
     // This function works in case of HSv5 rendezvous. It changes the state
     // according to the present state and received message type, as well as the
@@ -542,12 +542,10 @@ private:
     /// @param reqpkt Packet to be written with handshake data
     /// @param response incoming handshake response packet to be interpreted
     /// @param serv_addr incoming packet's address
-    /// @param synchro True when this function was called in blocking mode
     /// @param rst Current read status to know if the HS packet was freshly received from the peer, or this is only a periodic update (RST_AGAIN)
-    SRT_ATR_NODISCARD EConnectStatus processRendezvous(const CPacket &response, const sockaddr_any& serv_addr, bool synchro, EReadStatus,
-            CPacket& reqpkt);
+    SRT_ATR_NODISCARD EConnectStatus processRendezvous(const CPacket &response, const sockaddr_any& serv_addr, EReadStatus, CPacket& reqpkt);
     SRT_ATR_NODISCARD bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
-    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout, bool synchro) ATR_NOEXCEPT;
+    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout) ATR_NOEXCEPT;
     void applyResponseSettings() ATR_NOEXCEPT;
     SRT_ATR_NODISCARD EConnectStatus processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT;
     SRT_ATR_NODISCARD bool processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const CPacket& response, const sockaddr_any& serv_addr);

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -838,10 +838,9 @@ void CRendezvousQueue::insert(
             << " (total connectors: " << m_lRendezvousID.size() << ")");
 }
 
-void CRendezvousQueue::remove(const SRTSOCKET &id, bool should_lock)
+void CRendezvousQueue::remove(const SRTSOCKET &id)
 {
-    if (should_lock)
-        enterCS(m_RIDVectorLock);
+    ScopedLock lkv (m_RIDVectorLock);
 
     for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
     {
@@ -851,9 +850,6 @@ void CRendezvousQueue::remove(const SRTSOCKET &id, bool should_lock)
             break;
         }
     }
-
-    if (should_lock)
-        leaveCS(m_RIDVectorLock);
 }
 
 CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
@@ -886,17 +882,34 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id)
     return NULL;
 }
 
-struct FailedLinkInfo
+struct LinkStatusInfo
 {
     CUDT* u;
     SRTSOCKET id;
     int errorcode;
+    sockaddr_any peeraddr;
     int token;
+
+    struct HasID
+    {
+        SRTSOCKET id;
+        HasID(SRTSOCKET p): id(p) {}
+        bool operator()(const LinkStatusInfo& i)
+        {
+            return i.id == id;
+        }
+    };
 };
 
 void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket &response)
 {
-    vector<FailedLinkInfo> ufailed;
+    vector<LinkStatusInfo> ufailed, uprocess;
+
+#if ENABLE_HEAVY_LOGGING
+        int debug_nupd  = 0;
+        int debug_nrun  = 0;
+        int debug_nfail = 0;
+#endif
 
     {
         ScopedLock vg(m_RIDVectorLock);
@@ -907,12 +920,6 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
         HLOGC(cnlog.Debug,
                 log << "updateConnStatus: updating after getting pkt id=" << response.m_iID
                 << " status: " << ConnectStatusStr(cst));
-
-#if ENABLE_HEAVY_LOGGING
-        int debug_nupd  = 0;
-        int debug_nrun  = 0;
-        int debug_nfail = 0;
-#endif
 
         for (list<CRL>::iterator i = m_lRendezvousID.begin(), i_next = i; i != m_lRendezvousID.end(); i = i_next)
         {
@@ -972,9 +979,10 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
                         << " removed - EXPIRED ("
                         // The "enforced on FAILURE" is below when processAsyncConnectRequest failed.
                         << (is_zero(i->m_tsTTL) ? "enforced on FAILURE" : "passed TTL")
-                        << "). removing from queue");
-                // connection timer expired, acknowledge app via epoll
-                i->m_pUDT->m_bConnecting = false;
+                        << "). WILL REMOVE from queue");
+
+                // Set appropriate error information, but do not update yet.
+                // Exit the lock first. Collect objects to update them later.
                 int ccerror = SRT_ECONNREJ;
                 if (i->m_pUDT->m_RejectReason == SRT_REJ_UNKNOWN)
                 {
@@ -992,12 +1000,10 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
                     }
                 }
 
-                i->m_pUDT->updateBrokenConnection();
-
                 // The call to completeBrokenConnectionDependencies() cannot happen here
                 // under the lock of m_RIDVectorLock as it risks a deadlock. Collect it
                 // to update later.
-                FailedLinkInfo fi = {i->m_pUDT, i->m_iID, ccerror, -1};
+                LinkStatusInfo fi = {i->m_pUDT, i->m_iID, ccerror, i->m_PeerAddr, -1};
                 ufailed.push_back(fi);
 
                 /*
@@ -1020,46 +1026,11 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
             // Synchronous connection requests are handled in startConnect() completely.
             if (!i->m_pUDT->m_bSynRecving)
             {
-#if ENABLE_HEAVY_LOGGING
-                ++debug_nupd;
-#endif
-                // IMPORTANT INFORMATION concerning changes towards UDT legacy.
-                // In the UDT code there was no attempt to interpret any incoming data.
-                // All data from the incoming packet were considered to be already deployed into
-                // m_ConnRes field, and m_ConnReq field was considered at this time accordingly updated.
-                // Therefore this procedure did only one thing: craft a new handshake packet and send it.
-                // In SRT this may also interpret extra data (extensions in case when Agent is Responder)
-                // and the `response` packet may sometimes contain no data. Therefore the passed `rst`
-                // must be checked to distinguish the call by periodic update (RST_AGAIN) from a call
-                // due to have received the packet (RST_OK).
-                //
-                // In the below call, only the underlying `processRendezvous` function will be attempting
-                // to interpret these data (for caller-listener this was already done by `processConnectRequest`
-                // before calling this function), and it checks for the data presence.
+                IF_HEAVY_LOGGING(++debug_nupd);
 
-                EReadStatus    read_st = rst;
-                EConnectStatus conn_st = cst;
-
-                if (i->m_iID != response.m_iID)
-                {
-                    read_st = RST_AGAIN;
-                    conn_st = CONN_AGAIN;
-                }
-
-                if (!i->m_pUDT->processAsyncConnectRequest(read_st, conn_st, response, i->m_PeerAddr))
-                {
-                    // cst == CONN_REJECT can only be result of worker_ProcessAddressedPacket and
-                    // its already set in this case.
-                    LOGC(cnlog.Error, log << "RendezvousQueue: processAsyncConnectRequest FAILED. Setting TTL as EXPIRED.");
-                    FailedLinkInfo fi = { i->m_pUDT, i->m_iID, SRT_ECONNREJ, -1};
-                    ufailed.push_back(fi);
-                    i->m_pUDT->sendCtrl(UMSG_SHUTDOWN);
-                    i->m_tsTTL = steady_clock::time_point(); // Make it expire right now, will be picked up at the next iteration
-#if ENABLE_HEAVY_LOGGING
-                    ++debug_nfail;
-#endif
-                }
-
+                // Collect them so that they can be updated out of m_RIDVectorLock.
+                LinkStatusInfo fi = { i->m_pUDT, i->m_iID, SRT_SUCCESS, i->m_PeerAddr, -1};
+                uprocess.push_back(fi);
                 // NOTE: safe loop, the incrementation was done before the loop body,
                 // so the `i' node can be safely deleted. Just the body must end here.
                 continue;
@@ -1070,12 +1041,52 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
             }
         }
 
-        HLOGC(cnlog.Debug,
-                log << "updateConnStatus: " << debug_nupd << "/" << debug_nrun << " sockets updated ("
-                << (debug_nrun - debug_nupd) << " useless). REMOVED " << debug_nfail << " sockets.");
     }
 
     // [[using locked()]];
+
+    HLOGC(cnlog.Debug, log << "updateConnStatus: collected " << uprocess.size() << " for processing, "
+            << ufailed.size() << " to close");
+
+    for (vector<LinkStatusInfo>::iterator i = uprocess.begin(); i != uprocess.end(); ++i)
+    {
+        // IMPORTANT INFORMATION concerning changes towards UDT legacy.
+        // In the UDT code there was no attempt to interpret any incoming data.
+        // All data from the incoming packet were considered to be already deployed into
+        // m_ConnRes field, and m_ConnReq field was considered at this time accordingly updated.
+        // Therefore this procedure did only one thing: craft a new handshake packet and send it.
+        // In SRT this may also interpret extra data (extensions in case when Agent is Responder)
+        // and the `response` packet may sometimes contain no data. Therefore the passed `rst`
+        // must be checked to distinguish the call by periodic update (RST_AGAIN) from a call
+        // due to have received the packet (RST_OK).
+        //
+        // In the below call, only the underlying `processRendezvous` function will be attempting
+        // to interpret these data (for caller-listener this was already done by `processConnectRequest`
+        // before calling this function), and it checks for the data presence.
+
+        EReadStatus    read_st = rst;
+        EConnectStatus conn_st = cst;
+
+        if (i->id != response.m_iID)
+        {
+            read_st = RST_AGAIN;
+            conn_st = CONN_AGAIN;
+        }
+
+        HLOGC(cnlog.Debug, log << "updateConnStatus: processing async conn for @" << i->id << " FROM " << i->peeraddr.str());
+
+        if (!i->u->processAsyncConnectRequest(read_st, conn_st, response, i->peeraddr))
+        {
+            // cst == CONN_REJECT can only be result of worker_ProcessAddressedPacket and
+            // its already set in this case.
+            LinkStatusInfo fi = *i;
+            fi.errorcode = SRT_ECONNREJ;
+            ufailed.push_back(fi);
+            i->u->sendCtrl(UMSG_SHUTDOWN);
+            IF_HEAVY_LOGGING(++debug_nfail);
+        }
+
+    }
 
     // NOTE: it is "believed" here that all CUDT objects will not be
     // deleted in the meantime. This is based on a statement that at worst
@@ -1083,11 +1094,31 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
     // they are moved to ClosedSockets and it is believed that this function will
     // not be held on mutexes that long.
 
-    for (vector<FailedLinkInfo>::iterator i = ufailed.begin(); i != ufailed.end(); ++i)
+    for (vector<LinkStatusInfo>::iterator i = ufailed.begin(); i != ufailed.end(); ++i)
     {
         HLOGC(cnlog.Debug, log << "updateConnStatus: COMPLETING dep objects update on failed @" << i->id);
+        i->u->m_bConnecting = false;
+        i->u->updateBrokenConnection();
         i->u->completeBrokenConnectionDependencies(i->errorcode);
     }
+
+    {
+        // Now, additionally for every failed link reset the TTL so that
+        // they are set expired right now.
+        ScopedLock vg(m_RIDVectorLock);
+        for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
+        {
+            if (find_if(ufailed.begin(), ufailed.end(), LinkStatusInfo::HasID(i->m_iID)) != ufailed.end())
+            {
+                LOGC(cnlog.Error, log << "updateConnStatus: processAsyncConnectRequest FAILED on @" << i->m_iID << ". Setting TTL as EXPIRED.");
+                i->m_tsTTL = steady_clock::time_point(); // Make it expire right now, will be picked up at the next iteration
+            }
+        }
+    }
+
+    HLOGC(cnlog.Debug,
+            log << "updateConnStatus: " << debug_nupd << "/" << debug_nrun << " sockets updated ("
+            << (debug_nrun - debug_nupd) << " useless). REMOVED " << debug_nfail << " sockets.");
 }
 
 //
@@ -1686,10 +1717,10 @@ void CRcvQueue::registerConnector(const SRTSOCKET& id, CUDT* u, const sockaddr_a
     m_pRendezvousQueue->insert(id, u, addr, ttl);
 }
 
-void CRcvQueue::removeConnector(const SRTSOCKET &id, bool should_lock)
+void CRcvQueue::removeConnector(const SRTSOCKET &id)
 {
     HLOGC(cnlog.Debug, log << "removeConnector: removing @" << id);
-    m_pRendezvousQueue->remove(id, should_lock);
+    m_pRendezvousQueue->remove(id);
 
     ScopedLock bufferlock(m_BufferLock);
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -329,11 +329,7 @@ public:
    void insert(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr,
                const srt::sync::steady_clock::time_point &ttl);
 
-   // The should_lock parameter is given here to state as to whether
-   // the lock should be applied here. If called from some internals
-   // and the lock IS ALREADY APPLIED, use false here to prevent
-   // double locking and deadlock in result.
-   void remove(const SRTSOCKET& id, bool should_lock);
+   void remove(const SRTSOCKET& id);
    CUDT* retrieve(const sockaddr_any& addr, SRTSOCKET& id);
 
    void updateConnStatus(EReadStatus rst, EConnectStatus, const CPacket& response);
@@ -509,7 +505,7 @@ private:
    void removeListener(const CUDT* u);
 
    void registerConnector(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const srt::sync::steady_clock::time_point& ttl);
-   void removeConnector(const SRTSOCKET& id, bool should_lock = true);
+   void removeConnector(const SRTSOCKET& id);
 
    void setNewEntry(CUDT* u);
    bool ifNewEntry();

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -348,15 +348,6 @@ class InvertedLock
     Mutex *m_pMutex;
 
   public:
-    InvertedLock(Mutex *m)
-        : m_pMutex(m)
-    {
-        if (!m_pMutex)
-            return;
-
-        leaveCS(*m_pMutex);
-    }
-
     InvertedLock(Mutex& m)
         : m_pMutex(&m)
     {

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -460,7 +460,22 @@ public:
 
         // If a blocking call to srt_connect() returned error, then the state is not valid,
         // but we still check it because we know what it should be. This way we may see potential changes in the core behavior.
-        EXPECT_EQ(srt_getsockstate(m_caller_socket), expect.socket_state[CHECK_SOCKET_CALLER]);
+        if (is_blocking)
+        {
+            EXPECT_EQ(srt_getsockstate(m_caller_socket), expect.socket_state[CHECK_SOCKET_CALLER]);
+        }
+        // A caller socket, regardless of the mode, if it's not expected to be connected, check negatively.
+        if (expect.socket_state[CHECK_SOCKET_CALLER] == SRTS_CONNECTED)
+        {
+            EXPECT_EQ(srt_getsockstate(m_caller_socket), SRTS_CONNECTED);
+        }
+        else
+        {
+            // If the socket is not expected to be connected (might be CONNECTING),
+            // then it is ok if it's CONNECTING or BROKEN.
+            EXPECT_NE(srt_getsockstate(m_caller_socket), SRTS_CONNECTED);
+        }
+
         EXPECT_EQ(GetSocetkOption(m_caller_socket, SRTO_RCVKMSTATE), expect.km_state[CHECK_SOCKET_CALLER]);
 
         EXPECT_EQ(srt_getsockstate(m_listener_socket), SRTS_LISTENING);


### PR DESCRIPTION
The problem:

There was detected a deadlock and therefore the `synchro` parameter introduced, which passes down the call with a requirement to not lock the mutex, while it was causing a deadlock.

After a deep mutex analysis it turned out that the deadlock was actually caused by a mutex lock ordering violation, which has started from the `CRendezvousQueue::updateConnStatus`, which is called whole under a lock for `m_RIDVectorLock`. The extra update calls introduced for HSv5 required extra locking, which was in lock ordering violation against this mutex. The problem has been solved by collecting all sockets, that need to be updated in this function by these lockable calls, in a separate container, and then call the updates outside of the lock.