### PR TITLE
[core] Fixed order of group member state change before write ready

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5112,11 +5112,6 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
     s->m_pUDT->m_pSndQueue->m_pChannel->getSockAddr((s->m_SelfAddr));
     CIPAddress::pton((s->m_SelfAddr), s->m_pUDT->m_piSelfIP, m_PeerAddr);
 
-    s->m_Status = SRTS_CONNECTED;
-
-    // acknowledde any waiting epolls to write
-    s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_CONNECT, true);
-
     //int token = -1;
 #if ENABLE_EXPERIMENTAL_BONDING
     {
@@ -5145,6 +5140,11 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
         }
     }
 #endif
+
+    s->m_Status = SRTS_CONNECTED;
+
+    // acknowledde any waiting epolls to write
+    s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_CONNECT, true);
 
     CGlobEvent::triggerEvent();
 


### PR DESCRIPTION
The problem:

Write-readiness was set before the group state was upgraded from PENDING to IDLE. This brought a risk that the connecting function could exit before this state is changed and also the sending function might start the operation, catching all links PENDING, which resulted in error, even though the links are connected and the sending operation should at least try to send.