### PR TITLE
[core] Minor compiler warning fixes (conversion loss of data)

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -933,7 +933,7 @@ int CRcvBuffer::readBuffer(char* data, int len)
                 break; /* too early for this unit, return whatever was copied */
         }
 
-        const int pktlen = pkt.getLength();
+        const int pktlen = (int) pkt.getLength();
         const int remain_pktlen = pktlen - m_iNotch;
 
         const int unitsize = std::min(remain_pktlen, rs);

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -247,7 +247,7 @@ void CChannel::open(int family)
         ::freeaddrinfo(res);
         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
     }
-    m_BindAddr = sockaddr_any(res->ai_addr, res->ai_addrlen);
+    m_BindAddr = sockaddr_any(res->ai_addr, (sockaddr_any::len_t) res->ai_addrlen);
 
     ::freeaddrinfo(res);
 
@@ -538,14 +538,14 @@ void CChannel::getSockAddr(sockaddr_any& w_addr) const
     // space to copy the socket name, it doesn't have to be correlated
     // with the address family. So the maximum space for any name,
     // regardless of the family, does the job.
-    socklen_t namelen = w_addr.storage_size();
+    socklen_t namelen = (socklen_t) w_addr.storage_size();
     ::getsockname(m_iSocket, (w_addr.get()), (&namelen));
     w_addr.len = namelen;
 }
 
 void CChannel::getPeerAddr(sockaddr_any& w_addr) const
 {
-    socklen_t namelen = w_addr.storage_size();
+    socklen_t namelen = (socklen_t) w_addr.storage_size();
     ::getpeername(m_iSocket, (w_addr.get()), (&namelen));
     w_addr.len = namelen;
 }

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -579,7 +579,7 @@ void CMD5::compute(const char* input, unsigned char result[16])
    md5_state_t state;
 
    md5_init(&state);
-   md5_append(&state, (const md5_byte_t *)input, strlen(input));
+   md5_append(&state, (const md5_byte_t *)input, (int) strlen(input));
    md5_finish(&state, result);
 }
 

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -1416,7 +1416,7 @@ struct PacketMetric
 
     void update(size_t mult, uint64_t value)
     {
-        pkts += mult;
+        pkts += (uint32_t) mult;
         bytes += mult * value;
     }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1183,7 +1183,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 
     case SRTO_PBKEYLEN:
         if (m_pCryptoControl)
-            *(int32_t *)optval = m_pCryptoControl->KeyLen(); // Running Key length.
+            *(int32_t *)optval = (int32_t) m_pCryptoControl->KeyLen(); // Running Key length.
         else
             *(int32_t *)optval = m_iSndCryptoKeyLen; // May be 0.
         optlen = sizeof(int32_t);
@@ -1255,14 +1255,14 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         strcpy((char *)optval, m_sStreamName.c_str());
-        optlen = m_sStreamName.size();
+        optlen = (int) m_sStreamName.size();
         break;
 
     case SRTO_CONGESTION:
     {
         string tt = m_CongCtl.selected_name();
         strcpy((char *)optval, tt.c_str());
-        optlen = tt.size();
+        optlen = (int) tt.size();
     }
     break;
 
@@ -1273,7 +1273,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 
     case SRTO_PAYLOADSIZE:
         optlen         = sizeof(int);
-        *(int *)optval = m_zOPT_ExpPayloadSize;
+        *(int *)optval = (int) m_zOPT_ExpPayloadSize;
         break;
 
 #if ENABLE_EXPERIMENTAL_BONDING
@@ -1308,7 +1308,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         strcpy((char *)optval, m_OPT_PktFilterConfigString.c_str());
-        optlen = m_OPT_PktFilterConfigString.size();
+        optlen = (int) m_OPT_PktFilterConfigString.size();
         break;
 
     case SRTO_RETRANSMITALGO:
@@ -1803,7 +1803,7 @@ size_t CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
     return srtlen;
 }
 
-void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
+void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
 {
     CPacket srtpkt;
     int32_t srtcmd = (int32_t)cmd;
@@ -1819,7 +1819,7 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, int srtlen_in)
     // for incoming data. We have a guarantee that it won't be larger than SRTDATA_MAXSIZE.
     uint32_t srtdata[SRTDATA_SIZE];
 
-    int srtlen = 0;
+    size_t srtlen = 0;
 
     if (cmd == SRT_CMD_REJECT)
     {

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -370,7 +370,7 @@ public: // internal API
     static std::vector<SRTSOCKET> existingSockets();
 
     void addressAndSend(CPacket& pkt);
-    void sendSrtMsg(int cmd, uint32_t *srtdata_in = NULL, int srtlen_in = 0);
+    void sendSrtMsg(int cmd, uint32_t *srtdata_in = NULL, size_t srtlen_in = 0);
 
     bool isOPT_TsbPd() const { return m_bOPT_TsbPd; }
     int RTT() const { return m_iRTT; }

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -449,7 +449,7 @@ void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen SRT_ATR_UNUSED)
                 HLOGC(cnlog.Debug, log << "sendKeysToPeer: SENDING ki=" << ki << " len=" << m_SndKmMsg[ki].MsgLen
                         << " retry(updated)=" << m_SndKmMsg[ki].iPeerRetry);
                 m_SndKmLastTime = now;
-                m_parent->sendSrtMsg(SRT_CMD_KMREQ, (uint32_t *)m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen/sizeof(uint32_t));
+                m_parent->sendSrtMsg(SRT_CMD_KMREQ, (uint32_t *)m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen / sizeof(uint32_t));
             }
         }
     }
@@ -522,7 +522,7 @@ void CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
             {
                 HLOGC(cnlog.Debug, log << "regenCryptoKm: SENDING ki=" << ki << " len=" << m_SndKmMsg[ki].MsgLen
                         << " retry(updated)=" << m_SndKmMsg[ki].iPeerRetry);
-                m_parent->sendSrtMsg(SRT_CMD_KMREQ, (uint32_t *)m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen/sizeof(uint32_t));
+                m_parent->sendSrtMsg(SRT_CMD_KMREQ, (uint32_t *)m_SndKmMsg[ki].Msg, m_SndKmMsg[ki].MsgLen / sizeof(uint32_t));
                 sent++;
             }
         }

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -113,7 +113,7 @@ public:
     inline void setLength(size_t length)
     {
 #ifdef _WIN32
-        len = length;
+        len = (ULONG) length;
 #else
         iov_len = length;
 #endif

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -899,14 +899,14 @@ struct MapProxy
     }
 };
 
+/// Print some hash-based stamp of the first 16 bytes in the buffer
 inline std::string BufferStamp(const char* mem, size_t size)
 {
     using namespace std;
     char spread[16];
 
-    int n = 16-size;
-    if (n > 0)
-        memset((spread + 16 - n), 0, n);
+    if (size < 16)
+        memset((spread + size), 0, 16 - size);
     memcpy((spread), mem, min(size_t(16), size));
 
     // Now prepare 4 cells for uint32_t.
@@ -924,9 +924,7 @@ inline std::string BufferStamp(const char* mem, size_t size)
         }
 
     // Convert to hex string
-
     ostringstream os;
-
     os << hex << uppercase << setfill('0') << setw(8) << sum;
 
     return os.str();


### PR DESCRIPTION
Gradually fixing compiler warnings listed in #1646 

This PR fixes some of the C4267 warnings: 'var' conversion from 'size_t' to 'type' possible loss of data.

Roughly -70 C4267 warnings