### PR TITLE
[core] Fixed wrong max socket ID value formula

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -207,9 +207,9 @@ m_ClosedSockets()
 
    // Motivation: in case when rand() returns the value equal to RAND_MAX,
    // rand1_0 == 1, so the below formula will be
-   // 1 + (MAX_SOCKET_VAL-2) * 1 = 1 + MAX_SOCKET_VAL - 2 = MAX_SOCKET_VAL -1
+   // 1 + (MAX_SOCKET_VAL-1) * 1 = 1 + MAX_SOCKET_VAL - 1 = MAX_SOCKET_VAL
    // which is the highest allowed value for the socket.
-   m_SocketIDGenerator = 1 + int((MAX_SOCKET_VAL-2) * rand1_0);
+   m_SocketIDGenerator = 1 + int((MAX_SOCKET_VAL-1) * rand1_0);
    m_SocketIDGenerator_init = m_SocketIDGenerator;
 
    // XXX An unlikely exception thrown from the below calls
@@ -342,7 +342,7 @@ SRTSOCKET CUDTUnited::generateSocketID(bool for_group)
     {
         // We have a rollover on the socket value, so
         // definitely we haven't made the Columbus mistake yet.
-        m_SocketIDGenerator = MAX_SOCKET_VAL-1;
+        m_SocketIDGenerator = MAX_SOCKET_VAL;
     }
 
     // Check all sockets if any of them has this value.
@@ -388,7 +388,7 @@ SRTSOCKET CUDTUnited::generateSocketID(bool for_group)
                 // The socket value is in use.
                 --sockval;
                 if (sockval <= 0)
-                    sockval = MAX_SOCKET_VAL-1;
+                    sockval = MAX_SOCKET_VAL;
 
                 // Before continuing, check if we haven't rolled back to start again
                 // This is virtually impossible, so just make an RTI error.

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -205,7 +205,11 @@ m_ClosedSockets()
 
    const double rand1_0 = double(rand())/RAND_MAX;
 
-   m_SocketIDGenerator = 1 + int(MAX_SOCKET_VAL * rand1_0);
+   // Motivation: in case when rand() returns the value equal to RAND_MAX,
+   // rand1_0 == 1, so the below formula will be
+   // 1 + (MAX_SOCKET_VAL-2) * 1 = 1 + MAX_SOCKET_VAL - 2 = MAX_SOCKET_VAL -1
+   // which is the highest allowed value for the socket.
+   m_SocketIDGenerator = 1 + int((MAX_SOCKET_VAL-2) * rand1_0);
    m_SocketIDGenerator_init = m_SocketIDGenerator;
 
    // XXX An unlikely exception thrown from the below calls

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -203,7 +203,7 @@ public:
    ~CUDTUnited();
 
    // Public constants
-   static const int32_t MAX_SOCKET_VAL = SRTGROUP_MASK;    // maximum value for a regular socket
+   static const int32_t MAX_SOCKET_VAL = SRTGROUP_MASK - 1;    // maximum value for a regular socket
 
 public:
 

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -203,7 +203,7 @@ public:
    ~CUDTUnited();
 
    // Public constants
-   static const int32_t MAX_SOCKET_VAL = 1 << 29;    // maximum value for a regular socket
+   static const int32_t MAX_SOCKET_VAL = SRTGROUP_MASK;    // maximum value for a regular socket
 
 public:
 

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -192,8 +192,7 @@ bool CHandShake::valid()
     if (m_iVersion < CUDT::HS_VERSION_UDT4
             || m_iISN < 0 || m_iISN >= CSeqNo::m_iMaxSeqNo
             || m_iMSS < 32
-            || m_iFlightFlagSize < 2
-            || m_iID >= CUDTUnited::MAX_SOCKET_VAL)
+            || m_iFlightFlagSize < 2)
         return false;
 
     return true;


### PR DESCRIPTION
Changes:

1. Removed check if socket ID provided in the handshake fits in some range. This check is useless, sockets are allowed to have any value, even value in the group range if used against pre-1.4.2 version. Just not 0 (although this is a special value used in the handshake).
2. Definition of MAX_SOCKET_VAL fixed to be the same as SOCKGROUP_MASK, that is 0x40000000. 1 << 29 was wrong (0x20000000).
3. Fixed formula for translating random value into a random socket ID value. The old formula didn't take into account, though little probable, theoretically possible case when `rand()` returns exactly `RAND_MAX`.