### PR TITLE
[core] Fixed: lock around ackmessage

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7728,7 +7728,7 @@ void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
         ScopedLock glock (s_UDTUnited.m_GlobControlLock);
         if (m_parent->m_GroupOf)
         {
-            HLOGC(xtlog.Debug, log << "ACK: acking group sender buffer for #" << msgno_at_last_acked_seq);
+            HLOGC(inlog.Debug, log << "ACK: acking group sender buffer for #" << msgno_at_last_acked_seq);
 
             // Guard access to m_iSndAckedMsgNo field
             // Note: This can't be done inside CUDTGroup::ackMessage

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -4216,6 +4216,7 @@ int32_t CUDTGroup::addMessageToBuffer(const char* buf, size_t len, SRT_MSGCTRL& 
         // Very first packet, just set the msgno.
         m_iSndAckedMsgNo  = w_mc.msgno;
         m_iSndOldestMsgNo = w_mc.msgno;
+        HLOGC(gslog.Debug, log << "addMessageToBuffer: initial message no #" << w_mc.msgno);
     }
     else if (m_iSndOldestMsgNo != m_iSndAckedMsgNo)
     {
@@ -4241,6 +4242,8 @@ int32_t CUDTGroup::addMessageToBuffer(const char* buf, size_t len, SRT_MSGCTRL& 
 
         // Position at offset is not included
         m_iSndOldestMsgNo = m_iSndAckedMsgNo;
+        HLOGC(gslog.Debug,
+              log << "addMessageToBuffer: ... after: oldest #" << m_iSndOldestMsgNo);
     }
 
     m_SenderBuffer.resize(m_SenderBuffer.size() + 1);
@@ -4338,6 +4341,7 @@ int CUDTGroup::sendBackupRexmit(CUDT& core, SRT_MSGCTRL& w_mc)
     return stat;
 }
 
+// [[using locked(CUDTGroup::m_GroupLock)]];
 void CUDTGroup::ackMessage(int32_t msgno)
 {
     // The message id could not be identified, skip.


### PR DESCRIPTION
The problem: `ackMessage` was called without locking a group from the handler of UMSG_ACK, which might cause wrong timing for update of the field holding this last message number updated from ACK.