### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,22 @@ matrix:
             - make
             - cd ..
           env: BUILD_TYPE=Release
+          
+         # Power jobs
+        - os: linux
+          arch: ppc64le
+          env:
+          - BUILD_TYPE=Debug
+          - BUILD_OPTS='-DENABLE_CODE_COVERAGE=ON -DENABLE_EXPERIMENTAL_BONDING=ON'
+          - RUN_SONARCUBE=1
+          - RUN_CODECOV=1
+        - arch: ppc64le
+          env:
+          - BUILD_TYPE=Debug
+          - BUILD_OPTS='-DENABLE_LOGGING=OFF -DENABLE_MONOTONIC_CLOCK=ON -DENABLE_EXPERIMENTAL_BONDING=ON'
+        - os: linux
+          arch: ppc64le
+          env: BUILD_TYPE=Release
 script:
     - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
         export CC="x86_64-w64-mingw32-gcc";

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,16 +60,10 @@ matrix:
           arch: ppc64le
           env:
           - BUILD_TYPE=Debug
-          - BUILD_OPTS='-DENABLE_CODE_COVERAGE=ON -DENABLE_EXPERIMENTAL_BONDING=ON'
-          - RUN_SONARCUBE=1
-          - RUN_CODECOV=1
         - arch: ppc64le
           env:
-          - BUILD_TYPE=Debug
-          - BUILD_OPTS='-DENABLE_LOGGING=OFF -DENABLE_MONOTONIC_CLOCK=ON -DENABLE_EXPERIMENTAL_BONDING=ON'
-        - os: linux
-          arch: ppc64le
-          env: BUILD_TYPE=Release
+          - BUILD_TYPE=Release
+          - BUILD_OPTS='-DENABLE_MONOTONIC_CLOCK=ON'
 script:
     - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
         export CC="x86_64-w64-mingw32-gcc";


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.