### PR TITLE
Fixed SRT group stats: initialization and send stats for backup 

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -436,21 +436,21 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_MAXBW:
-        if (optlen < sizeof(m_config.m_llMaxBW))
+        if (size_t(optlen) < sizeof(m_config.m_llMaxBW))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         *(int64_t *)optval = m_config.m_llMaxBW;
         optlen             = sizeof(int64_t);
         break;
 
     case SRTO_INPUTBW:
-        if (optlen < sizeof(m_config.m_llInputBW))
+        if (size_t(optlen) < sizeof(m_config.m_llInputBW))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
        *(int64_t*)optval = m_config.m_llInputBW;
        optlen            = sizeof(int64_t);
        break;
 
     case SRTO_MININPUTBW:
-        if (optlen < sizeof (m_config.m_llMinInputBW))
+        if (size_t(optlen) < sizeof (m_config.m_llMinInputBW))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         *(int64_t*)optval = m_config.m_llMinInputBW;
         optlen            = sizeof(int64_t);
@@ -634,7 +634,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_CONNTIMEO:
-        *(int*)optval = count_milliseconds(m_config.m_tdConnTimeOut);
+        *(int*)optval = (int) count_milliseconds(m_config.m_tdConnTimeOut);
         optlen        = sizeof(int);
         break;
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -4154,6 +4154,9 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
     }
 
+    // At least one link has succeeded, update sending stats.
+    m_stats.sent.Update(len);
+
     // Now fill in the socket table. Check if the size is enough, if not,
     // then set the pointer to NULL and set the correct size.
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -317,6 +317,8 @@ CUDTGroup::CUDTGroup(SRT_GROUP_TYPE gtype)
     m_RcvEID = m_pGlobal->m_EPoll.create(&m_RcvEpolld);
     m_SndEID = m_pGlobal->m_EPoll.create(&m_SndEpolld);
 
+    m_stats.init();
+
     // Set this data immediately during creation before
     // two or more sockets start arguing about it.
     m_iLastSchedSeqNo = CUDT::generateISN();

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -291,6 +291,20 @@ TEST(Bonding, CloseGroupAndSocket)
         }
     }
 
+    // Some basic checks for group stats
+    SRT_TRACEBSTATS stats;
+    EXPECT_EQ(srt_bstats(ss, &stats, true), SRT_SUCCESS);
+    EXPECT_EQ(stats.pktSent, 0);
+    EXPECT_EQ(stats.pktSentTotal, 0);
+    EXPECT_EQ(stats.pktSentUnique, 0);
+    EXPECT_EQ(stats.pktSentUniqueTotal, 0);
+    EXPECT_EQ(stats.pktRecv, 0);
+    EXPECT_EQ(stats.pktRecvTotal, 0);
+    EXPECT_EQ(stats.pktRecvUnique, 0);
+    EXPECT_EQ(stats.pktRecvUniqueTotal, 0);
+    EXPECT_EQ(stats.pktRcvDrop, 0);
+    EXPECT_EQ(stats.pktRcvDropTotal, 0);
+
     std::cout << "Starting thread for sending:\n";
     std::thread sender([ss] {
         char buf[1316];


### PR DESCRIPTION
Two things were missing:
1. Initialization of group statistics;
2. Update of pktSentUnique in the Main/Backup sending.