### PR TITLE
Splitting sendBackup_CheckParallelLinks(..)

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -3974,7 +3974,6 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
         if (is_unstable && is_zero(u.m_tsUnstableSince)) // Add to unstable only if it wasn't unstable already
             insert_uniq((unstableLinks), d);
 
-        const Sendstate cstate = {d->id, &*d, stat, erc};
         d->sndresult  = stat;
         d->laststatus = d->ps->getStatus();
     }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -3758,8 +3758,8 @@ RetryWaitBlocked:
 }
 
 // [[using locked(this->m_GroupLock)]]
-void CUDTGroup::sendBackup_CheckParallelLinks(const vector<gli_t>& unstableLinks,
-                                              vector<gli_t>&       w_parallel)
+void CUDTGroup::sendBackup_SilenceRedundantLinks(const vector<gli_t>& unstableLinks,
+                                                 vector<gli_t>&       w_parallel)
 {
 #if ENABLE_HEAVY_LOGGING
     // Potential problem to be checked in developer mode
@@ -4100,7 +4100,7 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
 
     sendBackup_RetryWaitBlocked(unstableLinks, (parallel), (final_stat), (none_succeeded), (w_mc), (cx));
 
-    sendBackup_CheckParallelLinks(unstableLinks, (parallel));
+    sendBackup_SilenceRedundantLinks(unstableLinks, (parallel));
     // (closing condition checked inside this call)
 
     if (none_succeeded)

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -3541,11 +3541,11 @@ struct FByOldestActive
 
 // [[using locked(this->m_GroupLock)]]
 void CUDTGroup::sendBackup_RetryWaitBlocked(const vector<gli_t>& unstableLinks,
-    vector<gli_t>& w_parallel,
-    int& w_final_stat,
-    bool& w_none_succeeded,
-    SRT_MSGCTRL& w_mc,
-    CUDTException& w_cx)
+                                            vector<gli_t>&       w_parallel,
+                                            int&                 w_final_stat,
+                                            bool&                w_none_succeeded,
+                                            SRT_MSGCTRL&         w_mc,
+                                            CUDTException&       w_cx)
 {
     // In contradiction to broadcast sending, backup sending must check
     // the blocking state in total first. We need this information through

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -320,12 +320,14 @@ private:
     /// @param[in,out] w_wipeme a list of sockets to be removed from the group
     void send_CheckPendingSockets(const std::vector<SRTSOCKET>& pending, std::vector<SRTSOCKET>& w_wipeme);
     void send_CloseBrokenSockets(std::vector<SRTSOCKET>& w_wipeme);
+    void sendBackup_RetryWaitBlocked(const std::vector<gli_t>& unstable,
+        std::vector<gli_t>& w_parallel,
+        int& w_final_stat,
+        bool& w_none_succeeded,
+        SRT_MSGCTRL& w_mc,
+        CUDTException& w_cx);
     void sendBackup_CheckParallelLinks(const std::vector<gli_t>& unstable,
-                                       std::vector<gli_t>&       w_parallel,
-                                       int&                      w_final_stat,
-                                       bool&                     w_none_succeeded,
-                                       SRT_MSGCTRL&              w_mc,
-                                       CUDTException&            w_cx);
+                                       std::vector<gli_t>&       w_parallel);
 
     void send_CheckValidSockets();
 

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -326,8 +326,8 @@ private:
                                      bool&                     w_none_succeeded,
                                      SRT_MSGCTRL&              w_mc,
                                      CUDTException&            w_cx);
-    void sendBackup_CheckParallelLinks(const std::vector<gli_t>& unstable,
-                                       std::vector<gli_t>&       w_parallel);
+    void sendBackup_SilenceRedundantLinks(const std::vector<gli_t>& unstable,
+                                          std::vector<gli_t>&       w_parallel);
 
     void send_CheckValidSockets();
 

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -321,11 +321,11 @@ private:
     void send_CheckPendingSockets(const std::vector<SRTSOCKET>& pending, std::vector<SRTSOCKET>& w_wipeme);
     void send_CloseBrokenSockets(std::vector<SRTSOCKET>& w_wipeme);
     void sendBackup_RetryWaitBlocked(const std::vector<gli_t>& unstable,
-        std::vector<gli_t>& w_parallel,
-        int& w_final_stat,
-        bool& w_none_succeeded,
-        SRT_MSGCTRL& w_mc,
-        CUDTException& w_cx);
+                                     std::vector<gli_t>&       w_parallel,
+                                     int&                      w_final_stat,
+                                     bool&                     w_none_succeeded,
+                                     SRT_MSGCTRL&              w_mc,
+                                     CUDTException&            w_cx);
     void sendBackup_CheckParallelLinks(const std::vector<gli_t>& unstable,
                                        std::vector<gli_t>&       w_parallel);
 


### PR DESCRIPTION
The function `sendBackup_CheckParallelLinks` was doing two quite independent things:
- Retrying sending a packet in case not a single send operation has succeeded, but there are active links. Also blocking the `srt_sendmsg2` in blocking mode, and signalling an error in non-blocking mode.
- Silencing redundant active links if the main link is stable.

1. The first logic is now moved to `sendBackup_RetryWaitBlocked`,
2. The second logic is now moved to `sendBackup_SilenceRedundantLinks`
