### PR TITLE
[core] Prevent deletion of a socket that is still in any ULists

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2723,6 +2723,19 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
 
    CUDTSocket* const s = i->second;
 
+   // The socket may be in the trashcan now, but could
+   // still be under processing in the sender/receiver worker
+   // threads. If that's the case, SKIP IT THIS TIME. The
+   // socket will be checked next time the GC rollover starts.
+   CSNode* sn = s->m_pUDT->m_pSNode;
+   if (sn && sn->m_iHeapLoc != -1)
+       return;
+
+   CRNode* rn = s->m_pUDT->m_pRNode;
+   if (rn && rn->m_bOnList)
+       return;
+
+
 #if ENABLE_EXPERIMENTAL_BONDING
    if (s->m_GroupOf)
    {


### PR DESCRIPTION
This fix makes escaping from deletion process of a socket that isn't yet removed from all ULists.

The SndUList is the list of sockets for which sending should happen. It is expected that when the socket is closed, it will no longer reappear in the SndUList, although at the moment when GC is trying to delete the socket, it can remain in the SndUList and potentially sending might be performed. GC will then delay deletion of this socket for the next GC if so; this socket should not remain in the SndUList next time GC picks it up.

The RcvUList is the list of sockets for which reception through this queue should happen. Closed sockets should not put itself in this list, however it may happen that lately put socket in this list is being picked up by the receiver worker thread while the GC thread is trying to delete it. Deletion of this socket is then postponed up to the moment, when it is no longer in the RcvUList.

EDIT: The further tests didn't confirm that this fixes any problem. Likely this must be solved differently.