### PR TITLE
[build] Use Java 11 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: cpp
 dist: trusty
+jdk:
+  - oraclejdk11
 
 addons:
     apt:


### PR DESCRIPTION
SonarCloud complains about an outdated Java RT used.

### References

- [Building Java 11+ projects on Travis CI](https://www.deps.co/guides/travis-ci-latest-java/)
- [Building a Java project](https://docs.travis-ci.com/user/languages/java/)