### PR TITLE
[core] Added group receiver drop log warning

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2657,8 +2657,8 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 {
                     m_stats.recvDrop.UpdateTimes(jump, avgRcvPacketSize());
                     LOGC(brlog.Warn,
-                        log << "@" << m_GroupID << " GROUP RCV-DROPPED " << jump << " packet(s): seqno %"
-                        << m_RcvBaseSeqNo << " to %" << slowest_kangaroo->second.mctrl.pktseq);
+                         log << "@" << m_GroupID << " GROUP RCV-DROPPED " << jump << " packet(s): seqno %"
+                             << m_RcvBaseSeqNo << " to %" << slowest_kangaroo->second.mctrl.pktseq);
                 }
 
                 m_RcvBaseSeqNo    = slowest_kangaroo->second.mctrl.pktseq;

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2658,7 +2658,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                     m_stats.recvDrop.UpdateTimes(jump, avgRcvPacketSize());
                     LOGC(brlog.Warn,
                         log << "@" << m_GroupID << " GROUP RCV-DROPPED " << jump << " packet(s): seqno %"
-                        << m_RcvBaseSeqNo << " to " << slowest_kangaroo->second.mctrl.pktseq);
+                        << m_RcvBaseSeqNo << " to %" << slowest_kangaroo->second.mctrl.pktseq);
                 }
 
                 m_RcvBaseSeqNo    = slowest_kangaroo->second.mctrl.pktseq;

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2656,6 +2656,9 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 if (jump > 0)
                 {
                     m_stats.recvDrop.UpdateTimes(jump, avgRcvPacketSize());
+                    LOGC(brlog.Warn,
+                        log << "@" << m_GroupID << " GROUP RCV-DROPPED " << jump << " packet(s): seqno %"
+                        << m_RcvBaseSeqNo << " to " << slowest_kangaroo->second.mctrl.pktseq);
                 }
 
                 m_RcvBaseSeqNo    = slowest_kangaroo->second.mctrl.pktseq;

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2656,7 +2656,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 if (jump > 0)
                 {
                     m_stats.recvDrop.UpdateTimes(jump, avgRcvPacketSize());
-                    LOGC(brlog.Warn,
+                    LOGC(grlog.Warn,
                          log << "@" << m_GroupID << " GROUP RCV-DROPPED " << jump << " packet(s): seqno %"
                              << m_RcvBaseSeqNo << " to %" << slowest_kangaroo->second.mctrl.pktseq);
                 }


### PR DESCRIPTION
Added log message in case a packet is dropped due to a kangaroo link.

### TODO:
- [x] A packet can also be dropped in some other cases to be identified, which is also not shown in stats.
Somewhere related to this code block:
```c++
if (seqdiff > 1)
{
    HLOGC(grlog.Debug,
            log << "@" << id << " %" << mctrl.pktseq << " #" << mctrl.msgno << " AHEAD base=%"
                << m_RcvBaseSeqNo);
    p->packet.assign(buf, buf + stat);
    p->mctrl = mctrl;
    break; // Don't read from that socket anymore.
}
```

Fixes #1760