### PR TITLE
[core] CSync::wait_until is now mapped to CV::wait_until

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5753,7 +5753,7 @@ void *CUDT::tsbpd(void *param)
                   log << self->CONID() << "tsbpd: FUTURE PACKET seq=" << current_pkt_seq
                       << " T=" << FormatTime(tsbpdtime) << " - waiting " << count_milliseconds(timediff) << "ms");
             THREAD_PAUSED();
-            tsbpd_cc.wait_for(timediff);
+            tsbpd_cc.wait_until(tsbpdtime);
             THREAD_RESUMED();
         }
         else

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -475,26 +475,20 @@ public:
     /// Block the call until either @a timestamp time achieved
     /// or the conditional is signaled.
     /// @param [in] delay Maximum time to wait since the moment of the call
-    /// @retval true Resumed due to getting a CV signal
-    /// @retval false Resumed due to being past @a timestamp
+    /// @retval false if the relative timeout specified by rel_time expired,
+    /// @retval true if condition is signaled or spurious wake up.
     bool wait_for(const steady_clock::duration& delay)
     {
         return m_cond->wait_for(*m_locker, delay);
     }
 
-    // Wait until the given time is achieved. This actually
-    // refers to wait_for for the time remaining to achieve
-    // given time.
+    // Wait until the given time is achieved.
+    /// @param [in] exptime The target time to wait until.
+    /// @retval false if the target wait time is reached.
+    /// @retval true if condition is signal or spurious wake up.
     bool wait_until(const steady_clock::time_point& exptime)
     {
-        // This will work regardless as to which clock is in use. The time
-        // should be specified as steady_clock::time_point, so there's no
-        // question of the timer base.
-        steady_clock::time_point now = steady_clock::now();
-        if (now >= exptime)
-            return false; // timeout
-
-        return wait_for(exptime - now);
+        return m_cond->wait_until(*m_locker, exptime);
     }
 
     // Static ad-hoc version


### PR DESCRIPTION
`CSync::wait_until` is now mapped to `CV::wait_until` instead of `wait_for`.
When C++11 sync is enabled, it will reduce the number of time conversions.

### Test Confirmation

- C++11 sync (Windows -> Windows localhost): effective latency **[120ms; 135ms]**
- POSIX sync (Windows -> Windows localhost:) effective latency **[120ms; 136ms]**

_A work within #1674 to reduce changes when integrating the new receiver buffer._