### PR TITLE
[core] Fixed wrong check of common FEC configuration

### DIFF
--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -880,7 +880,8 @@ In case of the builtin `fec` filter, the mandatory parameter is `cols`, all
 others have their default values. For example, the configuration specified
 as `fec,cols:10` is `fec,rows:1,cols:10,arq:onreq,layout:even`.
 
-Examples for the builtin `fec` filter:
+Examples for the builtin `fec` filter (in "negotiated config" the parameters
+with default values are skipped):
 
 | Peer A               | Peer B      | Negotiated Config            | Result                   |
 |----------------------|-------------|------------------------------|--------------------------|

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -864,16 +864,24 @@ required, but it will accept any filter settings if provided by the peer. If
 this option is changed in both parties simultaneously, the resulting
 configuration will be an integrated configuration from both parties, that is,
 parameters that are set only on one side will have the value defined by that
-side, and parameters not set in either side will be set as default. In case
-when you use two different packet filter types, or for the same parameter
-there's a different value specified, it is treated as conflict, and the
-connection will be rejected.
+side, and parameters not set in either side will be set as default. In the
+following cases:
+
+* both sides define a different packet filter type
+* for the same key two different values were provided by both sides
+* mandatory parameters weren't provided by either side
+
+the connection will be rejected with `SRT_REJ_FILTER` code.
+
+In case of the builtin `fec` filter, the mandatory parameter is `cols`, all
+others have their default values.
 
 In general it is recommended that one party defines the full configuration,
 while the other keeps this value empty.
 
-If you read this option after the connection is established, it should return
-you the full configuration that has been agreed upon by both parties.
+If you read this option after the connection is established, it will return
+the full configuration that has been agreed upon by both parties (including
+default values).
 
 For details, see [Packet Filtering & FEC](packet-filtering-and-fec.md).
 

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -877,7 +877,19 @@ In the following cases:
 the connection will be rejected with `SRT_REJ_FILTER` code.
 
 In case of the builtin `fec` filter, the mandatory parameter is `cols`, all
-others have their default values.
+others have their default values. For example, the configuration specified
+as `fec,cols:10` is `fec,rows:1,cols:10,arq:onreq,layout:even`.
+
+Examples for the builtin `fec` filter:
+
+| Peer A               | Peer B      | Negotiated Config            | Result                   |
+|----------------------|-------------|------------------------------|--------------------------|
+| (no filter)          | (no filter) | (no filter)                  | OK                       |
+| fec                  | (no filter) | fec                          | missing `cols` parameter |
+| fec,cols:10          | fec         | fec,cols:10                  | OK                       |
+| FEC,cols:10          | FEC,cols:10 | FEC,cols:10                  | unknown filter 'FEC'     |
+| fec,layout:staircase | fec,cols:10 | fec,cols:10,layout:staircase | OK                       |
+| fec,cols:20          | fec,cols:10 | fec                          | parameter value conflict |
 
 In general it is recommended that one party defines the full configuration,
 while the other keeps this value empty.

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -227,7 +227,7 @@ The following table lists SRT socket options in alphabetical order. Option detai
 | [`SRTO_MSS`](#SRTO_MSS)                                |       | pre      | `int32_t` | bytes   | 1500          | 76..     | RW  | GSD   |
 | [`SRTO_NAKREPORT`](#SRTO_NAKREPORT)                    | 1.1.0 | pre      | `bool`    |         |  *            |          | RW  | GSD+  |
 | [`SRTO_OHEADBW`](#SRTO_OHEADBW)                        | 1.0.5 | post     | `int32_t` | %       | 25            | 5..100   | RW  | GSD   |
-| [`SRTO_PACKETFILTER`](#SRTO_PACKETFILTER)              | 1.4.0 | pre      | `string`  |         | ""            | [512]    | W   | GSD   |
+| [`SRTO_PACKETFILTER`](#SRTO_PACKETFILTER)              | 1.4.0 | pre      | `string`  |         | ""            | [512]    | RW  | GSD   |
 | [`SRTO_PASSPHRASE`](#SRTO_PASSPHRASE)                  | 0.0.0 | pre      | `string`  |         | ""            | [10..79] | W   | GSD   |
 | [`SRTO_PAYLOADSIZE`](#SRTO_PAYLOADSIZE)                | 1.3.0 | pre      | `int32_t` | bytes   | \*            | \*       | W   | GSD   |
 | [`SRTO_PBKEYLEN`](#SRTO_PBKEYLEN)                      | 0.0.0 | pre      | `int32_t` | bytes   | 0             | *        | RW  | GSD   |
@@ -854,7 +854,7 @@ and break quickly at any rise in packet loss.
 
 | OptName              | Since | Restrict | Type       |  Units  | Default  | Range  | Dir | Entity |
 | -------------------- | ----- | -------- | ---------- | ------- | -------- | ------ | --- | ------ |
-| `SRTO_PACKETFILTER`  | 1.4.0 | pre      | `string`   |         |  ""      | [512]  | W   | GSD    |
+| `SRTO_PACKETFILTER`  | 1.4.0 | pre      | `string`   |         |  ""      | [512]  | RW  | GSD    |
 
 Set up the packet filter. The string must match appropriate syntax for packet
 filter setup.
@@ -868,20 +868,23 @@ configuration integrating parameters from both parties, that is:
 * parameters that are set only on one side will have the value defined by that side
 * parameters not set in either side will be set as default
 
-In the following cases:
+The connection will be rejected with `SRT_REJ_FILTER` code in the following cases:
 
 * both sides define a different packet filter type
 * for the same key two different values were provided by both sides
 * mandatory parameters weren't provided by either side
 
-the connection will be rejected with `SRT_REJ_FILTER` code.
-
 In case of the built-in `fec` filter, the mandatory parameter is `cols`, all
 others have their default values. For example, the configuration specified
-as `fec,cols:10` is `fec,rows:1,cols:10,arq:onreq,layout:even`.
+as `fec,cols:10` is `fec,rows:1,cols:10,arq:onreq,layout:even`. See how to
+[configure the FEC Filter](packet-filtering-and-fec.md#configuring-the-fec-filter).
 
-Examples for the built-in `fec` filter (in "negotiated config" the parameters
-with default values are skipped):
+Below in the table are examples for the built-in `fec` filter. Note simplifications:
+
+* In "negotiated config" the parameters with default values are skipped
+
+* The "Result" column contains OK if the connection is accepted, otherwise it's
+rejected with SRT_REJ_FILTER code.
 
 | Peer A               | Peer B      | Negotiated Config            | Result                   |
 |----------------------|-------------|------------------------------|--------------------------|
@@ -895,9 +898,9 @@ with default values are skipped):
 In general it is recommended that one party defines the full configuration,
 while the other keeps this value empty.
 
-If you read this option after the connection is established, it will return
-the full configuration that has been agreed upon by both parties (including
-default values).
+Reading this option after the connection is established will return the full
+configuration that has been agreed upon by both parties (including default
+values).
 
 For details, see [Packet Filtering & FEC](packet-filtering-and-fec.md).
 

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -859,14 +859,14 @@ and break quickly at any rise in packet loss.
 Set up the packet filter. The string must match appropriate syntax for packet
 filter setup.
 
-Empty value of this option means that for this connection party filter isn't
+An empty value for this option means that for this connection the filter isn't
 required, but it will accept any filter settings if provided by the peer. If
-this option is changed in both parties simultaneously, the resulting
-configuration will be an integrated configuration from both parties, that is:
+this option is changed by both parties simultaneously, the result will be a
+configuration integrating parameters from both parties, that is:
 
-* parameters provided by both parties are taken, if they are identical
-* parameters provided by only one party are taken as they are
-* parameters not specified by either party will have the default value
+* parameters provided by both parties are accepted, if they are identical
+* parameters that are set only on one side will have the value defined by that side
+* parameters not set in either side will be set as default
 
 In the following cases:
 

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -876,11 +876,11 @@ In the following cases:
 
 the connection will be rejected with `SRT_REJ_FILTER` code.
 
-In case of the builtin `fec` filter, the mandatory parameter is `cols`, all
+In case of the built-in `fec` filter, the mandatory parameter is `cols`, all
 others have their default values. For example, the configuration specified
 as `fec,cols:10` is `fec,rows:1,cols:10,arq:onreq,layout:even`.
 
-Examples for the builtin `fec` filter (in "negotiated config" the parameters
+Examples for the built-in `fec` filter (in "negotiated config" the parameters
 with default values are skipped):
 
 | Peer A               | Peer B      | Negotiated Config            | Result                   |

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -862,10 +862,13 @@ filter setup.
 Empty value of this option means that for this connection party filter isn't
 required, but it will accept any filter settings if provided by the peer. If
 this option is changed in both parties simultaneously, the resulting
-configuration will be an integrated configuration from both parties, that is,
-parameters that are set only on one side will have the value defined by that
-side, and parameters not set in either side will be set as default. In the
-following cases:
+configuration will be an integrated configuration from both parties, that is:
+
+* parameters provided by both parties are taken, if they are identical
+* parameters provided by only one party are taken as they are
+* parameters not specified by either party will have the default value
+
+In the following cases:
 
 * both sides define a different packet filter type
 * for the same key two different values were provided by both sides

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -859,12 +859,21 @@ and break quickly at any rise in packet loss.
 Set up the packet filter. The string must match appropriate syntax for packet
 filter setup.
 
-As there can only be one configuration for both parties, it is recommended that
-one party defines the full configuration while the other only defines the matching
-packet filter type (for example, one sets `fec,cols:10,rows:-5,layout:staircase`
-and the other just `fec`). Both parties can also set this option to the same value.
-The packet filter function will attempt to merge configuration definitions, but if
-the options specified are in conflict, the connection will be rejected.
+Empty value of this option means that for this connection party filter isn't
+required, but it will accept any filter settings if provided by the peer. If
+this option is changed in both parties simultaneously, the resulting
+configuration will be an integrated configuration from both parties, that is,
+parameters that are set only on one side will have the value defined by that
+side, and parameters not set in either side will be set as default. In case
+when you use two different packet filter types, or for the same parameter
+there's a different value specified, it is treated as conflict, and the
+connection will be rejected.
+
+In general it is recommended that one party defines the full configuration,
+while the other keeps this value empty.
+
+If you read this option after the connection is established, it should return
+you the full configuration that has been agreed upon by both parties.
 
 For details, see [Packet Filtering & FEC](packet-filtering-and-fec.md).
 

--- a/docs/packet-filtering-and-fec.md
+++ b/docs/packet-filtering-and-fec.md
@@ -42,7 +42,8 @@ general syntax:
 ```
 The parts of this syntax are separated by commas. The first part is the name of 
 the filter. This is followed by one or more key:value pairs, the interpretation 
-of which depends on the filter type.
+of which depends on the filter type. Note that all keys and values are
+case-sensitive.
 
 You can try this out using the `SRTO_PACKETFILTER` option, or the
 `packetfilter` parameter in an SRT URI in the applications.

--- a/docs/packet-filtering-and-fec.md
+++ b/docs/packet-filtering-and-fec.md
@@ -49,7 +49,7 @@ You can try this out using the `SRTO_PACKETFILTER` option, or the
 `packetfilter` parameter in an SRT URI in the applications.
 
 The packet filter framework is open for extensions so that users may register
-their own filters. SRT provides also one builtin filter named "fec". This
+their own filters. SRT provides also one built-in filter named "fec". This
 filter implements the FEC mechanism, as described in SMPTE 2022-1-2007.
 
 ![SRT packet filter mechanism](/docs/images/packet-filter-mechanism.png)
@@ -57,7 +57,7 @@ filter implements the FEC mechanism, as described in SMPTE 2022-1-2007.
 On the input side, filtering occurs at the moment when a packet is extracted 
 from the send buffer. A filter may then do two things:
 
-* alter the packet before inserting it into the SRT channel (the builtin "fec"
+* alter the packet before inserting it into the SRT channel (the built-in "fec"
   filter doesn't do it, though)
 
 * insert another packet (such as an FEC control packet) into the channel ahead

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -462,7 +462,7 @@ extern const char* const srt_rejectreason_msg [] = {
     "Password required or unexpected",
     "MessageAPI/StreamAPI collision",
     "Congestion controller type collision",
-    "Packet Filter type collision",
+    "Packet Filter settings error",
     "Group settings collision",
     "Connection timeout"
 };

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2788,7 +2788,7 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
         }
         else
         {
-            if (!CheckFilterCompat(mycfg, cfg))
+            if (!CheckFilterCompat((mycfg), cfg))
                 return false;
         }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2640,6 +2640,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
 
                 if (!checkApplyFilterConfig(fltcfg))
                 {
+                    m_RejectReason = SRT_REJ_FILTER;
                     LOGC(cnlog.Error, log << "PEER'S FILTER CONFIG [" << fltcfg << "] has been rejected");
                     return false;
                 }
@@ -2747,7 +2748,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
 bool CUDT::checkApplyFilterConfig(const std::string &confstr)
 {
     SrtFilterConfig cfg;
-    if (!ParseFilterConfig(confstr, cfg))
+    if (!ParseFilterConfig(confstr, (cfg)))
         return false;
 
     // Now extract the type, if present, and
@@ -2767,7 +2768,7 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
         }
 
         SrtFilterConfig mycfg;
-        if (!ParseFilterConfig(thisconf, mycfg))
+        if (!ParseFilterConfig(thisconf, (mycfg)))
             return false;
 
         // Check only if both have set a filter of the same type.
@@ -2787,12 +2788,8 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
         }
         else
         {
-            // On a listener, only apply those that you haven't set
-            for (map<string, string>::iterator x = cfg.parameters.begin(); x != cfg.parameters.end(); ++x)
-            {
-                if (!mycfg.parameters.count(x->first))
-                    mycfg.parameters[x->first] = x->second;
-            }
+            if (!CheckFilterCompat(mycfg, cfg))
+                return false;
         }
 
         HLOGC(cnlog.Debug,
@@ -5487,10 +5484,20 @@ SRT_REJECT_REASON CUDT::setupCC()
         // At this point we state everything is checked and the appropriate
         // corrector type is already selected, so now create it.
         HLOGC(pflog.Debug, log << "filter: Configuring: " << m_config.m_PacketFilterConfig.c_str());
-        if (!m_PacketFilter.configure(this, &(m_pRcvQueue->m_UnitQueue), m_config.m_PacketFilterConfig.str()))
+        bool status = true;
+        try
         {
-            return SRT_REJ_FILTER;
+            // The filter configurer is build the way that allows to quit immediately
+            // exit by exception, but the exception is meant for the filter only.
+            status = m_PacketFilter.configure(this, &(m_pRcvQueue->m_UnitQueue), m_config.m_PacketFilterConfig.str());
         }
+        catch (CUDTException& )
+        {
+            status = false;
+        }
+
+        if (!status)
+            return SRT_REJ_FILTER;
 
         m_PktFilterRexmitLevel = m_PacketFilter.arqLevel();
     }

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -34,6 +34,9 @@
 using namespace std;
 using namespace srt_logging;
 
+
+const char FECFilterBuiltin::defaultConfig [] = "fec,cols:1,layout:even,arq:onreq";
+
 FECFilterBuiltin::FECFilterBuiltin(const SrtFilterInitializer &init, std::vector<SrtPacket> &provided, const string &confstr)
     : SrtPacketFilterBase(init)
     , m_fallback_level(SRT_ARQ_ONREQ)
@@ -2476,3 +2479,4 @@ size_t FECFilterBuiltin::ExtendColumns(size_t colgx)
 
     return colgx;
 }
+

--- a/srtcore/fec.h
+++ b/srtcore/fec.h
@@ -265,6 +265,8 @@ public:
     static const size_t EXTRA_SIZE = 4;
 
     virtual SRT_ARQLevel arqLevel() ATR_OVERRIDE { return m_fallback_level; }
+
+    static const char defaultConfig [];
 };
 
 #endif

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -42,9 +42,9 @@ bool ParseFilterConfig(std::string s, SrtFilterConfig& w_config)
 }
 
 // Parameters are passed by value because they need to be potentially modicied inside.
-bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer)
+bool CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer)
 {
-    PacketFilter::Factory* fac = PacketFilter::find(agent.type);
+    PacketFilter::Factory* fac = PacketFilter::find(w_agent.type);
     if (!fac)
         return false;
 
@@ -59,7 +59,7 @@ bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer)
     // Note that theoretically for FEC it could simply check for the "cols" parameter
     // that is the only mandatory one, but this is a procedure for packet filters in
     // general and every filter may define its own set of parameters and mandatory rules.
-    for (map<string, string>::iterator x = agent.parameters.begin(); x != agent.parameters.end(); ++x)
+    for (map<string, string>::iterator x = w_agent.parameters.begin(); x != w_agent.parameters.end(); ++x)
     {
         keys.insert(x->first);
         if (peer.parameters.count(x->first) == 0)
@@ -68,18 +68,18 @@ bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer)
     for (map<string, string>::iterator x = peer.parameters.begin(); x != peer.parameters.end(); ++x)
     {
         keys.insert(x->first);
-        if (agent.parameters.count(x->first) == 0)
-            agent.parameters[x->first] = x->second;
+        if (w_agent.parameters.count(x->first) == 0)
+            w_agent.parameters[x->first] = x->second;
     }
 
-    HLOGC(cnlog.Debug, log << "CheckFilterCompat: re-filled: AGENT:" << Printable(agent.parameters)
+    HLOGC(cnlog.Debug, log << "CheckFilterCompat: re-filled: AGENT:" << Printable(w_agent.parameters)
             << " PEER:" << Printable(peer.parameters));
 
     // Complete nonexistent keys with default values
     for (map<string, string>::iterator x = defaults.parameters.begin(); x != defaults.parameters.end(); ++x)
     {
-        if (!agent.parameters.count(x->first))
-            agent.parameters[x->first] = x->second;
+        if (!w_agent.parameters.count(x->first))
+            w_agent.parameters[x->first] = x->second;
         if (!peer.parameters.count(x->first))
             peer.parameters[x->first] = x->second;
     }
@@ -89,10 +89,10 @@ bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer)
         // Note: operator[] will insert an element with default value
         // if it doesn't exist. This will inject the empty string as value,
         // which is acceptable.
-        if (agent.parameters[*x] != peer.parameters[*x])
+        if (w_agent.parameters[*x] != peer.parameters[*x])
         {
             LOGC(cnlog.Error, log << "Packet Filter (" << defaults.type << "): collision on '" << (*x)
-                    << "' parameter (agent:" << agent.parameters[*x] << " peer:" << (peer.parameters[*x]) << ")");
+                    << "' parameter (agent:" << w_agent.parameters[*x] << " peer:" << (peer.parameters[*x]) << ")");
             return false;
         }
     }

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -54,6 +54,28 @@ bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer)
         return false;
     }
 
+    set<string> keys;
+    // Extract all keys to identify also unspecified parameters on both sides
+    // Note that theoretically for FEC it could simply check for the "cols" parameter
+    // that is the only mandatory one, but this is a procedure for packet filters in
+    // general and every filter may define its own set of parameters and mandatory rules.
+    for (map<string, string>::iterator x = agent.parameters.begin(); x != agent.parameters.end(); ++x)
+    {
+        keys.insert(x->first);
+        if (peer.parameters.count(x->first) == 0)
+            peer.parameters[x->first] = x->second;
+    }
+    for (map<string, string>::iterator x = peer.parameters.begin(); x != peer.parameters.end(); ++x)
+    {
+        keys.insert(x->first);
+        if (agent.parameters.count(x->first) == 0)
+            agent.parameters[x->first] = x->second;
+    }
+
+    HLOGC(cnlog.Debug, log << "CheckFilterCompat: re-filled: AGENT:" << Printable(agent.parameters)
+            << " PEER:" << Printable(peer.parameters));
+
+    // Complete nonexistent keys with default values
     for (map<string, string>::iterator x = defaults.parameters.begin(); x != defaults.parameters.end(); ++x)
     {
         if (!agent.parameters.count(x->first))
@@ -62,14 +84,15 @@ bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer)
             peer.parameters[x->first] = x->second;
     }
 
-    for (map<string, string>::iterator x = agent.parameters.begin(); x != agent.parameters.end(); ++x)
+    for (set<string>::iterator x = keys.begin(); x != keys.end(); ++x)
     {
-        if (peer.parameters.count(x->first) == 0)  // key not defined in peer
-            peer.parameters[x->first] = x->second; // override with a value from agent
-        else if (x->second != peer.parameters[x->first])
+        // Note: operator[] will insert an element with default value
+        // if it doesn't exist. This will inject the empty string as value,
+        // which is acceptable.
+        if (agent.parameters[*x] != peer.parameters[*x])
         {
-            LOGC(cnlog.Error, log << "Packet Filter (" << defaults.type << "): collision on '" << x->second
-                    << "' parameter (agent:" << x->second << " peer:" << (peer.parameters[x->first]) << ")");
+            LOGC(cnlog.Error, log << "Packet Filter (" << defaults.type << "): collision on '" << (*x)
+                    << "' parameter (agent:" << agent.parameters[*x] << " peer:" << (peer.parameters[*x]) << ")");
             return false;
         }
     }

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -46,7 +46,6 @@ public:
     };
 private:
     friend bool ParseFilterConfig(std::string s, SrtFilterConfig& out);
-    friend bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer);
 
     template <class Target>
     class Creator: public Factory
@@ -198,7 +197,7 @@ protected:
     std::vector<SrtPacket> m_provided;
 };
 
-bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer);
+bool CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer);
 
 inline void PacketFilter::feedSource(CPacket& w_packet) { SRT_ASSERT(m_filter); return m_filter->feedSource((w_packet)); }
 inline SRT_ARQLevel PacketFilter::arqLevel() { SRT_ASSERT(m_filter); return m_filter->arqLevel(); }

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -25,23 +25,28 @@ class PacketFilter
     friend class SrtPacketFilterBase;
 
 public:
-
     typedef std::vector< std::pair<int32_t, int32_t> > loss_seqs_t;
 
     typedef SrtPacketFilterBase* filter_create_t(const SrtFilterInitializer& init, std::vector<SrtPacket>&, const std::string& config);
 
-private:
-    friend bool ParseFilterConfig(std::string s, SrtFilterConfig& out);
     class Factory
     {
     public:
         virtual SrtPacketFilterBase* Create(const SrtFilterInitializer& init, std::vector<SrtPacket>& provided, const std::string& confstr) = 0;
 
         // Characteristic data
-        virtual size_t ExtraSize() = 0;
+        virtual size_t ExtraSize() const = 0;
 
+        // Represent default parameters. This is for completing and comparing
+        // filter configurations from both parties. Possible values to return:
+        // - an empty string (all parameters are mandatory)
+        // - a form of: "<filter-name>,<param1>:<value1>,..."
+        virtual std::string defaultConfig() const { return ""; }
         virtual ~Factory();
     };
+private:
+    friend bool ParseFilterConfig(std::string s, SrtFilterConfig& out);
+    friend bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer);
 
     template <class Target>
     class Creator: public Factory
@@ -52,7 +57,8 @@ private:
         { return new Target(init, provided, confstr); }
 
         // Import the extra size data
-        virtual size_t ExtraSize() ATR_OVERRIDE { return Target::EXTRA_SIZE; }
+        virtual size_t ExtraSize() const ATR_OVERRIDE { return Target::EXTRA_SIZE; }
+        virtual std::string defaultConfig() const ATR_OVERRIDE { return Target::defaultConfig; }
 
     public:
         Creator() {}
@@ -192,6 +198,7 @@ protected:
     std::vector<SrtPacket> m_provided;
 };
 
+bool CheckFilterCompat(SrtFilterConfig agent, SrtFilterConfig peer);
 
 inline void PacketFilter::feedSource(CPacket& w_packet) { SRT_ASSERT(m_filter); return m_filter->feedSource((w_packet)); }
 inline SRT_ARQLevel PacketFilter::arqLevel() { SRT_ASSERT(m_filter); return m_filter->arqLevel(); }

--- a/srtcore/packetfilter_api.h
+++ b/srtcore/packetfilter_api.h
@@ -79,7 +79,7 @@ struct SrtPacket
 };
 
 
-bool ParseFilterConfig(std::string s, SrtFilterConfig& out);
+bool ParseFilterConfig(std::string s, SrtFilterConfig& w_config);
 
 
 class SrtPacketFilterBase

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -719,16 +719,19 @@ void SrtCommon::Init(string host, int port, string path, map<string,string> par,
         bool blocking_snd = false, blocking_rcv = false;
         int dropdelay = 0;
         int size_int = sizeof (int), size_int64 = sizeof (int64_t), size_bool = sizeof (bool);
+        char packetfilter[100] = "";
+        int packetfilter_size = 100;
 
         srt_getsockflag(m_sock, SRTO_MAXBW, &bandwidth, &size_int64);
         srt_getsockflag(m_sock, SRTO_RCVLATENCY, &latency, &size_int);
         srt_getsockflag(m_sock, SRTO_RCVSYN, &blocking_rcv, &size_bool);
         srt_getsockflag(m_sock, SRTO_SNDSYN, &blocking_snd, &size_bool);
         srt_getsockflag(m_sock, SRTO_SNDDROPDELAY, &dropdelay, &size_int);
+        srt_getsockflag(m_sock, SRTO_PACKETFILTER, (packetfilter), (&packetfilter_size));
 
         Verb() << "OPTIONS: maxbw=" << bandwidth << " rcvlatency=" << latency << boolalpha
             << " blocking{rcv=" << blocking_rcv << " snd=" << blocking_snd
-            << "} snddropdelay=" << dropdelay;
+            << "} snddropdelay=" << dropdelay << " packetfilter=" << packetfilter;
     }
 
     if (!m_blocking_mode)


### PR DESCRIPTION
Fixes #1808

Fixed wrong approach for the configuration check and problems around it:

1. Rejection reason was set incorrectly for a case when the FEC configuration was rejected.
2. FEC configuration allowed to override parameters from listener from parameters from caller instead of rejecting colliding settings

Fixed:

The default configuration should be provided by the filter. This can be checked at the factory level, and lacking parameters can be post-filled in both configuration before comparison. Then, if settings for particular parameters differ in both configurations, the configuration is rejected, and so the connection. The following rules remain after this fix:

1. Empty string means adaptive settings. One party may enforce the settings to the other that has no filter set.
2. You are allowed to simply set the filter name as a config string, if the other party provides reset of the parameters, it will pass, but if the other party also provides only the name, or has an empty config string, which means adaptive, this will result in an incomplete FEC configuration and a rejected connection.