### PR TITLE
[apps] Show warning if UDP target is without host

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -1012,6 +1012,9 @@ class UdpTarget: public Target, public UdpCommon
 public:
     UdpTarget(string host, int port, const map<string,string>& attr )
     {
+        if (host.empty())
+            cerr << "\nWARN Host for UDP target is not provided. Will send to localhost:" << port << ".\n";
+
         Setup(host, port, attr);
         if (adapter != "")
         {


### PR DESCRIPTION
`srt-live-transmit` now shows a warning message if there is no host provided for UDP target.
Although it is a valid URI, it could be a good hint if there was an intent to actually send to some remote IP instead.

Addresses #1656 

Example output:
```shell
./srt-live-transmit srt://:4200 udp://:4201
Media path: 'srt://:4200' --> 'udp://:4201'

WARN Host for UDP target is not provided. Will send to localhost:4201.
```