### PR TITLE
[core] Redesigned and fixed locking errors around CSndUList

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -253,14 +253,11 @@ void CUnitQueue::makeUnitGood(CUnit *unit)
     ++m_iCount;
 }
 
-CSndUList::CSndUList()
+CSndUList::CSndUList(srt::sync::CTimer* pTimer)
     : m_pHeap(NULL)
     , m_iArrayLength(512)
     , m_iLastEntry(-1)
-    , m_ListLock()
-    , m_pWindowLock(NULL)
-    , m_pWindowCond(NULL)
-    , m_pTimer(NULL)
+    , m_pTimer(pTimer)
 {
     m_pHeap = new CSNode *[m_iArrayLength];
 }
@@ -272,7 +269,7 @@ CSndUList::~CSndUList()
 
 void CSndUList::update(const CUDT* u, EReschedule reschedule)
 {
-    ScopedLock listguard(m_ListLock);
+    ScopedLock listguard (m_ListEv.mutex());
 
     CSNode* n = u->m_pSNode;
 
@@ -298,7 +295,7 @@ void CSndUList::update(const CUDT* u, EReschedule reschedule)
 
 int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 {
-    ScopedLock listguard(m_ListLock);
+    ScopedLock listguard (m_ListEv.mutex());
 
     if (-1 == m_iLastEntry)
         return -1;
@@ -339,14 +336,14 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 
 void CSndUList::remove(const CUDT *u)
 {
-    ScopedLock listguard(m_ListLock);
+    ScopedLock listguard (m_ListEv.mutex());
 
     remove_(u);
 }
 
 steady_clock::time_point CSndUList::getNextProcTime()
 {
-    ScopedLock listguard(m_ListLock);
+    ScopedLock listguard (m_ListEv.mutex());
 
     if (-1 == m_iLastEntry)
         return steady_clock::time_point();
@@ -354,6 +351,7 @@ steady_clock::time_point CSndUList::getNextProcTime()
     return m_pHeap[0]->m_tsTimeStamp;
 }
 
+// [[using locked m_ListEv.mutex()]
 void CSndUList::realloc_()
 {
     CSNode **temp = NULL;
@@ -373,6 +371,7 @@ void CSndUList::realloc_()
     m_pHeap = temp;
 }
 
+// [[using locked m_ListEv.mutex()]
 void CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
 {
     // increase the heap array size if necessary
@@ -382,6 +381,7 @@ void CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
     insert_norealloc_(ts, u);
 }
 
+// [[using locked m_ListEv.mutex()]
 void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT* u)
 {
     CSNode *n = u->m_pSNode;
@@ -418,7 +418,7 @@ void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT
     // first entry, activate the sending queue
     if (0 == m_iLastEntry)
     {
-        CSync::lock_signal(*m_pWindowCond, *m_pWindowLock);
+        m_ListEv.notify_one();
     }
 }
 
@@ -466,10 +466,8 @@ CSndQueue::CSndQueue()
     : m_pSndUList(NULL)
     , m_pChannel(NULL)
     , m_pTimer(NULL)
-    , m_WindowCond()
     , m_bClosing(false)
 {
-    setupCond(m_WindowCond, "Window");
 }
 
 CSndQueue::~CSndQueue()
@@ -481,14 +479,13 @@ CSndQueue::~CSndQueue()
         m_pTimer->interrupt();
     }
 
-    CSync::lock_signal(m_WindowCond, m_WindowLock);
+    m_pSndUList->signal();
 
     if (m_WorkerThread.joinable())
     {
         HLOGC(rslog.Debug, log << "SndQueue: EXIT");
         m_WorkerThread.join();
     }
-    releaseCond(m_WindowCond);
 
     delete m_pSndUList;
 }
@@ -501,10 +498,7 @@ void CSndQueue::init(CChannel *c, CTimer *t)
 {
     m_pChannel                 = c;
     m_pTimer                   = t;
-    m_pSndUList                = new CSndUList;
-    m_pSndUList->m_pWindowLock = &m_WindowLock;
-    m_pSndUList->m_pWindowCond = &m_WindowCond;
-    m_pSndUList->m_pTimer      = m_pTimer;
+    m_pSndUList                = new CSndUList(m_pTimer);
 
 #if ENABLE_LOGGING
     ++m_counter;
@@ -555,14 +549,14 @@ void *CSndQueue::worker(void *param)
             self->m_WorkerStats.lNotReadyTs++;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
-            UniqueLock windlock (self->m_WindowLock);
-            CSync windsync  (self->m_WindowCond, windlock);
+            UniqueLock windlock (self->m_pSndUList->mutex());
 
             // wait here if there is no sockets with data to be sent
             THREAD_PAUSED();
-            if (!self->m_bClosing && (self->m_pSndUList->m_iLastEntry < 0))
+            // NOTE: CSndUList::empty_LOCKED requires lock on CSndUList::mutex()
+            if (!self->m_bClosing && self->m_pSndUList->empty_LOCKED())
             {
-                windsync.wait();
+                self->m_pSndUList->wait(windlock);
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
                 self->m_WorkerStats.lCondWait++;

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -156,11 +156,10 @@ struct CSNode
 
 class CSndUList
 {
-friend class CSndQueue;
 
 public:
-   CSndUList();
-   ~CSndUList();
+    CSndUList( srt::sync::CTimer* pTimer);
+    ~CSndUList();
 
 public:
 
@@ -191,6 +190,11 @@ public:
 
    srt::sync::steady_clock::time_point getNextProcTime();
 
+   bool empty_LOCKED()
+   {
+       return m_iLastEntry < 0;
+   }
+
 private:
 
    /// Doubles the size of the list.
@@ -217,12 +221,13 @@ private:
    int m_iArrayLength;			// physical length of the array
    int m_iLastEntry;			// position of last entry on the heap array
 
-   srt::sync::Mutex m_ListLock;
-
-   srt::sync::Mutex* m_pWindowLock;
-   srt::sync::Condition* m_pWindowCond;
-
+   srt::sync::CEvent m_ListEv;
    srt::sync::CTimer* m_pTimer;
+
+public: // ListEv forwarders
+   srt::sync::Mutex& mutex() { return m_ListEv.mutex(); }
+   void wait(srt::sync::UniqueLock& ul) { m_ListEv.wait(ul); }
+   void signal() { m_ListEv.lock_notify_one(); }
 
 private:
    CSndUList(const CSndUList&);
@@ -409,9 +414,6 @@ private:
    CSndUList* m_pSndUList;              // List of UDT instances for data sending
    CChannel* m_pChannel;                // The UDP channel for data sending
    srt::sync::CTimer* m_pTimer;         // Timing facility
-
-   srt::sync::Mutex m_WindowLock;
-   srt::sync::Condition m_WindowCond;
 
    volatile bool m_bClosing;            // closing the worker
 

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -151,8 +151,11 @@ void srt::sync::CEvent::lock_wait()
     return wait(lock);
 }
 
+// This function requires the unlockable scoped lock
+// that is the same as the builtin lock.
 void srt::sync::CEvent::wait(UniqueLock& lock)
 {
+    SRT_ASSERT(lock.mutex() == &m_lock);
     return m_cond.wait(lock);
 }
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -574,6 +574,9 @@ public:
 
     void notify_all();
 
+    void lock_notify_one() { CSync::lock_signal(m_cond, m_lock); }
+    void lock_notify_all() { CSync::lock_broadcast(m_cond, m_lock); }
+
 private:
     Mutex      m_lock;
     Condition  m_cond;


### PR DESCRIPTION
Changes:

1. The m_WindowLock and m_WindowCond has been moved from CSndQueue to CSndUList. This is actually something that works for the sake of the CSndUList object.
2. The m_WindowLock and m_ListLock have been unified.
3. The LOCK-CV pair has been implemented as common m_ListEv object.
4. Appropriate functions for locking access have been added so that the CSndQueue methods can make signal and waiting through the CSndUList object.

Fixed problems:

1. Locking wasn't applied on some methods of CSndUList while the internal data were used by other threads (notably CSndUList::m_iLastEntry, which should be updated in sync with other fields in this class; the so-far solution likely stated that this field can be read atomically, but in reality this was completely unnecessary if a lock needs to be applied anyway in order not to miss a signal on CV).
2. Separate m_ListLock and m_WindowLock were unnecessary because the first lock locks the access to the data of CSndUList and m_WindowLock is a lock for CV that should signal an important update of the internal data (new data have been added to the list). Using separate locks for these purposes only increased the possibility to miss the update signal.