### PR TITLE
Runtime link stability timeout for main/backup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ endforeach()
 # SRT_DEBUG_TSBPD_WRAP 1          /* Debug packet timestamp wraparound */
 # SRT_DEBUG_TLPKTDROP_DROPSEQ 1
 # SRT_DEBUG_SNDQ_HIGHRATE 1
+# SRT_DEBUG_BONDING_STATES 1
 # SRT_MAVG_SAMPLING_RATE 40       /* Max sampling rate */
 
 # option defaults

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -427,6 +427,8 @@ function will return the group, not this socket ID.
 | --------------------- | ----- | ------- | ---------- | ------ | -------- | ------ | --- | ------ |
 | `SRTO_GROUPSTABTIMEO` | 1.5.0 | pre     | `int32_t`  | ms     | 80       | 10-... | W   | GSD+   |
 
+**Not in use at the moment. Is to be repurposed in SRT v1.4.3!**
+
 This setting is used for groups of type `SRT_GTYPE_BACKUP`. It defines the stability
 timeout, which is the maximum interval between two consecutive packets retrieved from
 the peer on the currently active link. These two packets can be of any type,

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11172,7 +11172,7 @@ bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_rea
      * (keepalive fix)
      * duB:
      * It seems there is confusion of the direction of the Response here.
-     * LastRspTime is supposed to be when receiving (data/ctrl) from peer
+     * lastRspTime is supposed to be when receiving (data/ctrl) from peer
      * as shown in processCtrl and processData,
      * Here we set because we sent something?
      *

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -374,9 +374,12 @@ public: // internal API
 
     bool isOPT_TsbPd() const { return m_bOPT_TsbPd; }
     int RTT() const { return m_iRTT; }
+    int RTTVar() const { return m_iRTTVar; }
     int32_t sndSeqNo() const { return m_iSndCurrSeqNo; }
     int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
     bool overrideSndSeqNo(int32_t seq);
+    srt::sync::steady_clock::time_point LastRspTime() const { return m_tsLastRspTime; }
+    srt::sync::steady_clock::time_point ActivatedSince() const { return m_tsActivationSince; }
 
     int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
     int flowWindowSize() const { return m_iFlowWindowSize; }
@@ -386,6 +389,7 @@ public: // internal API
     int MSS() const { return m_iMSS; }
 
     uint32_t latency_us() const {return m_iTsbPdDelay_ms*1000; }
+    int peer_idle_tout_ms() const { return m_iOPT_PeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
     size_t OPT_PayloadSize() const { return m_zOPT_ExpPayloadSize; }
     int sndLossLength() { return m_pSndLossList->getLossLength(); }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -378,8 +378,8 @@ public: // internal API
     int32_t sndSeqNo() const { return m_iSndCurrSeqNo; }
     int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
     bool overrideSndSeqNo(int32_t seq);
-    srt::sync::steady_clock::time_point LastRspTime() const { return m_tsLastRspTime; }
-    srt::sync::steady_clock::time_point FreshActivationStart() const { return m_tsFreshActivation; }
+    srt::sync::steady_clock::time_point lastRspTime() const { return m_tsLastRspTime; }
+    srt::sync::steady_clock::time_point freshActivationStart() const { return m_tsFreshActivation; }
 
     int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
     int flowWindowSize() const { return m_iFlowWindowSize; }
@@ -388,8 +388,8 @@ public: // internal API
     int64_t maxBandwidth() const { return m_llMaxBW; }
     int MSS() const { return m_iMSS; }
 
-    uint32_t peer_latency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
-    int peer_idle_tout_ms() const { return m_iOPT_PeerIdleTimeout; }
+    uint32_t peerLatency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
+    int peerIdleTimeout_ms() const { return m_iOPT_PeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
     size_t OPT_PayloadSize() const { return m_zOPT_ExpPayloadSize; }
     int sndLossLength() { return m_pSndLossList->getLossLength(); }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -388,7 +388,7 @@ public: // internal API
     int64_t maxBandwidth() const { return m_llMaxBW; }
     int MSS() const { return m_iMSS; }
 
-    uint32_t latency_us() const {return m_iTsbPdDelay_ms*1000; }
+    uint32_t peer_latency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
     int peer_idle_tout_ms() const { return m_iOPT_PeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
     size_t OPT_PayloadSize() const { return m_zOPT_ExpPayloadSize; }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -379,7 +379,7 @@ public: // internal API
     int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
     bool overrideSndSeqNo(int32_t seq);
     srt::sync::steady_clock::time_point LastRspTime() const { return m_tsLastRspTime; }
-    srt::sync::steady_clock::time_point ActivatedSince() const { return m_tsActivationSince; }
+    srt::sync::steady_clock::time_point FreshActivationStart() const { return m_tsFreshActivation; }
 
     int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
     int flowWindowSize() const { return m_iFlowWindowSize; }


### PR DESCRIPTION
The existing option `SRTO_GROUPSTABTIMEO` sets a timeout for the last response time of a group member link.
The same value is used for all member links.

An optimal timeout value depends on the network conditions (RTT, loss rate), and can be calculated at runtime.

This PR replaces the usage of  `SRTO_GROUPSTABTIMEO`  with a dynamic link stability timeout calculated at runtime.

When an idle or newly connected link is activated, it first transits to an "activation phase" and stays there for `SRTO_PEERLATENCY + 50ms` with the minimum allowed value of 60 ms, and the maximum allowed value of `SRTO_PEERIDLETIMEO`.
It is expected that at the start of sending RTT, RTTVar and link stability are not yet known. Therefore a link needs to stay active for this period to judge if it is stable or not.

After the activation phase ends, the link stability timeout is determined as `2 × RTT+ 4 × RTTVar` with the minimum allowed value of 60 ms, and the maximum allowed value of `SRTO_LATENCY`.

Fixes #1768 

### TODO

- [x] Repurpose `SRTO_GROUPSTABTIMEO` to set the minimum timeout value -> moved to #1792.
- [x] PR #1774 extracts some minor renaming. Update this PR once that one is merged.
- [x] Replace 50ms in activation period with `5 * COMM_SYN_INTERVAL_US`
- [x] The `weight` parameter of `sendBackup_CheckRunningLinkStable` is only needed for tracing. To remove?
  **Decision**: leaving for now. Will be useful for further testing.
- [x] Remove PEERIDLETIMEO from initial stability timeout.
`Initial Link Stability Timeout = max(Minimum Link Stability Timeout, SRT Latency)`, where Minimum Link Stability Timeout = 60 ms
`Activation Period = Initial Link Stability Timeout + 5 * SYN, where SYN=10`
`Dynamic Link Stability Timeout = min(max(Minimum Link Stability Timeout, 2RTT + 4RTTVar), SRT Latency)`