### PR TITLE
[core] Fixed problem with possibly conflicting peer group id

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -224,7 +224,7 @@ public:
       /// @param [out] pps Variable (optional) to which the new socket will be written, if succeeded
       /// @return The new UDT socket ID, or INVALID_SOCK.
 
-   SRTSOCKET newSocket(CUDTSocket** pps = NULL);
+   SRTSOCKET newSocket(CUDTSocket** pps = NULL, SRTSOCKET forceid = SRT_INVALID_SOCK);
 
       /// Create a new UDT connection.
       /// @param [in] listen the listening UDT socket;
@@ -307,7 +307,7 @@ public:
    void deleteGroup(CUDTGroup* g);
 
    // [[using locked(m_GlobControlLock)]]
-   CUDTGroup* findPeerGroup_LOCKED(SRTSOCKET peergroup)
+   CUDTGroup* findPeerGroup_LOCKED(PeerGroupType peergroup)
    {
        for (groups_t::iterator i = m_Groups.begin();
                i != m_Groups.end(); ++i)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1244,7 +1244,7 @@ size_t CUDT::fillHsExtGroup(uint32_t* pcmdspec)
         | SrtHSRequest::HS_GROUP_FLAGS::wrap(flags)
         | SrtHSRequest::HS_GROUP_WEIGHT::wrap(m_parent->m_GroupMemberData->weight);
 
-    const uint32_t storedata [GRPD_E_SIZE] = { uint32_t(id), dataword };
+    const uint32_t storedata [GRPD_E_SIZE] = { uint32_t(id), dataword, srt::sync::getProcessID() };
     memcpy((space), storedata, sizeof storedata);
 
     const size_t ra_size = Size(storedata);
@@ -2835,7 +2835,7 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UNUSED, int hsreq_type_cmd SRT_ATR_UNUSED)
+bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size, int hsreq_type_cmd SRT_ATR_UNUSED)
 {
     // `data_size` isn't checked because we believe it's checked earlier.
     // Also this code doesn't predict to get any other format than the official one,
@@ -2845,6 +2845,10 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
     // We are granted these two fields do exist
     SRTSOCKET grpid = groupdata[GRPD_GROUPID];
     uint32_t gd = groupdata[GRPD_GROUPDATA];
+
+    uint32_t appid = 0;
+    if (data_size > GRPD_E_SIZE_V1)
+        appid = groupdata[GRPD_APPID];
 
     SRT_GROUP_TYPE gtp = SRT_GROUP_TYPE(SrtHSRequest::HS_GROUP_TYPE::unwrap(gd));
     int link_weight = SrtHSRequest::HS_GROUP_WEIGHT::unwrap(gd);
@@ -2896,6 +2900,8 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
         return false;
     }
 
+    PeerGroupType incoming_peer (grpid, appid, m_PeerAddr);
+
     ScopedLock guard_group_existence (s_UDTUnited.m_GlobControlLock);
 
     if (m_SrtHsSide == HSD_INITIATOR)
@@ -2926,12 +2932,12 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
             return false;
         }
 
-        SRTSOCKET peer = pg->peerid();
-        if (peer == -1)
+        PeerGroupType peer = pg->peerid();
+        if (peer.empty())
         {
             // This is the first connection within this group, so this group
             // has just been informed about the peer membership. Accept it.
-            pg->set_peerid(grpid);
+            pg->set_peerid(incoming_peer);
             HLOGC(cnlog.Debug, log << "HS/RSP: group $" << pg->id() << " mapped to peer mirror $" << pg->peerid());
         }
         // Otherwise the peer id must be the same as existing, otherwise
@@ -2939,7 +2945,7 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
         // (Note that the peer group is peer-specific, and peer id numbers
         // may repeat among sockets connected to groups established on
         // different peers).
-        else if (pg->peerid() != grpid)
+        else if (pg->peerid() != incoming_peer)
         {
             LOGC(cnlog.Error, log << "IPE: HS/RSP: group membership responded for peer $" << grpid
                     << " but the current socket's group $" << pg->id() << " has already a peer $" << peer);
@@ -2958,7 +2964,7 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
         // and its group ID will be added to the HS extensions as mirror group
         // ID to the peer.
 
-        SRTSOCKET lgid = makeMePeerOf(grpid, gtp, link_flags);
+        SRTSOCKET lgid = makeMePeerOf(incoming_peer, gtp, link_flags);
         if (!lgid)
             return true; // already done
 
@@ -2998,7 +3004,7 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
 // exclusively on the listener side (HSD_RESPONDER, HSv5+).
 
 // [[using locked(s_UDTUnited.m_GlobControlLock)]]
-SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t link_flags)
+SRTSOCKET CUDT::makeMePeerOf(PeerGroupType peergroup, SRT_GROUP_TYPE gtp, uint32_t link_flags)
 {
     // Note: This function will lock pg->m_GroupLock!
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -124,6 +124,8 @@ enum GroupDataItem
     GRPD_GROUPID,
     GRPD_GROUPDATA,
 
+    GRPD_APPID, GRPD_E_SIZE_V1  = GRPD_APPID, // size in previous version
+
     GRPD_E_SIZE
 };
 
@@ -141,6 +143,7 @@ enum SeqPairItems
 
 #if ENABLE_EXPERIMENTAL_BONDING
 class CUDTGroup;
+struct PeerGroupType;
 #endif
 
 // Extended SRT Congestion control class - only an incomplete definition required
@@ -185,9 +188,9 @@ private: // constructor and desctructor
 public: //API
     static int startup();
     static int cleanup();
-    static SRTSOCKET socket();
+    static SRTSOCKET socket(SRTSOCKET forceid = SRT_INVALID_SOCK);
 #if ENABLE_EXPERIMENTAL_BONDING
-    static SRTSOCKET createGroup(SRT_GROUP_TYPE);
+    static SRTSOCKET createGroup(SRT_GROUP_TYPE, const SRTSOCKET forceid = SRT_INVALID_SOCK);
     static int addSocketToGroup(SRTSOCKET socket, SRTSOCKET group);
     static int removeSocketFromGroup(SRTSOCKET socket);
     static SRTSOCKET getGroupOfSocket(SRTSOCKET socket);
@@ -512,11 +515,11 @@ private:
     SRT_ATR_NODISCARD bool checkApplyFilterConfig(const std::string& cs);
 
 #if ENABLE_EXPERIMENTAL_BONDING
-    static CUDTGroup& newGroup(const int); // defined EXCEPTIONALLY in api.cpp for convenience reasons
+    static CUDTGroup& newGroup(const int, SRTSOCKET forceid = SRT_INVALID_SOCK); // defined EXCEPTIONALLY in api.cpp for convenience reasons
     // Note: This is an "interpret" function, which should treat the tp as
     // "possibly group type" that might be out of the existing values.
     SRT_ATR_NODISCARD bool interpretGroup(const int32_t grpdata[], size_t data_size, int hsreq_type_cmd);
-    SRT_ATR_NODISCARD SRTSOCKET makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE tp, uint32_t link_flags);
+    SRT_ATR_NODISCARD SRTSOCKET makeMePeerOf(PeerGroupType peergroup, SRT_GROUP_TYPE tp, uint32_t link_flags);
     void synchronizeWithGroup(CUDTGroup* grp);
 #endif
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -282,7 +282,6 @@ CUDTGroup::SocketData CUDTGroup::prepareData(CUDTSocket* s)
 CUDTGroup::CUDTGroup(SRT_GROUP_TYPE gtype)
     : m_pGlobal(&CUDT::s_UDTUnited)
     , m_GroupID(-1)
-    , m_PeerGroupID(-1)
     , m_selfManaged(true)
     , m_bSyncOnMsgNo(false)
     , m_type(gtype)
@@ -989,7 +988,7 @@ void CUDTGroup::close()
         // removing themselves from the group when closing because they
         // are unaware of being group members.
         m_Group.clear();
-        m_PeerGroupID = -1;
+        m_PeerGroupID = PeerGroupType();
 
         set<int> epollid;
         {

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -24,6 +24,14 @@
 #else
 #include <pthread.h>
 #endif
+
+// For getProcessID()
+#ifdef _WIN32
+#include <processthreadsapi.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "utilities.h"
 
 class CUDTException;    // defined in common.h
@@ -809,6 +817,20 @@ void SetThreadLocalError(const CUDTException& e);
 /// Get thread local error
 /// @returns CUDTException pointer
 CUDTException& GetThreadLocalError();
+
+// This is something that can't be really portable, but
+// actually the version should be split into Windows and POSIX-compliant.
+inline uint32_t getProcessID()
+{
+#ifdef _WIN32
+    // This returns DWORD, which by definition
+    // is unsigned 32-bit integer.
+    return GetCurrentProcessId();
+#else
+    // Assume non-Windows platforms are POSIX-compliant.
+    return getpid();
+#endif
+}
 
 } // namespace sync
 } // namespace srt

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -95,6 +95,7 @@ protected:
     int srt_epoll = -1;
     SRT_EPOLL_T m_direction = SRT_EPOLL_OPT_NONE; //< Defines which of SND or RCV option variant should be used, also to set SRT_SENDER for output
     bool m_blocking_mode = true; //< enforces using SRTO_SNDSYN or SRTO_RCVSYN, depending on @a m_direction
+    SRTSOCKET m_forced_id = SRT_INVALID_SOCK;
     int m_timeout = 0; //< enforces using SRTO_SNDTIMEO or SRTO_RCVTIMEO, depending on @a m_direction
     bool m_tsbpdmode = true;
     int m_outgoing_port = 0;


### PR DESCRIPTION
Problem: Connections with group membership coming from two different applications may occasionally generate the same group ID. This way they are qualified to the same group on the listener side because of having the same peer group ID, although this is unwanted, as they should belong to different groups.

Solution: The peer group should be identified by three factors: Peer address, application ID and the peer group ID. This should fix the problem because:
1. If peer addresses are different, they should be distinct, even with identical application ID and group ID, which are possible.
2. If this is an application running on the same machine, they may have identical group ID and will have identical address, but the application ID will distinguish them
3. If two connections come with the same peer address and the same application ID, they are in the same application, so if group IDs don't differ, they really come from the same group at the caller side.

CONTROVERSY:

There's currently no possible way to extend the Group-type handshake extension. There's a condition that rejects the group extension if it's of size more than 2. This condition must be first removed and only the release in which this is fixed could be in future treated as the oldest backward-compatible version that can work with the release where this PR is merged.