### PR TITLE
[build] Using xenial dist in Travis with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: cpp
-dist: trusty
-jdk:
-  - oraclejdk11
+dist: xenial
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
     - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
         export CC="x86_64-w64-mingw32-gcc";
         export CXX="x86_64-w64-mingw32-g++";
-        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON" -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON" -DENABLE_APPS=OFF -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
       elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
         cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
       elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -88,8 +88,8 @@ script:
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6*";
+        source ./scripts/collect-gcov.sh
       fi
-    - source ./scripts/collect-gcov.sh
     - if (( "$RUN_CODECOV" )); then
         bash <(curl -s https://codecov.io/bash);
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
     - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
         export CC="x86_64-w64-mingw32-gcc";
         export CXX="x86_64-w64-mingw32-g++";
-        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON" -DENABLE_APPS=OFF -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON" -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
       elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
         cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
       elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
@@ -88,7 +88,7 @@ script:
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6*";
-        source ./scripts/collect-gcov.sh
+        source ./scripts/collect-gcov.sh;
       fi
     - if (( "$RUN_CODECOV" )); then
         bash <(curl -s https://codecov.io/bash);

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: xenial
+dist: bionic
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: bionic
+dist: xenial
 
 addons:
     apt:
@@ -68,7 +68,7 @@ script:
     - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
         export CC="x86_64-w64-mingw32-gcc";
         export CXX="x86_64-w64-mingw32-g++";
-        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON" -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
+        cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="OFF" -DUSE_OPENSSL_PC="OFF" -DOPENSSL_ROOT_DIR="$PWD/openssl" -DCMAKE_SYSTEM_NAME="Windows";
       elif [ "$TRAVIS_OS_NAME" == "linux" ]; then
         cmake . -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS -DENABLE_UNITTESTS="ON";
       elif [ "$TRAVIS_OS_NAME" == "osx" ]; then

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -449,7 +449,7 @@ bool DoUpload(UriParser& ut, string path, string filename,
             }
             Verb() << "Sending buffer still: bytes=" << bytes << " blocks="
                 << blocks;
-            this_thread::sleep_for(chrono::milliseconds(250));
+            std::this_thread::sleep_for(chrono::milliseconds(250));
         }
     }
 

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -449,7 +449,7 @@ bool DoUpload(UriParser& ut, string path, string filename,
             }
             Verb() << "Sending buffer still: bytes=" << bytes << " blocks="
                 << blocks;
-            std::this_thread::sleep_for(chrono::milliseconds(250));
+            srt::sync::this_thread::sleep_for(srt::sync::milliseconds_from(250));
         }
     }
 


### PR DESCRIPTION
SonarCould no longer supports Java versions below 11. Thus out Travis CI is failing at the moment.
This PR upgrades the Linux disttro used in Travis to Xenial, which has Java 11 by default.

Unfortunately, there are some issues with C++11 threads in MinGW build, but we only have them in unit tests now.
These unit tests are not run for MinGW build anyway, therefore it is pretty safe to exclude them from the build for MinGW.

And there is also a small fix for `srt-file-transmit` that allows building this app under MinGW and partially addresses issue #177.

- [SonarCloud end of pre Java 11 support](https://sonarcloud.io/documentation/appendices/end-of-support/)
- [Travis SonarCloud integration guide](https://docs.travis-ci.com/user/sonarcloud/)