### PR TITLE
[core] Minor: renamed CUDT m_tsTmpActiveSince to m_tsFreshActivation

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1556,7 +1556,7 @@ void CUDT::open()
 
     m_iReXmitCount   = 1;
     m_tsUnstableSince = steady_clock::time_point();
-    m_tsTmpActiveSince = steady_clock::time_point();
+    m_tsFreshActivation = steady_clock::time_point();
     m_iPktCount      = 0;
     m_iLightACKCount = 1;
 
@@ -5763,7 +5763,7 @@ void *CUDT::tsbpd(void *param)
 
         if (!is_zero(tsbpdtime))
         {
-            const steady_clock::duration timediff = tsbpdtime - steady_clock::now();
+            IF_HEAVY_LOGGING(const steady_clock::duration timediff = tsbpdtime - steady_clock::now());
             /*
              * Buffer at head of queue is not ready to play.
              * Schedule wakeup when it will be.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1189,8 +1189,8 @@ public:
     static const size_t MAX_SID_LENGTH = 512;
 
 private: // Timers functions
-    time_point m_tsTmpActiveSince; // time since temporary activated, or 0 if not temporary activated
-    time_point m_tsUnstableSince;  // time since unexpected ACK delay experienced, or 0 if link seems healthy
+    time_point m_tsFreshActivation; // time of fresh activation of the link, or 0 if not in activation phase or idle
+    time_point m_tsUnstableSince;   // time since unexpected ACK delay experienced, or 0 if link seems healthy
     
     static const int BECAUSE_NO_REASON = 0, // NO BITS
                      BECAUSE_ACK       = 1 << 0,

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1189,7 +1189,7 @@ public:
     static const size_t MAX_SID_LENGTH = 512;
 
 private: // Timers functions
-    time_point m_tsFreshActivation; // time of fresh activation of the link, or 0 if not in activation phase or idle
+    time_point m_tsFreshActivation; // time of fresh activation of the link, or 0 if past the activation phase or idle
     time_point m_tsUnstableSince;   // time since unexpected ACK delay experienced, or 0 if link seems healthy
     
     static const int BECAUSE_NO_REASON = 0, // NO BITS

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -3057,9 +3057,9 @@ bool CUDTGroup::sendBackup_CheckRunningStability(const gli_t d, const time_point
             {
                 check_stability = false;
                 HLOGC(gslog.Debug,
-                    log << "grp/sendBackup: link @" << d->id
-                        << " activated after ACK, "
-                           "not checking for stability");
+                      log << "grp/sendBackup: link @" << d->id
+                          << " activated after ACK, "
+                             "not checking for stability");
             }
             else
             {


### PR DESCRIPTION
Extracting some minor refactoring from a feature branch with runtime link stability threshold.

When a member link is activated, according to the new naming its state is "fresh activated", and it is in the "activation phase".
Therefore `CUDT::m_tsTmpActiveSince` is renamed to `m_tsFreshActivation`.