### PR TITLE
[build] Fixed build break with latest GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1189,6 +1189,16 @@ endif()
 
 
 if (ENABLE_UNITTESTS AND ENABLE_CXX11)
+
+	if (${CMAKE_VERSION} VERSION_LESS "3.10.0") 
+		message(STATUS "VERSION < 3.10 -- adding test using the old method")
+		set (USE_OLD_ADD_METHOD 1)
+	else()
+		message(STATUS "VERSION > 3.10 -- using NEW POLICY for in_list operator")
+		cmake_policy(SET CMP0057 NEW) # Support the new IN_LIST operator.
+	endif()
+
+
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 	find_package(GTest 1.8)
@@ -1217,13 +1227,12 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 		${PTHREAD_LIBRARY}
 		)
 
-	if (${CMAKE_VERSION} VERSION_LESS "3.10.0") 
+	if (USE_OLD_ADD_METHOD)
 		add_test(
 			NAME	test-srt
 			COMMAND	${CMAKE_BINARY_DIR}/test-srt
 		)
 	else()
-		cmake_policy(SET CMP0057 NEW) # Support the new IN_LIST operator.
 		gtest_add_tests(
 			test-srt
 			""


### PR DESCRIPTION
Before the fix (cmake version 3.10.2):
```shell
-- APP: test-srt: using default C++ standard
CMake Warning (dev) at /usr/share/cmake/Modules/GoogleTest.cmake:254 (if):
  Policy CMP0057 is not set: Support new IN_LIST if() operator.  Run "cmake
  --help-policy CMP0057" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
  IN_LIST will be interpreted as an operator when the policy is set to NEW.
  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  CMakeLists.txt:1227 (gtest_add_tests)
This warning is for project developers.  Use -Wno-dev to suppress it.
CMake Error at /usr/share/cmake/Modules/GoogleTest.cmake:254 (if):
  if given arguments:
    "test-srt" "IN_LIST" "allKeywords"
  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:1227 (gtest_add_tests)
-- Configuring incomplete, errors occurred!
See also "/home/sektor/repos/srt.gitd/main/build-test/CMakeFiles/CMakeOutput.log".
See also "/home/sektor/repos/srt.gitd/main/build-test/CMakeFiles/CMakeError.log".
CONFIGURE: cmake reported error: child process exited abnormally
```