### PR TITLE
[core] Fixing the wrong locking order around m_ConnectionLock (potential deadlock)

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2776,6 +2776,16 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
    // delete this one
    m_ClosedSockets.erase(i);
 
+   // XXX This below section can unlock m_GlobControlLock
+   // just for calling CUDT::closeInternal(), which is needed
+   // to avoid locking m_ConnectionLock after m_GlobControlLock,
+   // while m_ConnectionLock orders BEFORE m_GlobControlLock.
+   // This should be perfectly safe thing to do after the socket
+   // ID has been erased from m_ClosedSockets. No container access
+   // is done in this case.
+   //
+   // Report: P04-28
+
    HLOGC(smlog.Debug, log << "GC/removeSocket: closing associated UDT @" << u);
    s->m_pUDT->closeInternal();
    HLOGC(smlog.Debug, log << "GC/removeSocket: DELETING SOCKET @" << u);

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2784,7 +2784,7 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
    // ID has been erased from m_ClosedSockets. No container access
    // is done in this case.
    //
-   // Report: P04-28
+   // Report: P04-1.28, P04-2.27, P04-2.50, P04-2.55
 
    HLOGC(smlog.Debug, log << "GC/removeSocket: closing associated UDT @" << u);
    s->m_pUDT->closeInternal();

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2787,7 +2787,9 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
    // Report: P04-1.28, P04-2.27, P04-2.50, P04-2.55
 
    HLOGC(smlog.Debug, log << "GC/removeSocket: closing associated UDT @" << u);
+   leaveCS(m_GlobControlLock);
    s->m_pUDT->closeInternal();
+   enterCS(m_GlobControlLock);
    HLOGC(smlog.Debug, log << "GC/removeSocket: DELETING SOCKET @" << u);
    delete s;
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -905,6 +905,20 @@ void CUDT::setListenState()
     if (m_bListening)
         return;
 
+    // XXX likely the setListener() should be exempted
+    // from m_ConnectionLock because the already sanctioned order
+    // is m_LSLock, then m_ConnectionLock, while this below call
+    // locks m_LSLock.
+    //
+    // Likely LSLock guards only the m_pListener field, so
+    // m_ConnectionLock might not be required. Otherwise the
+    // m_ConnectionLock, if required, must be also applied again
+    // in setListener, or these functions should be merged into
+    // one again and m_LSLock should be acquired first.
+    //
+    // Reports: P04-2.27, P04-2.55, P04-2.60
+
+
     // if there is already another socket listening on the same port
     if (m_pRcvQueue->setListener(this) < 0)
         throw CUDTException(MJ_NOTSUP, MN_BUSY, 0);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5633,8 +5633,9 @@ void CUDT::addressAndSend(CPacket& w_pkt)
     m_pSndQueue->sendto(m_PeerAddr, w_pkt);
 }
 
-// [[using maybe_locked(m_GlobControlLock, if called from GC)]]
-bool CUDT::closeInternal()
+// [[using maybe_locked(m_GlobControlLock, if called from breakSocket_LOCKED, usually from GC)]]
+// [[using maybe_locked(m_parent->m_ControlLock, if called from srt_close())]]
+bool CUDT::closeInternal() ATR_NOEXCEPT
 {
     // NOTE: this function is called from within the garbage collector thread.
 
@@ -8620,7 +8621,7 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
     return 0;
 }
 
-std::pair<int, steady_clock::time_point> CUDT::packData(CPacket& w_packet)
+std::pair<int, steady_clock::time_point> CUDT::packData(CPacket& w_packet) ATR_NOEXCEPT
 {
     int payload = 0;
     bool probe = false;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -544,7 +544,7 @@ private:
 
     /// Close the opened UDT entity.
 
-    bool closeInternal();
+    bool closeInternal() ATR_NOEXCEPT;
     void updateBrokenConnection();
     void completeBrokenConnectionDependencies(int errorcode);
 
@@ -968,7 +968,7 @@ private: // Generation and processing of packets
     ///         The payload tells the size of the payload, packed in CPacket.
     ///         The timestamp is the full source/origin timestamp of the data.
     ///         If payload is <= 0, consider the timestamp value invalid.
-    std::pair<int, time_point> packData(CPacket& packet);
+    std::pair<int, time_point> packData(CPacket& packet) ATR_NOEXCEPT;
 
     int processData(CUnit* unit);
     void processClose();

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -326,9 +326,11 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     // dangerous in general, as when the Broken flag is not set, this
     // thread has at least 1 second to finish the job before u is potentially
     // deleted. This "time-defined" problem should be eliminated through
-    // another fix.
+    // another fix. Worth noting is that m_ListLock also doesn't currently
+    // prevent the socket from a premature deletion.
     //
-    // Report: P04-08
+    // Reports: P04-1.08, P04-1.29, P04-2.03, P04-2.28, P04-2.49,
+    //          P04-2.53, P04-2.54, P04-2.56
 
     // pack a packet from the socket
     const std::pair<int, steady_clock::time_point> res_time = u->packData((w_pkt));

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -327,6 +327,8 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     // thread has at least 1 second to finish the job before u is potentially
     // deleted. This "time-defined" problem should be eliminated through
     // another fix.
+    //
+    // Report: P04-08
 
     // pack a packet from the socket
     const std::pair<int, steady_clock::time_point> res_time = u->packData((w_pkt));

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -321,6 +321,13 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     if (!u->m_bConnected || u->m_bBroken)
         return -1;
 
+    // XXX This likely should be exempted from lock on m_ListLock,
+    // as inside it makes a lock on m_ConnectionLock. This shouldn't be
+    // dangerous in general, as when the Broken flag is not set, this
+    // thread has at least 1 second to finish the job before u is potentially
+    // deleted. This "time-defined" problem should be eliminated through
+    // another fix.
+
     // pack a packet from the socket
     const std::pair<int, steady_clock::time_point> res_time = u->packData((w_pkt));
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -333,7 +333,10 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     //          P04-2.53, P04-2.54, P04-2.56
 
     // pack a packet from the socket
+    leaveCS(m_ListLock);
     const std::pair<int, steady_clock::time_point> res_time = u->packData((w_pkt));
+    enterCS(m_ListLock);
+
 
     if (res_time.first <= 0)
         return -1;


### PR DESCRIPTION
There are two fixes provided:

1. Unlocking m_GlobControlLock before locking m_ConnectionLock in the call of CUDT::closeInternal. m_GlobControlLock orders after m_ConnectionLock.
2. Unlocking m_ListLock (from CSndUList/CSndQueue) before locking m_ConnectionLock in the call of CUDT::packData. m_ListLock orders after m_ConnectionLock.

The fix for m_LSLock in setListener is not provided. This problem should disappear after applying the above fixes, if not, a separate solution may be necessary. This problem is also connected to another problem for socket deletion procedure so better not be touched directly.

This addresses the problem collected in report P04 mentioned in Epic #1813
