### PR TITLE
[core] Fixed too early closed caller socket in background.

### DIFF
--- a/docs/API-functions.md
+++ b/docs/API-functions.md
@@ -783,6 +783,11 @@ is through the epoll flag with [`SRT_EPOLL_ERR`](#SRT_EPOLL_ERR). In this case y
 also call [`srt_getrejectreason`](#srt_getrejectreason) to get the detailed reason for 
 the error, including connection timeout ([`SRT_REJ_TIMEOUT`](#SRT_REJ_TIMEOUT)).
 
+Note that in case of failure the socket is in `SRTS_CONNECTING`, not in
+`SRTS_BROKEN` state. After the failure was reported and you read any extra
+information from the socket, the socket should be manually closed using
+`srt_close` function.
+
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/docs/API.md
+++ b/docs/API.md
@@ -154,6 +154,15 @@ and `remote_name` must use the same port. The peer to which this is going to con
 should call the same function, with appropriate local and remote addresses. A rendezvous
 connection means that both parties connect to one another simultaneously.
 
+**IMPORTANT**: The connection may fail, but the socket that was used for connecting
+is not automatically closed and it's also not in broken state (broken state can be
+only if a socket was first successfully connected and then broken). When using blocking
+mode, the connection failure will result in reporting an error from this function call.
+In non-blocking mode the connection failure is designated by the `SRT_EPOLL_ERR` flag
+set for this socket in the epoll container. After that failure you can read an extra
+information from the socket using `srt_getrejectreason` function, and then you should
+close the socket.
+
 ### Listener (Server) Example
 
 ```c++

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -415,22 +415,16 @@ public:
                     std::this_thread::sleep_for(std::chrono::milliseconds(50));
                 } while (!caller_done);
 
-                const SRT_SOCKSTATUS status = srt_getsockstate(accepted_socket);
+                EXPECT_EQ(srt_getsockstate(accepted_socket), expect.socket_state[CHECK_SOCKET_ACCEPTED]);
+                EXPECT_EQ(GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE), expect.km_state[CHECK_SOCKET_ACCEPTED]);
+
                 if (m_is_tracing)
                 {
+                    const SRT_SOCKSTATUS status = srt_getsockstate(accepted_socket);
                     std::cerr << "LATE Socket state accepted: " << m_socket_state[status]
                         << " (expected: " << m_socket_state[expect.socket_state[CHECK_SOCKET_ACCEPTED]] << ")\n";
                 }
 
-                if (expect.socket_state[CHECK_SOCKET_ACCEPTED] == SRTS_BROKEN)
-                {
-                    EXPECT_TRUE(accepted_socket == -1 || status == SRTS_BROKEN || status == SRTS_CLOSED);
-                }
-                else
-                {
-                    EXPECT_EQ(status, expect.socket_state[CHECK_SOCKET_ACCEPTED]);
-                    EXPECT_EQ(GetSocetkOption(accepted_socket, SRTO_SNDKMSTATE), expect.km_state[CHECK_SOCKET_ACCEPTED]);
-                }
             }
         });
 


### PR DESCRIPTION
Proper fix for #1736.

This reverses a change that was done in order to properly update groups when a caller socket has failed to connect. There was added a request to perform close-alike things (with setting flags and releasing thread-related resources) that caused the socket to be actually prematurely closed. This caused inability to properly deliver closure information to the caller callback and possibly too early execution of the GC on that socket that deleted the socket before it could be properly reported in the receiver queue thread.

This PR also contains reversal of the changes in the tests that were failing because of this problem.

Changes from #1736 could be also incorporated here as a sanity check.