### PR TITLE
[test] Added 1%% tolerance for long waiting time

### DIFF
--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -314,7 +314,8 @@ TEST(SyncEvent, WaitFor)
         // - SyncEvent::wait_for( 50us) took 6us
         // - SyncEvent::wait_for(100us) took 4us
         if (on_timeout) {
-            EXPECT_GE(waittime_us, timeout_us);
+            int tolerance = timeout_us/1000;
+            EXPECT_GE(waittime_us, timeout_us - tolerance);
         }
 #endif
         if (on_timeout) {

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -314,7 +314,7 @@ TEST(SyncEvent, WaitFor)
         // - SyncEvent::wait_for( 50us) took 6us
         // - SyncEvent::wait_for(100us) took 4us
         if (on_timeout) {
-            int tolerance = timeout_us/1000;
+            const int tolerance = timeout_us/1000;
             EXPECT_GE(waittime_us, timeout_us - tolerance);
         }
 #endif


### PR DESCRIPTION
This adds a 1/1000 of the original time as tolerance as to when the time can elapse earlier (that is, the given time isn't the exact minimum time expected to wait).