### PR TITLE
[core] Fixed incorrect group data sync on first connected socket

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1605,11 +1605,6 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
                 break;
             }
 
-            if (was_empty)
-            {
-                g.syncWithSocket(ns->core(), HSD_INITIATOR);
-            }
-
             HLOGC(aclog.Debug, log << "groupConnect: @" << sid << " connection successful, setting group OPEN (was "
                     << (g.m_bOpened ? "ALREADY" : "NOT") << "), will " << (block_new_opened ? "" : "NOT ")
                     << "block the connect call, status:" << SockStatusStr(st));
@@ -1911,6 +1906,12 @@ void CUDTUnited::deleteGroup(CUDTGroup* g)
     using srt_logging::gmlog;
 
     srt::sync::ScopedLock cg (m_GlobControlLock);
+    return deleteGroup_LOCKED(g);
+}
+
+// [[using locked(m_GlobControlLock)]]
+void CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
+{
     SRT_ASSERT(g->groupEmpty());
 
     // After that the group is no longer findable by GroupKeeper

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -305,6 +305,7 @@ public:
    }
 
    void deleteGroup(CUDTGroup* g);
+   void deleteGroup_LOCKED(CUDTGroup* g);
 
    // [[using locked(m_GlobControlLock)]]
    CUDTGroup* findPeerGroup_LOCKED(SRTSOCKET peergroup)


### PR DESCRIPTION
The call to `syncWithSocket` was done incorrectly and in addition the latency updated with the handshake was modified simultaneously while being read on the receiver worker thread that was about to establish the connection. In effect, the latency being used to set into the group data could be either the latency before or after negotiation depending on luck.

This PR makes two fixes:
1. The call to `syncWithSocket` in the connection API function handler is removed. This was not working in blocking mode (as per reason above), and in non-blocking it wasn't even executed. Instead this synchro is made at the time when the group is being set the peer ID at the first time, which is a good enough criterion to check if this is the very first connecting socket, and - as being executed as a part of group interpretation - happens after the latency coming from the listener being a negotiated value is already set. It all also happens under a lock of m_GlobControlLock and the m_GroupLock as well, so it will surely catch the very first connection within the group and skip the others.
2. Found a problem in the area of an IPE error fallback which when settings in the listener side group cannot be applied, the group is immediately deleted. This contained a nested lock on m_GlobControlLock, which will result in a deadlock, if a mutex isn't recursive by default.