### PR TITLE
[core] Fixed formal problems detected by clang

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -771,7 +771,7 @@ public:
         return right < *this;
     }
 
-    bool operator=(const this_t& right) const
+    bool operator==(const this_t& right) const
     {
         return number == right.number;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9668,8 +9668,10 @@ int CUDT::processData(CUnit* in_unit)
         std::string s = tns1.str();
         tns2 << "SRT:TsbPd:@" << s.substr(s.size()-2, 2);
 
-        ThreadName tn(tns2.str().c_str());
-        const char* thname = tns2.str().c_str();
+        const string& tn = tns2.str();
+
+        ThreadName tnkeep(tn.c_str());
+        const char* thname = tn.c_str();
 #else
         const char* thname = "SRT:TsbPd";
 #endif


### PR DESCRIPTION
1. Incorrect definition of RollNumber's operator==. This didn't make any real problem as neither = nor == were used in the code, but the definition was wrong.
2. Fixed wrong usage of temporary string object when setting thread name.