### PR TITLE
[BUG][core] Unguarded access to epolldesc from group sender code

### DIFF
--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -808,6 +808,12 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
     return 0;
 }
 
+bool CEPoll::empty(CEPollDesc& d)
+{
+    ScopedLock lg (m_EPollLock);
+    return d.watch_empty();
+}
+
 int CEPoll::release(const int eid)
 {
    ScopedLock pg(m_EPollLock);

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -60,7 +60,7 @@ modified by
 #include "udt.h"
 
 
-struct CEPollDesc
+class CEPollDesc
 {
    const int m_iID;                                // epoll ID
 
@@ -143,8 +143,6 @@ struct CEPollDesc
 std::string DisplayEpollWatch();
 #endif
 
-private:
-
    /// Sockets that are subscribed for events in this eid.
    ewatch_t m_USockWatchState;
 
@@ -159,7 +157,10 @@ private:
 
    enotice_t::iterator nullNotice() { return m_USockEventNotice.end(); }
 
-public:
+   // Only CEPoll class should have access to it.
+   // Guarding private access to the class is not necessary
+   // within the epoll module.
+   friend class CEPoll;
 
    CEPollDesc(int id, int localID)
        : m_iID(id)
@@ -422,6 +423,9 @@ public: // for CUDTUnited API
    /// @retval -1 error occurred
    /// @retval >=0 number of ready sockets (actually size of `st`)
    int swait(CEPollDesc& d, fmap_t& st, int64_t msTimeOut, bool report_by_exception = true);
+
+   /// Empty subscription check - for internal use only.
+   bool empty(CEPollDesc& d);
 
    /// Reports which events are ready on the given socket.
    /// @param mp socket event map retirned by `swait`


### PR DESCRIPTION
The problem detected by thread sanitizer: The calls to `m_SndEPolldesc->watch_empty()` is done without locking, while all operations on epoll require a lock on `CEPoll::m_EPollLock`.

Changes:
* Made whole CEPollDesc class private with exclusive access for CEPoll. This is to ensure that the CEPollDesc class isn't used "privately" by any other part of the code.
* Added an access function `CEPoll::empty` to return information about having no subscribers, with appropriate locking.