### PR TITLE
[devel] Added possibility to enforce socket/group ID value

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -224,7 +224,7 @@ public:
       /// @param [out] pps Variable (optional) to which the new socket will be written, if succeeded
       /// @return The new UDT socket ID, or INVALID_SOCK.
 
-   SRTSOCKET newSocket(CUDTSocket** pps = NULL);
+   SRTSOCKET newSocket(CUDTSocket** pps = NULL, SRTSOCKET forceid = SRT_INVALID_SOCK);
 
       /// Create a new UDT connection.
       /// @param [in] listen the listening UDT socket;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -184,9 +184,9 @@ private: // constructor and desctructor
 public: //API
     static int startup();
     static int cleanup();
-    static SRTSOCKET socket();
+    static SRTSOCKET socket(SRTSOCKET forceid = SRT_INVALID_SOCK);
 #if ENABLE_EXPERIMENTAL_BONDING
-    static SRTSOCKET createGroup(SRT_GROUP_TYPE);
+    static SRTSOCKET createGroup(SRT_GROUP_TYPE, const SRTSOCKET forceid = SRT_INVALID_SOCK);
     static int addSocketToGroup(SRTSOCKET socket, SRTSOCKET group);
     static int removeSocketFromGroup(SRTSOCKET socket);
     static SRTSOCKET getGroupOfSocket(SRTSOCKET socket);
@@ -511,7 +511,7 @@ private:
     SRT_ATR_NODISCARD bool checkApplyFilterConfig(const std::string& cs);
 
 #if ENABLE_EXPERIMENTAL_BONDING
-    static CUDTGroup& newGroup(const int); // defined EXCEPTIONALLY in api.cpp for convenience reasons
+    static CUDTGroup& newGroup(const int, SRTSOCKET forceid = SRT_INVALID_SOCK); // defined EXCEPTIONALLY in api.cpp for convenience reasons
     // Note: This is an "interpret" function, which should treat the tp as
     // "possibly group type" that might be out of the existing values.
     SRT_ATR_NODISCARD bool interpretGroup(const int32_t grpdata[], size_t data_size, int hsreq_type_cmd);

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -1,7 +1,6 @@
 
 SOURCES
 test_buffer.cpp
-test_bonding.cpp
 test_common.cpp
 test_connection_timeout.cpp
 test_many_connections.cpp
@@ -21,7 +20,6 @@ test_timer.cpp
 test_unitqueue.cpp
 test_utilities.cpp
 
-# Tests for bonding only - put here!
-
 SOURCES - ENABLE_EXPERIMENTAL_BONDING
+test_bonding.cpp
 

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -12,8 +12,6 @@
 #include <unistd.h>
 #endif
 
-#if ENABLE_EXPERIMENTAL_BONDING
-
 #include "gtest/gtest.h"
 
 #include "srt.h"
@@ -335,5 +333,3 @@ TEST(Bonding, CloseGroupAndSocket)
 
     srt_cleanup();
 }
-
-#endif // ENABLE_EXPERIMENTAL_BONDING

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -29,6 +29,7 @@
 #include "netinet_any.h"
 #include "common.h"
 #include "api.h"
+#include "core.h"
 #include "udt.h"
 #include "logging.h"
 #include "utilities.h"
@@ -232,6 +233,10 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
                 Error("With //group, the group 'type' must be specified.");
             }
 
+            auto* is = map_getp(par, "forceid");
+            if (is)
+                m_forced_id = stoi(*is);
+
             vector<string> parts;
             Split(m_group_type, '/', back_inserter(parts));
             if (parts.size() == 0 || parts.size() > 2)
@@ -355,6 +360,7 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
 
             par.erase("type");
             par.erase("nodes");
+            par.erase("forceid");
 
             // For a group-connect specification, it's
             // always the caller mode.
@@ -463,6 +469,12 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
             par["minversion"] = Sprint(version);
             Verb() << "\tFIXED: minversion = 0x" << std::hex << std::setfill('0') << std::setw(8) << version << std::dec;
         }
+    }
+
+    if (par.count("forceid"))
+    {
+        m_forced_id = stoi(par["forceid"]);
+        par.erase("forceid");
     }
 
     // Assign the others here.
@@ -887,7 +899,11 @@ void SrtCommon::OpenClient(string host, int port)
 
 void SrtCommon::PrepareClient()
 {
-    m_sock = srt_create_socket();
+    if (m_forced_id != SRT_INVALID_SOCK)
+        m_sock = CUDT::socket(m_forced_id);
+    else
+        m_sock = srt_create_socket();
+
     if (m_sock == SRT_ERROR)
         Error("srt_create_socket");
 
@@ -963,7 +979,11 @@ void SrtCommon::OpenGroupClient()
         Error("With //group, type='" + m_group_type + "' undefined");
     }
 
-    m_sock = srt_create_group(type);
+    if (m_forced_id != SRT_INVALID_SOCK)
+        m_sock = CUDT::createGroup(type, m_forced_id);
+    else
+        m_sock = srt_create_group(type);
+
     if (m_sock == -1)
         Error("srt_create_group");
 

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -95,6 +95,7 @@ protected:
     int srt_epoll = -1;
     SRT_EPOLL_T m_direction = SRT_EPOLL_OPT_NONE; //< Defines which of SND or RCV option variant should be used, also to set SRT_SENDER for output
     bool m_blocking_mode = true; //< enforces using SRTO_SNDSYN or SRTO_RCVSYN, depending on @a m_direction
+    SRTSOCKET m_forced_id = SRT_INVALID_SOCK;
     int m_timeout = 0; //< enforces using SRTO_SNDTIMEO or SRTO_RCVTIMEO, depending on @a m_direction
     bool m_tsbpdmode = true;
     int m_outgoing_port = 0;


### PR DESCRIPTION
Added API (internals only) to create a socket or group with enforced ID value.

Access through API: `CUDT::socket` and `CUDT::createGroup`.

Access through `srt-test-live` application: `forceid` parameter in SRT URI (both for group and socket).