### PR TITLE
[core] Fixed group rcv buffering of ignored packet

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2380,13 +2380,8 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                     msgbuf = lostbuf;
                     stat = ps->core().receiveMessage((lostbuf), SRT_LIVE_MAX_PLSIZE, (mctrl), CUDTUnited::ERH_RETURN);
                     HLOGC(grlog.Debug,
-                          log << "group/recv: @" << id << " IGNORED data with %" << mctrl.pktseq << " #" << mctrl.msgno
-                              << ": " << (stat <= 0 ? "(NOTHING)" : BufferStamp(lostbuf, stat)));
-                    if (stat > 0)
-                    {
-                        // TODO: Too early to conclude. May be an ahead packet.
-                        m_stats.recvDiscard.Update(stat);
-                    }
+                          log << "group/recv: @" << id << " EXTRACTED EXTRA data with %" << mctrl.pktseq
+                              << " #" << mctrl.msgno << ": " << (stat <= 0 ? "(NOTHING)" : BufferStamp(lostbuf, stat)));
                 }
                 else
                 {
@@ -2455,7 +2450,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                               log << "group/recv: @" << id << " %" << mctrl.pktseq << " #" << mctrl.msgno
                                   << " BEHIND base=%" << m_RcvBaseSeqNo << " - discarding");
                         // The sequence is recorded, the packet has to be discarded.
-                        // That's all.
+                        m_stats.recvDiscard.Update(stat);
                         continue;
                     }
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2383,7 +2383,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                     HLOGC(grlog.Debug,
                           log << "group/recv: @" << id << " EXTRACTED EXTRA data with %" << mctrl.pktseq
                               << " #" << mctrl.msgno << ": " << (stat <= 0 ? "(NOTHING)" : BufferStamp(extrabuf, stat))
-                              << (CSeqNo::seqcmp(mctrl.pktseq, m_RcvBaseSeqNo) > 0 ? " - TO STORE" : " - TO IGNORE"));
+                              << (CSeqNo::seqcmp(mctrl.pktseq, m_RcvBaseSeqNo) > 1 ? " - TO STORE" : " - TO IGNORE"));
                 }
                 else
                 {


### PR DESCRIPTION
One of the member links can provide a packet ahead of the current position after another link has provided a valid packet.
This AHEAD packet is saved in group's buffer. However, the payload of the packet was incorrect, as it was read to a buffer different from the one being saved.

Fixes #1799

### Ignoring Packet
Already have the one to deliver.

```c++
if (output_size)
{
    // We have already the data, so this must fall on the floor
    char lostbuf[SRT_LIVE_MAX_PLSIZE];
    stat = ps->core().receiveMessage((lostbuf), SRT_LIVE_MAX_PLSIZE, (mctrl), CUDTUnited::ERH_RETURN);
```

### Buffering Packet

Here `buf` is different from `lostbuf` where the packet was read to.

```c++
if (seqdiff > 1)
{
    HLOGC(grlog.Debug,
            log << "@" << id << " %" << mctrl.pktseq << " #" << mctrl.msgno << " AHEAD base=%"
                << m_RcvBaseSeqNo);
    p->packet.assign(buf, buf + stat);
    p->mctrl = mctrl;
    break; // Don't read from that socket anymore.
}
```

### TODO

- [x] Fix `recvDiscard` stats (see TODO comment in the code)