### PR TITLE
[core] Fixed Windows build with latest pthreads

### DIFF
--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -754,7 +754,7 @@ private:
 template <class Stream>
 inline Stream& operator<<(Stream& str, const CThread::id& cid)
 {
-#if defined(_WIN32) && defined(PTW32_VERSION)
+#if defined(_WIN32) && (defined(PTW32_VERSION) || defined (__PTW32_VERSION))
     // This is a version specific for pthread-win32 implementation
     // Here pthread_t type is a structure that is not convertible
     // to a number at all.


### PR DESCRIPTION
The latest pthreads for Windows does not define `PTW32_VERSION` macro. Looks like it was remamed to `__PTW32_VERSION`.

This PR adds an additional condition check to see if `__PTW32_VERSION` is defined.

- vcpkgversion 2021-01-13-d67989bce1043b98092ac45996a8230a059a2d7e
- pthreads:x64-windows                               3.0.0-6          pthreads for windows
  Version: 3.0.0-6
  Homepage: https://sourceware.org/pub/pthreads-win32/
  Description: pthreads for windows

Fixes #1815 