### PR TITLE
Fix build with GCC 11

### DIFF
--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -15,6 +15,7 @@
 //#define ENABLE_CXX17
 
 #include <cstdlib>
+#include <limits>
 #ifdef ENABLE_STDCXX_SYNC
 #include <chrono>
 #include <thread>


### PR DESCRIPTION
The 'limits' header must be included explicitly.