### PR TITLE
[core] Fixed bonding packet timestamping

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -1231,6 +1231,8 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
     }
 
     vector<Sendstate> sendstates;
+    if (w_mc.srctime == 0)
+        w_mc.srctime = count_microseconds(steady_clock::now().time_since_epoch());
 
     for (vector<gli_t>::iterator snd = activeLinks.begin(); snd != activeLinks.end(); ++snd)
     {
@@ -3960,6 +3962,8 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
 
     // Maximum weight of active links.
     uint16_t maxActiveWeight = 0;
+    if (w_mc.srctime == 0)
+        w_mc.srctime = count_microseconds(steady_clock::now().time_since_epoch());
 
     // We believe that we need to send the payload over every activeLinks link anyway.
     for (vector<gli_t>::iterator snd = activeLinks.begin(); snd != activeLinks.end(); ++snd)


### PR DESCRIPTION
A more safe and straightforward fix of the issue with timestamping packets for bonding, compared to #1767.


### The proposed fix

Use `srctime` for all member links, instead of using the `srctime` value set by the first member link which has successfully sent a packet.

### The issue

The source time of a packet is stored as the number of microseconds since the SRT internal clock epoch.
However internal clock accuracy might be higher than 1 μs (e.g. 1 ns).
Therefore, the value returned in `MSG_CTRL::src_time` may have a lower accuracy compared to the actual time point used to timestamp a packet.
In the case of group sender, in particular, this may result in 1 μs timestamp difference of the same packet, sent over several links. The first link will use internal clock accuracy, while other links will have a μs accuracy of the `src_time`.

Example:
```
@485676736: pkt seqno %2131373032 ts=254960 (ts 00:58:28.139419815 [STD], start time 00:58:27.884459430 [STD])
@485676735: pkt seqno %2131373032 ts=254959 (ts 00:58:28.139419000 [STD], start time 00:58:27.884459430 [STD])
```