### PR TITLE
[core] Bonding: refactoring receiving function

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5763,7 +5763,7 @@ void *CUDT::tsbpd(void *param)
 
         if (!is_zero(tsbpdtime))
         {
-            const steady_clock::duration timediff = tsbpdtime - steady_clock::now();
+            IF_HEAVY_LOGGING(const steady_clock::duration timediff = tsbpdtime - steady_clock::now());
             /*
              * Buffer at head of queue is not ready to play.
              * Schedule wakeup when it will be.

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2127,6 +2127,8 @@ vector<CUDTSocket*> CUDTGroup::recv_CollectReadReady(set<CUDTSocket*>& broken)
         if (ps)
             ready_sockets.push_back(ps);
     }
+    
+    leaveCS(CUDT::s_UDTUnited.m_GlobControlLock);
     return ready_sockets;
 }
 
@@ -2314,6 +2316,8 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
 
         // Will be filled inside
         const vector<CUDTSocket*> ready_sockets = recv_CollectReadReady(broken);
+        // m_GlobControlLock lifted, m_GroupLock still locked.
+        // Now we can safely do this scoped way.
 
         // Ok, now we need to have some extra qualifications:
         // 1. If a socket has no registry yet, we read anyway, just
@@ -2328,10 +2332,8 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
 
         int32_t next_seq = m_RcvBaseSeqNo;
 
-        leaveCS(CUDT::s_UDTUnited.m_GlobControlLock);
+        
 
-        // m_GlobControlLock lifted, m_GroupLock still locked.
-        // Now we can safely do this scoped way.
 
         if (m_bClosing)
         {

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2077,8 +2077,8 @@ vector<CUDTSocket*> CUDTGroup::recv_WaitForReadReady(const vector<CUDTSocket*>& 
     // If this set is empty, it won't roll even once, therefore output
     // will be surely empty. This will be checked then same way as when
     // reading from every socket resulted in error.
-    vector<CUDTSocket*> w_readReady;
-    w_readReady.reserve(sready.size());
+    vector<CUDTSocket*> readReady;
+    readReady.reserve(sready.size());
     for (CEPoll::fmap_t::const_iterator i = sready.begin(); i != sready.end(); ++i)
     {
         if (i->second & SRT_EPOLL_ERR)
@@ -2092,12 +2092,12 @@ vector<CUDTSocket*> CUDTGroup::recv_WaitForReadReady(const vector<CUDTSocket*>& 
         SRTSOCKET   id = i->first;
         CUDTSocket* ps = m_pGlobal->locateSocket_LOCKED(id);
         if (ps)
-            w_readReady.push_back(ps);
+            readReady.push_back(ps);
     }
     
     leaveCS(CUDT::s_UDTUnited.m_GlobControlLock);
 
-    return w_readReady;
+    return readReady;
 }
 
 void CUDTGroup::updateReadState(SRTSOCKET /* not sure if needed */, int32_t sequence)
@@ -2279,7 +2279,6 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
         // during the next time ahead check, after which they will become
         // horses.
 
-        //bool   still_alive = false;
         const size_t size = m_Group.size();
 
         // Prepare first the list of sockets to be added as connect-pending
@@ -3748,7 +3747,7 @@ RetryWaitBlocked:
 }
 
 // [[using locked(this->m_GroupLock)]]
-void CUDTGroup::sendBackup_SilenceRedundantLinks(vector<gli_t>&       w_parallel)
+void CUDTGroup::sendBackup_SilenceRedundantLinks(vector<gli_t>& w_parallel)
 {
     // The most important principle is to keep the data being sent constantly,
     // even if it means temporarily full redundancy. However, if you are certain

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -668,6 +668,9 @@ private:
     std::vector<CUDTSocket*> recv_CollectNonBroken(std::set<CUDTSocket*>& broken);
 
     /// The function polls alive member sockets and retrieves a list of read-ready.
+    /// [acquires lock for CUDT::s_UDTUnited.m_GlobControlLock]
+    /// [[using locked(m_GroupLock)]] temporally unlocks-locks internally
+    ///
     /// @returns list of read-ready sockets
     /// @throws CUDTException(MJ_CONNECTION, MN_NOCONN, 0)
     /// @throws CUDTException(MJ_AGAIN, MN_RDAVAIL, 0)

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -326,8 +326,7 @@ private:
                                      bool&                     w_none_succeeded,
                                      SRT_MSGCTRL&              w_mc,
                                      CUDTException&            w_cx);
-    void sendBackup_SilenceRedundantLinks(const std::vector<gli_t>& unstable,
-                                          std::vector<gli_t>&       w_parallel);
+    void sendBackup_SilenceRedundantLinks(std::vector<gli_t>&  w_parallel);
 
     void send_CheckValidSockets();
 
@@ -665,6 +664,14 @@ private:
     std::map<SRTSOCKET, ReadPos> m_Positions;
 
     ReadPos* checkPacketAhead();
+
+    std::vector<CUDTSocket*> recv_CollectNonBroken(std::set<CUDTSocket*>& broken);
+
+    /// The function polls alive member sockets and retrieves a list of read-ready.
+    /// @returns list of read-ready sockets
+    /// @throws CUDTException(MJ_CONNECTION, MN_NOCONN, 0)
+    /// @throws CUDTException(MJ_AGAIN, MN_RDAVAIL, 0)
+    std::vector<CUDTSocket*> recv_CollectReadReady(std::set<CUDTSocket*>& broken);
 
     // This is the sequence number of a packet that has been previously
     // delivered. Initially it should be set to SRT_SEQNO_NONE so that the sequence read

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -665,7 +665,7 @@ private:
 
     ReadPos* checkPacketAhead();
 
-    std::vector<CUDTSocket*> recv_CollectNonBroken(std::set<CUDTSocket*>& broken);
+    void recv_CollectAliveAndBroken(std::vector<CUDTSocket*>& w_alive, std::set<CUDTSocket*>& w_broken);
 
     /// The function polls alive member sockets and retrieves a list of read-ready.
     /// [acquires lock for CUDT::s_UDTUnited.m_GlobControlLock]
@@ -674,7 +674,7 @@ private:
     /// @returns list of read-ready sockets
     /// @throws CUDTException(MJ_CONNECTION, MN_NOCONN, 0)
     /// @throws CUDTException(MJ_AGAIN, MN_RDAVAIL, 0)
-    std::vector<CUDTSocket*> recv_CollectReadReady(std::set<CUDTSocket*>& broken);
+    std::vector<CUDTSocket*> recv_WaitForReadReady(const std::vector<CUDTSocket*>& aliveMembers, std::set<CUDTSocket*>& w_broken);
 
     // This is the sequence number of a packet that has been previously
     // delivered. Initially it should be set to SRT_SEQNO_NONE so that the sequence read


### PR DESCRIPTION
This PR mainly moves the part responsible for collecting alive links and polling them for read-readiness into a separate function, called from `CUDTGroup::recv(..)`.