### PR TITLE
[core] Restoring RTTVar from cached RTT after reconnection

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -871,7 +871,6 @@ void CUDT::open()
     m_iRTT    = 10 * COMM_SYN_INTERVAL_US;
     m_iRTTVar = m_iRTT >> 1;
 
-
     // set minimum NAK and EXP timeout to 300ms
     m_tdMinNakInterval = milliseconds_from(300);
     m_tdMinExpInterval = milliseconds_from(300);
@@ -4417,6 +4416,7 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
     if (m_pCache->lookup(&ib) >= 0)
     {
         m_iRTT       = ib.m_iRTT;
+        m_iRTTVar    = m_iRTT >> 1;
         m_iBandwidth = ib.m_iBandwidth;
     }
 
@@ -5315,6 +5315,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer,
     if (m_pCache->lookup(&ib) >= 0)
     {
         m_iRTT       = ib.m_iRTT;
+        m_iRTTVar    = m_iRTT >> 1;
         m_iBandwidth = ib.m_iBandwidth;
     }
 


### PR DESCRIPTION
## The Problem

After reconnection, the values of RTT and bandwidth are restored from the cache. RTTVar remains the default one which is 50 ms (half of the initial RTT = 100 ms).

```c++
CInfoBlock ib;
ib.m_iIPversion = peer.family();
CInfoBlock::convert(peer, ib.m_piIP);
if (m_pCache->lookup(&ib) >= 0)
{
    m_iRTT       = ib.m_iRTT;
    m_iBandwidth = ib.m_iBandwidth;
}
```

With the current fix, the value of RTTVar is set to `RTT (from cache) / 2` after reconnection.

Fixes partially #1769, see the [following comment](https://github.com/haivision/srt/issues/1769#issuecomment-775213157).

## To Reproduce

The fix can be tested with the help of `srt-xtransmit` application (`develop/bonding` branch) and Connection Bonding (Main/Backup) feature of SRT. It is required to emulate the breakage of the main link when it's deleted from the group and reconnection is happening.

Test Setup is the combination of small Flip&Flop (CentOS 7) and big LanForge with the following links connected:

```
FLIP                 ---- LanForge  ----                 FLOP

enp7s0 (192.168.4.1) ---- eth2-eth3 ---- (192.168.4.2) enp7s0    (Main link)
enp8s0 (192.168.3.1) ---- eth4-eth5 ---- (192.168.3.2) enp8s0    (Backup link)
```

**srt-xtransmit commands**

1) rcv (listener) - snd (caller)

```bash
# rcv (listener)
_build_bonding_main_backup_tracelog/bin/srt-xtransmit receive srt://:4200?latency=800 srt://:4201 --enable-metrics --metricsfile group-rcv-metrics.csv --metricsfreq 1s --statsfile group-rcv-stats.csv --statsfreq 1s -v

# snd (caller)
_build_bonding_main_backup_tracelog/bin/srt-xtransmit generate "srt://192.168.4.2:4200?latency=800&grouptype=backup&weight=75" srt://192.168.3.2:4201?weight=25 --sendrate 1Mbps --duration 130s --enable-metrics --statsfile group-snd-stats.csv --statsfreq 1s -v
```

2) rcv (caller) - snd (listener)

```bash
# snd (listener)
_build_bonding_main_backup_tracelog/bin/srt-xtransmit generate srt://:4200?latency=800 srt://:4201 --sendrate 1Mbps --duration 130s --enable-metrics --statsfile group-snd-stats.csv --statsfreq 1s -v

# rcv (caller)
_build_bonding_main_backup_tracelog/bin/srt-xtransmit receive "srt://192.168.4.1:4200?latency=800&grouptype=backup&weight=75" srt://192.168.3.1:4201?weight=25 --enable-metrics --metricsfile group-rcv-metrics.csv --metricsfreq 1s --statsfile group-rcv-stats.csv --statsfreq 1s -v
```

**To emulate the main link shutdown for 20s (higher than `SRTO_PEERIDLETIMEO = 5s`) and, as a result, reconnection for 2 times**
```
sleep 30 && echo ifdown $(date +"%F %T,%3N") && sudo ifdown enp7s0 && sleep 20 && echo ifup $(date +"%F %T,%3N") && sudo ifup enp7s0 && sleep 30 && echo ifdown $(date +"%F %T,%3N") && sudo ifdown enp7s0 && sleep 20 && echo ifup $(date +"%F %T,%3N") && sudo ifup enp7s0
```

**Scenario**

| Main Link (enp7s0)                              | Backup Link (enp8s0)                       | Bitrate, Mbps  | SRT Options  | 
| ------------------------------------ | ----------------------------------- | -------------- | ------------- | 
| RTT1 = 100 ms (faster link)                 | RTT2 = 200 ms                                  | 1                       | latency=800  | 

The RTT on the main link is taken lower than RTT on the backup link so that the main link connects first.

**Tracelog**

`srt-xtransmit` should be built with bonding and tracelog enabled:
```
cmake -DENABLE_EXPERIMENTAL_BONDING=ON -DENFORCE_SRT_DEBUG_BONDING_STATES=1 ../
cmake --build ./
```

**Screenshots**

Here is the screenshot showing the latest actual values of RTT (100517) and RTTVar (42) before the link is considered unstable and gets broken after `SRTO_PEERIDLETIMEO` is triggered.

<img width="902" alt="Screenshot 2021-03-12 at 12 56 13" src="https://user-images.githubusercontent.com/41019697/110937334-86512380-8332-11eb-8a24-adc30d88de3a.png">

Here is the screenshot showing the main link after it's up again (after reconnection). The RTT value (100517) is taken from cache, however RTTVar is equal to 50000 (half of the initial RTT = 100000). With the current fix, the RTTVar value will be taken as half RTT from cache which is 100517 / 2 = 50258.

<img width="914" alt="Screenshot 2021-03-12 at 12 56 47" src="https://user-images.githubusercontent.com/41019697/110937362-8f41f500-8332-11eb-8c9b-c11359f43466.png">
