### PR TITLE
[core] Fixed pre-initialization of the last sample time for groups

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1147,6 +1147,10 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
        {
            u = s->m_GroupOf->m_GroupID;
            s->core().m_OPT_GroupConnect = 1; // should be derived from ls, but make sure
+
+           // Mark the beginning of the connection at the moment
+           // when the group ID is returned to the app caller
+            s->m_GroupOf->m_stats.tsLastSampleTime = steady_clock::now();
        }
        else
        {
@@ -1615,6 +1619,8 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
             // Or, OPEN should be removed from here and srt_connect(_group)
             // should block always if the group doesn't have neither 1 conencted link
             g.m_bOpened = true;
+
+            g.m_stats.tsLastSampleTime = steady_clock::now();
 
             f->laststatus = st;
             // Check the socket status and update it.


### PR DESCRIPTION
There was a lacking initialization of `m_stats.tsLastSampleTime` that should be the "alleged previous sample time", which caused that the interval-based statistics for the very first probe looked ridiculous. This field was correctly initialized to 0, so there was no undefined behavior, but the time interval counted against this and the time when sampling was done was time since epoch.

This fix sets the current time to this value in two places:
- in case when the group was just connected (not connected before, and first-ever connection has been established)
- in case when the group was about to return from the `srt_accept` call

This should mimic the similar initialization done in `CUDT::clearData` that is called just after "opening".