### PR TITLE
[core] Fixed incorrect setting streamid in internal config in HS (last 4 characters)

### DIFF
--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -1442,6 +1442,10 @@ override the value from the other side resulting in an arbitrary winner. Also
 in this connection both peers are known to one another and both have equivalent 
 roles in the connection.
 
+- **IMPORTANT**: This option is not derived by the accepted socket from the listener
+socket and setting it on a listener socket (see `srt_listen` function) doesn't
+influence on anything.
+
 [Return to list](#list-of-options)
 
 ---

--- a/docs/APISocketOptions.md
+++ b/docs/APISocketOptions.md
@@ -1443,8 +1443,8 @@ in this connection both peers are known to one another and both have equivalent
 roles in the connection.
 
 - **IMPORTANT**: This option is not derived by the accepted socket from the listener
-socket and setting it on a listener socket (see `srt_listen` function) doesn't
-influence on anything.
+socket, and setting it on a listener socket (see `srt_listen` function) doesn't
+influence anything.
 
 [Return to list](#list-of-options)
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2571,7 +2571,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
                 // Un-swap on big endian machines
                 ItoHLA((uint32_t *)target, (uint32_t *)target, blocklen);
 
-                m_config.sStreamName.set(target, bytelen);
+                m_config.sStreamName.set(target, strlen(target));
                 HLOGC(cnlog.Debug,
                       log << "CONNECTOR'S REQUESTED SID [" << m_config.sStreamName.c_str() << "] (bytelen=" << bytelen
                           << " blocklen=" << blocklen << ")");

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -141,7 +141,7 @@ public:
 
     bool set(const char* s, size_t length)
     {
-        if (length >= SIZE)
+        if (length > SIZE)
             return false;
 
         memcpy(stor, s, length);

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -14,6 +14,8 @@
 #include <future>
 #include <thread>
 
+// SRT includes
+#include <socketconfig.h>
 #include "srt.h"
 
 using namespace std;
@@ -246,3 +248,145 @@ TEST_F(TestSocketOptions, MinInputBWRuntime)
     ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
 }
 
+TEST_F(TestSocketOptions, StreamIDWrongLen)
+{
+    char buffer[CSrtConfig::MAX_SID_LENGTH + 135];
+    for (size_t i = 0; i < sizeof buffer; ++i)
+        buffer[i] = 'a' + i % 25;
+
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, buffer, CSrtConfig::MAX_SID_LENGTH+1), SRT_ERROR);
+    EXPECT_EQ(srt_getlasterror(NULL), SRT_EINVPARAM);
+}
+
+// Try to set/get a 13-character string in SRTO_STREAMID.
+// This tests checks that the StreamID is set to the correct size
+// while it is transmitted as 16 characters in the Stream ID HS extension.
+TEST_F(TestSocketOptions, StreamIDOdd)
+{
+    // 13 characters, that is, 3*4+1
+    string sid_odd = "something1234";
+
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, sid_odd.c_str(), sid_odd.size()), SRT_SUCCESS);
+
+    char buffer[CSrtConfig::MAX_SID_LENGTH + 135];
+    int buffer_len = sizeof buffer;
+    EXPECT_EQ(srt_getsockopt(m_caller_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(std::string(buffer), sid_odd);
+    EXPECT_EQ(buffer_len, sid_odd.size());
+    EXPECT_EQ(strlen(buffer), sid_odd.size());
+
+    StartListener();
+    const SRTSOCKET accepted_sock = EstablishConnection();
+
+    // Check accepted socket inherits values
+    for (size_t i = 0; i < sizeof buffer; ++i)
+        buffer[i] = 'a';
+    buffer_len = (int)(sizeof buffer);
+    EXPECT_EQ(srt_getsockopt(accepted_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(buffer_len, sid_odd.size());
+    EXPECT_EQ(strlen(buffer), sid_odd.size());
+
+    ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
+}
+
+
+TEST_F(TestSocketOptions, StreamIDEven)
+{
+    // 12 characters = 4*3, that is, aligned to 4
+    string sid_even = "123412341234";
+
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, sid_even.c_str(), sid_even.size()), SRT_SUCCESS);
+
+    char buffer[CSrtConfig::MAX_SID_LENGTH + 135];
+    int buffer_len = sizeof buffer;
+    EXPECT_EQ(srt_getsockopt(m_caller_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(std::string(buffer), sid_even);
+    EXPECT_EQ(buffer_len, sid_even.size());
+    EXPECT_EQ(strlen(buffer), sid_even.size());
+
+    StartListener();
+    const SRTSOCKET accepted_sock = EstablishConnection();
+
+    // Check accepted socket inherits values
+    for (size_t i = 0; i < sizeof buffer; ++i)
+        buffer[i] = 'a';
+    buffer_len = (int)(sizeof buffer);
+    EXPECT_EQ(srt_getsockopt(accepted_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(buffer_len, sid_even.size());
+    EXPECT_EQ(strlen(buffer), sid_even.size());
+
+    ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
+}
+
+
+TEST_F(TestSocketOptions, StreamIDCloseFull)
+{
+    // 12 characters = 4*3, that is, aligned to 4
+    string sid_closefull;
+    for (size_t i = 0; i < CSrtConfig::MAX_SID_LENGTH-2; ++i)
+        sid_closefull += 'x';
+
+    // Just to manipulate the last ones.
+    size_t size = sid_closefull.size();
+    sid_closefull[size-2] = 'y';
+    sid_closefull[size-1] = 'z';
+
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, sid_closefull.c_str(), sid_closefull.size()), SRT_SUCCESS);
+
+    char buffer[CSrtConfig::MAX_SID_LENGTH + 135];
+    int buffer_len = sizeof buffer;
+    EXPECT_EQ(srt_getsockopt(m_caller_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(std::string(buffer), sid_closefull);
+    EXPECT_EQ(buffer_len, sid_closefull.size());
+    EXPECT_EQ(strlen(buffer), sid_closefull.size());
+
+    StartListener();
+    const SRTSOCKET accepted_sock = EstablishConnection();
+
+    // Check accepted socket inherits values
+    for (size_t i = 0; i < sizeof buffer; ++i)
+        buffer[i] = 'a';
+    buffer_len = (int)(sizeof buffer);
+    EXPECT_EQ(srt_getsockopt(accepted_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(buffer_len, sid_closefull.size());
+    EXPECT_EQ(strlen(buffer), sid_closefull.size());
+    EXPECT_EQ(buffer[sid_closefull.size()-1], 'z');
+
+    ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
+}
+
+TEST_F(TestSocketOptions, StreamIDFull)
+{
+    // 12 characters = 4*3, that is, aligned to 4
+    string sid_full;
+    for (size_t i = 0; i < CSrtConfig::MAX_SID_LENGTH; ++i)
+        sid_full += 'x';
+
+    // Just to manipulate the last ones.
+    size_t size = sid_full.size();
+    sid_full[size-2] = 'y';
+    sid_full[size-1] = 'z';
+
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, sid_full.c_str(), sid_full.size()), SRT_SUCCESS);
+
+    char buffer[CSrtConfig::MAX_SID_LENGTH + 135];
+    int buffer_len = sizeof buffer;
+    EXPECT_EQ(srt_getsockopt(m_caller_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(std::string(buffer), sid_full);
+    EXPECT_EQ(buffer_len, sid_full.size());
+    EXPECT_EQ(strlen(buffer), sid_full.size());
+
+    StartListener();
+    const SRTSOCKET accepted_sock = EstablishConnection();
+
+    // Check accepted socket inherits values
+    for (size_t i = 0; i < sizeof buffer; ++i)
+        buffer[i] = 'a';
+    buffer_len = (int)(sizeof buffer);
+    EXPECT_EQ(srt_getsockopt(accepted_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
+    EXPECT_EQ(buffer_len, sid_full.size());
+    EXPECT_EQ(strlen(buffer), sid_full.size());
+    EXPECT_EQ(buffer[sid_full.size()-1], 'z');
+
+    ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
+}

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -319,26 +319,26 @@ TEST_F(TestSocketOptions, StreamIDEven)
 }
 
 
-TEST_F(TestSocketOptions, StreamIDCloseFull)
+TEST_F(TestSocketOptions, StreamIDAlmostFull)
 {
     // 12 characters = 4*3, that is, aligned to 4
-    string sid_closefull;
+    string sid_amost_full;
     for (size_t i = 0; i < CSrtConfig::MAX_SID_LENGTH-2; ++i)
-        sid_closefull += 'x';
+        sid_amost_full += 'x';
 
     // Just to manipulate the last ones.
-    size_t size = sid_closefull.size();
-    sid_closefull[size-2] = 'y';
-    sid_closefull[size-1] = 'z';
+    size_t size = sid_amost_full.size();
+    sid_amost_full[size-2] = 'y';
+    sid_amost_full[size-1] = 'z';
 
-    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, sid_closefull.c_str(), sid_closefull.size()), SRT_SUCCESS);
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, sid_amost_full.c_str(), sid_amost_full.size()), SRT_SUCCESS);
 
     char buffer[CSrtConfig::MAX_SID_LENGTH + 135];
     int buffer_len = sizeof buffer;
     EXPECT_EQ(srt_getsockopt(m_caller_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
-    EXPECT_EQ(std::string(buffer), sid_closefull);
-    EXPECT_EQ(buffer_len, sid_closefull.size());
-    EXPECT_EQ(strlen(buffer), sid_closefull.size());
+    EXPECT_EQ(std::string(buffer), sid_amost_full);
+    EXPECT_EQ(buffer_len, sid_amost_full.size());
+    EXPECT_EQ(strlen(buffer), sid_amost_full.size());
 
     StartListener();
     const SRTSOCKET accepted_sock = EstablishConnection();
@@ -348,9 +348,9 @@ TEST_F(TestSocketOptions, StreamIDCloseFull)
         buffer[i] = 'a';
     buffer_len = (int)(sizeof buffer);
     EXPECT_EQ(srt_getsockopt(accepted_sock, 0, SRTO_STREAMID, &buffer, &buffer_len), SRT_SUCCESS);
-    EXPECT_EQ(buffer_len, sid_closefull.size());
-    EXPECT_EQ(strlen(buffer), sid_closefull.size());
-    EXPECT_EQ(buffer[sid_closefull.size()-1], 'z');
+    EXPECT_EQ(buffer_len, sid_amost_full.size());
+    EXPECT_EQ(strlen(buffer), sid_amost_full.size());
+    EXPECT_EQ(buffer[sid_amost_full.size()-1], 'z');
 
     ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
 }


### PR DESCRIPTION
The problem:

The STREAMID (like all other string-type extensions) if it was set the length 509-512 (which is still legal), was rejected during setting of the config string because the length was taken as 512.

The string is passed in 4-byte chunks, which is then padded with zeros if the number of characters is not aligned to 4. The length to set the string was however calculated as the size of the extension data (which are 128 for the given sizes) multiplied by size of the field (4), which resulted to always 512, which exceeds the allowed size.

As the size of the actual string should be up to the first 0, the length should be taken directly by `strlen` because the length calculated out of `blocklen` may include the padding zeros, which makes the size wrong.

Additionally fixed bug in StringStorage: the condition for too big length is wrong.