### PR TITLE
Removed 'm_' prefix in socket config structs

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -168,7 +168,7 @@ bool CUDTSocket::readReady()
 bool CUDTSocket::writeReady()
 {
     return (m_pUDT->m_bConnected
-                && (m_pUDT->m_pSndBuffer->getCurrBufSize() < m_pUDT->m_config.m_iSndBufSize))
+                && (m_pUDT->m_pSndBuffer->getCurrBufSize() < m_pUDT->m_config.iSndBufSize))
         || broken();
 }
 
@@ -531,7 +531,7 @@ int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, 
 
          w_hs.m_iISN = ns->m_pUDT->m_iISN;
          w_hs.m_iMSS = ns->m_pUDT->MSS();
-         w_hs.m_iFlightFlagSize = ns->m_pUDT->m_config.m_iFlightFlagSize;
+         w_hs.m_iFlightFlagSize = ns->m_pUDT->m_config.iFlightFlagSize;
          w_hs.m_iReqType = URQ_CONCLUSION;
          w_hs.m_iID = ns->m_SocketID;
 
@@ -1004,7 +1004,7 @@ int CUDTUnited::listen(const SRTSOCKET u, int backlog)
    // [[using assert(s->m_Status == OPENED)]];
 
    // listen is not supported in rendezvous connection setup
-   if (s->m_pUDT->m_config.m_bRendezvous)
+   if (s->m_pUDT->m_config.bRendezvous)
       throw CUDTException(MJ_NOTSUP, MN_ISRENDEZVOUS, 0);
 
    s->m_uiBackLog = backlog;
@@ -1077,7 +1077,7 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
       throw CUDTException(MJ_NOTSUP, MN_NOLISTEN, 0);
 
    // no "accept" in rendezvous connection setup
-   if (ls->m_pUDT->m_config.m_bRendezvous)
+   if (ls->m_pUDT->m_config.bRendezvous)
    {
        LOGC(cnlog.Fatal, log << "CUDTUnited::accept: RENDEZVOUS flag passed through check in srt_listen when it set listen state");
        // This problem should never happen because `srt_listen` function should have
@@ -1107,7 +1107,7 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
            ls->m_QueuedSockets.erase(b);
            accepted = true;
        }
-       else if (!ls->m_pUDT->m_config.m_bSynRecving)
+       else if (!ls->m_pUDT->m_config.bSynRecving)
        {
            accepted = true;
        }
@@ -1122,7 +1122,7 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
    if (u == CUDT::INVALID_SOCK)
    {
       // non-blocking receiving, no connection available
-      if (!ls->m_pUDT->m_config.m_bSynRecving)
+      if (!ls->m_pUDT->m_config.bSynRecving)
          throw CUDTException(MJ_AGAIN, MN_RDAVAIL, 0);
 
       // listening socket is closed
@@ -1134,13 +1134,13 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
       throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
 
    // Set properly the SRTO_GROUPCONNECT flag
-   s->core().m_config.m_GroupConnect = 0;
+   s->core().m_config.iGroupConnect = 0;
 
    // Check if LISTENER has the SRTO_GROUPCONNECT flag set,
    // and the already accepted socket has successfully joined
    // the mirror group. If so, RETURN THE GROUP ID, not the socket ID.
 #if ENABLE_EXPERIMENTAL_BONDING
-   if (ls->m_pUDT->m_config.m_GroupConnect == 1 && s->m_GroupOf)
+   if (ls->m_pUDT->m_config.iGroupConnect == 1 && s->m_GroupOf)
    {
        // Put a lock to protect the group against accidental deletion
        // in the meantime.
@@ -1150,7 +1150,7 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
        if (s->m_GroupOf)
        {
            u = s->m_GroupOf->m_GroupID;
-           s->core().m_config.m_GroupConnect = 1; // should be derived from ls, but make sure
+           s->core().m_config.iGroupConnect = 1; // should be derived from ls, but make sure
 
            // Mark the beginning of the connection at the moment
            // when the group ID is returned to the app caller
@@ -1498,14 +1498,14 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         }
 
         // Set it the groupconnect option, as all in-group sockets should have.
-        ns->m_pUDT->m_config.m_GroupConnect = 1;
+        ns->m_pUDT->m_config.iGroupConnect = 1;
 
         // Every group member will have always nonblocking
         // (this implies also non-blocking connect/accept).
         // The group facility functions will block when necessary
         // using epoll_wait.
-        ns->m_pUDT->m_config.m_bSynRecving = false;
-        ns->m_pUDT->m_config.m_bSynSending = false;
+        ns->m_pUDT->m_config.bSynRecving = false;
+        ns->m_pUDT->m_config.bSynSending = false;
 
         HLOGC(aclog.Debug, log << "groupConnect: NOTIFIED AS PENDING @" << sid << " both read and write");
         // If this socket is not to block the current connect process,
@@ -1827,7 +1827,7 @@ int CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_
 
    if (s->m_Status == SRTS_INIT)
    {
-       if (s->m_pUDT->m_config.m_bRendezvous)
+       if (s->m_pUDT->m_config.bRendezvous)
            throw CUDTException(MJ_NOTSUP, MN_ISRENDUNBOUND, 0);
 
        // If bind() was done first on this socket, then the
@@ -1957,7 +1957,7 @@ int CUDTUnited::close(CUDTSocket* s)
 
    HLOGC(smlog.Debug, log << s->m_pUDT->CONID() << " CLOSING (removing from listening, closing CUDT)");
 
-   const bool synch_close_snd = s->m_pUDT->m_config.m_bSynSending;
+   const bool synch_close_snd = s->m_pUDT->m_config.bSynSending;
 
    SRTSOCKET u = s->m_SocketID;
 
@@ -2322,7 +2322,7 @@ int CUDTUnited::selectEx(
          {
             if (s->m_pUDT->m_bConnected
                && (s->m_pUDT->m_pSndBuffer->getCurrBufSize()
-                  < s->m_pUDT->m_config.m_iSndBufSize))
+                  < s->m_pUDT->m_config.iSndBufSize))
             {
                writefds->push_back(s->m_SocketID);
                ++ count;
@@ -2827,7 +2827,7 @@ void CUDTUnited::updateMux(
    // In such a case rely exclusively on that very socket and
    // use it the way as it is configured, of course, create also
    // always a new multiplexer for that very socket.
-   if (!udpsock && s->m_pUDT->m_config.m_bReuseAddr)
+   if (!udpsock && s->m_pUDT->m_config.bReuseAddr)
    {
       const int port = addr.hport();
 
@@ -2993,7 +2993,7 @@ bool CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
        if (!mux && fallback)
        {
            // It is allowed to reuse this multiplexer, but the socket must allow both IPv4 and IPv6
-           if (fallback->m_mcfg.m_iIpV6Only == 0)
+           if (fallback->m_mcfg.iIpV6Only == 0)
            {
                HLOGC(smlog.Warn, log << "updateListenerMux: reusing multiplexer from different family");
                mux = fallback;

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -341,7 +341,7 @@ void CChannel::setUDPSockOpt()
       }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-      if (!m_mcfg.strBindToDevice.empty())
+      if (!m_mcfg.sBindToDevice.empty())
       {
           if (m_BindAddr.family() != AF_INET)
           {
@@ -350,7 +350,7 @@ void CChannel::setUDPSockOpt()
           }
 
           if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_BINDTODEVICE,
-                      m_mcfg.strBindToDevice.c_str(), m_mcfg.strBindToDevice.size()))
+                      m_mcfg.sBindToDevice.c_str(), m_mcfg.sBindToDevice.size()))
           {
               char buf[255];
               const char* err = SysStrError(NET_ERROR, buf, 255);

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -181,16 +181,16 @@ void CChannel::createSocket(int family)
 #endif
 #endif // ENABLE_SOCK_CLOEXEC
 
-    if ((m_mcfg.m_iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
+    if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {
         int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY,
-                m_mcfg.pvIpV6Only(), sizeof(int));
+                m_mcfg.pcIpV6Only(), sizeof(int));
         if (res == -1)
         {
             int err = errno;
             char msg[160];
             LOGC(kmlog.Error, log << "::setsockopt: failed to set IPPROTO_IPV6/IPV6_V6ONLY = "
-                    << m_mcfg.m_iIpV6Only << ": " << SysStrError(err, msg, 159));
+                    << m_mcfg.iIpV6Only << ": " << SysStrError(err, msg, 159));
         }
     }
 
@@ -266,22 +266,22 @@ void CChannel::setUDPSockOpt()
    #if defined(BSD) || TARGET_OS_MAC
       // BSD system will fail setsockopt if the requested buffer size exceeds system maximum value
       int maxsize = 64000;
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pvUDPRcvBufSize(), sizeof(int)))
+      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pcUDPRcvBufSize(), sizeof(int)))
          ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*)&maxsize, sizeof(int));
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pvUDPSndBufSize(), sizeof(int)))
+      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pcUDPSndBufSize(), sizeof(int)))
          ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*)&maxsize, sizeof(int));
    #else
       // for other systems, if requested is greated than maximum, the maximum value will be automactally used
-      if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pvUDPRcvBufSize(), sizeof(int))) ||
-          (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pvUDPSndBufSize(), sizeof(int))))
+      if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pcUDPRcvBufSize(), sizeof(int))) ||
+          (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pcUDPSndBufSize(), sizeof(int))))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
    #endif
 
-      if (m_mcfg.m_iIpTTL != -1)
+      if (m_mcfg.iIpTTL != -1)
       {
           if (m_BindAddr.family() == AF_INET)
           {
-              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pvIpTTL(), sizeof (int)))
+              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pcIpTTL(), sizeof (int)))
                   throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
           }
           else
@@ -291,7 +291,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IPV6_UNICAST_HOPS ONLY UNLESS it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, m_mcfg.pvIpTTL(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, m_mcfg.pcIpTTL(), sizeof (int)))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -299,7 +299,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IP_TTL ONLY WHEN it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pvIpTTL(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pcIpTTL(), sizeof (int)))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -307,11 +307,11 @@ void CChannel::setUDPSockOpt()
           }
       }
 
-      if (m_mcfg.m_iIpToS != -1)
+      if (m_mcfg.iIpToS != -1)
       {
           if (m_BindAddr.family() == AF_INET)
           {
-              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pvIpToS(), sizeof (int)))
+              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pcIpToS(), sizeof (int)))
                   throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
           }
           else
@@ -322,7 +322,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IPV6_TCLASS ONLY UNLESS it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, m_mcfg.pvIpToS(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, m_mcfg.pcIpToS(), sizeof (int)))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -332,7 +332,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IP_TOS ONLY WHEN it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pvIpToS(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pcIpToS(), sizeof (int)))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -341,7 +341,7 @@ void CChannel::setUDPSockOpt()
       }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-      if (!m_mcfg.m_BindToDevice.empty())
+      if (!m_mcfg.strBindToDevice.empty())
       {
           if (m_BindAddr.family() != AF_INET)
           {
@@ -350,7 +350,7 @@ void CChannel::setUDPSockOpt()
           }
 
           if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_BINDTODEVICE,
-                      m_mcfg.m_BindToDevice.c_str(), m_mcfg.m_BindToDevice.size()))
+                      m_mcfg.strBindToDevice.c_str(), m_mcfg.strBindToDevice.size()))
           {
               char buf[255];
               const char* err = SysStrError(NET_ERROR, buf, 255);
@@ -398,15 +398,15 @@ void CChannel::close() const
 int CChannel::getSndBufSize()
 {
    socklen_t size = sizeof(socklen_t);
-   ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pvUDPSndBufSize(), &size);
-   return m_mcfg.m_iUDPSndBufSize;
+   ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pcUDPSndBufSize(), &size);
+   return m_mcfg.iUDPSndBufSize;
 }
 
 int CChannel::getRcvBufSize()
 {
    socklen_t size = sizeof(socklen_t);
-   ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pvUDPRcvBufSize(), &size);
-   return m_mcfg.m_iUDPRcvBufSize;
+   ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pcUDPRcvBufSize(), &size);
+   return m_mcfg.iUDPRcvBufSize;
 }
 
 void CChannel::setConfig(const CSrtMuxerConfig& config)
@@ -422,11 +422,11 @@ int CChannel::getIpTTL() const
    socklen_t size = sizeof(int);
    if (m_BindAddr.family() == AF_INET)
    {
-      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pvIpTTL(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pcIpTTL(), &size);
    }
    else if (m_BindAddr.family() == AF_INET6)
    {
-      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, m_mcfg.pvIpTTL(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, m_mcfg.pcIpTTL(), &size);
    }
    else
    {
@@ -434,7 +434,7 @@ int CChannel::getIpTTL() const
        LOGC(kmlog.Error, log << "IPE: CChannel::getIpTTL called with unset family");
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
    }
-   return m_mcfg.m_iIpTTL;
+   return m_mcfg.iIpTTL;
 }
 
 int CChannel::getIpToS() const
@@ -445,12 +445,12 @@ int CChannel::getIpToS() const
    socklen_t size = sizeof(int);
    if (m_BindAddr.family() == AF_INET)
    {
-      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pvIpToS(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pcIpToS(), &size);
    }
    else if (m_BindAddr.family() == AF_INET6)
    {
 #ifdef IPV6_TCLASS
-      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, m_mcfg.pvIpToS(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, m_mcfg.pcIpToS(), &size);
 #endif
    }
    else
@@ -459,7 +459,7 @@ int CChannel::getIpToS() const
        LOGC(kmlog.Error, log << "IPE: CChannel::getIpToS called with unset family");
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
    }
-   return m_mcfg.m_iIpToS;
+   return m_mcfg.iIpToS;
 }
 
 #ifdef SRT_ENABLE_BINDTODEVICE

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -184,7 +184,7 @@ void CChannel::createSocket(int family)
     if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {
         int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY,
-                m_mcfg.pcIpV6Only(), sizeof(int));
+                (const char*) &m_mcfg.iIpV6Only, sizeof(int));
         if (res == -1)
         {
             int err = errno;
@@ -266,14 +266,14 @@ void CChannel::setUDPSockOpt()
    #if defined(BSD) || TARGET_OS_MAC
       // BSD system will fail setsockopt if the requested buffer size exceeds system maximum value
       int maxsize = 64000;
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pcUDPRcvBufSize(), sizeof(int)))
-         ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*)&maxsize, sizeof(int));
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pcUDPSndBufSize(), sizeof(int)))
-         ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*)&maxsize, sizeof(int));
+      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*) &m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize))
+         ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*) &maxsize, sizeof maxsize);
+      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize))
+         ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*) &maxsize, sizeof maxsize);
    #else
       // for other systems, if requested is greated than maximum, the maximum value will be automactally used
-      if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pcUDPRcvBufSize(), sizeof(int))) ||
-          (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pcUDPSndBufSize(), sizeof(int))))
+      if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*) &m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize)) ||
+          (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*) &m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize)))
          throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
    #endif
 
@@ -281,7 +281,7 @@ void CChannel::setUDPSockOpt()
       {
           if (m_BindAddr.family() == AF_INET)
           {
-              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pcIpTTL(), sizeof (int)))
+              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*) &m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
                   throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
           }
           else
@@ -291,7 +291,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IPV6_UNICAST_HOPS ONLY UNLESS it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, m_mcfg.pcIpTTL(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char*) &m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -299,7 +299,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IP_TTL ONLY WHEN it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pcIpTTL(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*) &m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -311,7 +311,7 @@ void CChannel::setUDPSockOpt()
       {
           if (m_BindAddr.family() == AF_INET)
           {
-              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pcIpToS(), sizeof (int)))
+              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*) &m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
                   throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
           }
           else
@@ -322,7 +322,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IPV6_TCLASS ONLY UNLESS it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, m_mcfg.pcIpToS(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (const char*) &m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -332,7 +332,7 @@ void CChannel::setUDPSockOpt()
               // For specified IPv6 address, set IP_TOS ONLY WHEN it's an IPv4-mapped-IPv6
               if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
               {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pcIpToS(), sizeof (int)))
+                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*) &m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
                   {
                       throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
                   }
@@ -397,15 +397,15 @@ void CChannel::close() const
 
 int CChannel::getSndBufSize()
 {
-   socklen_t size = sizeof(socklen_t);
-   ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, m_mcfg.pcUDPSndBufSize(), &size);
+    socklen_t size = (socklen_t) sizeof m_mcfg.iUDPSndBufSize;
+   ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*) &m_mcfg.iUDPSndBufSize, &size);
    return m_mcfg.iUDPSndBufSize;
 }
 
 int CChannel::getRcvBufSize()
 {
-   socklen_t size = sizeof(socklen_t);
-   ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, m_mcfg.pcUDPRcvBufSize(), &size);
+    socklen_t size = (socklen_t) sizeof m_mcfg.iUDPRcvBufSize;
+   ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*) &m_mcfg.iUDPRcvBufSize, &size);
    return m_mcfg.iUDPRcvBufSize;
 }
 
@@ -419,14 +419,14 @@ int CChannel::getIpTTL() const
    if (m_iSocket == INVALID_SOCKET)
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   socklen_t size = sizeof(int);
+   socklen_t size = (socklen_t) sizeof m_mcfg.iIpTTL;
    if (m_BindAddr.family() == AF_INET)
    {
-      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TTL, m_mcfg.pcIpTTL(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (char*) &m_mcfg.iIpTTL, &size);
    }
    else if (m_BindAddr.family() == AF_INET6)
    {
-      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, m_mcfg.pcIpTTL(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (char*) &m_mcfg.iIpTTL, &size);
    }
    else
    {
@@ -442,15 +442,15 @@ int CChannel::getIpToS() const
    if (m_iSocket == INVALID_SOCKET)
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   socklen_t size = sizeof(int);
+   socklen_t size = (socklen_t) sizeof m_mcfg.iIpToS;
    if (m_BindAddr.family() == AF_INET)
    {
-      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TOS, m_mcfg.pcIpToS(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (char*) &m_mcfg.iIpToS, &size);
    }
    else if (m_BindAddr.family() == AF_INET6)
    {
 #ifdef IPV6_TCLASS
-      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, m_mcfg.pcIpToS(), &size);
+      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (char*) &m_mcfg.iIpToS, &size);
 #endif
    }
    else

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -184,7 +184,7 @@ void CChannel::createSocket(int family)
     if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {
         int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY,
-                (const char*) &m_mcfg.iIpV6Only, sizeof(int));
+                (const char*) &m_mcfg.iIpV6Only, sizeof m_mcfg.iIpV6Only);
         if (res == -1)
         {
             int err = errno;
@@ -397,14 +397,14 @@ void CChannel::close() const
 
 int CChannel::getSndBufSize()
 {
-    socklen_t size = (socklen_t) sizeof m_mcfg.iUDPSndBufSize;
+   socklen_t size = (socklen_t) sizeof m_mcfg.iUDPSndBufSize;
    ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*) &m_mcfg.iUDPSndBufSize, &size);
    return m_mcfg.iUDPSndBufSize;
 }
 
 int CChannel::getRcvBufSize()
 {
-    socklen_t size = (socklen_t) sizeof m_mcfg.iUDPRcvBufSize;
+   socklen_t size = (socklen_t) sizeof m_mcfg.iUDPRcvBufSize;
    ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*) &m_mcfg.iUDPRcvBufSize, &size);
    return m_mcfg.iUDPRcvBufSize;
 }

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -188,8 +188,8 @@ public:
     virtual int ACKTimeout_us() const { return 0; }
 
     // Called when the settings concerning m_llMaxBW were changed.
-    // Arg 1: value of CUDT::m_llMaxBW
-    // Arg 2: value calculated out of CUDT::m_config::llInputBW and CUDT::m_config::iOverheadBW.
+    // Arg 1: value of CUDT's m_config.m_llMaxBW
+    // Arg 2: value calculated out of CUDT's m_config.llInputBW and m_config.iOverheadBW.
     virtual void updateBandwidth(int64_t, int64_t) {}
 
     virtual bool needsQuickACK(const CPacket&)

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -189,7 +189,7 @@ public:
 
     // Called when the settings concerning m_llMaxBW were changed.
     // Arg 1: value of CUDT::m_llMaxBW
-    // Arg 2: value calculated out of CUDT::m_llInputBW and CUDT::m_iOverheadBW.
+    // Arg 2: value calculated out of CUDT::m_config::llInputBW and CUDT::m_config::iOverheadBW.
     virtual void updateBandwidth(int64_t, int64_t) {}
 
     virtual bool needsQuickACK(const CPacket&)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -145,7 +145,7 @@ void CUDT::construct()
     m_tsLastReqTime       = steady_clock::time_point();
     m_SrtHsSide           = HSD_DRAW;
 
-    m_lPeerSrtVersion        = 0; // not defined until connected.
+    m_uPeerSrtVersion        = 0; // not defined until connected.
 
     m_iTsbPdDelay_ms     = 0;
     m_iPeerTsbPdDelay_ms = 0;
@@ -197,7 +197,7 @@ CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
     m_config            = ancestor.m_config;
     m_SrtHsSide         = ancestor.m_SrtHsSide; // actually it sets it to HSD_RESPONDER
     m_bTLPktDrop        = ancestor.m_bTLPktDrop;
-    m_iReorderTolerance = m_config.m_iMaxReorderTolerance;  // Initialize with maximum value
+    m_iReorderTolerance = m_config.iMaxReorderTolerance;  // Initialize with maximum value
 
     // Runtime
     m_pCache = ancestor.m_pCache;
@@ -352,7 +352,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
             break;
 
         case SRTO_LOSSMAXTTL:
-            m_iReorderTolerance = m_config.m_iMaxReorderTolerance;
+            m_iReorderTolerance = m_config.iMaxReorderTolerance;
 
         default: break;
         }
@@ -366,17 +366,17 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
     switch (optName)
     {
     case SRTO_MSS:
-        *(int *)optval = m_config.m_iMSS;
+        *(int *)optval = m_config.iMSS;
         optlen         = sizeof(int);
         break;
 
     case SRTO_SNDSYN:
-        *(bool *)optval = m_config.m_bSynSending;
+        *(bool *)optval = m_config.bSynSending;
         optlen          = sizeof(bool);
         break;
 
     case SRTO_RCVSYN:
-        *(bool *)optval = m_config.m_bSynRecving;
+        *(bool *)optval = m_config.bSynRecving;
         optlen          = sizeof(bool);
         break;
 
@@ -386,17 +386,17 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_FC:
-        *(int *)optval = m_config.m_iFlightFlagSize;
+        *(int *)optval = m_config.iFlightFlagSize;
         optlen         = sizeof(int);
         break;
 
     case SRTO_SNDBUF:
-        *(int *)optval = m_config.m_iSndBufSize * (m_config.m_iMSS - CPacket::UDP_HDR_SIZE);
+        *(int *)optval = m_config.iSndBufSize * (m_config.iMSS - CPacket::UDP_HDR_SIZE);
         optlen         = sizeof(int);
         break;
 
     case SRTO_RCVBUF:
-        *(int *)optval = m_config.m_iRcvBufSize * (m_config.m_iMSS - CPacket::UDP_HDR_SIZE);
+        *(int *)optval = m_config.iRcvBufSize * (m_config.iMSS - CPacket::UDP_HDR_SIZE);
         optlen         = sizeof(int);
         break;
 
@@ -404,63 +404,63 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         if (optlen < (int)(sizeof(linger)))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        *(linger *)optval = m_config.m_Linger;
+        *(linger *)optval = m_config.Linger;
         optlen            = sizeof(linger);
         break;
 
     case SRTO_UDP_SNDBUF:
-        *(int *)optval = m_config.m_iUDPSndBufSize;
+        *(int *)optval = m_config.iUDPSndBufSize;
         optlen         = sizeof(int);
         break;
 
     case SRTO_UDP_RCVBUF:
-        *(int *)optval = m_config.m_iUDPRcvBufSize;
+        *(int *)optval = m_config.iUDPRcvBufSize;
         optlen         = sizeof(int);
         break;
 
     case SRTO_RENDEZVOUS:
-        *(bool *)optval = m_config.m_bRendezvous;
+        *(bool *)optval = m_config.bRendezvous;
         optlen          = sizeof(bool);
         break;
 
     case SRTO_SNDTIMEO:
-        *(int *)optval = m_config.m_iSndTimeOut;
+        *(int *)optval = m_config.iSndTimeOut;
         optlen         = sizeof(int);
         break;
 
     case SRTO_RCVTIMEO:
-        *(int *)optval = m_config.m_iRcvTimeOut;
+        *(int *)optval = m_config.iRcvTimeOut;
         optlen         = sizeof(int);
         break;
 
     case SRTO_REUSEADDR:
-        *(bool *)optval = m_config.m_bReuseAddr;
+        *(bool *)optval = m_config.bReuseAddr;
         optlen          = sizeof(bool);
         break;
 
     case SRTO_MAXBW:
-        if (size_t(optlen) < sizeof(m_config.m_llMaxBW))
+        if (size_t(optlen) < sizeof(m_config.llMaxBW))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        *(int64_t *)optval = m_config.m_llMaxBW;
+        *(int64_t *)optval = m_config.llMaxBW;
         optlen             = sizeof(int64_t);
         break;
 
     case SRTO_INPUTBW:
-        if (size_t(optlen) < sizeof(m_config.m_llInputBW))
+        if (size_t(optlen) < sizeof(m_config.llInputBW))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-       *(int64_t*)optval = m_config.m_llInputBW;
+       *(int64_t*)optval = m_config.llInputBW;
        optlen            = sizeof(int64_t);
        break;
 
     case SRTO_MININPUTBW:
-        if (size_t(optlen) < sizeof (m_config.m_llMinInputBW))
+        if (size_t(optlen) < sizeof (m_config.llMinInputBW))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        *(int64_t*)optval = m_config.m_llMinInputBW;
+        *(int64_t*)optval = m_config.llMinInputBW;
         optlen            = sizeof(int64_t);
         break;
 
     case SRTO_OHEADBW:
-        *(int32_t *)optval = m_config.m_iOverheadBW;
+        *(int32_t *)optval = m_config.iOverheadBW;
         optlen = sizeof(int32_t);
         break;
 
@@ -480,7 +480,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
             if (m_pRcvBuffer && m_pRcvBuffer->isRcvDataReady())
                 event |= SRT_EPOLL_IN;
             leaveCS(m_RecvLock);
-            if (m_pSndBuffer && (m_config.m_iSndBufSize > m_pSndBuffer->getCurrBufSize()))
+            if (m_pSndBuffer && (m_config.iSndBufSize > m_pSndBuffer->getCurrBufSize()))
                 event |= SRT_EPOLL_OUT;
         }
         *(int32_t *)optval = event;
@@ -512,7 +512,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         if (m_bOpened)
             *(int32_t *)optval = m_pSndQueue->getIpTTL();
         else
-            *(int32_t *)optval = m_config.m_iIpTTL;
+            *(int32_t *)optval = m_config.iIpTTL;
         optlen = sizeof(int32_t);
         break;
 
@@ -520,7 +520,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         if (m_bOpened)
             *(int32_t *)optval = m_pSndQueue->getIpToS();
         else
-            *(int32_t *)optval = m_config.m_iIpToS;
+            *(int32_t *)optval = m_config.iIpToS;
         optlen = sizeof(int32_t);
         break;
 
@@ -536,8 +536,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         }
 
         // Fallback: return from internal data
-        strcpy(((char*)optval), m_config.m_BindToDevice.c_str());
-        optlen = m_config.m_BindToDevice.size();
+        strcpy(((char*)optval), m_config.BindToDevice.c_str());
+        optlen = m_config.BindToDevice.size();
 #else
         LOGC(smlog.Error, log << "SRTO_BINDTODEVICE is not supported on that platform");
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -545,12 +545,12 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SENDER:
-        *(int32_t *)optval = m_config.m_bDataSender;
+        *(int32_t *)optval = m_config.bDataSender;
         optlen             = sizeof(int32_t);
         break;
 
     case SRTO_TSBPDMODE:
-        *(int32_t *)optval = m_config.m_bTSBPD;
+        *(int32_t *)optval = m_config.bTSBPD;
         optlen             = sizeof(int32_t);
         break;
 
@@ -559,7 +559,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         if (m_bConnected)
             *(int32_t *)optval = m_iTsbPdDelay_ms;
         else
-            *(int32_t *)optval = m_config.m_iRcvLatency;
+            *(int32_t *)optval = m_config.iRcvLatency;
         optlen             = sizeof(int32_t);
         break;
 
@@ -567,7 +567,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         if (m_bConnected)
             *(int32_t *)optval = m_iPeerTsbPdDelay_ms;
         else
-            *(int32_t *)optval = m_config.m_iPeerLatency;
+            *(int32_t *)optval = m_config.iPeerLatency;
 
         optlen             = sizeof(int32_t);
         break;
@@ -578,7 +578,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SNDDROPDELAY:
-        *(int32_t *)optval = m_config.m_iSndDropDelay;
+        *(int32_t *)optval = m_config.iSndDropDelay;
         optlen             = sizeof(int32_t);
         break;
 
@@ -586,14 +586,14 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         if (m_pCryptoControl)
             *(int32_t *)optval = (int32_t) m_pCryptoControl->KeyLen(); // Running Key length.
         else
-            *(int32_t *)optval = m_config.m_iSndCryptoKeyLen; // May be 0.
+            *(int32_t *)optval = m_config.iSndCryptoKeyLen; // May be 0.
         optlen = sizeof(int32_t);
         break;
 
     case SRTO_KMSTATE:
         if (!m_pCryptoControl)
             *(int32_t *)optval = SRT_KM_S_UNSECURED;
-        else if (m_config.m_bDataSender)
+        else if (m_config.bDataSender)
             *(int32_t *)optval = m_pCryptoControl->m_SndKmState;
         else
             *(int32_t *)optval = m_pCryptoControl->m_RcvKmState;
@@ -617,67 +617,67 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_LOSSMAXTTL:
-        *(int32_t*)optval = m_config.m_iMaxReorderTolerance;
+        *(int32_t*)optval = m_config.iMaxReorderTolerance;
         optlen = sizeof(int32_t);
         break;
 
     case SRTO_NAKREPORT:
-        *(bool *)optval = m_config.m_bRcvNakReport;
+        *(bool *)optval = m_config.bRcvNakReport;
         optlen          = sizeof(bool);
         break;
 
     case SRTO_VERSION:
-        *(int32_t *)optval = m_config.m_lSrtVersion;
+        *(int32_t *)optval = m_config.uSrtVersion;
         optlen             = sizeof(int32_t);
         break;
 
     case SRTO_PEERVERSION:
-        *(int32_t *)optval = m_lPeerSrtVersion;
+        *(int32_t *)optval = m_uPeerSrtVersion;
         optlen             = sizeof(int32_t);
         break;
 
     case SRTO_CONNTIMEO:
-        *(int*)optval = (int) count_milliseconds(m_config.m_tdConnTimeOut);
+        *(int*)optval = (int) count_milliseconds(m_config.tdConnTimeOut);
         optlen        = sizeof(int);
         break;
 
     case SRTO_DRIFTTRACER:
-        *(int*)optval = m_config.m_bDriftTracer;
+        *(int*)optval = m_config.bDriftTracer;
         optlen        = sizeof(int);
         break;
 
     case SRTO_MINVERSION:
-        *(uint32_t *)optval = m_config.m_lMinimumPeerSrtVersion;
+        *(uint32_t *)optval = m_config.uMinimumPeerSrtVersion;
         optlen              = sizeof(uint32_t);
         break;
 
     case SRTO_STREAMID:
-        if (size_t(optlen) < m_config.m_StreamName.size() + 1)
+        if (size_t(optlen) < m_config.sStreamName.size() + 1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        strcpy((char *)optval, m_config.m_StreamName.c_str());
-        optlen = (int) m_config.m_StreamName.size();
+        strcpy((char *)optval, m_config.sStreamName.c_str());
+        optlen = (int) m_config.sStreamName.size();
         break;
 
     case SRTO_CONGESTION:
-        strcpy((char *)optval, m_config.m_Congestion.c_str());
-        optlen = (int) m_config.m_Congestion.size();
+        strcpy((char *)optval, m_config.sCongestion.c_str());
+        optlen = (int) m_config.sCongestion.size();
         break;
 
     case SRTO_MESSAGEAPI:
         optlen          = sizeof(bool);
-        *(bool *)optval = m_config.m_bMessageAPI;
+        *(bool *)optval = m_config.bMessageAPI;
         break;
 
     case SRTO_PAYLOADSIZE:
         optlen         = sizeof(int);
-        *(int *)optval = (int) m_config.m_zExpPayloadSize;
+        *(int *)optval = (int) m_config.zExpPayloadSize;
         break;
 
 #if ENABLE_EXPERIMENTAL_BONDING
     case SRTO_GROUPCONNECT:
         optlen         = sizeof (int);
-        *(int*)optval = m_config.m_GroupConnect;
+        *(int*)optval = m_config.iGroupConnect;
         break;
 
     case SRTO_GROUPTYPE:
@@ -688,29 +688,29 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 
     case SRTO_ENFORCEDENCRYPTION:
         optlen             = sizeof(int32_t); // also with TSBPDMODE and SENDER
-        *(int32_t *)optval = m_config.m_bEnforcedEnc;
+        *(int32_t *)optval = m_config.bEnforcedEnc;
         break;
 
     case SRTO_IPV6ONLY:
         optlen         = sizeof(int);
-        *(int *)optval = m_config.m_iIpV6Only;
+        *(int *)optval = m_config.iIpV6Only;
         break;
 
     case SRTO_PEERIDLETIMEO:
-        *(int *)optval = m_config.m_iPeerIdleTimeout;
+        *(int *)optval = m_config.iPeerIdleTimeout;
         optlen         = sizeof(int);
         break;
 
     case SRTO_PACKETFILTER:
-        if (size_t(optlen) < m_config.m_PacketFilterConfig.size() + 1)
+        if (size_t(optlen) < m_config.sPacketFilterConfig.size() + 1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        strcpy((char *)optval, m_config.m_PacketFilterConfig.c_str());
-        optlen = (int) m_config.m_PacketFilterConfig.size();
+        strcpy((char *)optval, m_config.sPacketFilterConfig.c_str());
+        optlen = (int) m_config.sPacketFilterConfig.size();
         break;
 
     case SRTO_RETRANSMITALGO:
-        *(int32_t *)optval = m_config.m_iRetransmitAlgo;
+        *(int32_t *)optval = m_config.iRetransmitAlgo;
         optlen         = sizeof(int32_t);
         break;
 
@@ -747,7 +747,7 @@ bool CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
     if (that->m_bConnected)
         return false;
 
-    that->m_config.m_StreamName.set(sid);
+    that->m_config.sStreamName.set(sid);
     return true;
 }
 
@@ -757,7 +757,7 @@ std::string CUDT::getstreamid(SRTSOCKET u)
     if (!that)
         return "";
 
-    return that->m_config.m_StreamName.str();
+    return that->m_config.sStreamName.str();
 }
 
 // XXX REFACTOR: Make common code for CUDT constructor and clearData,
@@ -765,7 +765,7 @@ std::string CUDT::getstreamid(SRTSOCKET u)
 void CUDT::clearData()
 {
     // Initial sequence number, loss, acknowledgement, etc.
-    int udpsize = m_config.m_iMSS - CPacket::UDP_HDR_SIZE;
+    int udpsize = m_config.iMSS - CPacket::UDP_HDR_SIZE;
 
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
 
@@ -839,8 +839,8 @@ void CUDT::clearData()
     // should they be set to possibly true.
     m_bTsbPd         = false;
     m_bGroupTsbPd    = false;
-    m_iTsbPdDelay_ms = m_config.m_iRcvLatency;
-    m_bTLPktDrop     = m_config.m_bTLPktDrop;
+    m_iTsbPdDelay_ms = m_config.iRcvLatency;
+    m_bTLPktDrop     = m_config.bTLPktDrop;
     m_bPeerTLPktDrop = false;
 
     m_bPeerNakReport = false;
@@ -936,7 +936,7 @@ size_t CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, 
 
     memset((aw_srtdata), 0, sizeof(uint32_t) * srtlen);
     /* Current version (1.x.x) SRT handshake */
-    aw_srtdata[SRT_HS_VERSION] = m_config.m_lSrtVersion; /* Required version */
+    aw_srtdata[SRT_HS_VERSION] = m_config.uSrtVersion; /* Required version */
     aw_srtdata[SRT_HS_FLAGS] |= SrtVersionCapabilities();
 
     switch (msgtype)
@@ -963,10 +963,10 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unu
     // not set TsbPd mode, it will simply ignore the proposed latency (PeerTsbPdDelay), although
     // if it has received the Rx latency as well, it must honor it and respond accordingly
     // (the latter is only in case of HSv5 and bidirectional connection).
-    if (m_config.m_bTSBPD)
+    if (m_config.bTSBPD)
     {
-        m_iTsbPdDelay_ms     = m_config.m_iRcvLatency;
-        m_iPeerTsbPdDelay_ms = m_config.m_iPeerLatency;
+        m_iTsbPdDelay_ms     = m_config.iRcvLatency;
+        m_iPeerTsbPdDelay_ms = m_config.iPeerLatency;
         /*
          * Sent data is real-time, use Time-based Packet Delivery,
          * set option bit and configured delay
@@ -995,7 +995,7 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unu
         }
     }
 
-    if (m_config.m_bRcvNakReport)
+    if (m_config.bRcvNakReport)
         aw_srtdata[SRT_HS_FLAGS] |= SRT_OPT_NAKREPORT;
 
     // I support SRT_OPT_REXMITFLG. Do you?
@@ -1003,7 +1003,7 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unu
 
     // Declare the API used. The flag is set for "stream" API because
     // the older versions will never set this flag, but all old SRT versions use message API.
-    if (!m_config.m_bMessageAPI)
+    if (!m_config.bMessageAPI)
         aw_srtdata[SRT_HS_FLAGS] |= SRT_OPT_STREAM;
 
     HLOGC(cnlog.Debug,
@@ -1074,7 +1074,7 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unu
     if (m_bTLPktDrop)
         aw_srtdata[SRT_HS_FLAGS] |= SRT_OPT_TLPKTDROP;
 
-    if (m_config.m_bRcvNakReport)
+    if (m_config.bRcvNakReport)
     {
         // HSv5: Note that this setting is independent on the value of
         // m_bPeerNakReport, which represent this setting in the peer.
@@ -1088,11 +1088,11 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unu
          * Disabling TLPktDrop in the receiver SRT Handshake Reply prevents the sender
          * from enabling Too-Late Packet Drop.
          */
-        if (m_lPeerSrtVersion <= SrtVersion(1, 0, 7))
+        if (m_uPeerSrtVersion <= SrtVersion(1, 0, 7))
             aw_srtdata[SRT_HS_FLAGS] &= ~SRT_OPT_TLPKTDROP;
     }
 
-    if (m_config.m_lSrtVersion >= SrtVersion(1, 2, 0))
+    if (m_config.uSrtVersion >= SrtVersion(1, 2, 0))
     {
         if (!m_bPeerRexmitFlag)
         {
@@ -1392,12 +1392,12 @@ bool CUDT::createSrtHandshake(
         //
         // Keep 0 in the SRT_HSTYPE_HSFLAGS field, but still advertise PBKEYLEN
         // in the SRT_HSTYPE_ENCFLAGS field.
-        w_hs.m_iType                  = SrtHSRequest::wrapFlags(false /*no magic in HSFLAGS*/, m_config.m_iSndCryptoKeyLen);
+        w_hs.m_iType                  = SrtHSRequest::wrapFlags(false /*no magic in HSFLAGS*/, m_config.iSndCryptoKeyLen);
 
-        IF_HEAVY_LOGGING(bool whether = m_config.m_iSndCryptoKeyLen != 0);
+        IF_HEAVY_LOGGING(bool whether = m_config.iSndCryptoKeyLen != 0);
         HLOGC(cnlog.Debug,
               log << "createSrtHandshake: " << (whether ? "" : "NOT ")
-                  << " Advertising PBKEYLEN - value = " << m_config.m_iSndCryptoKeyLen);
+                  << " Advertising PBKEYLEN - value = " << m_config.iSndCryptoKeyLen);
 
         // Note: This is required only when sending a HS message without SRT extensions.
         // When this is to be sent with SRT extensions, then KMREQ will be attached here
@@ -1441,7 +1441,7 @@ bool CUDT::createSrtHandshake(
     bool have_sid = false;
     if (srths_cmd == SRT_CMD_HSREQ)
     {
-        if (!m_config.m_StreamName.empty())
+        if (!m_config.sStreamName.empty())
         {
             have_sid = true;
             w_hs.m_iType |= CHandShake::HS_EXT_CONFIG;
@@ -1459,7 +1459,7 @@ bool CUDT::createSrtHandshake(
         {
             peer_filter_capable = true;
         }
-        else if (IsSet(m_lPeerSrtFlags, SRT_OPT_FILTERCAP))
+        else if (IsSet(m_uPeerSrtFlags, SRT_OPT_FILTERCAP))
         {
             peer_filter_capable = true;
         }
@@ -1478,7 +1478,7 @@ bool CUDT::createSrtHandshake(
     // possibly confronted with the contents of m_OPT_FECConfigString,
     // and if it decided to go with filter, it will be nonempty.
     bool have_filter  = false;
-    if (peer_filter_capable && !m_config.m_PacketFilterConfig.empty())
+    if (peer_filter_capable && !m_config.sPacketFilterConfig.empty())
     {
         have_filter = true;
         w_hs.m_iType |= CHandShake::HS_EXT_CONFIG;
@@ -1486,7 +1486,7 @@ bool CUDT::createSrtHandshake(
     }
 
     bool have_congctl = false;
-    const string sm = m_config.m_Congestion.str();
+    const string sm = m_config.sCongestion.str();
     if (sm != "" && sm != "live")
     {
         have_congctl = true;
@@ -1501,7 +1501,7 @@ bool CUDT::createSrtHandshake(
     // KMRSP must be always sent when:
     // - Agent set a password, Peer did not send KMREQ: Agent sets snd=NOSECRET.
     // - Agent set no password, but Peer sent KMREQ: Ageng sets rcv=NOSECRET.
-    if (m_config.m_CryptoSecret.len > 0 || kmdata_wordsize > 0)
+    if (m_config.CryptoSecret.len > 0 || kmdata_wordsize > 0)
     {
         have_kmreq = true;
         w_hs.m_iType |= CHandShake::HS_EXT_KMREQ;
@@ -1579,7 +1579,7 @@ bool CUDT::createSrtHandshake(
         // the conclusion packet.
         size_t size_limit = m_iMaxSRTPayloadSize / 2;
 
-        if (m_config.m_StreamName.size() >= size_limit)
+        if (m_config.sStreamName.size() >= size_limit)
         {
             m_RejectReason = SRT_REJ_ROGUE;
             LOGC(cnlog.Warn,
@@ -1588,11 +1588,11 @@ bool CUDT::createSrtHandshake(
         }
 
         offset += ra_size + 1;
-        ra_size = fillHsExtConfigString(p + offset - 1, SRT_CMD_SID, m_config.m_StreamName.str());
+        ra_size = fillHsExtConfigString(p + offset - 1, SRT_CMD_SID, m_config.sStreamName.str());
 
         HLOGC(cnlog.Debug,
-              log << "createSrtHandshake: after SID [" << m_config.m_StreamName.c_str()
-                  << "] length=" << m_config.m_StreamName.size() << " alignedln=" << (4 * ra_size)
+              log << "createSrtHandshake: after SID [" << m_config.sStreamName.c_str()
+                  << "] length=" << m_config.sStreamName.size() << " alignedln=" << (4 * ra_size)
                   << ": offset=" << offset << " SID size=" << ra_size << " space left: " << (total_ra_size - offset));
     }
 
@@ -1614,11 +1614,11 @@ bool CUDT::createSrtHandshake(
     if (have_filter)
     {
         offset += ra_size + 1;
-        ra_size = fillHsExtConfigString(p + offset - 1, SRT_CMD_FILTER, m_config.m_PacketFilterConfig.str());
+        ra_size = fillHsExtConfigString(p + offset - 1, SRT_CMD_FILTER, m_config.sPacketFilterConfig.str());
 
         HLOGC(cnlog.Debug,
-              log << "createSrtHandshake: after filter [" << m_config.m_PacketFilterConfig.c_str() << "] length="
-                  << m_config.m_PacketFilterConfig.size() << " alignedln=" << (4 * ra_size) << ": offset=" << offset
+              log << "createSrtHandshake: after filter [" << m_config.sPacketFilterConfig.c_str() << "] length="
+                  << m_config.sPacketFilterConfig.size() << " alignedln=" << (4 * ra_size) << ": offset=" << offset
                   << " filter size=" << ra_size << " space left: " << (total_ra_size - offset));
     }
 
@@ -1669,7 +1669,7 @@ bool CUDT::createSrtHandshake(
     {
         HLOGC(cnlog.Debug,
               log << "createSrtHandshake: "
-                  << (m_config.m_CryptoSecret.len > 0 ? "Agent uses ENCRYPTION" : "Peer requires ENCRYPTION"));
+                  << (m_config.CryptoSecret.len > 0 ? "Agent uses ENCRYPTION" : "Peer requires ENCRYPTION"));
         if (srtkm_cmd == SRT_CMD_KMREQ)
         {
             bool have_any_keys = false;
@@ -1844,7 +1844,7 @@ bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
             {
                 if (len_out == 1)
                 {
-                    if (m_config.m_bEnforcedEnc)
+                    if (m_config.bEnforcedEnc)
                     {
                         LOGC(cnlog.Warn,
                              log << "KMREQ FAILURE: " << KmStateStr(SRT_KM_STATE(srtdata_out[0]))
@@ -1907,8 +1907,8 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
 
     // Prepare the initial runtime values of latency basing on the option values.
     // They are going to get the value fixed HERE.
-    m_iTsbPdDelay_ms     = m_config.m_iRcvLatency;
-    m_iPeerTsbPdDelay_ms = m_config.m_iPeerLatency;
+    m_iTsbPdDelay_ms     = m_config.iRcvLatency;
+    m_iPeerTsbPdDelay_ms = m_config.iPeerLatency;
 
     if (bytelen < SRT_CMD_HSREQ_MINSZ)
     {
@@ -1926,12 +1926,12 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
          srtdata[SRT_HS_FLAGS],
          SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]));
 
-    m_lPeerSrtVersion = srtdata[SRT_HS_VERSION];
-    m_lPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
+    m_uPeerSrtVersion = srtdata[SRT_HS_VERSION];
+    m_uPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
 
     if (hsv == CUDT::HS_VERSION_UDT4)
     {
-        if (m_lPeerSrtVersion >= SRT_VERSION_FEAT_HSv5)
+        if (m_uPeerSrtVersion >= SRT_VERSION_FEAT_HSv5)
         {
             m_RejectReason = SRT_REJ_ROGUE;
             LOGC(cnlog.Error,
@@ -1942,7 +1942,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
     }
     else
     {
-        if (m_lPeerSrtVersion < SRT_VERSION_FEAT_HSv5)
+        if (m_uPeerSrtVersion < SRT_VERSION_FEAT_HSv5)
         {
             m_RejectReason = SRT_REJ_ROGUE;
             LOGC(cnlog.Error,
@@ -1952,31 +1952,31 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
     }
 
     // Check also if the version satisfies the minimum required version
-    if (m_lPeerSrtVersion < m_config.m_lMinimumPeerSrtVersion)
+    if (m_uPeerSrtVersion < m_config.uMinimumPeerSrtVersion)
     {
         m_RejectReason = SRT_REJ_VERSION;
         LOGC(cnlog.Error,
-             log << "HSREQ/rcv: Peer version: " << SrtVersionString(m_lPeerSrtVersion)
-                 << " is too old for requested: " << SrtVersionString(m_config.m_lMinimumPeerSrtVersion)
+             log << "HSREQ/rcv: Peer version: " << SrtVersionString(m_uPeerSrtVersion)
+                 << " is too old for requested: " << SrtVersionString(m_config.uMinimumPeerSrtVersion)
                  << " - REJECTING");
         return SRT_CMD_REJECT;
     }
 
     HLOGC(cnlog.Debug,
-          log << "HSREQ/rcv: PEER Version: " << SrtVersionString(m_lPeerSrtVersion) << " Flags: " << m_lPeerSrtFlags
-              << "(" << SrtFlagString(m_lPeerSrtFlags)
-              << ") Min req version:" << SrtVersionString(m_config.m_lMinimumPeerSrtVersion));
+          log << "HSREQ/rcv: PEER Version: " << SrtVersionString(m_uPeerSrtVersion) << " Flags: " << m_uPeerSrtFlags
+              << "(" << SrtFlagString(m_uPeerSrtFlags)
+              << ") Min req version:" << SrtVersionString(m_config.uMinimumPeerSrtVersion));
 
-    m_bPeerRexmitFlag = IsSet(m_lPeerSrtFlags, SRT_OPT_REXMITFLG);
+    m_bPeerRexmitFlag = IsSet(m_uPeerSrtFlags, SRT_OPT_REXMITFLG);
     HLOGF(cnlog.Debug, "HSREQ/rcv: peer %s REXMIT flag", m_bPeerRexmitFlag ? "UNDERSTANDS" : "DOES NOT UNDERSTAND");
 
     // Check if both use the same API type. Reject if not.
-    bool peer_message_api = !IsSet(m_lPeerSrtFlags, SRT_OPT_STREAM);
-    if (peer_message_api != m_config.m_bMessageAPI)
+    bool peer_message_api = !IsSet(m_uPeerSrtFlags, SRT_OPT_STREAM);
+    if (peer_message_api != m_config.bMessageAPI)
     {
         m_RejectReason = SRT_REJ_MESSAGEAPI;
         LOGC(cnlog.Error,
-             log << "HSREQ/rcv: Agent uses " << (m_config.m_bMessageAPI ? "MESSAGE" : "STREAM")
+             log << "HSREQ/rcv: Agent uses " << (m_config.bMessageAPI ? "MESSAGE" : "STREAM")
                  << " API, but the Peer declares " << (peer_message_api ? "MESSAGE" : "STREAM")
                  << " API. Not compatible transmission type, rejecting.");
         return SRT_CMD_REJECT;
@@ -2000,7 +2000,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
         // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         // |      Receiver TSBPD Delay     |       Sender TSBPD Delay      |
         // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND) || IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDSND) || IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDRCV))
         {
             m_RejectReason = SRT_REJ_ROGUE;
             LOGC(cnlog.Error,
@@ -2017,7 +2017,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
 
     const uint32_t latencystr = srtdata[SRT_HS_LATENCY];
 
-    if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND))
+    if (IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDSND))
     {
         // TimeStamp-based Packet Delivery feature enabled
         if (!isOPT_TsbPd())
@@ -2066,7 +2066,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
     // that the peer INITIATOR will receive the data and informs about its predefined
     // latency. We need to maximize this with our setting of the peer's latency and
     // record as peer's latency, which will be then sent back with HSRSP.
-    if (hsv > CUDT::HS_VERSION_UDT4 && IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
+    if (hsv > CUDT::HS_VERSION_UDT4 && IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDRCV))
     {
         // So, PEER uses TSBPD, set the flag.
         // NOTE: it doesn't matter, if AGENT uses TSBPD.
@@ -2092,12 +2092,12 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
     {
         // This is HSv5, do the same things as required for the sending party in HSv4,
         // as in HSv5 this can also be a sender.
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_TLPKTDROP))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_TLPKTDROP))
         {
             // Too late packets dropping feature supported
             m_bPeerTLPktDrop = true;
         }
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_NAKREPORT))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_NAKREPORT))
         {
             // Peer will send Periodic NAK Reports
             m_bPeerNakReport = true;
@@ -2147,22 +2147,22 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t 
         HLOGC(cnlog.Debug, log << "HSRSP/rcv: PEER START TIME already set (derived): " << FormatTime(m_tsRcvPeerStartTime));
     }
 
-    m_lPeerSrtVersion = srtdata[SRT_HS_VERSION];
-    m_lPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
+    m_uPeerSrtVersion = srtdata[SRT_HS_VERSION];
+    m_uPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
 
     HLOGF(cnlog.Debug,
           "HSRSP/rcv: Version: %s Flags: SND:%08X (%s)",
-          SrtVersionString(m_lPeerSrtVersion).c_str(),
-          m_lPeerSrtFlags,
-          SrtFlagString(m_lPeerSrtFlags).c_str());
+          SrtVersionString(m_uPeerSrtVersion).c_str(),
+          m_uPeerSrtFlags,
+          SrtFlagString(m_uPeerSrtFlags).c_str());
 
     // Basic version check
-    if (m_lPeerSrtVersion < m_config.m_lMinimumPeerSrtVersion)
+    if (m_uPeerSrtVersion < m_config.uMinimumPeerSrtVersion)
     {
         m_RejectReason = SRT_REJ_VERSION;
         LOGC(cnlog.Error,
-             log << "HSRSP/rcv: Peer version: " << SrtVersionString(m_lPeerSrtVersion)
-                 << " is too old for requested: " << SrtVersionString(m_config.m_lMinimumPeerSrtVersion)
+             log << "HSRSP/rcv: Peer version: " << SrtVersionString(m_uPeerSrtVersion)
+                 << " is too old for requested: " << SrtVersionString(m_config.uMinimumPeerSrtVersion)
                  << " - REJECTING");
         return SRT_CMD_REJECT;
     }
@@ -2170,7 +2170,7 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t 
     if (hsv == CUDT::HS_VERSION_UDT4)
     {
         // The old HSv4 way: extract just one value and put it under peer.
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDRCV))
         {
             // TsbPd feature enabled
             m_bPeerTsbPd         = true;
@@ -2186,7 +2186,7 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t 
         // HSv5 way: extract the receiver latency and sender latency, if used.
 
         // PEER WILL RECEIVE TSBPD == AGENT SHALL SEND TSBPD.
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDRCV))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDRCV))
         {
             // TsbPd feature enabled
             m_bPeerTsbPd         = true;
@@ -2199,7 +2199,7 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t 
         }
 
         // PEER WILL SEND TSBPD == AGENT SHALL RECEIVE TSBPD.
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_TSBPDSND))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_TSBPDSND))
         {
             if (!isOPT_TsbPd())
             {
@@ -2217,21 +2217,21 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t 
         }
     }
 
-    if ((m_config.m_lSrtVersion >= SrtVersion(1, 0, 5)) && IsSet(m_lPeerSrtFlags, SRT_OPT_TLPKTDROP))
+    if ((m_config.uSrtVersion >= SrtVersion(1, 0, 5)) && IsSet(m_uPeerSrtFlags, SRT_OPT_TLPKTDROP))
     {
         // Too late packets dropping feature supported
         m_bPeerTLPktDrop = true;
     }
 
-    if ((m_config.m_lSrtVersion >= SrtVersion(1, 1, 0)) && IsSet(m_lPeerSrtFlags, SRT_OPT_NAKREPORT))
+    if ((m_config.uSrtVersion >= SrtVersion(1, 1, 0)) && IsSet(m_uPeerSrtFlags, SRT_OPT_NAKREPORT))
     {
         // Peer will send Periodic NAK Reports
         m_bPeerNakReport = true;
     }
 
-    if (m_config.m_lSrtVersion >= SrtVersion(1, 2, 0))
+    if (m_config.uSrtVersion >= SrtVersion(1, 2, 0))
     {
-        if (IsSet(m_lPeerSrtFlags, SRT_OPT_REXMITFLG))
+        if (IsSet(m_uPeerSrtFlags, SRT_OPT_REXMITFLG))
         {
             // Peer will use REXMIT flag in packet retransmission.
             m_bPeerRexmitFlag = true;
@@ -2408,7 +2408,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
 #ifdef SRT_ENABLE_ENCRYPTION
         if (!m_pCryptoControl->hasPassphrase())
         {
-            if (m_config.m_bEnforcedEnc)
+            if (m_config.bEnforcedEnc)
             {
                 m_RejectReason = SRT_REJ_UNSECURE;
                 LOGC(cnlog.Error,
@@ -2459,7 +2459,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
                 {
                     // This means that there was an abnormal encryption situation occurred.
                     // This is inacceptable in case of strict encryption.
-                    if (m_config.m_bEnforcedEnc)
+                    if (m_config.bEnforcedEnc)
                     {
                         if (m_pCryptoControl->m_RcvKmState == SRT_KM_S_BADSECRET)
                         {
@@ -2479,7 +2479,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
             else if (cmd == SRT_CMD_KMRSP)
             {
                 int res = m_pCryptoControl->processSrtMsg_KMRSP(begin + 1, bytelen, HS_VERSION_SRT1);
-                if (m_config.m_bEnforcedEnc && res == -1)
+                if (m_config.bEnforcedEnc && res == -1)
                 {
                     m_RejectReason = SRT_REJ_UNSECURE;
                     LOGC(cnlog.Error, log << "KMRSP failed - rejecting connection as per enforced encryption.");
@@ -2524,11 +2524,11 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
 
     bool   have_congctl = false;
     bool   have_filter  = false;
-    string agsm = m_config.m_Congestion.str();
+    string agsm = m_config.sCongestion.str();
     if (agsm == "")
     {
         agsm = "live";
-        m_config.m_Congestion.set("live", 4);
+        m_config.sCongestion.set("live", 4);
     }
 
     bool have_group ATR_UNUSED = false;
@@ -2574,9 +2574,9 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
                 // Un-swap on big endian machines
                 ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
 
-                m_config.m_StreamName.set(target, bytelen);
+                m_config.sStreamName.set(target, bytelen);
                 HLOGC(cnlog.Debug,
-                      log << "CONNECTOR'S REQUESTED SID [" << m_config.m_StreamName.c_str() << "] (bytelen=" << bytelen
+                      log << "CONNECTOR'S REQUESTED SID [" << m_config.sStreamName.c_str() << "] (bytelen=" << bytelen
                           << " blocklen=" << blocklen << ")");
             }
             else if (cmd == SRT_CMD_CONGESTION)
@@ -2701,9 +2701,9 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
 
     // Post-checks
     // Check if peer declared encryption
-    if (!encrypted && m_config.m_CryptoSecret.len > 0)
+    if (!encrypted && m_config.CryptoSecret.len > 0)
     {
-        if (m_config.m_bEnforcedEnc)
+        if (m_config.bEnforcedEnc)
         {
             m_RejectReason = SRT_REJ_UNSECURE;
             LOGC(cnlog.Error,
@@ -2766,13 +2766,13 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
     if (!PacketFilter::correctConfig(cfg))
         return false;
 
-    string thisconf = m_config.m_PacketFilterConfig.str();
+    string thisconf = m_config.sPacketFilterConfig.str();
 
     // Now parse your own string, if you have it.
     if (thisconf != "")
     {
         // - for rendezvous, both must be exactly the same (it's unspecified, which will be the first one)
-        if (m_config.m_bRendezvous && thisconf != confstr)
+        if (m_config.bRendezvous && thisconf != confstr)
         {
             return false;
         }
@@ -2817,7 +2817,7 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
             myos << "," << x->first << ":" << x->second;
         }
 
-        m_config.m_PacketFilterConfig.set(myos.str());
+        m_config.sPacketFilterConfig.set(myos.str());
 
         HLOGC(cnlog.Debug, log << "checkApplyFilterConfig: Effective config: " << thisconf);
     }
@@ -2825,16 +2825,16 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
     {
         // Take the foreign configuration as a good deal.
         HLOGC(cnlog.Debug, log << "checkApplyFilterConfig: Good deal config: " << thisconf);
-        m_config.m_PacketFilterConfig.set(confstr);
+        m_config.sPacketFilterConfig.set(confstr);
     }
 
     size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - cfg.extra_size;
-    if (m_config.m_zExpPayloadSize > efc_max_payload_size)
+    if (m_config.zExpPayloadSize > efc_max_payload_size)
     {
         LOGC(cnlog.Warn,
              log << "Due to filter-required extra " << cfg.extra_size << " bytes, SRTO_PAYLOADSIZE fixed to "
                  << efc_max_payload_size << " bytes");
-        m_config.m_zExpPayloadSize = efc_max_payload_size;
+        m_config.zExpPayloadSize = efc_max_payload_size;
     }
 
     return true;
@@ -2856,7 +2856,7 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
     int link_weight = SrtHSRequest::HS_GROUP_WEIGHT::unwrap(gd);
     uint32_t link_flags = SrtHSRequest::HS_GROUP_FLAGS::unwrap(gd);
 
-    if (m_config.m_GroupConnect == 0)
+    if (m_config.iGroupConnect == 0)
     {
         m_RejectReason = SRT_REJ_GROUP;
         LOGC(cnlog.Error, log << "HS/GROUP: this socket is not allowed for group connect.");
@@ -3077,8 +3077,8 @@ SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t l
     }
 
     // Setting non-blocking reading for group socket.
-    s->core().m_config.m_bSynRecving = false;
-    s->core().m_config.m_bSynSending = false;
+    s->core().m_config.bSynRecving = false;
+    s->core().m_config.bSynSending = false;
 
     // Copy of addSocketToGroup. No idea how many parts could be common, not much.
 
@@ -3206,7 +3206,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     ScopedLock cg (m_ConnectionLock);
 
     HLOGC(aclog.Debug, log << CONID() << "startConnect: -> " << serv_addr.str()
-            << (m_config.m_bSynRecving ? " (SYNCHRONOUS)" : " (ASYNCHRONOUS)") << "...");
+            << (m_config.bSynRecving ? " (SYNCHRONOUS)" : " (ASYNCHRONOUS)") << "...");
 
     if (!m_bOpened)
         throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
@@ -3223,9 +3223,9 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     // register this socket in the rendezvous queue
     // RendezevousQueue is used to temporarily store incoming handshake, non-rendezvous connections also require this
     // function
-    steady_clock::duration ttl = m_config.m_tdConnTimeOut;
+    steady_clock::duration ttl = m_config.tdConnTimeOut;
 
-    if (m_config.m_bRendezvous)
+    if (m_config.bRendezvous)
         ttl *= 10;
 
     const steady_clock::time_point ttl_time = steady_clock::now() + ttl;
@@ -3239,7 +3239,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     m_ConnReq.m_iType = UDT_DGRAM;
 
     // This is my current configuration
-    if (m_config.m_bRendezvous)
+    if (m_config.bRendezvous)
     {
         // For rendezvous, use version 5 in the waveahand and the cookie.
         // In case when you get the version 4 waveahand, simply switch to
@@ -3256,11 +3256,11 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 
         // This will be also passed to a HSv4 rendezvous, but fortunately the old
         // SRT didn't read this field from URQ_WAVEAHAND message, only URQ_CONCLUSION.
-        m_ConnReq.m_iType           = SrtHSRequest::wrapFlags(false /* no MAGIC here */, m_config.m_iSndCryptoKeyLen);
-        bool whether SRT_ATR_UNUSED = m_config.m_iSndCryptoKeyLen != 0;
+        m_ConnReq.m_iType           = SrtHSRequest::wrapFlags(false /* no MAGIC here */, m_config.iSndCryptoKeyLen);
+        bool whether SRT_ATR_UNUSED = m_config.iSndCryptoKeyLen != 0;
         HLOGC(aclog.Debug,
               log << "startConnect (rnd): " << (whether ? "" : "NOT ")
-                  << " Advertising PBKEYLEN - value = " << m_config.m_iSndCryptoKeyLen);
+                  << " Advertising PBKEYLEN - value = " << m_config.iSndCryptoKeyLen);
         m_RdvState  = CHandShake::RDV_WAVING;
         m_SrtHsSide = HSD_DRAW; // initially not resolved.
     }
@@ -3281,7 +3281,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
         m_RdvState           = CHandShake::RDV_INVALID;
     }
 
-    m_ConnReq.m_iMSS            = m_config.m_iMSS;
+    m_ConnReq.m_iMSS            = m_config.iMSS;
     // Defined as the size of the receiver buffer in packets, unless
     // SRTO_FC has been set to a less value.
     m_ConnReq.m_iFlightFlagSize = m_config.flightCapacity();
@@ -3357,7 +3357,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     //////////////////////////////////////////////////////
     // SYNCHRO BAR
     //////////////////////////////////////////////////////
-    if (!m_config.m_bSynRecving)
+    if (!m_config.bSynRecving)
     {
         HLOGC(cnlog.Debug, log << CONID() << "startConnect: ASYNC MODE DETECTED. Deferring the process to RcvQ:worker");
         return;
@@ -3394,7 +3394,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
             HLOGC(cnlog.Debug,
                   log << "startConnect: LOOP: time to send (" << count_milliseconds(tdiff) << " > 250 ms). size=" << reqpkt.getLength());
 
-            if (m_config.m_bRendezvous)
+            if (m_config.bRendezvous)
                 reqpkt.m_iID = m_ConnRes.m_iID;
 
             now = steady_clock::now();
@@ -3555,7 +3555,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
             m_RejectReason = RejectReasonForURQ(m_ConnRes.m_iReqType);
             e              = CUDTException(MJ_SETUP, MN_REJECTED, 0);
         }
-        else if ((!m_config.m_bRendezvous) && (m_ConnRes.m_iISN != m_iISN)) // secuity check
+        else if ((!m_config.bRendezvous) && (m_ConnRes.m_iISN != m_iISN)) // secuity check
             e = CUDTException(MJ_SETUP, MN_SECURITY, 0);
     }
 
@@ -3575,7 +3575,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     HLOGC(cnlog.Debug,
           log << "startConnect: END. Parameters:"
                  " mss="
-              << m_config.m_iMSS << " max-cwnd-size=" << m_CongCtl->cgWindowMaxSize()
+              << m_config.iMSS << " max-cwnd-size=" << m_CongCtl->cgWindowMaxSize()
               << " cwnd-size=" << m_CongCtl->cgWindowSize() << " rtt=" << m_iRTT << " bw=" << m_iBandwidth);
 }
 
@@ -3619,7 +3619,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
           log << "processAsyncConnectRequest: REQ-TIME: HIGH. Should prevent too quick responses.");
     m_tsLastReqTime = now;
     // ID = 0, connection request
-    request.m_iID = !m_config.m_bRendezvous ? 0 : m_ConnRes.m_iID;
+    request.m_iID = !m_config.bRendezvous ? 0 : m_ConnRes.m_iID;
 
     bool status = true;
 
@@ -4110,7 +4110,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
     // For HSv4, the data sender is INITIATOR, and the data receiver is RESPONDER,
     // regardless of the connecting side affiliation. This will be changed for HSv5.
     bool          bidirectional = false;
-    HandshakeSide hsd           = m_config.m_bDataSender ? HSD_INITIATOR : HSD_RESPONDER;
+    HandshakeSide hsd           = m_config.bDataSender ? HSD_INITIATOR : HSD_RESPONDER;
     // (defined here due to 'goto' below).
 
     // SRT peer may send the SRT handshake private message (type 0x7fff) before a keep-alive.
@@ -4124,7 +4124,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
     // For the initial form this value should not be checked.
     bool hsv5 = m_ConnRes.m_iVersion >= HS_VERSION_SRT1;
 
-    if (m_config.m_bRendezvous &&
+    if (m_config.bRendezvous &&
         (m_RdvState == CHandShake::RDV_CONNECTED   // somehow Rendezvous-v5 switched it to CONNECTED.
          || !response.isControl()                  // WAS A PAYLOAD PACKET.
          || (response.getType() == UMSG_KEEPALIVE) // OR WAS A UMSG_KEEPALIVE message.
@@ -4188,7 +4188,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
         // Yes, we do abort to prevent buffer overrun. Set your MSS correctly
         // and you'll avoid problems.
         m_RejectReason = SRT_REJ_ROGUE;
-        LOGC(cnlog.Fatal, log << "MSS size " << m_config.m_iMSS << "exceeds MTU size!");
+        LOGC(cnlog.Fatal, log << "MSS size " << m_config.iMSS << "exceeds MTU size!");
         return CONN_REJECT;
     }
 
@@ -4197,7 +4197,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
     // The CCryptoControl attached object must be created early
     // because it will be required to create a conclusion handshake in HSv5
     //
-    if (m_config.m_bRendezvous)
+    if (m_config.bRendezvous)
     {
         // SANITY CHECK: A rendezvous socket should reject any caller requests (it's not a listener)
         if (m_ConnRes.m_iReqType == URQ_INDUCTION)
@@ -4296,7 +4296,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
                 m_ConnReq.m_extension = true;
 
                 // For HSv5, the caller is INITIATOR and the listener is RESPONDER.
-                // The m_config.m_bDataSender value should be completely ignored and the
+                // The m_config.bDataSender value should be completely ignored and the
                 // connection is always bidirectional.
                 bidirectional = true;
                 hsd           = HSD_INITIATOR;
@@ -4328,9 +4328,9 @@ bool CUDT::applyResponseSettings() ATR_NOEXCEPT
     }
 
     // Re-configure according to the negotiated values.
-    m_config.m_iMSS      = m_ConnRes.m_iMSS;
+    m_config.iMSS      = m_ConnRes.m_iMSS;
     m_iFlowWindowSize    = m_ConnRes.m_iFlightFlagSize;
-    int udpsize          = m_config.m_iMSS - CPacket::UDP_HDR_SIZE;
+    int udpsize          = m_config.iMSS - CPacket::UDP_HDR_SIZE;
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
     m_iPeerISN           = m_ConnRes.m_iISN;
 
@@ -4560,27 +4560,27 @@ void CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t ty
     if (enc_flags >= 2 && enc_flags <= 4) // 2 = 128, 3 = 192, 4 = 256
     {
         int rcv_pbkeylen = SrtHSRequest::SRT_PBKEYLEN_BITS::wrap(enc_flags);
-        if (m_config.m_iSndCryptoKeyLen == 0)
+        if (m_config.iSndCryptoKeyLen == 0)
         {
-            m_config.m_iSndCryptoKeyLen = rcv_pbkeylen;
+            m_config.iSndCryptoKeyLen = rcv_pbkeylen;
             HLOGC(cnlog.Debug, log << loghdr << ": PBKEYLEN adopted from advertised value: "
-                  << m_config.m_iSndCryptoKeyLen);
+                  << m_config.iSndCryptoKeyLen);
         }
-        else if (m_config.m_iSndCryptoKeyLen != rcv_pbkeylen)
+        else if (m_config.iSndCryptoKeyLen != rcv_pbkeylen)
         {
             // Conflict. Use SRTO_SENDER flag to check if this side should accept
             // the enforcement, otherwise simply let it win.
-            if (!m_config.m_bDataSender)
+            if (!m_config.bDataSender)
             {
                 LOGC(cnlog.Warn,
-                     log << loghdr << ": PBKEYLEN conflict - OVERRIDDEN " << m_config.m_iSndCryptoKeyLen << " by "
+                     log << loghdr << ": PBKEYLEN conflict - OVERRIDDEN " << m_config.iSndCryptoKeyLen << " by "
                          << rcv_pbkeylen << " from PEER (as AGENT is not SRTO_SENDER)");
-                m_config.m_iSndCryptoKeyLen = rcv_pbkeylen;
+                m_config.iSndCryptoKeyLen = rcv_pbkeylen;
             }
             else
             {
                 LOGC(cnlog.Warn,
-                     log << loghdr << ": PBKEYLEN conflict - keep " << m_config.m_iSndCryptoKeyLen
+                     log << loghdr << ": PBKEYLEN conflict - keep " << m_config.iSndCryptoKeyLen
                          << "; peer-advertised PBKEYLEN " << rcv_pbkeylen << " rejected because Agent is SRTO_SENDER");
             }
         }
@@ -5073,7 +5073,7 @@ void *CUDT::tsbpd(void *param)
              * There are packets ready to be delivered
              * signal a waiting "recv" call if there is any data available
              */
-            if (self->m_config.m_bSynRecving)
+            if (self->m_config.bSynRecving)
             {
                 recvdata_cc.signal_locked(recv_lock);
             }
@@ -5214,17 +5214,17 @@ bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUD
         }
         else
         {
-            hsd = m_config.m_bDataSender ? HSD_INITIATOR : HSD_RESPONDER;
+            hsd = m_config.bDataSender ? HSD_INITIATOR : HSD_RESPONDER;
         }
     }
 
     try
     {
         m_pSndBuffer = new CSndBuffer(32, m_iMaxSRTPayloadSize);
-        m_pRcvBuffer = new CRcvBuffer(&(m_pRcvQueue->m_UnitQueue), m_config.m_iRcvBufSize);
+        m_pRcvBuffer = new CRcvBuffer(&(m_pRcvQueue->m_UnitQueue), m_config.iRcvBufSize);
         // after introducing lite ACK, the sndlosslist may not be cleared in time, so it requires twice space.
         m_pSndLossList = new CSndLossList(m_iFlowWindowSize * 2);
-        m_pRcvLossList = new CRcvLossList(m_config.m_iFlightFlagSize);
+        m_pRcvLossList = new CRcvLossList(m_config.iFlightFlagSize);
     }
     catch (...)
     {
@@ -5250,7 +5250,7 @@ void CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
 {
     // this is a reponse handshake
     w_hs.m_iReqType        = URQ_CONCLUSION;
-    w_hs.m_iMSS            = m_config.m_iMSS;
+    w_hs.m_iMSS            = m_config.iMSS;
     w_hs.m_iFlightFlagSize = m_config.flightCapacity();
     w_hs.m_iID             = m_SocketID;
 
@@ -5274,7 +5274,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer,
     m_tsRcvPeerStartTime = steady_clock::time_point(); // will be set correctly at SRT HS
 
     // Uses the smaller MSS between the peers
-    m_config.m_iMSS = std::min(m_config.m_iMSS, w_hs.m_iMSS);
+    m_config.iMSS = std::min(m_config.iMSS, w_hs.m_iMSS);
 
     // exchange info for maximum flow window size
     m_iFlowWindowSize = w_hs.m_iFlightFlagSize;
@@ -5297,7 +5297,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer,
 
     rewriteHandshakeData(peer, (w_hs));
 
-    int udpsize          = m_config.m_iMSS - CPacket::UDP_HDR_SIZE;
+    int udpsize          = m_config.iMSS - CPacket::UDP_HDR_SIZE;
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
     HLOGC(cnlog.Debug, log << "acceptAndRespond: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
 
@@ -5455,12 +5455,12 @@ bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     // These data should probably be filled only upon
     // reception of the conclusion handshake - otherwise
     // they have outdated values.
-    m_pCryptoControl->setCryptoSecret(m_config.m_CryptoSecret);
+    m_pCryptoControl->setCryptoSecret(m_config.CryptoSecret);
 
-    if (bidirectional || m_config.m_bDataSender)
+    if (bidirectional || m_config.bDataSender)
     {
-        HLOGC(rslog.Debug, log << "createCrypter: setting RCV/SND KeyLen=" << m_config.m_iSndCryptoKeyLen);
-        m_pCryptoControl->setCryptoKeylen(m_config.m_iSndCryptoKeyLen);
+        HLOGC(rslog.Debug, log << "createCrypter: setting RCV/SND KeyLen=" << m_config.iSndCryptoKeyLen);
+        m_pCryptoControl->setCryptoKeylen(m_config.iSndCryptoKeyLen);
     }
 
     return m_pCryptoControl->init(side, bidirectional);
@@ -5477,28 +5477,28 @@ SRT_REJECT_REASON CUDT::setupCC()
     // XXX Not sure about that. May happen that AGENT wants
     // tsbpd mode, but PEER doesn't, even in bidirectional mode.
     // This way, the reception side should get precedense.
-    // if (bidirectional || m_config.m_bDataSender || m_bTwoWayData)
+    // if (bidirectional || m_config.bDataSender || m_bTwoWayData)
     //    m_bPeerTsbPd = m_bTSBPD;
 
     // SrtCongestion will retrieve whatever parameters it needs
     // from *this.
 
-    bool res = m_CongCtl.select(m_config.m_Congestion.str());
+    bool res = m_CongCtl.select(m_config.sCongestion.str());
     if (!res || !m_CongCtl.configure(this))
     {
         return SRT_REJ_CONGESTION;
     }
 
     // Configure filter module
-    if (!m_config.m_PacketFilterConfig.empty())
+    if (!m_config.sPacketFilterConfig.empty())
     {
         // This string, when nonempty, defines that the corrector shall be
         // configured. Otherwise it's left uninitialized.
 
         // At this point we state everything is checked and the appropriate
         // corrector type is already selected, so now create it.
-        HLOGC(pflog.Debug, log << "filter: Configuring: " << m_config.m_PacketFilterConfig.c_str());
-        if (!m_PacketFilter.configure(this, &(m_pRcvQueue->m_UnitQueue), m_config.m_PacketFilterConfig.str()))
+        HLOGC(pflog.Debug, log << "filter: Configuring: " << m_config.sPacketFilterConfig.c_str());
+        if (!m_PacketFilter.configure(this, &(m_pRcvQueue->m_UnitQueue), m_config.sPacketFilterConfig.str()))
         {
             return SRT_REJ_FILTER;
         }
@@ -5527,7 +5527,7 @@ SRT_REJECT_REASON CUDT::setupCC()
     m_tsLastSndTime          = currtime;
 
     HLOGC(rslog.Debug,
-          log << "setupCC: setting parameters: mss=" << m_config.m_iMSS << " maxCWNDSize/FlowWindowSize=" << m_iFlowWindowSize
+          log << "setupCC: setting parameters: mss=" << m_config.iMSS << " maxCWNDSize/FlowWindowSize=" << m_iFlowWindowSize
               << " rcvrate=" << m_iDeliveryRate << "p/s (" << m_iByteDeliveryRate << "B/S)"
               << " rtt=" << m_iRTT << " bw=" << m_iBandwidth);
 
@@ -5544,7 +5544,7 @@ void CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timebase)
     // Do a fast pre-check first - this simply declares that agent uses HSv5
     // and the legacy SRT Handshake is not to be done. Second check is whether
     // agent is sender (=initiator in HSv4).
-    if (!isOPT_TsbPd() || !m_config.m_bDataSender)
+    if (!isOPT_TsbPd() || !m_config.bDataSender)
         return;
 
     if (m_iSndHsRetryCnt <= 0)
@@ -5647,23 +5647,23 @@ bool CUDT::closeInternal()
     // that it's in response to a broken connection.
     HLOGC(smlog.Debug, log << CONID() << " - closing socket:");
 
-    if (m_config.m_Linger.l_onoff != 0)
+    if (m_config.Linger.l_onoff != 0)
     {
         const steady_clock::time_point entertime = steady_clock::now();
 
         HLOGC(smlog.Debug, log << CONID() << " ... (linger)");
         while (!m_bBroken && m_bConnected && (m_pSndBuffer->getCurrBufSize() > 0) &&
-               (steady_clock::now() - entertime < seconds_from(m_config.m_Linger.l_linger)))
+               (steady_clock::now() - entertime < seconds_from(m_config.Linger.l_linger)))
         {
             // linger has been checked by previous close() call and has expired
             if (m_tsLingerExpiration >= entertime)
                 break;
 
-            if (!m_config.m_bSynSending)
+            if (!m_config.bSynSending)
             {
                 // if this socket enables asynchronous sending, return immediately and let GC to close it later
                 if (is_zero(m_tsLingerExpiration))
-                    m_tsLingerExpiration = entertime + seconds_from(m_config.m_Linger.l_linger);
+                    m_tsLingerExpiration = entertime + seconds_from(m_config.Linger.l_linger);
 
                 HLOGC(smlog.Debug,
                       log << "CUDT::close: linger-nonblocking, setting expire time T="
@@ -5794,7 +5794,7 @@ bool CUDT::closeInternal()
     m_pCryptoControl.reset();
     leaveCS(m_RcvBufferLock);
 
-    m_lPeerSrtVersion        = SRT_VERSION_UNK;
+    m_uPeerSrtVersion        = SRT_VERSION_UNK;
     m_tsRcvPeerStartTime     = steady_clock::time_point();
 
     m_bOpened = false;
@@ -5840,7 +5840,7 @@ int CUDT::receiveBuffer(char *data, int len)
             return 0;
         }
         HLOGC(arlog.Debug,
-              log << (m_config.m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown ? "" : "no")
+              log << (m_config.bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown ? "" : "no")
                   << " SHUTDOWN. Reporting as BROKEN.");
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
     }
@@ -5849,14 +5849,14 @@ int CUDT::receiveBuffer(char *data, int len)
     CSync tscond (m_RcvTsbPdCond, recvguard);
     if (!m_pRcvBuffer->isRcvDataReady())
     {
-        if (!m_config.m_bSynRecving)
+        if (!m_config.bSynRecving)
         {
             throw CUDTException(MJ_AGAIN, MN_RDAVAIL, 0);
         }
         else
         {
             /* Kick TsbPd thread to schedule next wakeup (if running) */
-            if (m_config.m_iRcvTimeOut < 0)
+            if (m_config.iRcvTimeOut < 0)
             {
                 THREAD_PAUSED();
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
@@ -5869,7 +5869,7 @@ int CUDT::receiveBuffer(char *data, int len)
             else
             {
                 const steady_clock::time_point exptime =
-                    steady_clock::now() + milliseconds_from(m_config.m_iRcvTimeOut);
+                    steady_clock::now() + milliseconds_from(m_config.iRcvTimeOut);
                 THREAD_PAUSED();
                 while (stillConnected() && !m_pRcvBuffer->isRcvDataReady())
                 {
@@ -5888,13 +5888,13 @@ int CUDT::receiveBuffer(char *data, int len)
     if ((m_bBroken || m_bClosing) && !m_pRcvBuffer->isRcvDataReady())
     {
         // See at the beginning
-        if (!m_config.m_bMessageAPI && m_bShutdown)
+        if (!m_config.bMessageAPI && m_bShutdown)
         {
             HLOGC(arlog.Debug, log << "STREAM API, SHUTDOWN: marking as EOF");
             return 0;
         }
         HLOGC(arlog.Debug,
-              log << (m_config.m_bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown ? "" : "no")
+              log << (m_config.bMessageAPI ? "MESSAGE" : "STREAM") << " API, " << (m_bShutdown ? "" : "no")
                   << " SHUTDOWN. Reporting as BROKEN.");
 
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -5919,7 +5919,7 @@ int CUDT::receiveBuffer(char *data, int len)
         s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_IN, false);
     }
 
-    if ((res <= 0) && (m_config.m_iRcvTimeOut >= 0))
+    if ((res <= 0) && (m_config.iRcvTimeOut >= 0))
         throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
 
     return res;
@@ -5932,7 +5932,7 @@ void CUDT::checkNeedDrop(bool& w_bCongestion)
     if (!m_bPeerTLPktDrop)
         return;
 
-    if (!m_config.m_bMessageAPI)
+    if (!m_config.bMessageAPI)
     {
         LOGC(aslog.Error, log << "The SRTO_TLPKTDROP flag can only be used with message API.");
         throw CUDTException(MJ_NOTSUP, MN_INVALBUFFERAPI, 0);
@@ -5949,9 +5949,9 @@ void CUDT::checkNeedDrop(bool& w_bCongestion)
     // picture rate would be useful in auto SRT setting for min latency
     // XXX Make SRT_TLPKTDROP_MINTHRESHOLD_MS option-configurable
     int threshold_ms = 0;
-    if (m_config.m_iSndDropDelay >= 0)
+    if (m_config.iSndDropDelay >= 0)
     {
-        threshold_ms = std::max(m_iPeerTsbPdDelay_ms + m_config.m_iSndDropDelay, +SRT_TLPKTDROP_MINTHRESHOLD_MS) +
+        threshold_ms = std::max(m_iPeerTsbPdDelay_ms + m_config.iSndDropDelay, +SRT_TLPKTDROP_MINTHRESHOLD_MS) +
                        (2 * COMM_SYN_INTERVAL_US / 1000);
     }
 
@@ -6069,7 +6069,7 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     {
         SrtCongestion::TransAPI api = SrtCongestion::STA_MESSAGE;
         CodeMinor               mn  = MN_INVALMSGAPI;
-        if (!m_config.m_bMessageAPI)
+        if (!m_config.bMessageAPI)
         {
             api = SrtCongestion::STA_BUFFER;
             mn  = MN_INVALBUFFERAPI;
@@ -6097,11 +6097,11 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     //   out a message of a length that exceeds the total size of the sending
     //   buffer (configurable by SRTO_SNDBUF).
 
-    if (m_config.m_bMessageAPI && len > int(m_config.m_iSndBufSize * m_iMaxSRTPayloadSize))
+    if (m_config.bMessageAPI && len > int(m_config.iSndBufSize * m_iMaxSRTPayloadSize))
     {
         LOGC(aslog.Error,
              log << "Message length (" << len << ") exceeds the size of sending buffer: "
-                 << (m_config.m_iSndBufSize * m_iMaxSRTPayloadSize) << ". Use SRTO_SNDBUF if needed.");
+                 << (m_config.iSndBufSize * m_iMaxSRTPayloadSize) << ". Use SRTO_SNDBUF if needed.");
         throw CUDTException(MJ_NOTSUP, MN_XSIZE, 0);
     }
 
@@ -6130,7 +6130,7 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     checkNeedDrop((bCongestion));
 
     int minlen = 1; // Minimum sender buffer space required for STREAM API
-    if (m_config.m_bMessageAPI)
+    if (m_config.bMessageAPI)
     {
         // For MESSAGE API the minimum outgoing buffer space required is
         // the size that can carry over the whole message as passed here.
@@ -6141,14 +6141,14 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     {
         //>>We should not get here if SRT_ENABLE_TLPKTDROP
         // XXX Check if this needs to be removed, or put to an 'else' condition for m_bTLPktDrop.
-        if (!m_config.m_bSynSending)
+        if (!m_config.bSynSending)
             throw CUDTException(MJ_AGAIN, MN_WRAVAIL, 0);
 
         {
             // wait here during a blocking sending
             UniqueLock sendblock_lock (m_SendBlockLock);
 
-            if (m_config.m_iSndTimeOut < 0)
+            if (m_config.iSndTimeOut < 0)
             {
                 while (stillConnected() && sndBuffersLeft() < minlen && m_bPeerHealth)
                     m_SendBlockCond.wait(sendblock_lock);
@@ -6156,7 +6156,7 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
             else
             {
                 const steady_clock::time_point exptime =
-                    steady_clock::now() + milliseconds_from(m_config.m_iSndTimeOut);
+                    steady_clock::now() + milliseconds_from(m_config.iSndTimeOut);
                 THREAD_PAUSED();
                 while (stillConnected() && sndBuffersLeft() < minlen && m_bPeerHealth)
                 {
@@ -6186,7 +6186,7 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
          */
         if (sndBuffersLeft() < minlen)
         {
-            if (m_config.m_iSndTimeOut >= 0)
+            if (m_config.iSndTimeOut >= 0)
                 throw CUDTException(MJ_AGAIN, MN_XMTIMEOUT, 0);
 
             // XXX This looks very weird here, however most likely
@@ -6220,7 +6220,7 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     }
 
     int size = len;
-    if (!m_config.m_bMessageAPI)
+    if (!m_config.bMessageAPI)
     {
         // For STREAM API it's allowed to send less bytes than the given buffer.
         // Just return how many bytes were actually scheduled for writing.
@@ -6271,7 +6271,7 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
             throw CUDTException(MJ_NOTSUP, MN_INVALMSGAPI);
         }
 
-        if (w_mctrl.srctime && (!m_config.m_bMessageAPI || !m_bTsbPd))
+        if (w_mctrl.srctime && (!m_config.bMessageAPI || !m_bTsbPd))
         {
             HLOGC(aslog.Warn,
                 log << "Source time can only be used with TSBPD and Message API enabled. Using default time instead.");
@@ -6353,7 +6353,7 @@ int CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
     }
 
-    if (m_config.m_bMessageAPI)
+    if (m_config.bMessageAPI)
         return receiveMessage(data, len, (w_mctrl));
 
     return receiveBuffer(data, len);
@@ -6422,7 +6422,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
 
         if (res == 0)
         {
-            if (!m_config.m_bMessageAPI && m_bShutdown)
+            if (!m_config.bMessageAPI && m_bShutdown)
                 return 0;
             // Forced to return error instead of throwing exception.
             if (!by_exception)
@@ -6435,7 +6435,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
 
     const int seqdistance = -1;
 
-    if (!m_config.m_bSynRecving)
+    if (!m_config.bSynRecving)
     {
         HLOGC(arlog.Debug, log << CONID() << "receiveMessage: BEGIN ASYNC MODE. Going to extract payload size=" << len);
         enterCS(m_RcvBufferLock);
@@ -6495,7 +6495,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
     int  res     = 0;
     bool timeout = false;
     // Do not block forever, check connection status each 1 sec.
-    const steady_clock::duration recv_timeout = m_config.m_iRcvTimeOut < 0 ? seconds_from(1) : milliseconds_from(m_config.m_iRcvTimeOut);
+    const steady_clock::duration recv_timeout = m_config.iRcvTimeOut < 0 ? seconds_from(1) : milliseconds_from(m_config.iRcvTimeOut);
 
     CSync recv_cond (m_RecvDataCond, recvguard);
 
@@ -6535,7 +6535,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
 
                 if (!recv_cond.wait_until(exptime))
                 {
-                    if (m_config.m_iRcvTimeOut >= 0) // otherwise it's "no timeout set"
+                    if (m_config.iRcvTimeOut >= 0) // otherwise it's "no timeout set"
                         timeout = true;
                     HLOGP(tslog.Debug,
                           "receiveMessage: DATA COND: EXPIRED -- checking connection conditions and rolling again");
@@ -6568,7 +6568,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
             // Forced to return 0 instead of throwing exception.
             if (!by_exception)
                 return APIError(MJ_CONNECTION, MN_CONNLOST, 0);
-            if (!m_config.m_bMessageAPI && m_bShutdown)
+            if (!m_config.bMessageAPI && m_bShutdown)
                 return 0;
             throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
         }
@@ -6604,7 +6604,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
     // Unblock when required
     // LOGC(tslog.Debug, "RECVMSG/EXIT RES " << res << " RCVTIMEOUT");
 
-    if ((res <= 0) && (m_config.m_iRcvTimeOut >= 0))
+    if ((res <= 0) && (m_config.iRcvTimeOut >= 0))
     {
         // Forced to return -1 instead of throwing exception.
         if (!by_exception)
@@ -6743,7 +6743,7 @@ int64_t CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
     else if ((m_bBroken || m_bClosing) && !m_pRcvBuffer->isRcvDataReady())
     {
-        if (!m_config.m_bMessageAPI && m_bShutdown)
+        if (!m_config.bMessageAPI && m_bShutdown)
             return 0;
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
     }
@@ -6832,7 +6832,7 @@ int64_t CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
             throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
         else if ((m_bBroken || m_bClosing) && !m_pRcvBuffer->isRcvDataReady())
         {
-            if (!m_config.m_bMessageAPI && m_bShutdown)
+            if (!m_config.bMessageAPI && m_bShutdown)
                 return 0;
             throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
         }
@@ -6950,9 +6950,9 @@ void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
     perf->msRTT               = (double)m_iRTT / 1000.0;
     perf->msSndTsbPdDelay     = m_bPeerTsbPd ? m_iPeerTsbPdDelay_ms : 0;
     perf->msRcvTsbPdDelay     = isOPT_TsbPd() ? m_iTsbPdDelay_ms : 0;
-    perf->byteMSS             = m_config.m_iMSS;
+    perf->byteMSS             = m_config.iMSS;
 
-    perf->mbpsMaxBW = m_config.m_llMaxBW > 0 ? Bps2Mbps(m_config.m_llMaxBW)
+    perf->mbpsMaxBW = m_config.llMaxBW > 0 ? Bps2Mbps(m_config.llMaxBW)
                       : m_CongCtl.ready()    ? Bps2Mbps(m_CongCtl->sndBandwidth())
                                              : 0;
 
@@ -6976,7 +6976,7 @@ void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
             }
             perf->byteSndBuf += (perf->pktSndBuf * pktHdrSize);
             //<
-            perf->byteAvailSndBuf = (m_config.m_iSndBufSize - perf->pktSndBuf) * m_config.m_iMSS;
+            perf->byteAvailSndBuf = (m_config.iSndBufSize - perf->pktSndBuf) * m_config.iMSS;
         }
         else
         {
@@ -6988,7 +6988,7 @@ void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 
         if (m_pRcvBuffer)
         {
-            perf->byteAvailRcvBuf = m_pRcvBuffer->getAvailBufSize() * m_config.m_iMSS;
+            perf->byteAvailRcvBuf = m_pRcvBuffer->getAvailBufSize() * m_config.iMSS;
             if (instantaneous) // no need for historical API for Rcv side
             {
                 perf->pktRcvBuf = m_pRcvBuffer->getRcvDataSize(perf->byteRcvBuf, perf->msRcvBuf);
@@ -7076,24 +7076,24 @@ bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
         EInitEvent only_input = arg.get<EventVariant::INIT>();
         // false = TEV_INIT_RESET: in the beginning, or when MAXBW was changed.
 
-        if (only_input && m_config.m_llMaxBW)
+        if (only_input && m_config.llMaxBW)
         {
-            HLOGC(rslog.Debug, log << CONID() << "updateCC/TEV_INIT: non-RESET stage and m_config.m_llMaxBW already set to " << m_config.m_llMaxBW);
+            HLOGC(rslog.Debug, log << CONID() << "updateCC/TEV_INIT: non-RESET stage and m_config.llMaxBW already set to " << m_config.llMaxBW);
             // Don't change
         }
-        else // either m_config.m_llMaxBW == 0 or only_input == TEV_INIT_RESET
+        else // either m_config.llMaxBW == 0 or only_input == TEV_INIT_RESET
         {
             // Use the values:
             // - if SRTO_MAXBW is >0, use it.
             // - if SRTO_MAXBW == 0, use SRTO_INPUTBW + SRTO_OHEADBW
             // - if SRTO_INPUTBW == 0, pass 0 to requst in-buffer sampling
             // Bytes/s
-            int bw = m_config.m_llMaxBW != 0 ? m_config.m_llMaxBW :                       // When used SRTO_MAXBW
-                         m_config.m_llInputBW != 0 ? withOverhead(m_config.m_llInputBW) : // SRTO_INPUTBW + SRT_OHEADBW
+            int bw = m_config.llMaxBW != 0 ? m_config.llMaxBW :                       // When used SRTO_MAXBW
+                         m_config.llInputBW != 0 ? withOverhead(m_config.llInputBW) : // SRTO_INPUTBW + SRT_OHEADBW
                              0; // When both MAXBW and INPUTBW are 0, request in-buffer sampling
 
             // Note: setting bw == 0 uses BW_INFINITE value in LiveCC
-            m_CongCtl->updateBandwidth(m_config.m_llMaxBW, bw);
+            m_CongCtl->updateBandwidth(m_config.llMaxBW, bw);
 
             if (only_input == TEV_INIT_OHEADBW)
             {
@@ -7108,7 +7108,7 @@ bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
             }
 
             HLOGC(rslog.Debug,
-                  log << CONID() << "updateCC/TEV_INIT: updating BW=" << m_config.m_llMaxBW
+                  log << CONID() << "updateCC/TEV_INIT: updating BW=" << m_config.llMaxBW
                       << (only_input == TEV_INIT_RESET
                               ? " (UNCHANGED)"
                               : only_input == TEV_INIT_OHEADBW ? " (only Overhead)" : " (updated sampling rate)"));
@@ -7121,7 +7121,7 @@ bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
     {
         // Specific part done when MaxBW is set to 0 (auto) and InputBW is 0.
         // This requests internal input rate sampling.
-        if (m_config.m_llMaxBW == 0 && m_config.m_llInputBW == 0)
+        if (m_config.llMaxBW == 0 && m_config.llInputBW == 0)
         {
             // Get auto-calculated input rate, Bytes per second
             const int64_t inputbw = m_pSndBuffer->getInputRate();
@@ -7134,7 +7134,7 @@ bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
              * Keep previously set maximum in that case (inputbw == 0).
              */
             if (inputbw >= 0)
-                m_CongCtl->updateBandwidth(0, withOverhead(std::max(m_config.m_llMinInputBW, inputbw))); // Bytes/sec
+                m_CongCtl->updateBandwidth(0, withOverhead(std::max(m_config.llMinInputBW, inputbw))); // Bytes/sec
         }
     }
 
@@ -7550,7 +7550,7 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
         }
         else
         {
-            if (m_config.m_bSynRecving)
+            if (m_config.bSynRecving)
             {
                 // signal a waiting "recv" call if there is any data available
                 CSync::lock_signal(m_RecvDataCond, m_RecvLock);
@@ -7626,13 +7626,13 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
             data[ACKD_BANDWIDTH] = m_RcvTimeWindow.getBandwidth();
 
             //>>Patch while incompatible (1.0.2) receiver floating around
-            if (m_lPeerSrtVersion == SrtVersion(1, 0, 2))
+            if (m_uPeerSrtVersion == SrtVersion(1, 0, 2))
             {
                 data[ACKD_RCVRATE] = rcvRate;                                     // bytes/sec
                 data[ACKD_XMRATE] = data[ACKD_BANDWIDTH] * m_iMaxSRTPayloadSize; // bytes/sec
                 ctrlsz = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER102;
             }
-            else if (m_lPeerSrtVersion >= SrtVersion(1, 0, 3))
+            else if (m_uPeerSrtVersion >= SrtVersion(1, 0, 3))
             {
                 // Normal, currently expected version.
                 data[ACKD_RCVRATE] = rcvRate; // bytes/sec
@@ -7734,7 +7734,7 @@ void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
     // insert this socket to snd list if it is not on the list yet
     m_pSndQueue->m_pSndUList->update(this, CSndUList::DONT_RESCHEDULE);
 
-    if (m_config.m_bSynSending)
+    if (m_config.bSynSending)
     {
         CSync::lock_signal(m_SendBlockCond, m_SendBlockLock);
     }
@@ -8143,7 +8143,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
         // inaccurate. Additionally it won't lock if TSBPD mode is off, and
         // won't update anything. Note that if you set TSBPD mode and use
         // srt_recvfile (which doesn't make any sense), you'll have a deadlock.
-        if (m_config.m_bDriftTracer)
+        if (m_config.bDriftTracer)
         {
             steady_clock::duration udrift(0);
             steady_clock::time_point newtimebase;
@@ -8196,7 +8196,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
         HLOGC(inlog.Debug, log << CONID() << "processCtrl: got HS: " << req.show());
 
         if ((req.m_iReqType > URQ_INDUCTION_TYPES) // acually it catches URQ_INDUCTION and URQ_ERROR_* symbols...???
-            || (m_config.m_bRendezvous && (req.m_iReqType != URQ_AGREEMENT))) // rnd sends AGREEMENT in rsp to CONCLUSION
+            || (m_config.bRendezvous && (req.m_iReqType != URQ_AGREEMENT))) // rnd sends AGREEMENT in rsp to CONCLUSION
         {
             // The peer side has not received the handshake message, so it keeps querying
             // resend the handshake packet
@@ -8208,12 +8208,12 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
             // - this is any of URQ_ERROR_* - well...
             CHandShake initdata;
             initdata.m_iISN            = m_iISN;
-            initdata.m_iMSS            = m_config.m_iMSS;
-            initdata.m_iFlightFlagSize = m_config.m_iFlightFlagSize;
+            initdata.m_iMSS            = m_config.iMSS;
+            initdata.m_iFlightFlagSize = m_config.iFlightFlagSize;
 
             // For rendezvous we do URQ_WAVEAHAND/URQ_CONCLUSION --> URQ_AGREEMENT.
             // For client-server we do URQ_INDUCTION --> URQ_CONCLUSION.
-            initdata.m_iReqType = (!m_config.m_bRendezvous) ? URQ_CONCLUSION : URQ_AGREEMENT;
+            initdata.m_iReqType = (!m_config.bRendezvous) ? URQ_CONCLUSION : URQ_AGREEMENT;
             initdata.m_iID      = m_SocketID;
 
             uint32_t kmdata[SRTDATA_MAXSIZE];
@@ -8243,7 +8243,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
                         // and should be added with HSRSP/KMRSP), or it's a belated handshake
                         // of Rendezvous when it has already considered itself connected.
                         // Sanity check - according to the rules, there should be no such situation
-                        if (m_config.m_bRendezvous && m_SrtHsSide == HSD_RESPONDER)
+                        if (m_config.bRendezvous && m_SrtHsSide == HSD_RESPONDER)
                         {
                             LOGC(inlog.Error,
                                  log << CONID() << "processCtrl/HS: IPE???: RESPONDER should receive all its handshakes in "
@@ -8545,7 +8545,7 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
             continue;
         }
 
-        if (m_bPeerNakReport && m_config.m_iRetransmitAlgo != 0)
+        if (m_bPeerNakReport && m_config.iRetransmitAlgo != 0)
         {
             const steady_clock::time_point tsLastRexmit = m_pSndBuffer->getPacketRexmitTime(offset);
             if (tsLastRexmit >= time_nak)
@@ -9755,7 +9755,7 @@ CUDT::loss_seqs_t CUDT::defaultPacketArrival(void* vself, CPacket& pkt)
 /// will be set to the tolerance value, which means that later packet retransmission
 /// will not be required immediately, but only after receiving N next packets that
 /// do not include the lacking packet.
-/// The tolerance is not increased infinitely - it's bordered by m_iMaxReorderTolerance.
+/// The tolerance is not increased infinitely - it's bordered by iMaxReorderTolerance.
 /// This value can be set in options - SRT_LOSSMAXTTL.
 void CUDT::unlose(const CPacket &packet)
 {
@@ -9786,7 +9786,7 @@ void CUDT::unlose(const CPacket &packet)
             leaveCS(m_StatsLock);
             if (seqdiff > m_iReorderTolerance)
             {
-                const int new_tolerance = min(seqdiff, m_config.m_iMaxReorderTolerance);
+                const int new_tolerance = min(seqdiff, m_config.iMaxReorderTolerance);
                 HLOGF(qrlog.Debug,
                       "Belated by %d seqs - Reorder tolerance %s %d",
                       seqdiff,
@@ -10104,11 +10104,11 @@ int CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
         // Additionally, set this field to a MAGIC value. This field isn't used during INDUCTION
         // by HSv4 client, HSv5 client can use it to additionally verify that this is a HSv5 listener.
         // In this field we also advertise the PBKEYLEN value. When 0, it's considered not advertised.
-        hs.m_iType = SrtHSRequest::wrapFlags(true /*put SRT_MAGIC_CODE in HSFLAGS*/, m_config.m_iSndCryptoKeyLen);
-        bool whether SRT_ATR_UNUSED = m_config.m_iSndCryptoKeyLen != 0;
+        hs.m_iType = SrtHSRequest::wrapFlags(true /*put SRT_MAGIC_CODE in HSFLAGS*/, m_config.iSndCryptoKeyLen);
+        bool whether SRT_ATR_UNUSED = m_config.iSndCryptoKeyLen != 0;
         HLOGC(cnlog.Debug,
               log << "processConnectRequest: " << (whether ? "" : "NOT ")
-                  << " Advertising PBKEYLEN - value = " << m_config.m_iSndCryptoKeyLen);
+                  << " Advertising PBKEYLEN - value = " << m_config.iSndCryptoKeyLen);
 
         size_t size = packet.getLength();
         hs.store_to((packet.m_pcData), (size));
@@ -10406,11 +10406,11 @@ int CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
     // by the filter. By this reason they appear often out of order
     // and for adding them properly the loss list container wasn't
     // prepared. This then requires some more effort to implement.
-    if (!m_config.m_bRcvNakReport || m_PktFilterRexmitLevel != SRT_ARQ_ALWAYS)
+    if (!m_config.bRcvNakReport || m_PktFilterRexmitLevel != SRT_ARQ_ALWAYS)
         return BECAUSE_NO_REASON;
 
     /*
-     * m_config.m_bRcvNakReport enables NAK reports for SRT.
+     * m_config.bRcvNakReport enables NAK reports for SRT.
      * Retransmission based on timeout is bandwidth consuming,
      * not knowing what to retransmit when the only NAK sent by receiver is lost,
      * all packets past last ACK are retransmitted (rexmitMethod() == SRM_FASTREXMIT).
@@ -10479,7 +10479,7 @@ bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_rea
         return false;
 
     // ms -> us
-    const int PEER_IDLE_TMO_US = m_config.m_iPeerIdleTimeout * 1000;
+    const int PEER_IDLE_TMO_US = m_config.iPeerIdleTimeout * 1000;
     // Haven't received any information from the peer, is it dead?!
     // timeout: at least 16 expirations and must be greater than 5 seconds
     if ((m_iEXPCount > COMM_RESPONSE_MAX_EXP) &&
@@ -10733,7 +10733,7 @@ void CUDT::addEPoll(const int eid)
     }
     leaveCS(m_RecvLock);
 
-    if (m_config.m_iSndBufSize > m_pSndBuffer->getCurrBufSize())
+    if (m_config.iSndBufSize > m_pSndBuffer->getCurrBufSize())
     {
         s_UDTUnited.m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_OUT, true);
     }
@@ -10908,14 +10908,14 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs
     }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-    if (have_group && acore->m_config.m_GroupConnect == 0)
+    if (have_group && acore->m_config.iGroupConnect == 0)
     {
         HLOGC(cnlog.Debug, log << "runAcceptHook: REJECTING connection WITHOUT calling the hook - groups not allowed");
         return false;
     }
 
     // Update the groupconnect flag
-    acore->m_config.m_GroupConnect = have_group ? 1 : 0;
+    acore->m_config.iGroupConnect = have_group ? 1 : 0;
     acore->m_HSGroupType = gt;
 #endif
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -536,8 +536,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         }
 
         // Fallback: return from internal data
-        strcpy(((char*)optval), m_config.BindToDevice.c_str());
-        optlen = m_config.BindToDevice.size();
+        strcpy(((char*)optval), m_config.sBindToDevice.c_str());
+        optlen = m_config.sBindToDevice.size();
 #else
         LOGC(smlog.Error, log << "SRTO_BINDTODEVICE is not supported on that platform");
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -2506,7 +2506,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
         // When encryption is not enabled at compile time, behave as if encryption wasn't set,
         // so accordingly to StrictEncryption flag.
 
-        if (m_config.m_bEnforcedEnc)
+        if (m_config.bEnforcedEnc)
         {
             m_RejectReason = SRT_REJ_UNSECURE;
             LOGC(cnlog.Error,

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -144,18 +144,15 @@ void CUDT::construct()
     m_RejectReason        = SRT_REJ_UNKNOWN;
     m_tsLastReqTime       = steady_clock::time_point();
     m_SrtHsSide           = HSD_DRAW;
-
-    m_uPeerSrtVersion        = 0; // not defined until connected.
-
-    m_iTsbPdDelay_ms     = 0;
-    m_iPeerTsbPdDelay_ms = 0;
-
-    m_bPeerTsbPd         = false;
-    m_iPeerTsbPdDelay_ms = 0;
-    m_bTsbPd             = false;
-    m_bTsbPdAckWakeup    = false;
-    m_bGroupTsbPd = false;
-    m_bPeerTLPktDrop     = false;
+    m_uPeerSrtVersion     = 0; // not defined until connected.
+    m_iTsbPdDelay_ms      = 0;
+    m_iPeerTsbPdDelay_ms  = 0;
+    m_bPeerTsbPd          = false;
+    m_iPeerTsbPdDelay_ms  = 0;
+    m_bTsbPd              = false;
+    m_bTsbPdAckWakeup     = false;
+    m_bGroupTsbPd         = false;
+    m_bPeerTLPktDrop      = false;
 
     // Initilize mutex and condition variables
     initSynch();
@@ -4328,9 +4325,9 @@ bool CUDT::applyResponseSettings() ATR_NOEXCEPT
     }
 
     // Re-configure according to the negotiated values.
-    m_config.iMSS      = m_ConnRes.m_iMSS;
+    m_config.iMSS        = m_ConnRes.m_iMSS;
     m_iFlowWindowSize    = m_ConnRes.m_iFlightFlagSize;
-    int udpsize          = m_config.iMSS - CPacket::UDP_HDR_SIZE;
+    const int udpsize    = m_config.iMSS - CPacket::UDP_HDR_SIZE;
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
     m_iPeerISN           = m_ConnRes.m_iISN;
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -300,7 +300,7 @@ public: // internal API
     void addressAndSend(CPacket& pkt);
     void sendSrtMsg(int cmd, uint32_t *srtdata_in = NULL, size_t srtlen_in = 0);
 
-    bool isOPT_TsbPd() const { return m_config.m_bTSBPD; }
+    bool isOPT_TsbPd() const { return m_config.bTSBPD; }
     int RTT() const { return m_iRTT; }
     int RTTVar() const { return m_iRTTVar; }
     int32_t sndSeqNo() const { return m_iSndCurrSeqNo; }
@@ -313,13 +313,13 @@ public: // internal API
     int flowWindowSize() const { return m_iFlowWindowSize; }
     int32_t deliveryRate() const { return m_iDeliveryRate; }
     int bandwidth() const { return m_iBandwidth; }
-    int64_t maxBandwidth() const { return m_config.m_llMaxBW; }
-    int MSS() const { return m_config.m_iMSS; }
+    int64_t maxBandwidth() const { return m_config.llMaxBW; }
+    int MSS() const { return m_config.iMSS; }
 
     uint32_t peerLatency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
-    int peerIdleTimeout_ms() const { return m_config.m_iPeerIdleTimeout; }
+    int peerIdleTimeout_ms() const { return m_config.iPeerIdleTimeout; }
     size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
-    size_t OPT_PayloadSize() const { return m_config.m_zExpPayloadSize; }
+    size_t OPT_PayloadSize() const { return m_config.zExpPayloadSize; }
     int sndLossLength() { return m_pSndLossList->getLossLength(); }
     int32_t ISN() const { return m_iISN; }
     int32_t peerISN() const { return m_iPeerISN; }
@@ -367,7 +367,7 @@ public: // internal API
         const int ps = maxPayloadSize();
         if (len == 0) // wierd, can't use non-static data member as default argument!
             len = ps;
-        return m_config.m_bMessageAPI ? (len+ps-1)/ps : 1;
+        return m_config.bMessageAPI ? (len+ps-1)/ps : 1;
     }
 
     int32_t makeTS(const time_point& from_time) const
@@ -422,7 +422,7 @@ public: // internal API
     SRTU_PROPERTY_RO(bool, isClosing, m_bClosing);
     SRTU_PROPERTY_RO(CRcvBuffer*, rcvBuffer, m_pRcvBuffer);
     SRTU_PROPERTY_RO(bool, isTLPktDrop, m_bTLPktDrop);
-    SRTU_PROPERTY_RO(bool, isSynReceiving, m_config.m_bSynRecving);
+    SRTU_PROPERTY_RO(bool, isSynReceiving, m_config.bSynRecving);
     SRTU_PROPERTY_RR(srt::sync::Condition*, recvDataCond, &m_RecvDataCond);
     SRTU_PROPERTY_RR(srt::sync::Condition*, recvTsbPdCond, &m_RcvTsbPdCond);
 
@@ -648,7 +648,7 @@ private:
 
     int64_t withOverhead(int64_t basebw)
     {
-        return (basebw * (100 + m_config.m_iOverheadBW))/100;
+        return (basebw * (100 + m_config.iOverheadBW))/100;
     }
 
     static double Bps2Mbps(int64_t basebw)
@@ -674,7 +674,7 @@ private:
 
     int sndBuffersLeft()
     {
-        return m_config.m_iSndBufSize - m_pSndBuffer->getCurrBufSize();
+        return m_config.iSndBufSize - m_pSndBuffer->getCurrBufSize();
     }
 
     time_point socketStartTime()
@@ -864,8 +864,8 @@ private: // Receiving related data
 
     int32_t m_iPeerISN;                          // Initial Sequence Number of the peer side
 
-    uint32_t m_lPeerSrtVersion;
-    uint32_t m_lPeerSrtFlags;
+    uint32_t m_uPeerSrtVersion;
+    uint32_t m_uPeerSrtFlags;
 
     bool m_bTsbPd;                               // Peer sends TimeStamp-Based Packet Delivery Packets 
     bool m_bGroupTsbPd;                          // TSBPD should be used for GROUP RECEIVER instead.

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -584,8 +584,8 @@ bool CCryptoControl::init(HandshakeSide side, bool bidirectional SRT_ATR_UNUSED)
     // Set security-pending state, if a password was set.
     m_SndKmState = hasPassphrase() ? SRT_KM_S_SECURING : SRT_KM_S_UNSECURED;
 
-    m_KmPreAnnouncePkt = m_parent->m_config.m_uKmPreAnnouncePkt;
-    m_KmRefreshRatePkt = m_parent->m_config.m_uKmRefreshRatePkt;
+    m_KmPreAnnouncePkt = m_parent->m_config.uKmPreAnnouncePkt;
+    m_KmRefreshRatePkt = m_parent->m_config.uKmRefreshRatePkt;
 
     if ( side == HSD_INITIATOR )
     {

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -47,6 +47,7 @@ PROTECTED HEADERS
 platform_sys.h
 udt.h
 
+PRIVATE HEADERS
 api.h
 buffer.h
 cache.h

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -47,7 +47,6 @@ PROTECTED HEADERS
 platform_sys.h
 udt.h
 
-PRIVATE HEADERS
 api.h
 buffer.h
 cache.h

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -527,16 +527,16 @@ void CUDTGroup::deriveSettings(CUDT* u)
     // the option is altered on the group.
 
     // SRTO_RCVSYN
-    m_bSynRecving = u->m_config.m_bSynRecving;
+    m_bSynRecving = u->m_config.bSynRecving;
 
     // SRTO_SNDSYN
-    m_bSynSending = u->m_config.m_bSynSending;
+    m_bSynSending = u->m_config.bSynSending;
 
     // SRTO_RCVTIMEO
-    m_iRcvTimeOut = u->m_config.m_iRcvTimeOut;
+    m_iRcvTimeOut = u->m_config.iRcvTimeOut;
 
     // SRTO_SNDTIMEO
-    m_iSndTimeOut = u->m_config.m_iSndTimeOut;
+    m_iSndTimeOut = u->m_config.iSndTimeOut;
 
     // Ok, this really is disgusting, but there's only one way
     // to properly do it. Would be nice to have some more universal
@@ -552,58 +552,58 @@ void CUDTGroup::deriveSettings(CUDT* u)
 #define IM(option, field) importOption(m_config, option, u->m_config.field)
 #define IMF(option, field) importOption(m_config, option, u->field)
 
-    IM(SRTO_MSS, m_iMSS);
-    IM(SRTO_FC, m_iFlightFlagSize);
+    IM(SRTO_MSS, iMSS);
+    IM(SRTO_FC, iFlightFlagSize);
 
     // Nonstandard
-    importOption(m_config, SRTO_SNDBUF, u->m_config.m_iSndBufSize * (u->m_config.m_iMSS - CPacket::UDP_HDR_SIZE));
-    importOption(m_config, SRTO_RCVBUF, u->m_config.m_iRcvBufSize * (u->m_config.m_iMSS - CPacket::UDP_HDR_SIZE));
+    importOption(m_config, SRTO_SNDBUF, u->m_config.iSndBufSize * (u->m_config.iMSS - CPacket::UDP_HDR_SIZE));
+    importOption(m_config, SRTO_RCVBUF, u->m_config.iRcvBufSize * (u->m_config.iMSS - CPacket::UDP_HDR_SIZE));
 
-    IM(SRTO_LINGER, m_Linger);
-    IM(SRTO_UDP_SNDBUF, m_iUDPSndBufSize);
-    IM(SRTO_UDP_RCVBUF, m_iUDPRcvBufSize);
+    IM(SRTO_LINGER, Linger);
+    IM(SRTO_UDP_SNDBUF, iUDPSndBufSize);
+    IM(SRTO_UDP_RCVBUF, iUDPRcvBufSize);
     // SRTO_RENDEZVOUS: impossible to have it set on a listener socket.
     // SRTO_SNDTIMEO/RCVTIMEO: groupwise setting
-    IM(SRTO_CONNTIMEO, m_tdConnTimeOut);
-    IM(SRTO_DRIFTTRACER, m_bDriftTracer);
+    IM(SRTO_CONNTIMEO, tdConnTimeOut);
+    IM(SRTO_DRIFTTRACER, bDriftTracer);
     // Reuseaddr: true by default and should only be true.
-    IM(SRTO_MAXBW, m_llMaxBW);
-    IM(SRTO_INPUTBW, m_llInputBW);
-    IM(SRTO_MININPUTBW, m_llMinInputBW);
-    IM(SRTO_OHEADBW, m_iOverheadBW);
-    IM(SRTO_IPTOS, m_iIpToS);
-    IM(SRTO_IPTTL, m_iIpTTL);
-    IM(SRTO_TSBPDMODE, m_bTSBPD);
-    IM(SRTO_RCVLATENCY, m_iRcvLatency);
-    IM(SRTO_PEERLATENCY, m_iPeerLatency);
-    IM(SRTO_SNDDROPDELAY, m_iSndDropDelay);
-    IM(SRTO_PAYLOADSIZE, m_zExpPayloadSize);
+    IM(SRTO_MAXBW, llMaxBW);
+    IM(SRTO_INPUTBW, llInputBW);
+    IM(SRTO_MININPUTBW, llMinInputBW);
+    IM(SRTO_OHEADBW, iOverheadBW);
+    IM(SRTO_IPTOS, iIpToS);
+    IM(SRTO_IPTTL, iIpTTL);
+    IM(SRTO_TSBPDMODE, bTSBPD);
+    IM(SRTO_RCVLATENCY, iRcvLatency);
+    IM(SRTO_PEERLATENCY, iPeerLatency);
+    IM(SRTO_SNDDROPDELAY, iSndDropDelay);
+    IM(SRTO_PAYLOADSIZE, zExpPayloadSize);
     IMF(SRTO_TLPKTDROP, m_bTLPktDrop);
 
-    importOption(m_config, SRTO_STREAMID, u->m_config.m_StreamName.str());
+    importOption(m_config, SRTO_STREAMID, u->m_config.sStreamName.str());
 
-    IM(SRTO_MESSAGEAPI, m_bMessageAPI);
-    IM(SRTO_NAKREPORT, m_bRcvNakReport);
-    IM(SRTO_MINVERSION, m_lMinimumPeerSrtVersion);
-    IM(SRTO_ENFORCEDENCRYPTION, m_bEnforcedEnc);
-    IM(SRTO_IPV6ONLY, m_iIpV6Only);
-    IM(SRTO_PEERIDLETIMEO, m_iPeerIdleTimeout);
-    IM(SRTO_GROUPSTABTIMEO, m_uStabilityTimeout);
+    IM(SRTO_MESSAGEAPI, bMessageAPI);
+    IM(SRTO_NAKREPORT, bRcvNakReport);
+    IM(SRTO_MINVERSION, uMinimumPeerSrtVersion);
+    IM(SRTO_ENFORCEDENCRYPTION, bEnforcedEnc);
+    IM(SRTO_IPV6ONLY, iIpV6Only);
+    IM(SRTO_PEERIDLETIMEO, iPeerIdleTimeout);
+    IM(SRTO_GROUPSTABTIMEO, uStabilityTimeout);
 
-    importOption(m_config, SRTO_PACKETFILTER, u->m_config.m_PacketFilterConfig.str());
+    importOption(m_config, SRTO_PACKETFILTER, u->m_config.sPacketFilterConfig.str());
 
     importOption(m_config, SRTO_PBKEYLEN, u->m_pCryptoControl->KeyLen());
 
     // Passphrase is empty by default. Decipher the passphrase and
     // store as passphrase option
-    if (u->m_config.m_CryptoSecret.len)
+    if (u->m_config.CryptoSecret.len)
     {
-        string password((const char*)u->m_config.m_CryptoSecret.str, u->m_config.m_CryptoSecret.len);
+        string password((const char*)u->m_config.CryptoSecret.str, u->m_config.CryptoSecret.len);
         m_config.push_back(ConfigItem(SRTO_PASSPHRASE, password.c_str(), password.size()));
     }
 
-    IM(SRTO_KMREFRESHRATE, m_uKmRefreshRatePkt);
-    IM(SRTO_KMPREANNOUNCE, m_uKmPreAnnouncePkt);
+    IM(SRTO_KMREFRESHRATE, uKmRefreshRatePkt);
+    IM(SRTO_KMPREANNOUNCE, uKmPreAnnouncePkt);
 
     string cc = u->m_CongCtl.selected_name();
     if (cc != "live")

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -246,7 +246,7 @@ bool PacketFilter::configure(CUDT* parent, CUnitQueue* uq, const std::string& co
     init.snd_isn = parent->sndSeqNo();
     init.rcv_isn = parent->rcvSeqNo();
     init.payload_size = parent->OPT_PayloadSize();
-    init.rcvbuf_size = parent->m_config.m_iRcvBufSize;
+    init.rcvbuf_size = parent->m_config.iRcvBufSize;
 
     // Found a filter, so call the creation function
     m_filter = selector->second->Create(init, m_provided, confstr);

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1024,7 +1024,7 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
 
             // This queue is used only in case of Async mode (rendezvous or caller-listener).
             // Synchronous connection requests are handled in startConnect() completely.
-            if (!i->m_pUDT->m_config.m_bSynRecving)
+            if (!i->m_pUDT->m_config.bSynRecving)
             {
                 IF_HEAVY_LOGGING(++debug_nupd);
 
@@ -1536,7 +1536,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
 
     // asynchronous connect: call connect here
     // otherwise wait for the UDT socket to retrieve this packet
-    if (!u->m_config.m_bSynRecving)
+    if (!u->m_config.bSynRecving)
     {
         HLOGC(cnlog.Debug, log << "AsyncOrRND: packet RESOLVED TO @" << id << " -- continuing as ASYNC CONNECT");
         // This is practically same as processConnectResponse, just this applies

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -82,7 +82,7 @@ struct CSrtMuxerConfig
     bool bReuseAddr; // reuse an exiting port or not, for UDP multiplexer
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-    std::string strBindToDevice;
+    std::string sBindToDevice;
 #endif
     int iUDPSndBufSize; // UDP sending buffer size
     int iUDPRcvBufSize; // UDP receiving buffer size
@@ -107,7 +107,7 @@ struct CSrtMuxerConfig
             && CEQUAL(iIpV6Only)
             && CEQUAL(bReuseAddr)
 #ifdef SRT_ENABLE_BINDTODEVICE
-            && CEQUAL(strBindToDevice)
+            && CEQUAL(sBindToDevice)
 #endif
             && CEQUAL(iUDPSndBufSize)
             && CEQUAL(iUDPRcvBufSize);
@@ -603,7 +603,7 @@ struct CSrtConfigSetter<SRTO_BINDTODEVICE>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        co.strBindToDevice = val;
+        co.sBindToDevice = val;
 #else
         (void)co; // prevent warning
         (void)optval;

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -87,18 +87,6 @@ struct CSrtMuxerConfig
     int iUDPSndBufSize; // UDP sending buffer size
     int iUDPRcvBufSize; // UDP receiving buffer size
 
-    // Some shortcuts
-#define DEFINEP(psym)                                          \
-    char*       pc##psym() { return (char*) &i##psym; }        \
-    const char* pc##psym() const { return (char*) &i##psym; }
-
-    DEFINEP(UDPSndBufSize);
-    DEFINEP(UDPRcvBufSize);
-    DEFINEP(IpV6Only);
-    DEFINEP(IpTTL);
-    DEFINEP(IpToS);
-#undef DEFINEP
-
     bool operator==(const CSrtMuxerConfig& other) const
     {
 #define CEQUAL(field) (field == other.field)

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -76,21 +76,21 @@ struct CSrtMuxerConfig
 {
     static const int DEF_UDP_BUFFER_SIZE = 65536;
 
-    int  m_iIpTTL;
-    int  m_iIpToS;
-    int  m_iIpV6Only;  // IPV6_V6ONLY option (-1 if not set)
-    bool m_bReuseAddr; // reuse an exiting port or not, for UDP multiplexer
+    int  iIpTTL;
+    int  iIpToS;
+    int  iIpV6Only;  // IPV6_V6ONLY option (-1 if not set)
+    bool bReuseAddr; // reuse an exiting port or not, for UDP multiplexer
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-    std::string m_BindToDevice;
+    std::string strBindToDevice;
 #endif
-    int m_iUDPSndBufSize; // UDP sending buffer size
-    int m_iUDPRcvBufSize; // UDP receiving buffer size
+    int iUDPSndBufSize; // UDP sending buffer size
+    int iUDPRcvBufSize; // UDP receiving buffer size
 
     // Some shortcuts
-#define DEFINEP(psym)                                                                                                  \
-    char*       pv##psym() { return (char*)&m_i##psym; }                                                               \
-    const char* pv##psym() const { return (char*)&m_i##psym; }
+#define DEFINEP(psym)                                          \
+    char*       pc##psym() { return (char*) &i##psym; }        \
+    const char* pc##psym() const { return (char*) &i##psym; }
 
     DEFINEP(UDPSndBufSize);
     DEFINEP(UDPRcvBufSize);
@@ -102,25 +102,25 @@ struct CSrtMuxerConfig
     bool operator==(const CSrtMuxerConfig& other) const
     {
 #define CEQUAL(field) (field == other.field)
-        return CEQUAL(m_iIpTTL)
-            && CEQUAL(m_iIpToS)
-            && CEQUAL(m_iIpV6Only)
-            && CEQUAL(m_bReuseAddr)
+        return CEQUAL(iIpTTL)
+            && CEQUAL(iIpToS)
+            && CEQUAL(iIpV6Only)
+            && CEQUAL(bReuseAddr)
 #ifdef SRT_ENABLE_BINDTODEVICE
-            && CEQUAL(m_BindToDevice)
+            && CEQUAL(strBindToDevice)
 #endif
-            && CEQUAL(m_iUDPSndBufSize)
-            && CEQUAL(m_iUDPRcvBufSize);
+            && CEQUAL(iUDPSndBufSize)
+            && CEQUAL(iUDPRcvBufSize);
 #undef CEQUAL
     }
 
     CSrtMuxerConfig()
-        : m_iIpTTL(-1) /* IPv4 TTL or IPv6 HOPs [1..255] (-1:undefined) */
-        , m_iIpToS(-1) /* IPv4 Type of Service or IPv6 Traffic Class [0x00..0xff] (-1:undefined) */
-        , m_iIpV6Only(-1)
-        , m_bReuseAddr(true) // This is default in SRT
-        , m_iUDPSndBufSize(DEF_UDP_BUFFER_SIZE)
-        , m_iUDPRcvBufSize(DEF_UDP_BUFFER_SIZE)
+        : iIpTTL(-1) /* IPv4 TTL or IPv6 HOPs [1..255] (-1:undefined) */
+        , iIpToS(-1) /* IPv4 Type of Service or IPv6 Traffic Class [0x00..0xff] (-1:undefined) */
+        , iIpV6Only(-1)
+        , bReuseAddr(true) // This is default in SRT
+        , iUDPSndBufSize(DEF_UDP_BUFFER_SIZE)
+        , iUDPRcvBufSize(DEF_UDP_BUFFER_SIZE)
     {
     }
 };
@@ -201,127 +201,127 @@ struct CSrtConfig: CSrtMuxerConfig
     static const size_t MAX_PFILTER_LENGTH = 64;
     static const size_t MAX_CONG_LENGTH    = 16;
 
-    int    m_iMSS;            // Maximum Segment Size, in bytes
-    size_t m_zExpPayloadSize; // Expected average payload size (user option)
+    int    iMSS;            // Maximum Segment Size, in bytes
+    size_t zExpPayloadSize; // Expected average payload size (user option)
 
     // Options
-    bool   m_bSynSending;     // Sending syncronization mode
-    bool   m_bSynRecving;     // Receiving syncronization mode
-    int    m_iFlightFlagSize; // Maximum number of packets in flight from the peer side
-    int    m_iSndBufSize;     // Maximum UDT sender buffer size
-    int    m_iRcvBufSize;     // Maximum UDT receiver buffer size
-    linger m_Linger;          // Linger information on close
-    bool   m_bRendezvous;     // Rendezvous connection mode
+    bool   bSynSending;     // Sending syncronization mode
+    bool   bSynRecving;     // Receiving syncronization mode
+    int    iFlightFlagSize; // Maximum number of packets in flight from the peer side
+    int    iSndBufSize;     // Maximum UDT sender buffer size
+    int    iRcvBufSize;     // Maximum UDT receiver buffer size
+    linger Linger;          // Linger information on close
+    bool   bRendezvous;     // Rendezvous connection mode
 
-    duration m_tdConnTimeOut; // connect timeout in milliseconds
-    bool     m_bDriftTracer;
-    int      m_iSndTimeOut; // sending timeout in milliseconds
-    int      m_iRcvTimeOut; // receiving timeout in milliseconds
-    int64_t  m_llMaxBW;     // maximum data transfer rate (threshold)
+    duration tdConnTimeOut; // connect timeout in milliseconds
+    bool     bDriftTracer;
+    int      iSndTimeOut; // sending timeout in milliseconds
+    int      iRcvTimeOut; // receiving timeout in milliseconds
+    int64_t  llMaxBW;     // maximum data transfer rate (threshold)
 
     // These fields keep the options for encryption
     // (SRTO_PASSPHRASE, SRTO_PBKEYLEN). Crypto object is
     // created later and takes values from these.
-    HaiCrypt_Secret m_CryptoSecret;
-    int             m_iSndCryptoKeyLen;
+    HaiCrypt_Secret CryptoSecret;
+    int             iSndCryptoKeyLen;
 
-    // XXX Consider removing. The m_bDataSender stays here
+    // XXX Consider removing. The bDataSender stays here
     // in order to maintain the HS side selection in HSv4.
-    bool m_bDataSender;
+    bool bDataSender;
 
-    bool     m_bMessageAPI;
-    bool     m_bTSBPD;        // Whether AGENT will do TSBPD Rx (whether peer does, is not agent's problem)
-    int      m_iRcvLatency;   // Agent's Rx latency
-    int      m_iPeerLatency;  // Peer's Rx latency for the traffic made by Agent's Tx.
-    bool     m_bTLPktDrop;    // Whether Agent WILL DO TLPKTDROP on Rx.
-    int      m_iSndDropDelay; // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
-    bool     m_bEnforcedEnc;  // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
-    int      m_GroupConnect;
-    int      m_iPeerIdleTimeout; // Timeout for hearing anything from the peer.
-    uint32_t m_uStabilityTimeout;
-    int      m_iRetransmitAlgo;
+    bool     bMessageAPI;
+    bool     bTSBPD;        // Whether AGENT will do TSBPD Rx (whether peer does, is not agent's problem)
+    int      iRcvLatency;   // Agent's Rx latency
+    int      iPeerLatency;  // Peer's Rx latency for the traffic made by Agent's Tx.
+    bool     bTLPktDrop;    // Whether Agent WILL DO TLPKTDROP on Rx.
+    int      iSndDropDelay; // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
+    bool     bEnforcedEnc;  // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
+    int      iGroupConnect;     // 1 - allow group connections
+    int      iPeerIdleTimeout; // Timeout for hearing anything from the peer.
+    uint32_t uStabilityTimeout;
+    int      iRetransmitAlgo;
 
-    int64_t m_llInputBW;         // Input stream rate (bytes/sec). 0: use internally estimated input bandwidth
-    int64_t m_llMinInputBW;      // Minimum input stream rate estimate (bytes/sec)
-    int  m_iOverheadBW;          // Percent above input stream rate (applies if m_llMaxBW == 0)
-    bool m_bRcvNakReport;        // Enable Receiver Periodic NAK Reports
-    int  m_iMaxReorderTolerance; //< Maximum allowed value for dynamic reorder tolerance
+    int64_t llInputBW;         // Input stream rate (bytes/sec). 0: use internally estimated input bandwidth
+    int64_t llMinInputBW;      // Minimum input stream rate estimate (bytes/sec)
+    int  iOverheadBW;          // Percent above input stream rate (applies if llMaxBW == 0)
+    bool bRcvNakReport;        // Enable Receiver Periodic NAK Reports
+    int  iMaxReorderTolerance; //< Maximum allowed value for dynamic reorder tolerance
 
     // For the use of CCryptoControl
     // HaiCrypt configuration
-    unsigned int m_uKmRefreshRatePkt;
-    unsigned int m_uKmPreAnnouncePkt;
+    unsigned int uKmRefreshRatePkt;
+    unsigned int uKmPreAnnouncePkt;
 
-    uint32_t m_lSrtVersion;
-    uint32_t m_lMinimumPeerSrtVersion;
+    uint32_t uSrtVersion;
+    uint32_t uMinimumPeerSrtVersion;
 
-    StringStorage<MAX_CONG_LENGTH>    m_Congestion;
-    StringStorage<MAX_PFILTER_LENGTH> m_PacketFilterConfig;
-    StringStorage<MAX_SID_LENGTH>     m_StreamName;
+    StringStorage<MAX_CONG_LENGTH>    sCongestion;
+    StringStorage<MAX_PFILTER_LENGTH> sPacketFilterConfig;
+    StringStorage<MAX_SID_LENGTH>     sStreamName;
 
     // Shortcuts and utilities
     int32_t flightCapacity()
     {
-        return std::min(m_iRcvBufSize, m_iFlightFlagSize);
+        return std::min(iRcvBufSize, iFlightFlagSize);
     }
 
     CSrtConfig()
-        : m_iMSS(DEF_MSS)
-        , m_zExpPayloadSize(SRT_LIVE_DEF_PLSIZE)
-        , m_bSynSending(true)
-        , m_bSynRecving(true)
-        , m_iFlightFlagSize(DEF_FLIGHT_SIZE)
-        , m_iSndBufSize(DEF_BUFFER_SIZE)
-        , m_iRcvBufSize(DEF_BUFFER_SIZE)
-        , m_bRendezvous(false)
-        , m_tdConnTimeOut(srt::sync::seconds_from(DEF_CONNTIMEO_S))
-        , m_bDriftTracer(true)
-        , m_iSndTimeOut(-1)
-        , m_iRcvTimeOut(-1)
-        , m_llMaxBW(-1)
-        , m_bDataSender(false)
-        , m_bMessageAPI(true)
-        , m_bTSBPD(true)
-        , m_iRcvLatency(SRT_LIVE_DEF_LATENCY_MS)
-        , m_iPeerLatency(0)
-        , m_bTLPktDrop(true)
-        , m_iSndDropDelay(0)
-        , m_bEnforcedEnc(true)
-        , m_GroupConnect(0)
-        , m_iPeerIdleTimeout(COMM_RESPONSE_TIMEOUT_MS)
-        , m_uStabilityTimeout(COMM_DEF_STABILITY_TIMEOUT_US)
-        , m_iRetransmitAlgo(0)
-        , m_llInputBW(0)
-        , m_llMinInputBW(0)
-        , m_iOverheadBW(25)
-        , m_bRcvNakReport(true)
-        , m_iMaxReorderTolerance(0) // Sensible optimal value is 10, 0 preserves old behavior
-        , m_uKmRefreshRatePkt(0)
-        , m_uKmPreAnnouncePkt(0)
-        , m_lSrtVersion(SRT_DEF_VERSION)
-        , m_lMinimumPeerSrtVersion(SRT_VERSION_MAJ1)
+        : iMSS(DEF_MSS)
+        , zExpPayloadSize(SRT_LIVE_DEF_PLSIZE)
+        , bSynSending(true)
+        , bSynRecving(true)
+        , iFlightFlagSize(DEF_FLIGHT_SIZE)
+        , iSndBufSize(DEF_BUFFER_SIZE)
+        , iRcvBufSize(DEF_BUFFER_SIZE)
+        , bRendezvous(false)
+        , tdConnTimeOut(srt::sync::seconds_from(DEF_CONNTIMEO_S))
+        , bDriftTracer(true)
+        , iSndTimeOut(-1)
+        , iRcvTimeOut(-1)
+        , llMaxBW(-1)
+        , bDataSender(false)
+        , bMessageAPI(true)
+        , bTSBPD(true)
+        , iRcvLatency(SRT_LIVE_DEF_LATENCY_MS)
+        , iPeerLatency(0)
+        , bTLPktDrop(true)
+        , iSndDropDelay(0)
+        , bEnforcedEnc(true)
+        , iGroupConnect(0)
+        , iPeerIdleTimeout(COMM_RESPONSE_TIMEOUT_MS)
+        , uStabilityTimeout(COMM_DEF_STABILITY_TIMEOUT_US)
+        , iRetransmitAlgo(0)
+        , llInputBW(0)
+        , llMinInputBW(0)
+        , iOverheadBW(25)
+        , bRcvNakReport(true)
+        , iMaxReorderTolerance(0) // Sensible optimal value is 10, 0 preserves old behavior
+        , uKmRefreshRatePkt(0)
+        , uKmPreAnnouncePkt(0)
+        , uSrtVersion(SRT_DEF_VERSION)
+        , uMinimumPeerSrtVersion(SRT_VERSION_MAJ1)
 
     {
         // Default UDT configurations
-        m_iUDPRcvBufSize = m_iRcvBufSize * m_iMSS;
+        iUDPRcvBufSize = iRcvBufSize * iMSS;
 
         // Linger: LIVE mode defaults, please refer to `SRTO_TRANSTYPE` option
         // for other modes.
-        m_Linger.l_onoff   = 0;
-        m_Linger.l_linger  = 0;
-        m_CryptoSecret.len = 0;
-        m_iSndCryptoKeyLen = 0;
+        Linger.l_onoff   = 0;
+        Linger.l_linger  = 0;
+        CryptoSecret.len = 0;
+        iSndCryptoKeyLen = 0;
 
         // Default congestion is "live".
         // Available builtin congestions: "file".
         // Others can be registerred.
-        m_Congestion.set("live", 4);
+        sCongestion.set("live", 4);
     }
 
     ~CSrtConfig()
     {
         // Wipeout critical data
-        memset(&m_CryptoSecret, 0, sizeof(m_CryptoSecret));
+        memset(&CryptoSecret, 0, sizeof(CryptoSecret));
     }
 
     int set(SRT_SOCKOPT optName, const void* val, int size);
@@ -410,13 +410,13 @@ struct CSrtConfigSetter<SRTO_MSS>
         if (ival < int(CPacket::UDP_HDR_SIZE + CHandShake::m_iContentSize))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        co.m_iMSS = ival;
+        co.iMSS = ival;
 
         // Packet size cannot be greater than UDP buffer size
-        if (co.m_iMSS > co.m_iUDPSndBufSize)
-            co.m_iMSS = co.m_iUDPSndBufSize;
-        if (co.m_iMSS > co.m_iUDPRcvBufSize)
-            co.m_iMSS = co.m_iUDPRcvBufSize;
+        if (co.iMSS > co.iUDPSndBufSize)
+            co.iMSS = co.iUDPSndBufSize;
+        if (co.iMSS > co.iUDPRcvBufSize)
+            co.iMSS = co.iUDPRcvBufSize;
     }
 };
 
@@ -429,7 +429,7 @@ struct CSrtConfigSetter<SRTO_FC>
         if (fc < 1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL);
 
-        co.m_iFlightFlagSize = std::min(fc, +co.DEF_MAX_FLIGHT_PKT);
+        co.iFlightFlagSize = std::min(fc, +co.DEF_MAX_FLIGHT_PKT);
     }
 };
 
@@ -442,7 +442,7 @@ struct CSrtConfigSetter<SRTO_SNDBUF>
         if (bs <= 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        co.m_iSndBufSize = bs / (co.m_iMSS - CPacket::UDP_HDR_SIZE);
+        co.iSndBufSize = bs / (co.iMSS - CPacket::UDP_HDR_SIZE);
     }
 };
 
@@ -456,17 +456,17 @@ struct CSrtConfigSetter<SRTO_RCVBUF>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         // Mimimum recv buffer size is 32 packets
-        const int mssin_size = co.m_iMSS - CPacket::UDP_HDR_SIZE;
+        const int mssin_size = co.iMSS - CPacket::UDP_HDR_SIZE;
 
         // XXX This magic 32 deserves some constant
         if (val > mssin_size * co.DEF_MAX_FLIGHT_PKT)
-            co.m_iRcvBufSize = val / mssin_size;
+            co.iRcvBufSize = val / mssin_size;
         else
-            co.m_iRcvBufSize = co.DEF_MAX_FLIGHT_PKT;
+            co.iRcvBufSize = co.DEF_MAX_FLIGHT_PKT;
 
         // recv buffer MUST not be greater than FC size
-        if (co.m_iRcvBufSize > co.m_iFlightFlagSize)
-            co.m_iRcvBufSize = co.m_iFlightFlagSize;
+        if (co.iRcvBufSize > co.iFlightFlagSize)
+            co.iRcvBufSize = co.iFlightFlagSize;
     }
 };
 
@@ -475,7 +475,7 @@ struct CSrtConfigSetter<SRTO_LINGER>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_Linger = cast_optval<linger>(optval, optlen);
+        co.Linger = cast_optval<linger>(optval, optlen);
     }
 };
 
@@ -484,7 +484,7 @@ struct CSrtConfigSetter<SRTO_UDP_SNDBUF>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iUDPSndBufSize = std::max(co.m_iMSS, cast_optval<int>(optval, optlen));
+        co.iUDPSndBufSize = std::max(co.iMSS, cast_optval<int>(optval, optlen));
     }
 };
 
@@ -493,7 +493,7 @@ struct CSrtConfigSetter<SRTO_UDP_RCVBUF>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iUDPRcvBufSize = std::max(co.m_iMSS, cast_optval<int>(optval, optlen));
+        co.iUDPRcvBufSize = std::max(co.iMSS, cast_optval<int>(optval, optlen));
     }
 };
 template<>
@@ -501,7 +501,7 @@ struct CSrtConfigSetter<SRTO_RENDEZVOUS>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bRendezvous = cast_optval<bool>(optval, optlen);
+        co.bRendezvous = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -510,7 +510,7 @@ struct CSrtConfigSetter<SRTO_SNDTIMEO>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iSndTimeOut = cast_optval<int>(optval, optlen);
+        co.iSndTimeOut = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -519,7 +519,7 @@ struct CSrtConfigSetter<SRTO_RCVTIMEO>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iRcvTimeOut = cast_optval<int>(optval, optlen);
+        co.iRcvTimeOut = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -528,7 +528,7 @@ struct CSrtConfigSetter<SRTO_SNDSYN>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bSynSending = cast_optval<bool>(optval, optlen);
+        co.bSynSending = cast_optval<bool>(optval, optlen);
     }
 };
 template<>
@@ -536,7 +536,7 @@ struct CSrtConfigSetter<SRTO_RCVSYN>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bSynRecving = cast_optval<bool>(optval, optlen);
+        co.bSynRecving = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -545,7 +545,7 @@ struct CSrtConfigSetter<SRTO_REUSEADDR>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bReuseAddr = cast_optval<bool>(optval, optlen);
+        co.bReuseAddr = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -558,7 +558,7 @@ struct CSrtConfigSetter<SRTO_MAXBW>
         if (val < -1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        co.m_llMaxBW = val;
+        co.llMaxBW = val;
     }
 };
 
@@ -570,7 +570,7 @@ struct CSrtConfigSetter<SRTO_IPTTL>
         int val = cast_optval<int>(optval, optlen);
         if (!(val == -1) && !((val >= 1) && (val <= 255)))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        co.m_iIpTTL = cast_optval<int>(optval);
+        co.iIpTTL = cast_optval<int>(optval);
     }
 };
 template<>
@@ -578,7 +578,7 @@ struct CSrtConfigSetter<SRTO_IPTOS>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iIpToS = cast_optval<int>(optval, optlen);
+        co.iIpToS = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -603,7 +603,7 @@ struct CSrtConfigSetter<SRTO_BINDTODEVICE>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        co.m_BindToDevice = val;
+        co.strBindToDevice = val;
 #else
         (void)co; // prevent warning
         (void)optval;
@@ -622,7 +622,7 @@ struct CSrtConfigSetter<SRTO_INPUTBW>
         const int64_t val = cast_optval<int64_t>(optval, optlen);
         if (val < 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        co.m_llInputBW = val;
+        co.llInputBW = val;
     }
 };
 template<>
@@ -633,7 +633,7 @@ struct CSrtConfigSetter<SRTO_MININPUTBW>
         const int64_t val = cast_optval<int64_t>(optval, optlen);
         if (val < 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        co.m_llMinInputBW = val;
+        co.llMinInputBW = val;
     }
 };
 template<>
@@ -644,7 +644,7 @@ struct CSrtConfigSetter<SRTO_OHEADBW>
         const int32_t val = cast_optval<int32_t>(optval, optlen);
         if (val < 5 || val > 100)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-        co.m_iOverheadBW = val;
+        co.iOverheadBW = val;
     }
 };
 template<>
@@ -652,7 +652,7 @@ struct CSrtConfigSetter<SRTO_SENDER>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bDataSender = cast_optval<bool>(optval, optlen);
+        co.bDataSender = cast_optval<bool>(optval, optlen);
     }
 };
 template<>
@@ -660,7 +660,7 @@ struct CSrtConfigSetter<SRTO_TSBPDMODE>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bTSBPD = cast_optval<bool>(optval, optlen);
+        co.bTSBPD = cast_optval<bool>(optval, optlen);
     }
 };
 template<>
@@ -668,8 +668,8 @@ struct CSrtConfigSetter<SRTO_LATENCY>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iRcvLatency     = cast_optval<int>(optval, optlen);
-        co.m_iPeerLatency = cast_optval<int>(optval);
+        co.iRcvLatency     = cast_optval<int>(optval, optlen);
+        co.iPeerLatency = cast_optval<int>(optval);
     }
 };
 template<>
@@ -677,7 +677,7 @@ struct CSrtConfigSetter<SRTO_RCVLATENCY>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iRcvLatency = cast_optval<int>(optval, optlen);
+        co.iRcvLatency = cast_optval<int>(optval, optlen);
     }
 };
 template<>
@@ -685,7 +685,7 @@ struct CSrtConfigSetter<SRTO_PEERLATENCY>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iPeerLatency = cast_optval<int>(optval, optlen);
+        co.iPeerLatency = cast_optval<int>(optval, optlen);
     }
 };
 template<>
@@ -693,7 +693,7 @@ struct CSrtConfigSetter<SRTO_TLPKTDROP>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bTLPktDrop = cast_optval<bool>(optval, optlen);
+        co.bTLPktDrop = cast_optval<bool>(optval, optlen);
     }
 };
 template<>
@@ -703,7 +703,7 @@ struct CSrtConfigSetter<SRTO_SNDDROPDELAY>
     {
         // Surprise: you may be connected to alter this option.
         // The application may manipulate this option on sender while transmitting.
-        co.m_iSndDropDelay = cast_optval<int>(optval, optlen);
+        co.iSndDropDelay = cast_optval<int>(optval, optlen);
     }
 };
 template<>
@@ -718,10 +718,10 @@ struct CSrtConfigSetter<SRTO_PASSPHRASE>
         if ((optlen != 0) && (optlen < 10 || optlen > HAICRYPT_SECRET_MAX_SZ))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        memset(&co.m_CryptoSecret, 0, sizeof(co.m_CryptoSecret));
-        co.m_CryptoSecret.typ = HAICRYPT_SECTYP_PASSPHRASE;
-        co.m_CryptoSecret.len = (optlen <= (int)sizeof(co.m_CryptoSecret.str) ? optlen : (int)sizeof(co.m_CryptoSecret.str));
-        memcpy((co.m_CryptoSecret.str), optval, co.m_CryptoSecret.len);
+        memset(&co.CryptoSecret, 0, sizeof(co.CryptoSecret));
+        co.CryptoSecret.typ = HAICRYPT_SECTYP_PASSPHRASE;
+        co.CryptoSecret.len = (optlen <= (int)sizeof(co.CryptoSecret.str) ? optlen : (int)sizeof(co.CryptoSecret.str));
+        memcpy((co.CryptoSecret.str), optval, co.CryptoSecret.len);
 #else
         (void)co; // prevent warning
         (void)optval;
@@ -778,7 +778,7 @@ struct CSrtConfigSetter<SRTO_PBKEYLEN>
         //    listener, and both URQ_WAVEAHAND and URQ_CONCLUSION in case
         //    of rendezvous, as it is the matter of luck who of them will
         //    eventually become the initiator). This way the receiver
-        //    being an initiator will set m_iSndCryptoKeyLen before setting
+        //    being an initiator will set iSndCryptoKeyLen before setting
         //    up KMREQ for sending to the sender-responder.
         //
         // Note that in HSv5 if both sides set PBKEYLEN, the responder
@@ -786,7 +786,7 @@ struct CSrtConfigSetter<SRTO_PBKEYLEN>
         // will be the one advertised by the responder). If none sets,
         // PBKEYLEN will default to 16.
 
-        co.m_iSndCryptoKeyLen = v;
+        co.iSndCryptoKeyLen = v;
 #else
         (void)co; // prevent warning
         (void)optval;
@@ -802,7 +802,7 @@ struct CSrtConfigSetter<SRTO_NAKREPORT>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bRcvNakReport = cast_optval<bool>(optval, optlen);
+        co.bRcvNakReport = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -812,7 +812,7 @@ struct CSrtConfigSetter<SRTO_CONNTIMEO>
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
         using namespace srt::sync;
-        co.m_tdConnTimeOut = milliseconds_from(cast_optval<int>(optval, optlen));
+        co.tdConnTimeOut = milliseconds_from(cast_optval<int>(optval, optlen));
     }
 };
 
@@ -821,7 +821,7 @@ struct CSrtConfigSetter<SRTO_DRIFTTRACER>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bDriftTracer = cast_optval<bool>(optval, optlen);
+        co.bDriftTracer = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -830,7 +830,7 @@ struct CSrtConfigSetter<SRTO_LOSSMAXTTL>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iMaxReorderTolerance = cast_optval<int>(optval, optlen);
+        co.iMaxReorderTolerance = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -839,7 +839,7 @@ struct CSrtConfigSetter<SRTO_VERSION>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_lSrtVersion = cast_optval<uint32_t>(optval, optlen);
+        co.uSrtVersion = cast_optval<uint32_t>(optval, optlen);
     }
 };
 
@@ -848,7 +848,7 @@ struct CSrtConfigSetter<SRTO_MINVERSION>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_lMinimumPeerSrtVersion = cast_optval<uint32_t>(optval, optlen);
+        co.uMinimumPeerSrtVersion = cast_optval<uint32_t>(optval, optlen);
     }
 };
 
@@ -860,7 +860,7 @@ struct CSrtConfigSetter<SRTO_STREAMID>
         if (size_t(optlen) > CSrtConfig::MAX_SID_LENGTH)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        co.m_StreamName.set((const char*)optval, optlen);
+        co.sStreamName.set((const char*)optval, optlen);
     }
 };
 
@@ -883,7 +883,7 @@ struct CSrtConfigSetter<SRTO_CONGESTION>
         if (!res)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        co.m_Congestion.set(val);
+        co.sCongestion.set(val);
     }
 };
 
@@ -892,7 +892,7 @@ struct CSrtConfigSetter<SRTO_MESSAGEAPI>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bMessageAPI = cast_optval<bool>(optval, optlen);
+        co.bMessageAPI = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -909,13 +909,13 @@ struct CSrtConfigSetter<SRTO_PAYLOADSIZE>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        if (!co.m_PacketFilterConfig.empty())
+        if (!co.sPacketFilterConfig.empty())
         {
             // This means that the filter might have been installed before,
             // and the fix to the maximum payload size was already applied.
             // This needs to be checked now.
             SrtFilterConfig fc;
-            if (!ParseFilterConfig(co.m_PacketFilterConfig.str(), fc))
+            if (!ParseFilterConfig(co.sPacketFilterConfig.str(), fc))
             {
                 // Break silently. This should not happen
                 LOGC(aclog.Error, log << "SRTO_PAYLOADSIZE: IPE: failing filter configuration installed");
@@ -923,7 +923,7 @@ struct CSrtConfigSetter<SRTO_PAYLOADSIZE>
             }
 
             size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
-            if (co.m_zExpPayloadSize > efc_max_payload_size)
+            if (co.zExpPayloadSize > efc_max_payload_size)
             {
                 LOGC(aclog.Error,
                      log << "SRTO_PAYLOADSIZE: value exceeds SRT_LIVE_MAX_PLSIZE decreased by " << fc.extra_size
@@ -932,7 +932,7 @@ struct CSrtConfigSetter<SRTO_PAYLOADSIZE>
             }
         }
 
-        co.m_zExpPayloadSize = cast_optval<int>(optval, optlen);
+        co.zExpPayloadSize = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -953,17 +953,17 @@ struct CSrtConfigSetter<SRTO_TRANSTYPE>
             // - linger: off
             // - congctl: live
             // - extraction method: message (reading call extracts one message)
-            co.m_bTSBPD          = true;
-            co.m_iRcvLatency     = SRT_LIVE_DEF_LATENCY_MS;
-            co.m_iPeerLatency    = 0;
-            co.m_bTLPktDrop      = true;
-            co.m_iSndDropDelay   = 0;
-            co.m_bMessageAPI     = true;
-            co.m_bRcvNakReport   = true;
-            co.m_zExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
-            co.m_Linger.l_onoff  = 0;
-            co.m_Linger.l_linger = 0;
-            co.m_Congestion.set("live", 4);
+            co.bTSBPD          = true;
+            co.iRcvLatency     = SRT_LIVE_DEF_LATENCY_MS;
+            co.iPeerLatency    = 0;
+            co.bTLPktDrop      = true;
+            co.iSndDropDelay   = 0;
+            co.bMessageAPI     = true;
+            co.bRcvNakReport   = true;
+            co.zExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
+            co.Linger.l_onoff  = 0;
+            co.Linger.l_linger = 0;
+            co.sCongestion.set("live", 4);
             break;
 
         case SRTT_FILE:
@@ -973,17 +973,17 @@ struct CSrtConfigSetter<SRTO_TRANSTYPE>
             // - linger: 2 minutes (180s)
             // - congctl: file (original UDT congestion control)
             // - extraction method: stream (reading call extracts as many bytes as available and fits in buffer)
-            co.m_bTSBPD          = false;
-            co.m_iRcvLatency     = 0;
-            co.m_iPeerLatency    = 0;
-            co.m_bTLPktDrop      = false;
-            co.m_iSndDropDelay   = -1;
-            co.m_bMessageAPI     = false;
-            co.m_bRcvNakReport   = false;
-            co.m_zExpPayloadSize = 0; // use maximum
-            co.m_Linger.l_onoff  = 1;
-            co.m_Linger.l_linger = CSrtConfig::DEF_LINGER_S;
-            co.m_Congestion.set("file", 4);
+            co.bTSBPD          = false;
+            co.iRcvLatency     = 0;
+            co.iPeerLatency    = 0;
+            co.bTLPktDrop      = false;
+            co.iSndDropDelay   = -1;
+            co.bMessageAPI     = false;
+            co.bRcvNakReport   = false;
+            co.zExpPayloadSize = 0; // use maximum
+            co.Linger.l_onoff  = 1;
+            co.Linger.l_linger = CSrtConfig::DEF_LINGER_S;
+            co.sCongestion.set("file", 4);
             break;
 
         default:
@@ -998,7 +998,7 @@ struct CSrtConfigSetter<SRTO_GROUPCONNECT>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_GroupConnect = cast_optval<int>(optval, optlen);
+        co.iGroupConnect = cast_optval<int>(optval, optlen);
     }
 };
 #endif
@@ -1012,13 +1012,13 @@ struct CSrtConfigSetter<SRTO_KMREFRESHRATE>
 
         // If you first change the KMREFRESHRATE, KMPREANNOUNCE
         // will be set to the maximum allowed value
-        co.m_uKmRefreshRatePkt = cast_optval<int>(optval, optlen);
-        if (co.m_uKmPreAnnouncePkt == 0 || co.m_uKmPreAnnouncePkt > (co.m_uKmRefreshRatePkt - 1) / 2)
+        co.uKmRefreshRatePkt = cast_optval<int>(optval, optlen);
+        if (co.uKmPreAnnouncePkt == 0 || co.uKmPreAnnouncePkt > (co.uKmRefreshRatePkt - 1) / 2)
         {
-            co.m_uKmPreAnnouncePkt = (co.m_uKmRefreshRatePkt - 1) / 2;
+            co.uKmPreAnnouncePkt = (co.uKmRefreshRatePkt - 1) / 2;
             LOGC(aclog.Warn,
-                 log << "SRTO_KMREFRESHRATE=0x" << std::hex << co.m_uKmRefreshRatePkt << ": setting SRTO_KMPREANNOUNCE=0x"
-                     << std::hex << co.m_uKmPreAnnouncePkt);
+                 log << "SRTO_KMREFRESHRATE=0x" << std::hex << co.uKmRefreshRatePkt << ": setting SRTO_KMPREANNOUNCE=0x"
+                     << std::hex << co.uKmPreAnnouncePkt);
         }
     }
 };
@@ -1031,7 +1031,7 @@ struct CSrtConfigSetter<SRTO_KMPREANNOUNCE>
         using namespace srt_logging;
 
         const int val = cast_optval<int>(optval, optlen);
-        const int kmref = co.m_uKmRefreshRatePkt == 0 ? HAICRYPT_DEF_KM_REFRESH_RATE : co.m_uKmRefreshRatePkt;
+        const int kmref = co.uKmRefreshRatePkt == 0 ? HAICRYPT_DEF_KM_REFRESH_RATE : co.uKmRefreshRatePkt;
         if (val > (kmref - 1) / 2)
         {
             LOGC(aclog.Error,
@@ -1040,7 +1040,7 @@ struct CSrtConfigSetter<SRTO_KMPREANNOUNCE>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        co.m_uKmPreAnnouncePkt = val;
+        co.uKmPreAnnouncePkt = val;
     }
 };
 
@@ -1049,7 +1049,7 @@ struct CSrtConfigSetter<SRTO_ENFORCEDENCRYPTION>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_bEnforcedEnc = cast_optval<bool>(optval, optlen);
+        co.bEnforcedEnc = cast_optval<bool>(optval, optlen);
     }
 };
 
@@ -1058,7 +1058,7 @@ struct CSrtConfigSetter<SRTO_PEERIDLETIMEO>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iPeerIdleTimeout = cast_optval<int>(optval, optlen);
+        co.iPeerIdleTimeout = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -1067,7 +1067,7 @@ struct CSrtConfigSetter<SRTO_IPV6ONLY>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iIpV6Only = cast_optval<int>(optval, optlen);
+        co.iIpV6Only = cast_optval<int>(optval, optlen);
     }
 };
 
@@ -1090,15 +1090,15 @@ struct CSrtConfigSetter<SRTO_PACKETFILTER>
         }
 
         size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
-        if (co.m_zExpPayloadSize > efc_max_payload_size)
+        if (co.zExpPayloadSize > efc_max_payload_size)
         {
             LOGC(aclog.Warn,
                     log << "Due to filter-required extra " << fc.extra_size << " bytes, SRTO_PAYLOADSIZE fixed to "
                     << efc_max_payload_size << " bytes");
-            co.m_zExpPayloadSize = efc_max_payload_size;
+            co.zExpPayloadSize = efc_max_payload_size;
         }
 
-        co.m_PacketFilterConfig.set(arg);
+        co.sPacketFilterConfig.set(arg);
     }
 };
 
@@ -1117,7 +1117,7 @@ struct CSrtConfigSetter<SRTO_GROUPSTABTIMEO>
 
         // Search if you already have SRTO_PEERIDLETIMEO set
 
-        const int idletmo = co.m_iPeerIdleTimeout;
+        const int idletmo = co.iPeerIdleTimeout;
 
         // Both are in milliseconds.
         // This option is RECORDED in microseconds, while
@@ -1130,7 +1130,7 @@ struct CSrtConfigSetter<SRTO_GROUPSTABTIMEO>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        co.m_uStabilityTimeout = val * 1000;
+        co.uStabilityTimeout = val * 1000;
     }
 };
 #endif
@@ -1140,7 +1140,7 @@ struct CSrtConfigSetter<SRTO_RETRANSMITALGO>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.m_iRetransmitAlgo = cast_optval<int32_t>(optval, optlen);
+        co.iRetransmitAlgo = cast_optval<int32_t>(optval, optlen);
     }
 };
 

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -224,7 +224,7 @@ struct CSrtConfig: CSrtMuxerConfig
     bool     bTLPktDrop;    // Whether Agent WILL DO TLPKTDROP on Rx.
     int      iSndDropDelay; // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
     bool     bEnforcedEnc;  // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
-    int      iGroupConnect;     // 1 - allow group connections
+    int      iGroupConnect;    // 1 - allow group connections
     int      iPeerIdleTimeout; // Timeout for hearing anything from the peer.
     uint32_t uStabilityTimeout;
     int      iRetransmitAlgo;


### PR DESCRIPTION
`CSrtConfig`, `CSrtMuxerConfig` and others as of now are structures.
They allow public access to their members. Members currently have `m_` prefix, which is intended to identify private members.

**Changes:**
- [x] Removed `m_` prefix of members in `CSrtConfig`, `CSrtMuxerConfig` etc.
- [x] A function returning pointer to `char` must have a `pc` prefix instead of `pv`, therefore renamed `pvUDPRcvBufSize()` et al to `pcUDPRcvBufSize()` et al according to Hungarian notation.

```c++
const char* pcUDPRcvBufSize() const;
```