### PR TITLE
[core] A change in setupCC to access CUnitQueue via CRcvQueue instead of CRcvBuffer

### DIFF
--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -511,7 +511,6 @@ public:
    int64_t getDrift() const { return m_DriftTracer.drift(); }
 
 public:
-
    int32_t getTopMsgno() const;
 
    // @return Wrap check value
@@ -524,13 +523,6 @@ public:
    time_point debugGetDeliveryTime(int offset);
 
    size_t dropData(int len);
-   
-   // Required by PacketFilter facility to use as a storage
-   // for provided packets
-   CUnitQueue* getUnitQueue()
-   {
-       return m_pUnitQueue;
-   }
 
 private:
    int extractData(char *data, int len, int p, int q, bool passack);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6108,7 +6108,7 @@ SRT_REJECT_REASON CUDT::setupCC()
         // At this point we state everything is checked and the appropriate
         // corrector type is already selected, so now create it.
         HLOGC(pflog.Debug, log << "filter: Configuring: " << m_OPT_PktFilterConfigString);
-        if (!m_PacketFilter.configure(this, m_pRcvBuffer->getUnitQueue(), m_OPT_PktFilterConfigString))
+        if (!m_PacketFilter.configure(this, &(m_pRcvQueue->m_UnitQueue), m_OPT_PktFilterConfigString))
         {
             return SRT_REJ_FILTER;
         }


### PR DESCRIPTION
_A work within #1674 to reduce changes when integrating the new receiver buffer._

### TODO:

- [x] Delete `CRcvBuffer::getUnitQueue()`