### PR TITLE
[core] Minor warnings fixes (C4267): type conversion with possible loss of data

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1415,7 +1415,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
             {
                 HLOGC(aclog.Debug, log << "groupConnect: OPTION @" << sid << " #" << g.m_config[i].so);
                 error_reason = "setting group-derived option: #" + Sprint(g.m_config[i].so);
-                ns->core().setOpt(g.m_config[i].so, &g.m_config[i].value[0], g.m_config[i].value.size());
+                ns->core().setOpt(g.m_config[i].so, &g.m_config[i].value[0], (int) g.m_config[i].value.size());
             }
 
             // Do not try to set a user option if failed already.
@@ -1702,7 +1702,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
             break;
         }
         HLOGC(aclog.Debug, log << "groupConnect: first connection, applying EPOLL WAITING.");
-        int len = spawned.size();
+        int len = (int) spawned.size();
         vector<SRTSOCKET> ready(spawned.size());
         const int estat = srt_epoll_wait(eid,
                     NULL, NULL,  // IN/ACCEPT

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -994,7 +994,7 @@ int CRcvBuffer::readBufferToFile(fstream& ofs, int len)
 #if ENABLE_LOGGING
         trace_seq = pkt.getSeqNo();
 #endif
-        const int pktlen = pkt.getLength();
+        const int pktlen = (int) pkt.getLength();
         const int remain_pktlen = pktlen - m_iNotch;
 
         const int unitsize = std::min(remain_pktlen, rs);
@@ -2295,7 +2295,7 @@ bool CRcvBuffer::scanMsg(int& w_p, int& w_q, bool& w_passack)
         }
 
         rmpkts++;
-        rmbytes += freeUnitAt(m_iStartPos);
+        rmbytes += (int) freeUnitAt((size_t) m_iStartPos);
 
         m_iStartPos = shiftFwd(m_iStartPos);
     }

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -100,7 +100,7 @@ FECFilterBuiltin::FECFilterBuiltin(const SrtFilterInitializer &init, std::vector
         {
             if (level == levelnames[i])
             {
-                lv = i;
+                lv = (int) i;
                 break;
             }
         }
@@ -293,7 +293,7 @@ void FECFilterBuiltin::ConfigureGroup(Group& g, int32_t seqno, size_t gstep, siz
 
 void FECFilterBuiltin::ResetGroup(Group& g)
 {
-    int32_t new_seq_base = CSeqNo::incseq(g.base, g.drop);
+    int32_t new_seq_base = CSeqNo::incseq(g.base, (int) g.drop);
 
     HLOGC(pflog.Debug, log << "FEC: ResetGroup (step=" << g.step << "): base %" << g.base << " -> %" << new_seq_base);
 
@@ -377,7 +377,8 @@ void FECFilterBuiltin::feedSource(CPacket& packet)
             return;
         }
 
-        int vert_pos = vert_off / sizeRow();
+        SRT_ASSERT(vert_off > 0);
+        size_t vert_pos = vert_off / sizeRow();
 
         HLOGC(pflog.Debug, log << "FEC:feedSource: %" << packet.getSeqNo()
                 << " B:%" << baseoff << " H:*[" << horiz_pos << "] V(B=%" << vert_base

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -377,8 +377,8 @@ void FECFilterBuiltin::feedSource(CPacket& packet)
             return;
         }
 
-        SRT_ASSERT(vert_off > 0);
-        size_t vert_pos = vert_off / sizeRow();
+        SRT_ASSERT(vert_off >= 0);
+        const size_t vert_pos = vert_off / sizeRow();
 
         HLOGC(pflog.Debug, log << "FEC:feedSource: %" << packet.getSeqNo()
                 << " B:%" << baseoff << " H:*[" << horiz_pos << "] V(B=%" << vert_base
@@ -2252,4 +2252,3 @@ int FECFilterBuiltin::ExtendColumns(int colgx)
 
     return colgx;
 }
-

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -254,7 +254,7 @@ void CPacket::setLength(size_t len)
    m_PacketVector[PV_DATA].setLength(len);
 }
 
-void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, int size)
+void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
 {
     // Set (bit-0 = 1) and (bit-1~15 = type)
     setControl(pkttype);

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -247,7 +247,7 @@ public:
       /// @param rparam [in] pointer to the second data structure, explained by the packet type.
       /// @param size [in] size of rparam, in number of bytes;
 
-   void pack(UDTMessageType pkttype, const int32_t* lparam = NULL, void* rparam = NULL, int size = 0);
+   void pack(UDTMessageType pkttype, const int32_t* lparam = NULL, void* rparam = NULL, size_t size = 0);
 
       /// Read the packet vector.
       /// @return Pointer to the packet vector.

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1129,7 +1129,7 @@ CRcvQueue::CRcvQueue()
     , m_pHash(NULL)
     , m_pChannel(NULL)
     , m_pTimer(NULL)
-    , m_iPayloadSize()
+    , m_szPayloadSize()
     , m_bClosing(false)
     , m_LSLock()
     , m_pListener(NULL)
@@ -1175,11 +1175,11 @@ CRcvQueue::~CRcvQueue()
 #endif
 
 
-void CRcvQueue::init(int qsize, int payload, int version, int hsize, CChannel *cc, CTimer *t)
+void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel *cc, CTimer *t)
 {
-    m_iPayloadSize = payload;
+    m_szPayloadSize = payload;
 
-    m_UnitQueue.init(qsize, payload, version);
+    m_UnitQueue.init(qsize, (int) payload, version);
 
     m_pHash = new CHash;
     m_pHash->init(hsize);
@@ -1362,8 +1362,8 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
     {
         // no space, skip this packet
         CPacket temp;
-        temp.m_pcData = new char[m_iPayloadSize];
-        temp.setLength(m_iPayloadSize);
+        temp.m_pcData = new char[m_szPayloadSize];
+        temp.setLength(m_szPayloadSize);
         THREAD_PAUSED();
         EReadStatus rst = m_pChannel->recvfrom((w_addr), (temp));
         THREAD_RESUMED();
@@ -1376,7 +1376,7 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
         return rst == RST_ERROR ? RST_ERROR : RST_AGAIN;
     }
 
-    w_unit->m_Packet.setLength(m_iPayloadSize);
+    w_unit->m_Packet.setLength(m_szPayloadSize);
 
     // reading next incoming packet, recvfrom returns -1 is nothing has been received
     THREAD_PAUSED();

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -461,7 +461,7 @@ public:
       /// @param [in] c UDP channel to be associated to the queue
       /// @param [in] t timer
 
-   void init(int size, int payload, int version, int hsize, CChannel* c, srt::sync::CTimer* t);
+   void init(int size, size_t payload, int version, int hsize, CChannel* c, srt::sync::CTimer* t);
 
       /// Read a packet for a specific UDT socket id.
       /// @param [in] id Socket ID
@@ -493,7 +493,7 @@ private:
    CChannel* m_pChannel;        // UDP channel for receving packets
    srt::sync::CTimer* m_pTimer; // shared timer with the snd queue
 
-   int m_iPayloadSize;          // packet payload size
+   size_t m_szPayloadSize;      // packet payload size
 
    volatile bool m_bClosing;    // closing the worker
 #if ENABLE_LOGGING

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -310,7 +310,7 @@ public:
        // the ETH+IP+UDP+SRT header part elliminates the constant packet delivery time influence.
        //
        const size_t pktsz = pkt.getLength();
-       m_aProbeWindow[m_iProbeWindowPtr] = pktsz ? timediff_times_pl_size / pktsz : int(timediff);
+       m_aProbeWindow[m_iProbeWindowPtr] = pktsz ? int(timediff_times_pl_size / pktsz) : int(timediff);
 
        // OLD CODE BEFORE BSTATS:
        // record the probing packets interval


### PR DESCRIPTION
Another small portion of minor warnings fixes (C4267): conversion from 'size_t' to 'type' with possible loss of data.
Addresses #1646 