### PR TITLE
[core] fix dllexport of srt_rejectreason_str()

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -980,7 +980,7 @@ SRT_API int srt_getsndbuffer(SRTSOCKET sock, size_t* blocks, size_t* bytes);
 SRT_API int srt_getrejectreason(SRTSOCKET sock);
 SRT_API int srt_setrejectreason(SRTSOCKET sock, int value);
 SRT_API extern const char* const srt_rejectreason_msg [];
-const char* srt_rejectreason_str(int id);
+SRT_API const char* srt_rejectreason_str(int id);
 
 SRT_API uint32_t srt_getversion(void);
 


### PR DESCRIPTION
Add missing SRT_API marker to the function's declaration. Fixes
undefined reference when linking to libsrt on Windows.