### PR TITLE
[build] Fixed CMake CMP0048 policy restriction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,17 +9,21 @@
 
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
 set (SRT_VERSION 1.4.2)
+
+set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
+include(haiUtil) # needed for set_version_variables
 # CMake version 3.0 introduced the VERSION option of the project() command
 # to specify a project version as well as the name.
 if(${CMAKE_VERSION} VERSION_LESS "3.0.0")
   project(SRT C CXX)
+  # Sets SRT_VERSION_MJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
+  set_version_variables(SRT_VERSION ${SRT_VERSION})
 else()
   cmake_policy(SET CMP0048 NEW)
+  # Also sets SRT_VERSION_MJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
   project(SRT VERSION ${SRT_VERSION} LANGUAGES C CXX)
 endif()
 
-set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
-include(haiUtil)
 include(FindPkgConfig)
 # XXX See 'if (MINGW)' condition below, may need fixing.
 include(FindThreads)
@@ -46,9 +50,6 @@ set_if(SYMLINKABLE LINUX OR DARWIN OR BSD OR CYGWIN OR GNU)
 if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
 	include(GNUInstallDirs)
 endif()
-
-# Sets SRT_VERSION_MJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
-set_version_variables(SRT_VERSION ${SRT_VERSION})
 
 # The CMAKE_BUILD_TYPE seems not to be always set, weird.
 if (NOT DEFINED ENABLE_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,11 @@ include(haiUtil) # needed for set_version_variables
 # to specify a project version as well as the name.
 if(${CMAKE_VERSION} VERSION_LESS "3.0.0")
   project(SRT C CXX)
-  # Sets SRT_VERSION_MJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
+  # Sets SRT_VERSION_MAJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
   set_version_variables(SRT_VERSION ${SRT_VERSION})
 else()
   cmake_policy(SET CMP0048 NEW)
-  # Also sets SRT_VERSION_MJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
+  # Also sets SRT_VERSION_MAJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
   project(SRT VERSION ${SRT_VERSION} LANGUAGES C CXX)
 endif()
 
@@ -1202,8 +1202,6 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 	MafReadDir(test filelist.maf
 		SOURCES SOURCES_unittests
 	)
-	
-	message(STATUS "Unit test sources: ${SOURCES_unittests}")
 
 	srt_add_program(test-srt ${SOURCES_unittests})
 	srt_make_application(test-srt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,15 @@
 #
 
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
-# XXX This can be potentially done in future, but there still exist
-# some dependent project using cmake 2.8 - this can't be done this way.
-#cmake_minimum_required (VERSION 3.0.2 FATAL_ERROR)
-#project(SRT VERSION "1.4.2")
-project(SRT C CXX)
+set (SRT_VERSION 1.4.2)
+# CMake version 3.0 introduced the VERSION option of the project() command
+# to specify a project version as well as the name.
+if(${CMAKE_VERSION} VERSION_LESS "3.0.0")
+  project(SRT C CXX)
+else()
+  cmake_policy(SET CMP0048 NEW)
+  project(SRT VERSION ${SRT_VERSION} LANGUAGES C CXX)
+endif()
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil)
@@ -43,7 +47,7 @@ if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
 	include(GNUInstallDirs)
 endif()
 
-set (SRT_VERSION 1.4.2)
+# Sets SRT_VERSION_MJOR, SRT_VERSION_MINOR, SRT_VERSION_PATCH
 set_version_variables(SRT_VERSION ${SRT_VERSION})
 
 # The CMAKE_BUILD_TYPE seems not to be always set, weird.
@@ -774,8 +778,6 @@ MafReadDir(srtcore filelist.maf
 	PROTECTED_HEADERS HEADERS_srt
 	PRIVATE_HEADERS HEADERS_srt_private
 )
-
-message(STATUS "SRT Sources: ${SOURCES_srt}")
 
 # Auto generated version file and add it to the HEADERS_srt list.
 if(DEFINED ENV{APPVEYOR_BUILD_NUMBER})


### PR DESCRIPTION
CMake version 3.0 introduced the VERSION option of the `project()` command to specify a project version as well as the name.
CMake version 3.19.3 warns when the policy is not set and uses OLD behavior.
See [CMP0048](https://cmake.org/cmake/help/latest/policy/CMP0048.html).

```shell
CMake Warning (dev) at CMakeLists.txt:15 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    CMAKE_PROJECT_VERSION
    CMAKE_PROJECT_VERSION_MAJOR
    CMAKE_PROJECT_VERSION_MINOR
    CMAKE_PROJECT_VERSION_PATCH
```

This PR uses the new policy for CMake Versions above 3.0.