### PR TITLE
[core] Added possibility to use option container for single socket

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -4226,6 +4226,33 @@ SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
    }
 }
 
+int CUDT::applyConfigObject(SRTSOCKET u, const SRT_SocketOptionObject& opt)
+{
+    try
+    {
+        SRT_ERRNO e = s_UDTUnited.locateSocket(u, s_UDTUnited.ERH_THROW)->m_pUDT->applyConfigObject(opt);
+        if (e != SRT_SUCCESS) // Not supported for now, just leaving for future.
+        {
+            SetThreadLocalError(CUDTException(MJ_NOTSUP, MN_INVAL));
+            return SRT_ERROR;
+        }
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return SRT_ERROR;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "getUDTHandle: UNEXPECTED EXCEPTION: "
+                << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return SRT_ERROR;
+    }
+
+    return 0;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1321,53 +1321,10 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
     }
 }
 
-#if ENABLE_EXPERIMENTAL_BONDING
 bool SRT_SocketOptionObject::add(SRT_SOCKOPT optname, const void* optval, size_t optlen)
 {
     // Check first if this option is allowed to be set
     // as on a member socket.
-
-    switch (optname)
-    {
-    case SRTO_BINDTODEVICE:
-    case SRTO_CONNTIMEO:
-    case SRTO_DRIFTTRACER:
-        //SRTO_FC - not allowed to be different among group members
-    case SRTO_GROUPSTABTIMEO:
-        //SRTO_INPUTBW - per transmission setting
-    case SRTO_IPTOS:
-    case SRTO_IPTTL:
-    case SRTO_KMREFRESHRATE:
-    case SRTO_KMPREANNOUNCE:
-        //SRTO_LATENCY - per transmission setting
-        //SRTO_LINGER - not for managed sockets
-    case SRTO_LOSSMAXTTL:
-        //SRTO_MAXBW - per transmission setting
-        //SRTO_MESSAGEAPI - groups are live mode only
-        //SRTO_MINVERSION - per group connection setting
-    case SRTO_NAKREPORT:
-        //SRTO_OHEADBW - per transmission setting
-        //SRTO_PACKETFILTER - per transmission setting
-        //SRTO_PASSPHRASE - per group connection setting
-        //SRTO_PASSPHRASE - per transmission setting
-        //SRTO_PBKEYLEN - per group connection setting
-    case SRTO_PEERIDLETIMEO:
-    case SRTO_RCVBUF:
-        //SRTO_RCVSYN - must be always false in groups
-        //SRTO_RCVTIMEO - must be alwyas -1 in groups
-    case SRTO_SNDBUF:
-    case SRTO_SNDDROPDELAY:
-        //SRTO_TLPKTDROP - per transmission setting
-        //SRTO_TSBPDMODE - per transmission setting
-    case SRTO_UDP_RCVBUF:
-    case SRTO_UDP_SNDBUF:
-        break;
-
-    default:
-        // Other options are not allowed
-        return false;
-
-    }
 
     // Header size will get the size likely aligned, but it won't
     // hurt if the memory size will be up to 4 bytes more than
@@ -1386,14 +1343,72 @@ bool SRT_SocketOptionObject::add(SRT_SOCKOPT optname, const void* optval, size_t
     return true;
 }
 
+SRT_ERRNO CUDT::applyConfigObject(const SRT_SocketOptionObject& opt)
+{
+    SRT_SOCKOPT this_opt = SRTO_VERSION;
+    for (size_t i = 0; i < opt.options.size(); ++i)
+    {
+        SRT_SocketOptionObject::SingleOption* o = opt.options[i];
+        HLOGC(smlog.Debug, log << "applyConfigObject: OPTION @" << m_SocketID << " #" << o->option);
+        this_opt = SRT_SOCKOPT(o->option);
+        setOpt(this_opt, o->storage, o->length);
+    }
+    return SRT_SUCCESS;
+}
+
+#if ENABLE_EXPERIMENTAL_BONDING
 SRT_ERRNO CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
 {
     SRT_SOCKOPT this_opt = SRTO_VERSION;
     for (size_t i = 0; i < opt.options.size(); ++i)
     {
         SRT_SocketOptionObject::SingleOption* o = opt.options[i];
-        HLOGC(smlog.Debug, log << "applyMemberConfigObject: OPTION @" << m_SocketID << " #" << o->option);
         this_opt = SRT_SOCKOPT(o->option);
+
+        switch (this_opt)
+        {
+        case SRTO_BINDTODEVICE:
+        case SRTO_CONNTIMEO:
+        case SRTO_DRIFTTRACER:
+            //SRTO_FC - not allowed to be different among group members
+        case SRTO_GROUPSTABTIMEO:
+            //SRTO_INPUTBW - per transmission setting
+        case SRTO_IPTOS:
+        case SRTO_IPTTL:
+        case SRTO_KMREFRESHRATE:
+        case SRTO_KMPREANNOUNCE:
+            //SRTO_LATENCY - per transmission setting
+            //SRTO_LINGER - not for managed sockets
+        case SRTO_LOSSMAXTTL:
+            //SRTO_MAXBW - per transmission setting
+            //SRTO_MESSAGEAPI - groups are live mode only
+            //SRTO_MINVERSION - per group connection setting
+        case SRTO_NAKREPORT:
+            //SRTO_OHEADBW - per transmission setting
+            //SRTO_PACKETFILTER - per transmission setting
+            //SRTO_PASSPHRASE - per group connection setting
+            //SRTO_PASSPHRASE - per transmission setting
+            //SRTO_PBKEYLEN - per group connection setting
+        case SRTO_PEERIDLETIMEO:
+        case SRTO_RCVBUF:
+            //SRTO_RCVSYN - must be always false in groups
+            //SRTO_RCVTIMEO - must be alwyas -1 in groups
+        case SRTO_SNDBUF:
+        case SRTO_SNDDROPDELAY:
+            //SRTO_TLPKTDROP - per transmission setting
+            //SRTO_TSBPDMODE - per transmission setting
+        case SRTO_UDP_RCVBUF:
+        case SRTO_UDP_SNDBUF:
+            break;
+
+        default:
+            // Other options are not allowed
+            LOGC(smlog.Error, log << "applyMemberConfigObject: OPTION #" << o->option << " not allowed on members");
+
+            continue; // Simply ignore. It's not a big deal, and interrupting connection process would be hard here.
+        }
+
+        HLOGC(smlog.Debug, log << "applyConfigObject: OPTION @" << m_SocketID << " #" << o->option);
         setOpt(this_opt, o->storage, o->length);
     }
     return SRT_SUCCESS;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -138,8 +138,6 @@ enum SeqPairItems
     SEQ_BEGIN = 0, SEQ_END = 1, SEQ_SIZE = 2
 };
 
-#if ENABLE_EXPERIMENTAL_BONDING
-
 struct SRT_SocketOptionObject
 {
     struct SingleOption
@@ -166,6 +164,7 @@ struct SRT_SocketOptionObject
     bool add(SRT_SOCKOPT optname, const void* optval, size_t optlen);
 };
 
+#if ENABLE_EXPERIMENTAL_BONDING
 class CUDTGroup;
 #endif
 
@@ -305,6 +304,7 @@ public: //API
     static int rejectReason(SRTSOCKET s);
     static int rejectReason(SRTSOCKET s, int value);
     static int64_t socketStartTime(SRTSOCKET s);
+    static int applyConfigObject(SRTSOCKET s, const SRT_SocketOptionObject& opt);
 
 public: // internal API
     // This is public so that it can be used directly in API implementation functions.
@@ -685,9 +685,10 @@ private:
 
     void getOpt(SRT_SOCKOPT optName, void* optval, int& w_optlen);
 
-#if ENABLE_EXPERIMENTAL_BONDING
     /// Applies the configuration set on the socket.
     /// Any errors in this process are reported by exception.
+    SRT_ERRNO applyConfigObject(const SRT_SocketOptionObject& opt);
+#if ENABLE_EXPERIMENTAL_BONDING
     SRT_ERRNO applyMemberConfigObject(const SRT_SocketOptionObject& opt);
 #endif
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -759,6 +759,7 @@ SRT_API       SRTSOCKET srt_create_socket(void);
 // Stubs when off
 
 typedef struct SRT_SocketGroupData_ SRT_SOCKGROUPDATA;
+typedef struct SRT_SocketOptionObject SRT_SOCKOPT_CONFIG;
 
 #if ENABLE_EXPERIMENTAL_BONDING
 
@@ -796,8 +797,6 @@ struct SRT_SocketGroupData_
     int token;
 };
 
-typedef struct SRT_SocketOptionObject SRT_SOCKOPT_CONFIG;
-
 typedef struct SRT_GroupMemberConfig_
 {
     SRTSOCKET id;
@@ -816,14 +815,16 @@ SRT_API SRTSOCKET srt_groupof      (SRTSOCKET socket);
 SRT_API       int srt_group_data   (SRTSOCKET socketgroup, SRT_SOCKGROUPDATA* output, size_t* inoutlen);
 SRT_API       int srt_group_configure(SRTSOCKET socketgroup, const char* str);
 
-SRT_API SRT_SOCKOPT_CONFIG* srt_create_config(void);
-SRT_API void srt_delete_config(SRT_SOCKOPT_CONFIG* config /*nullable*/);
-SRT_API int srt_config_add(SRT_SOCKOPT_CONFIG* config, SRT_SOCKOPT option, const void* contents, int len);
-
 SRT_API SRT_SOCKGROUPCONFIG srt_prepare_endpoint(const struct sockaddr* src /*nullable*/, const struct sockaddr* adr, int namelen);
 SRT_API       int srt_connect_group(SRTSOCKET group, SRT_SOCKGROUPCONFIG name [], int arraysize);
 
 #endif // ENABLE_EXPERIMENTAL_BONDING
+
+SRT_API SRT_SOCKOPT_CONFIG* srt_create_config(void);
+SRT_API SRT_SOCKOPT_CONFIG* srt_clone_config(const SRT_SOCKOPT_CONFIG* old);
+SRT_API void srt_delete_config(SRT_SOCKOPT_CONFIG* config /*nullable*/);
+SRT_API int srt_config_add(SRT_SOCKOPT_CONFIG* config, SRT_SOCKOPT option, const void* contents, int len);
+SRT_API int srt_config_apply(SRT_SOCKOPT_CONFIG* config, SRTSOCKET s);
 
 SRT_API       int srt_bind         (SRTSOCKET u, const struct sockaddr* name, int namelen);
 SRT_API       int srt_bind_acquire (SRTSOCKET u, UDPSOCKET sys_udp_sock);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -49,10 +49,16 @@ int srt_group_configure(SRTSOCKET socketgroup, const char* str)
 {
     return CUDT::configureGroup(socketgroup, str);
 }
+#endif
 
 SRT_SOCKOPT_CONFIG* srt_create_config()
 {
     return new SRT_SocketOptionObject;
+}
+
+SRT_SOCKOPT_CONFIG* srt_clone_config(const SRT_SOCKOPT_CONFIG* old)
+{
+    return new SRT_SocketOptionObject(*old);
 }
 
 void srt_delete_config(SRT_SOCKOPT_CONFIG* in)
@@ -70,7 +76,21 @@ int srt_config_add(SRT_SOCKOPT_CONFIG* config, SRT_SOCKOPT option, const void* c
 
     return 0;
 }
-#endif
+
+int srt_config_apply(SRT_SOCKOPT_CONFIG* config, SRTSOCKET s)
+{
+    if (!config)
+        return SRT_ERROR;
+
+    if (s == SRT_INVALID_SOCK)
+        return SRT_ERROR;
+
+    if (CUDT::applyConfigObject(s, *config) == SRT_ERROR)
+        return SRT_ERROR;
+
+    return 0;
+}
+
 
 // int srt_bind_multicast()
 

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -120,4 +120,31 @@ TEST_F(TestSocketOptions, LossMaxTTL)
     ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
 }
 
+TEST_F(TestSocketOptions, OptionsContainer)
+{
+    SRT_SOCKOPT_CONFIG* cfg = srt_create_config();
+
+    int no = 0;
+    srt_config_add(cfg, SRTO_SNDSYN, &no, sizeof no);
+    srt_config_add(cfg, SRTO_RCVSYN, &no, sizeof no);
+
+    ASSERT_EQ(srt_config_apply(cfg, m_caller_sock), SRT_SUCCESS);
+
+    SRT_SOCKOPT_CONFIG* cfg2 = srt_clone_config(cfg);
+
+    int out = 321;
+    int s_out = sizeof (out);
+    ASSERT_EQ(srt_getsockflag(m_listen_sock, SRTO_RCVSYN, &out, &s_out), SRT_SUCCESS);
+    ASSERT_EQ(out, 1);
+
+    ASSERT_EQ(srt_config_apply(cfg2, m_listen_sock), SRT_SUCCESS);
+
+    ASSERT_EQ(srt_getsockflag(m_listen_sock, SRTO_RCVSYN, &out, &s_out), SRT_SUCCESS);
+
+    EXPECT_EQ(out, 0);
+
+    srt_delete_config(cfg);
+    srt_delete_config(cfg2);
+}
+
 


### PR DESCRIPTION
Fixes #1752 

This adds new functionality for the configuration object so far used only to set options in sockets created for group members.

CHANGED BEHAVIOR: options are no longer checked if allowed during adding to the container because options are now as good for single sockets and member sockets. This is now only checked when applying, and if an option cannot be allowed to be altered on a member socket, it's ignored. There's no better solution for it, unless a separate function is created for adding option to the container when it's intended for single socket or when it's intended for member sockets, and do checks depending on that. Or, possibly set a special flag in the config object, so then two different methods for creating the config object would have to be provided, which could be hard to be done right with the current API.