### PR TITLE
[build] Fixed PowerShell script to not fail on CMake warning.

### DIFF
--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -134,12 +134,19 @@ if ( $VS_VERSION -eq '2019' ) {
 # fire cmake to build project files
 $execVar = "cmake ../ -G`"$CMAKE_GENERATOR`" $cmakeFlags"
 Write-Output $execVar
+
+# Reset reaction to Continue for cmake as it sometimes tends to print
+# things on stderr, which is understood by PowerShell as error. The
+# exit code from cmake will be checked anyway.
+$ErrorActionPreference = "Continue"
 Invoke-Expression "& $execVar"
 
 # check build ran OK, exit if cmake failed
 if( $LASTEXITCODE -ne 0 ) {
     return $LASTEXITCODE
 }
+
+$ErrorActionPreference = "Stop"
 
 # run the set-version-metadata script to inject build numbers into appveyors console and the resulting DLL
 . $PSScriptRoot/set-version-metadata.ps1


### PR DESCRIPTION
CMake complaints about CMake version 2.8.8 requirement of GTest.
Versions below 2.8.12 will soon become deprecated.

Extracted from #1731