### PR TITLE
[core] Fixed packet drop when reading from members

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2095,7 +2095,8 @@ vector<CUDTSocket*> CUDTGroup::recv_WaitForReadReady(const vector<CUDTSocket*>& 
         }
         else if (sock->core().m_pRcvBuffer->isRcvDataReady())
         {
-            // No reqd-readiness on the socket, but could have missed or not yet handled, so check the state manually
+            // No read-readiness reported by epoll, but probably missed or not yet handled
+            // as the receiver buffer is read-ready.
             readReady.push_back(sock);
         }
     }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2093,20 +2093,10 @@ vector<CUDTSocket*> CUDTGroup::recv_WaitForReadReady(const vector<CUDTSocket*>& 
 
             readReady.push_back(*sockiter);
         }
-        else
+        else if (sock->core().m_pRcvBuffer->isRcvDataReady())
         {
             // No reqd-readiness on the socket, but could have missed or not yet handled, so check the state manually
-            steady_clock::time_point tsbpdtime;
-            int current_pkt_seq = 0;
-
-            int32_t skiptoseqno = SRT_SEQNO_NONE;
-            bool    passack     = true; // Get next packet to wait for even if not acked
-            const bool rxready = sock->core().m_pRcvBuffer->getRcvFirstMsg((tsbpdtime), (passack), (skiptoseqno), (current_pkt_seq));
-
-            if (rxready)
-            {
-                readReady.push_back(sock);
-            }
+            readReady.push_back(sock);
         }
     }
     


### PR DESCRIPTION
TSBPD thread of a group member might not yet trigger epoll read-ready event, while it is potentially ready.
If another member signals read-readiness ahead of the current position it will result in a packet drop by a group.

This PR changes the logic of a group waiting for read-readiness.
When a notification is received, not only notified sockets are added to the reading list, but also those not notified, but with receiver buffer ready to read.

Fixes #1755 
Fixes: #1757 (likely the same reason, tests show no losses when switching back)