### PR TITLE
[core] Improved RCV-DROPPED log message

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5654,12 +5654,12 @@ void *CUDT::tsbpd(void *param)
                         timediff_us = count_microseconds(steady_clock::now() - tsbpdtime);
 #if ENABLE_HEAVY_LOGGING
                     HLOGC(tslog.Debug,
-                          log << self->CONID() << "tsbpd: DROPSEQ: up to seq=" << CSeqNo::decseq(skiptoseqno) << " ("
+                          log << self->CONID() << "tsbpd: DROPSEQ: up to seqno %" << CSeqNo::decseq(skiptoseqno) << " ("
                               << seqlen << " packets) playable at " << FormatTime(tsbpdtime) << " delayed "
                               << (timediff_us / 1000) << "." << std::setw(3) << std::setfill('0') << (timediff_us % 1000) << " ms");
 #endif
                     LOGC(brlog.Warn,
-                         log << "RCV-DROPPED " << seqlen << " packets, packet seqno " << skiptoseqno
+                         log << "RCV-DROPPED " << seqlen << " packets, packet seqno %" << skiptoseqno
                              << " delayed for " << (timediff_us / 1000) << "." << std::setw(3) << std::setfill('0')
                              << (timediff_us % 1000) << " ms");
 #endif

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5659,7 +5659,7 @@ void *CUDT::tsbpd(void *param)
                               << (timediff_us / 1000) << "." << std::setw(3) << std::setfill('0') << (timediff_us % 1000) << " ms");
 #endif
                     LOGC(brlog.Warn,
-                         log << "RCV-DROPPED " << seqlen << " packets, packet seqno %" << skiptoseqno
+                         log << "RCV-DROPPED " << seqlen << " packet(s), packet seqno %" << skiptoseqno
                              << " delayed for " << (timediff_us / 1000) << "." << std::setw(3) << std::setfill('0')
                              << (timediff_us % 1000) << " ms");
 #endif

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5656,9 +5656,12 @@ void *CUDT::tsbpd(void *param)
                     HLOGC(tslog.Debug,
                           log << self->CONID() << "tsbpd: DROPSEQ: up to seq=" << CSeqNo::decseq(skiptoseqno) << " ("
                               << seqlen << " packets) playable at " << FormatTime(tsbpdtime) << " delayed "
-                              << (timediff_us / 1000) << "." << (timediff_us % 1000) << " ms");
+                              << (timediff_us / 1000) << "." << std::setw(3) << std::setfill('0') << (timediff_us % 1000) << " ms");
 #endif
-                    LOGC(brlog.Warn, log << "RCV-DROPPED packet delay=" << (timediff_us/1000) << "ms");
+                    LOGC(brlog.Warn,
+                         log << "RCV-DROPPED " << seqlen << " packets, packet seqno " << skiptoseqno
+                             << " delayed for " << (timediff_us / 1000) << "." << std::setw(3) << std::setfill('0')
+                             << (timediff_us % 1000) << " ms");
 #endif
 
                     tsbpdtime = steady_clock::time_point(); //Next sent ack will unblock


### PR DESCRIPTION
The proposed message format:

```shell
W:SRT.br: RCV-DROPPED 1 packet(s), packet seqno %625560260 delayed for 0.707 ms
```

instead of

```shell
W:SRT.br: RCV-DROPPED packet delay=0ms
```

Fixed fractional part formatting in the heavy log.

Fixes #1659.