### PR TITLE
[apps] Fix too premature stopped reading in srt-file-transmit

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -520,8 +520,6 @@ bool DoDownload(UriParser& us, string directory, string filename,
         status = srt_getsockstate(s);
         Verb() << "Event with status " << status << "\n";
 
-        bool broken = false;
-
         switch (status)
         {
             case SRTS_LISTENING:
@@ -560,9 +558,11 @@ bool DoDownload(UriParser& us, string directory, string filename,
             }
             break;
 
+            // No need to do any special action in case of broken.
+            // The app will just try to read and in worst case it will
+            // get an error.
             case SRTS_BROKEN:
             cerr << "Connection closed, reading buffer remains\n";
-            broken = true;
             break;
 
             case SRTS_NONEXIST:
@@ -608,7 +608,7 @@ bool DoDownload(UriParser& us, string directory, string filename,
             if (n == 0)
             {
                 result = true;
-                cerr << "Download COMPLETE.";
+                cerr << "Download COMPLETE.\n";
                 break;
             }
 

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -520,6 +520,8 @@ bool DoDownload(UriParser& us, string directory, string filename,
         status = srt_getsockstate(s);
         Verb() << "Event with status " << status << "\n";
 
+        bool broken = false;
+
         switch (status)
         {
             case SRTS_LISTENING:
@@ -557,7 +559,12 @@ bool DoDownload(UriParser& us, string directory, string filename,
                 }
             }
             break;
+
             case SRTS_BROKEN:
+            cerr << "Connection closed, reading buffer remains\n";
+            broken = true;
+            break;
+
             case SRTS_NONEXIST:
             case SRTS_CLOSED:
             {


### PR DESCRIPTION
Fixes #1764 

The problem: In `DoDownload` the application was incorrectly reacting on `SRTS_BROKEN` state by stopping reading too prematurely, while there were still data to extract, causing randomly cut files.