### PR TITLE
[testapp] Fixed hangup when exitting on interrupt

### DIFF
--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -101,14 +101,11 @@ struct AlarmExit: public std::runtime_error
     }
 };
 
-volatile bool int_state = false;
 volatile bool timer_state = false;
 void OnINT_ForceExit(int)
 {
     cerr << "\n-------- REQUESTED INTERRUPT!\n";
-    int_state = true;
-    if ( transmit_throw_on_interrupt )
-        throw ForcedExit("Requested exception interrupt");
+    transmit_int_state = true;
 }
 
 std::string g_interrupt_reason;
@@ -116,7 +113,7 @@ std::string g_interrupt_reason;
 void OnAlarm_Interrupt(int)
 {
     cerr << "\n---------- INTERRUPT ON TIMEOUT: hang on " << g_interrupt_reason << "!\n";
-    int_state = false; // JIC
+    transmit_int_state = true; // JIC
     timer_state = true;
     throw AlarmExit("Watchdog bites hangup");
 }
@@ -419,6 +416,8 @@ int main( int argc, char** argv )
     if ( !SysInitializeNetwork() )
         throw std::runtime_error("Can't initialize network!");
 
+    srt_startup();
+
     // Symmetrically, this does a cleanup; put into a local destructor to ensure that
     // it's called regardless of how this function returns.
     struct NetworkCleanup
@@ -426,6 +425,7 @@ int main( int argc, char** argv )
         ~NetworkCleanup()
         {
             SysCleanupNetwork();
+            srt_cleanup();
         }
     } cleanupobj;
 
@@ -835,7 +835,7 @@ int main( int argc, char** argv )
     }
     catch(std::exception& x)
     {
-        if (::int_state)
+        if (::transmit_int_state)
         {
             // The application was terminated by SIGINT or SIGTERM.
             // Don't print anything, just exit gently like ffmpeg.
@@ -939,7 +939,7 @@ int main( int argc, char** argv )
 
             Verb() << "sent";
 
-            if ( int_state )
+            if (::transmit_int_state)
             {
                 Verror() << "\n (interrupted on request)";
                 break;
@@ -985,7 +985,7 @@ int main( int argc, char** argv )
         {
             Verror() << "Exit on timeout.";
         }
-        else if (::int_state)
+        else if (::transmit_int_state)
         {
             Verror() << "Exit on interrupt.";
             // Do nothing.

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -49,6 +49,7 @@ using srt_logging::MemberStatusStr;
 #endif
 
 volatile bool transmit_throw_on_interrupt = false;
+volatile bool transmit_int_state = false;
 int transmit_bw_report = 0;
 unsigned transmit_stats_report = 0;
 size_t transmit_chunk_size = SRT_LIVE_DEF_PLSIZE;
@@ -530,8 +531,15 @@ void SrtCommon::AcceptNewClient()
 
         int len = 2;
         SRTSOCKET ready[2];
-        if (srt_epoll_wait(srt_conn_epoll, 0, 0, ready, &len, -1, 0, 0, 0, 0) == -1)
+        while (srt_epoll_wait(srt_conn_epoll, 0, 0, ready, &len, 1000, 0, 0, 0, 0) == -1)
+        {
+            if (::transmit_int_state)
+                Error("srt_epoll_wait for srt_accept: interrupt");
+
+            if (srt_getlasterror(NULL) == SRT_ETIMEOUT)
+                continue;
             Error("srt_epoll_wait(srt_conn_epoll)");
+        }
 
         Verb() << "[EPOLL: " << len << " sockets] " << VerbNoEOL;
     }
@@ -785,6 +793,11 @@ int SrtCommon::ConfigurePost(SRTSOCKET sock)
 
         if (m_timeout)
             result = srt_setsockopt(sock, 0, SRTO_RCVTIMEO, &m_timeout, sizeof m_timeout);
+        else
+        {
+            int timeout = 1000;
+            result = srt_setsockopt(sock, 0, SRTO_RCVTIMEO, &timeout, sizeof timeout);
+        }
         if (result == -1)
             return result;
     }
@@ -2274,6 +2287,9 @@ MediaPacket SrtSource::Read(size_t chunk)
         }
 #endif
 
+        if (::transmit_int_state)
+            Error("srt_recvmsg2: interrupted");
+
         ::transmit_throw_on_interrupt = true;
         stat = srt_recvmsg2(m_sock, data.data(), chunk, &mctrl);
         ::transmit_throw_on_interrupt = false;
@@ -2323,6 +2339,13 @@ Epoll_again:
                     }
                     // If was -1, then passthru.
                 }
+            }
+            else
+            {
+                // In blocking mode it uses a minimum of 1s timeout,
+                // and continues only if interrupt not requested.
+                if (srt_getlasterror(NULL) == SRT_EASYNCRCV)
+                    continue;
             }
             Error("srt_recvmsg2");
         }

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -22,6 +22,7 @@
 
 extern srt_listen_callback_fn* transmit_accept_hook_fn;
 extern void* transmit_accept_hook_op;
+extern volatile bool transmit_int_state;
 
 extern std::shared_ptr<SrtStatsWriter> transmit_stats_writer;
 


### PR DESCRIPTION
This changes the way how Control-C and SIGINT handling is done by simply setting a flag and checking the flag often during transmission and the interrupt does a gently exit.