### PR TITLE
[core] Main-backup: renaming member link arrays

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -1448,7 +1448,9 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
 
     // First thing then, find out if at least one link was successful.
     // even if it was one of the idle links.
-    // The first successful link sets the sequence.
+    // The first successful link sets the sequence, the followin links derive it.
+    // If there are no active links (only idle), the sending sequence number will be taken as is
+    // from the FIRST activated idle link.
 
     vector<SocketData*> successful, blocked;
 
@@ -3282,7 +3284,7 @@ bool CUDTGroup::sendBackup_IsActivationNeeded(const vector<gli_t>&    idleLinks,
         {
             LOGC(gslog.Debug,
                  log << "grp/sendBackup: found link weight " << idleLinks[0]->weight << " PREF OVER "
-                     << maxActiveWeight << " (highest from activeLinks) - will activate an idle link");
+                     << maxActiveWeight << " (highest from active links) - will activate an idle link");
             activate_reason = "found higher weight link";
         }
 #endif

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -3309,7 +3309,6 @@ size_t CUDTGroup::sendBackup_TryActivateIdleLink(const vector<gli_t>&          i
                                                  int32_t&                      w_curseq,
                                                  int32_t&                      w_final_stat,
                                                  CUDTException&                w_cx,
-                                                 vector<Sendstate>&            w_sendstates,
                                                  vector<gli_t>&                w_parallel,
                                                  vector<SRTSOCKET>&            w_wipeme,
                                                  const string& activate_reason ATR_UNUSED)
@@ -3374,9 +3373,6 @@ size_t CUDTGroup::sendBackup_TryActivateIdleLink(const vector<gli_t>&          i
 
         d->sndresult  = stat;
         d->laststatus = d->ps->getStatus();
-
-        const Sendstate cstate = {d->id, &*d, stat, erc};
-        w_sendstates.push_back(cstate);
 
         if (stat != -1)
         {
@@ -3917,8 +3913,6 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
     }
 #endif
 
-    vector<Sendstate> sendstates;
-
     // Ok, we've separated the unstable from activeLinks just to know if:
     // - we have any STABLE activeLinks (if not, we must activate a backup link)
     // - we have multiple stable activeLinks and we need to stop all but one
@@ -3977,11 +3971,11 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
                                                      (nsuccessful),
                                                      (is_unstable));
 
+        // TODO: Wasn't it done in sendBackup_QualifyMemberStates()? Sanity check?
         if (is_unstable && is_zero(u.m_tsUnstableSince)) // Add to unstable only if it wasn't unstable already
             insert_uniq((unstableLinks), d);
 
         const Sendstate cstate = {d->id, &*d, stat, erc};
-        sendstates.push_back(cstate);
         d->sndresult  = stat;
         d->laststatus = d->ps->getStatus();
     }
@@ -4080,7 +4074,6 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
                                      (curseq),
                                      (final_stat),
                                      (cx),
-                                     (sendstates),
                                      (parallel),
                                      (wipeme),
                                      activate_reason);

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -1447,10 +1447,9 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
     // Links that were successful, have the len value in state.
 
     // First thing then, find out if at least one link was successful.
-    // even if it was one of the idle links.
-    // The first successful link sets the sequence, the followin links derive it.
-    // If there are no active links (only idle), the sending sequence number will be taken as is
-    // from the FIRST activated idle link.
+    // The first successful link sets the sequence value,
+    // the following links derive it. This might be also the first idle
+    // link with its random-generated ISN, if there were no active links.
 
     vector<SocketData*> successful, blocked;
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -1447,10 +1447,8 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
     // Links that were successful, have the len value in state.
 
     // First thing then, find out if at least one link was successful.
-    // This might even be one of the idle links only, this doesn't matter.
-    // If there were any running links successful, they have set the sequence.
-    // If there were only some successfully reactivated idle link, the first
-    // idler has defined the sequence.
+    // even if it was one of the idle links.
+    // The first successful link sets the sequence.
 
     vector<SocketData*> successful, blocked;
 
@@ -3637,7 +3635,7 @@ RetryWaitBlocked:
             // Some sockets could have been closed in the meantime.
             if (m_SndEpolld->watch_empty())
             {
-                HLOGC(gslog.Debug, log << "grp/sendBackup: no more active sockets - group broken");
+                HLOGC(gslog.Debug, log << "grp/sendBackup: no more sockets available for sending - group broken");
                 throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
             }
 

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -314,6 +314,10 @@ private:
                                       std::vector<gli_t>&       w_parallel,
                                       std::vector<SRTSOCKET>&   w_wipeme,
                                       const std::string&        activate_reason);
+
+    /// Check if pending sockets are to be closed.
+    /// @param[in]     pending pending sockets
+    /// @param[in,out] w_wipeme a list of sockets to be removed from the group
     void send_CheckPendingSockets(const std::vector<SRTSOCKET>& pending, std::vector<SRTSOCKET>& w_wipeme);
     void send_CloseBrokenSockets(std::vector<SRTSOCKET>& w_wipeme);
     void sendBackup_CheckParallelLinks(const std::vector<gli_t>& unstable,

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -297,13 +297,13 @@ private:
     /// has a higher weight than any link currently active
     /// (those are collected in 'sendable_pri').
     /// If there are no sendable, a new link needs to be activated anyway.
-    bool sendBackup_IsActivationNeeded(const std::vector<CUDTGroup::gli_t>&  idlers,
+    bool sendBackup_IsActivationNeeded(const std::vector<CUDTGroup::gli_t>&  idleLinks,
         const std::vector<gli_t>& unstable,
         const std::vector<gli_t>& sendable,
         const uint16_t max_sendable_weight,
         std::string& activate_reason) const;
 
-    size_t sendBackup_TryActivateIdleLink(const std::vector<gli_t>& idlers,
+    size_t sendBackup_TryActivateIdleLink(const std::vector<gli_t>& idleLinks,
                                       const char*               buf,
                                       const int                 len,
                                       bool&                     w_none_succeeded,

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -236,18 +236,18 @@ private:
     
     /// Qualify states of member links.
     /// [[using locked(this->m_GroupLock, m_pGlobal->m_GlobControlLock)]]
-    /// @param[in] currtime    current timestamp
-    /// @param[out] w_wipeme   broken links or links about to be closed
-    /// @param[out] w_idlers   idle links
-    /// @param[out] w_pending  links pending to be connected
-    /// @param[out] w_unstable member links qualified as unstable
-    /// @param[out] w_sendable all running member links, including unstable
+    /// @param[in] currtime          current timestamp
+    /// @param[out] w_wipeme         broken links or links about to be closed
+    /// @param[out] w_idleLinks      idle links (connected, but not used for transmission)
+    /// @param[out] w_pendingLinks   links pending to be connected
+    /// @param[out] w_unstableLinks  active member links qualified as unstable
+    /// @param[out] w_activeLinks    all active member links, including unstable
     void sendBackup_QualifyMemberStates(const steady_clock::time_point& currtime,
         std::vector<SRTSOCKET>& w_wipeme,
-        std::vector<gli_t>& w_idlers,
-        std::vector<SRTSOCKET>& w_pending,
-        std::vector<gli_t>& w_unstable,
-        std::vector<gli_t>& w_sendable);
+        std::vector<gli_t>& w_idleLinks,
+        std::vector<SRTSOCKET>& w_pendingLinks,
+        std::vector<gli_t>& w_unstableLinks,
+        std::vector<gli_t>& w_activeLinks);
 
     /// Check if a running link is stable.
     /// @retval true running link is stable

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -264,7 +264,7 @@ private:
     /// @param[out] w_curseq       Group's current sequence number (either -1 or the value used already for other links)
     /// @param[out] w_parallel     Parallel link container (will be filled inside this function)
     /// @param[out] w_final_stat   Status to be reported by this function eventually
-    /// @param[out] w_maxActiveWight Maximum weight value of active links
+    /// @param[out] w_maxActiveWeight Maximum weight value of active links
     /// @param[out] w_nsuccessful  Updates the number of successful links
     /// @param[out] w_is_unstable  Set true if sending resulted in AGAIN error.
     ///
@@ -279,7 +279,7 @@ private:
                                     int32_t&            w_curseq,
                                     std::vector<gli_t>& w_parallel,
                                     int&                w_final_stat,
-                                    uint16_t&           w_maxActiveWight,
+                                    uint16_t&           w_maxActiveWeight,
                                     size_t&             w_nsuccessful,
                                     bool&               w_is_unstable);
     void sendBackup_Buffering(const char* buf, const int len, int32_t& curseq, SRT_MSGCTRL& w_mc);

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -311,7 +311,6 @@ private:
                                       int32_t&                  w_curseq,
                                       int32_t&                  w_final_stat,
                                       CUDTException&            w_cx,
-                                      std::vector<Sendstate>&   w_sendstates,
                                       std::vector<gli_t>&       w_parallel,
                                       std::vector<SRTSOCKET>&   w_wipeme,
                                       const std::string&        activate_reason);

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -231,7 +231,7 @@ private:
     int sendBackupRexmit(CUDT& core, SRT_MSGCTRL& w_mc);
 
     // Support functions for sendBackup and sendBroadcast
-    bool send_CheckIdle(const gli_t d, std::vector<SRTSOCKET>& w_wipeme, std::vector<SRTSOCKET>& w_pending);
+    bool send_CheckIdle(const gli_t d, std::vector<SRTSOCKET>& w_wipeme, std::vector<SRTSOCKET>& w_pendingLinks);
     void sendBackup_CheckIdleTime(gli_t w_d);
     
     /// Qualify states of member links.
@@ -239,13 +239,13 @@ private:
     /// @param[in] currtime          current timestamp
     /// @param[out] w_wipeme         broken links or links about to be closed
     /// @param[out] w_idleLinks      idle links (connected, but not used for transmission)
-    /// @param[out] w_pendingLinks   links pending to be connected
+    /// @param[out] w_pendingSockets sockets pending to be connected
     /// @param[out] w_unstableLinks  active member links qualified as unstable
     /// @param[out] w_activeLinks    all active member links, including unstable
     void sendBackup_QualifyMemberStates(const steady_clock::time_point& currtime,
         std::vector<SRTSOCKET>& w_wipeme,
         std::vector<gli_t>& w_idleLinks,
-        std::vector<SRTSOCKET>& w_pendingLinks,
+        std::vector<SRTSOCKET>& w_pendingSockets,
         std::vector<gli_t>& w_unstableLinks,
         std::vector<gli_t>& w_activeLinks);
 
@@ -264,7 +264,7 @@ private:
     /// @param[out] w_curseq       Group's current sequence number (either -1 or the value used already for other links)
     /// @param[out] w_parallel     Parallel link container (will be filled inside this function)
     /// @param[out] w_final_stat   Status to be reported by this function eventually
-    /// @param[out] w_max_sendable_weight Maximum weight value of sendable links
+    /// @param[out] w_maxActiveWight Maximum weight value of active links
     /// @param[out] w_nsuccessful  Updates the number of successful links
     /// @param[out] w_is_unstable  Set true if sending resulted in AGAIN error.
     ///
@@ -279,7 +279,7 @@ private:
                                     int32_t&            w_curseq,
                                     std::vector<gli_t>& w_parallel,
                                     int&                w_final_stat,
-                                    uint16_t&           w_max_sendable_weight,
+                                    uint16_t&           w_maxActiveWight,
                                     size_t&             w_nsuccessful,
                                     bool&               w_is_unstable);
     void sendBackup_Buffering(const char* buf, const int len, int32_t& curseq, SRT_MSGCTRL& w_mc);


### PR DESCRIPTION
List of changes:

- `vector<gli_t> idlers` -> `idleLinks`
- `vector<SRTSOCKET> pending` -> `pendingSockets`
- `vector<gli_t> sendable` -> `activeLinks`
- `vector<Sendstate> sendstates` not used in the backup mode, removed.
- `vector<gli_t> unstable` - `unstableLinks`
- `uint16_t max_sendable_weight` -> `maxActiveWeight`