### PR TITLE
[core] Added locking around group status modification when broken

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10697,6 +10697,7 @@ void CUDT::completeBrokenConnectionDependencies(int errorcode)
         if (m_parent->m_GroupOf)
         {
             token = m_parent->m_GroupMemberData->token;
+            ScopedLock guard_group (*m_parent->m_GroupOf->exp_groupLock());
             if (m_parent->m_GroupMemberData->sndstate == SRT_GST_PENDING)
             {
                 HLOGC(gmlog.Debug, log << "updateBrokenConnection: a pending link was broken - will be removed");


### PR DESCRIPTION
(NOT YET TESTED)

This adds synchronization to setting the group status for a member. Group is being locked for that purpose. The finding from sanitizer refers to `CUDTGroup::getStatus` which locks the group for that purpose, and adding a lock for a group at the function setting the status preserves the lock ordering as described in `LowLevelInfo.md`.