### PR TITLE
[core] Fix warning and workaround ABI compatibility due to ENABLE_EXPERIMENTAL_BONDING

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -161,6 +161,10 @@ static const int32_t SRTGROUP_MASK = (1 << 30);
    typedef int SYSSOCKET;
 #endif
 
+#ifndef ENABLE_EXPERIMENTAL_BONDING
+#define ENABLE_EXPERIMENTAL_BONDING 0
+#endif
+
 typedef SYSSOCKET UDPSOCKET;
 
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -239,12 +239,12 @@ typedef enum SRT_SOCKOPT {
    SRTO_ENFORCEDENCRYPTION,  // Connection to be rejected or quickly broken when one side encryption set or bad password
    SRTO_IPV6ONLY,            // IPV6_V6ONLY mode
    SRTO_PEERIDLETIMEO,       // Peer-idle timeout (max time of silence heard from peer) in [ms]
+   SRTO_BINDTODEVICE,        // Forward the SOL_SOCKET/SO_BINDTODEVICE option on socket (pass packets only from that device)
 #if ENABLE_EXPERIMENTAL_BONDING
    SRTO_GROUPCONNECT,        // Set on a listener to allow group connection
    SRTO_GROUPSTABTIMEO,      // Stability timeout (backup groups) in [us]
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake
 #endif
-   SRTO_BINDTODEVICE,        // Forward the SOL_SOCKET/SO_BINDTODEVICE option on socket (pass packets only from that device)
    SRTO_PACKETFILTER = 60,   // Add and configure a packet filter
    SRTO_RETRANSMITALGO = 61  // An option to select packet retransmission algorithm
 } SRT_SOCKOPT;


### PR DESCRIPTION
The warning can be triggered when srt.h is included by other project.