### PR TITLE
[apps] Fix virtual destructor for abstract struct SrtStatData

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -405,7 +405,6 @@ struct SrtStatsTableInit
         STAT(RECV, bytesLost, byteRcvLoss);
         STAT(RECV, bytesDropped, byteRcvDrop);
         STAT(RECV, mbitRate, mbpsRecvRate);
-
     }
 } g_SrtStatsTableInit (g_SrtStatsTable);
 

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -380,7 +380,6 @@ public:
 
 protected:
     std::map<std::string, std::string> options;
-
 };
 
 extern std::vector<std::unique_ptr<SrtStatData>> g_SrtStatsTable;

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -333,6 +333,7 @@ struct SrtStatData
     std::string longname;
 
     SrtStatData(SrtStatCat cat, std::string n, std::string l): category(cat), name(n), longname(l) {}
+    virtual ~SrtStatData() {}
 
     virtual void PrintValue(std::ostream& str, const CBytePerfMon& mon) = 0;
 };


### PR DESCRIPTION
Added virtual destructor for abstract struct SrtStatData.
A build warning after #1743.

```
/c++/v1/memory:2368:5: warning: delete called on 'SrtStatData' that is abstract but has non-virtual destructor
      [-Wdelete-abstract-non-virtual-dtor]
    delete __ptr;
    ^
/c++/v1/memory:2623:7: note: in instantiation of member function 'std::__1::default_delete<SrtStatData>::operator()'
      requested here
      __ptr_.second()(__tmp);
      ^
/c++/v1/memory:2577:19: note: in instantiation of member function 'std::__1::unique_ptr<SrtStatData,
      std::__1::default_delete<SrtStatData> >::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
/c++/v1/memory:1936:64: note: in instantiation of member function 'std::__1::unique_ptr<SrtStatData,
      std::__1::default_delete<SrtStatData> >::~unique_ptr' requested here
    _LIBCPP_INLINE_VISIBILITY void destroy(pointer __p) {__p->~_Tp();}
                                                               ^
/c++/v1/memory:1798:18: note: in instantiation of member function 'std::__1::allocator<std::__1::unique_ptr<SrtStatData,
      std::__1::default_delete<SrtStatData> > >::destroy' requested here
            {__a.destroy(__p);}
                 ^
/c++/v1/memory:1635:14: note: in instantiation of function template specialization
      'std::__1::allocator_traits<std::__1::allocator<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > > >::__destroy<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> >
      >' requested here
            {__destroy(__has_destroy<allocator_type, _Tp*>(), __a, __p);}
             ^
/c++/v1/vector:426:25: note: in instantiation of function template specialization
      'std::__1::allocator_traits<std::__1::allocator<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > > >::destroy<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > >'
      requested here
        __alloc_traits::destroy(__alloc(), _VSTD::__to_address(--__soon_to_be_end));
                        ^
/c++/v1/vector:369:29: note: in instantiation of member function
      'std::__1::__vector_base<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> >, std::__1::allocator<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > >
      >::__destruct_at_end' requested here
    void clear() _NOEXCEPT {__destruct_at_end(__begin_);}
                            ^
/c++/v1/vector:463:9: note: in instantiation of member function
      'std::__1::__vector_base<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> >, std::__1::allocator<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > > >::clear'
      requested here
        clear();
        ^
/c++/v1/vector:495:5: note: in instantiation of member function
      'std::__1::__vector_base<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> >, std::__1::allocator<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > >
      >::~__vector_base' requested here
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/apps/apputil.cpp:364:33: note: in instantiation of member function 'std::__1::vector<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> >,
      std::__1::allocator<std::__1::unique_ptr<SrtStatData, std::__1::default_delete<SrtStatData> > > >::vector' requested here
vector<unique_ptr<SrtStatData>> g_SrtStatsTable;
```