### PR TITLE
[core] Extended logs for negative or zero RTT estimate on the receiver side

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8214,7 +8214,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
             }
 
             LOGC(inlog.Error,
-                 log << CONID() << "IPE: ACK record not found, RTT estimate impossible "
+                 log << CONID() << "IPE: ACK record not found, can't estimate RTT "
                      << "(ACK number: " << ctrlpkt.getAckSeqNo() << ", last ACK sent: " << m_iAckSeqNo
                      << ", RTT (EWMA): " << m_iRTT << ")");
             break;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8200,7 +8200,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
         int32_t ack = 0;
 
         // Calculate RTT estimate on the receiver side based on ACK/ACKACK pair
-        const int rtt = m_ACKWindow.acknowledge(ctrlpkt.getAckSeqNo(), ack);
+        const int rtt = m_ACKWindow.acknowledge(ctrlpkt.getAckSeqNo(), ack, currtime);
 
         if (rtt == -1)
         {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8198,7 +8198,10 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
     case UMSG_ACKACK: // 110 - Acknowledgement of Acknowledgement
     {
         int32_t ack = 0;
+
+        // Calculate RTT estimate on the receiver side based on ACK/ACKACK pair
         const int rtt = m_ACKWindow.acknowledge(ctrlpkt.getAckSeqNo(), ack);
+
         if (rtt <= 0)
         {
             LOGC(inlog.Error,
@@ -8207,10 +8210,10 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
             break;
         }
 
-        // if increasing delay detected...
+        // If increasing delay is detected
         //   sendCtrl(UMSG_CGWARNING);
 
-        // RTT EWMA
+        // Calculate RTT (EWMA) on the receiver side
         m_iRTTVar = avg_iir<4>(m_iRTTVar, abs(rtt - m_iRTT));
         m_iRTT = avg_iir<8>(m_iRTT, rtt);
 
@@ -8240,7 +8243,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
 #endif
         }
 
-        // update last ACK that has been received by the sender
+        // Update last ACK that has been received by the sender
         if (CSeqNo::seqcmp(ack, m_iRcvLastAckAck) > 0)
             m_iRcvLastAckAck = ack;
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8202,11 +8202,23 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
         // Calculate RTT estimate on the receiver side based on ACK/ACKACK pair
         const int rtt = m_ACKWindow.acknowledge(ctrlpkt.getAckSeqNo(), ack);
 
+        if (rtt == -1)
+        {
+            LOGC(inlog.Error,
+                 log << CONID() << "IPE: The record about ACK is not found, "
+                     << "RTT estimate at the receiver side can not be calculated "
+                     << "(ACK number: " << ctrlpkt.getAckSeqNo() << ", last ACK sent: " << m_iAckSeqNo
+                     << ", oldest ACK record: " << "not yet available" << ", RTT (EWMA): " << m_iRTT << ")");
+            break;
+        }
+
         if (rtt <= 0)
         {
             LOGC(inlog.Error,
-                 log << CONID() << "IPE: ACK node overwritten when acknowledging " << ctrlpkt.getAckSeqNo()
-                     << " (ack extracted: " << ack << ")");
+                 log << CONID() << "IPE: RTT estimate obtained by the receiver is negative or zero, "
+                     << "there may have been a time shift "
+                     << "(current time: " << FormatTime(currtime) << ", the time of sending ACK: " << "not yet available"
+                     << ", RTT estimate: " << rtt << "). The usage of monotonic clocks is recommended. ");
             break;
         }
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -259,23 +259,22 @@ public: // internal API
         }
     };
 
-    static const SRTSOCKET INVALID_SOCK = -1;         // invalid socket descriptor
-    static const int ERROR = -1;                      // socket api error returned value
+    static const       SRTSOCKET INVALID_SOCK   = -1;           // Invalid socket descriptor
+    static const int   ERROR                    = -1;           // Socket api error returned value
 
     static const int HS_VERSION_UDT4 = 4;
     static const int HS_VERSION_SRT1 = 5;
 
     // Parameters
     //
-    // Note: use notation with X*1000*1000* ... instead of million zeros in a row.
-    // In C++17 there is a possible notation of 5'000'000 for convenience, but that's
-    // something only for a far future.
-    static const int COMM_RESPONSE_MAX_EXP = 16;
-    static const int SRT_TLPKTDROP_MINTHRESHOLD_MS = 1000;
-    static const uint64_t COMM_KEEPALIVE_PERIOD_US = 1*1000*1000;
-    static const int32_t COMM_SYN_INTERVAL_US = 10*1000;
-    static const int COMM_CLOSE_BROKEN_LISTENER_TIMEOUT_MS = 3000;
-    static const uint16_t MAX_WEIGHT = 32767;
+    // Note: use notation with X*1000*1000*... instead of million zeros in a row
+    static const int        COMM_RESPONSE_MAX_EXP                   = 16;
+    static const int        SRT_TLPKTDROP_MINTHRESHOLD_MS           = 1000;
+    static const uint64_t   COMM_KEEPALIVE_PERIOD_US                = 1*1000*1000;
+    static const int32_t    COMM_SYN_INTERVAL_US                    = 10*1000;
+    static const int        COMM_CLOSE_BROKEN_LISTENER_TIMEOUT_MS   = 3000;
+    static const uint16_t   MAX_WEIGHT                              = 32767;
+    static const size_t     ACK_WND_SIZE                            = 1024;
 
     int handshakeVersion()
     {
@@ -295,37 +294,38 @@ public: // internal API
 
     SRTSOCKET socketID() const { return m_SocketID; }
 
-    static CUDT* getUDTHandle(SRTSOCKET u);
-    static std::vector<SRTSOCKET> existingSockets();
+    static CUDT*                    getUDTHandle(SRTSOCKET u);
+    static std::vector<SRTSOCKET>   existingSockets();
 
     void addressAndSend(CPacket& pkt);
     void sendSrtMsg(int cmd, uint32_t *srtdata_in = NULL, size_t srtlen_in = 0);
 
-    bool isOPT_TsbPd() const { return m_config.bTSBPD; }
-    int RTT() const { return m_iRTT; }
-    int RTTVar() const { return m_iRTTVar; }
-    int32_t sndSeqNo() const { return m_iSndCurrSeqNo; }
-    int32_t schedSeqNo() const { return m_iSndNextSeqNo; }
-    bool overrideSndSeqNo(int32_t seq);
-    srt::sync::steady_clock::time_point lastRspTime() const { return m_tsLastRspTime; }
-    srt::sync::steady_clock::time_point freshActivationStart() const { return m_tsFreshActivation; }
+    bool        isOPT_TsbPd()                   const { return m_config.bTSBPD; }
+    int         RTT()                           const { return m_iRTT; }
+    int         RTTVar()                        const { return m_iRTTVar; }
+    int32_t     sndSeqNo()                      const { return m_iSndCurrSeqNo; }
+    int32_t     schedSeqNo()                    const { return m_iSndNextSeqNo; }
+    bool        overrideSndSeqNo(int32_t seq);
 
-    int32_t rcvSeqNo() const { return m_iRcvCurrSeqNo; }
-    int flowWindowSize() const { return m_iFlowWindowSize; }
-    int32_t deliveryRate() const { return m_iDeliveryRate; }
-    int bandwidth() const { return m_iBandwidth; }
-    int64_t maxBandwidth() const { return m_config.llMaxBW; }
-    int MSS() const { return m_config.iMSS; }
+    srt::sync::steady_clock::time_point   lastRspTime()             const { return m_tsLastRspTime; }
+    srt::sync::steady_clock::time_point   freshActivationStart()    const { return m_tsFreshActivation; }
 
-    uint32_t peerLatency_us() const {return m_iPeerTsbPdDelay_ms * 1000; }
-    int peerIdleTimeout_ms() const { return m_config.iPeerIdleTimeout; }
-    size_t maxPayloadSize() const { return m_iMaxSRTPayloadSize; }
-    size_t OPT_PayloadSize() const { return m_config.zExpPayloadSize; }
-    int sndLossLength() { return m_pSndLossList->getLossLength(); }
-    int32_t ISN() const { return m_iISN; }
-    int32_t peerISN() const { return m_iPeerISN; }
-    duration minNAKInterval() const { return m_tdMinNakInterval; }
-    sockaddr_any peerAddr() const { return m_PeerAddr; }
+    int32_t     rcvSeqNo()          const { return m_iRcvCurrSeqNo; }
+    int         flowWindowSize()    const { return m_iFlowWindowSize; }
+    int32_t     deliveryRate()      const { return m_iDeliveryRate; }
+    int         bandwidth()         const { return m_iBandwidth; }
+    int64_t     maxBandwidth()      const { return m_config.llMaxBW; }
+    int         MSS()               const { return m_config.iMSS; }
+
+    uint32_t        peerLatency_us()        const { return m_iPeerTsbPdDelay_ms * 1000; }
+    int             peerIdleTimeout_ms()    const { return m_config.iPeerIdleTimeout; }
+    size_t          maxPayloadSize()        const { return m_iMaxSRTPayloadSize; }
+    size_t          OPT_PayloadSize()       const { return m_config.zExpPayloadSize; }
+    int             sndLossLength()               { return m_pSndLossList->getLossLength(); }
+    int32_t         ISN()                   const { return m_iISN; }
+    int32_t         peerISN()               const { return m_iPeerISN; }
+    duration        minNAKInterval()        const { return m_tdMinNakInterval; }
+    sockaddr_any    peerAddr()              const { return m_PeerAddr; }
 
     /// Returns the number of packets in flight (sent, but not yet acknowledged).
     /// @param lastack is the sequence number of the first unacknowledged packet.
@@ -691,28 +691,28 @@ private:
     static loss_seqs_t defaultPacketArrival(void* vself, CPacket& pkt);
     static loss_seqs_t groupPacketArrival(void* vself, CPacket& pkt);
 
-    static CUDTUnited s_UDTUnited;               // UDT global management base
+    static CUDTUnited s_UDTUnited;                      // UDT global management base
 
 private: // Identification
-    CUDTSocket* const m_parent; // temporary, until the CUDTSocket class is merged with CUDT
-    SRTSOCKET m_SocketID;                        // UDT socket number
-    SRTSOCKET m_PeerID;                          // peer id, for multiplexer
+    CUDTSocket* const   m_parent;                       // Temporary, until the CUDTSocket class is merged with CUDT
+    SRTSOCKET           m_SocketID;                     // UDT socket number
+    SRTSOCKET           m_PeerID;                       // Peer ID, for multiplexer
 
     // HSv4 (legacy handshake) support)
-    time_point m_tsSndHsLastTime;	    //Last SRT handshake request time
-    int      m_iSndHsRetryCnt;       //SRT handshake retries left
+    time_point  m_tsSndHsLastTime;                      // Last SRT handshake request time
+    int         m_iSndHsRetryCnt;                       // SRT handshake retries left
 
 #if ENABLE_EXPERIMENTAL_BONDING
-    SRT_GROUP_TYPE m_HSGroupType;   // group type about-to-be-set in the handshake
+    SRT_GROUP_TYPE m_HSGroupType;   // Group type about-to-be-set in the handshake
 #endif
 
 private:
-    int                       m_iMaxSRTPayloadSize; // Maximum/regular payload size, in bytes
-    int                       m_iTsbPdDelay_ms;     // Rx delay to absorb burst in milliseconds
-    int                       m_iPeerTsbPdDelay_ms; // Tx delay that the peer uses to absorb burst in milliseconds
-    bool                      m_bTLPktDrop;         // Enable Too-late Packet Drop
-    UniquePtr<CCryptoControl> m_pCryptoControl;     // congestion control SRT class (small data extension)
-    CCache<CInfoBlock>*       m_pCache;             // network information cache
+    int                       m_iMaxSRTPayloadSize;     // Maximum/regular payload size, in bytes
+    int                       m_iTsbPdDelay_ms;         // Rx delay to absorb burst, in milliseconds
+    int                       m_iPeerTsbPdDelay_ms;     // Tx delay that the peer uses to absorb burst, in milliseconds
+    bool                      m_bTLPktDrop;             // Enable Too-late Packet Drop
+    UniquePtr<CCryptoControl> m_pCryptoControl;         // Congestion control SRT class (small data extension)
+    CCache<CInfoBlock>*       m_pCache;                 // Network information cache
 
     // Congestion control
     std::vector<EventSlot> m_Slots[TEV_E_SIZE];
@@ -727,7 +727,7 @@ private:
     void EmitSignal(ETransmissionEvent tev, EventVariant var);
 
     // Internal state
-    volatile bool m_bListening;                  // If the UDT entit is listening to connection
+    volatile bool m_bListening;                  // If the UDT entity is listening to connection
     volatile bool m_bConnecting;                 // The short phase when connect() is called but not yet completed
     volatile bool m_bConnected;                  // Whether the connection is on or off
     volatile bool m_bClosing;                    // If the UDT entity is closing
@@ -736,7 +736,7 @@ private:
     volatile bool m_bPeerHealth;                 // If the peer status is normal
     volatile int m_RejectReason;
     bool m_bOpened;                              // If the UDT entity has been opened
-    int m_iBrokenCounter;                        // a counter (number of GC checks) to let the GC tag this socket as disconnected
+    int m_iBrokenCounter;                        // A counter (number of GC checks) to let the GC tag this socket as disconnected
 
     int m_iEXPCount;                             // Expiration counter
     int m_iBandwidth;                            // Estimated bandwidth, number of packets per second
@@ -746,8 +746,8 @@ private:
     int m_iByteDeliveryRate;                     // Byte arrival rate at the receiver side
 
 
-    CHandShake m_ConnReq;                        // connection request
-    CHandShake m_ConnRes;                        // connection response
+    CHandShake m_ConnReq;                        // Connection request
+    CHandShake m_ConnRes;                        // Connection response
     CHandShake::RendezvousState m_RdvState;      // HSv5 rendezvous state
     HandshakeSide m_SrtHsSide;                   // HSv5 rendezvous handshake side resolved from cookie contest (DRAW if not yet resolved)
 
@@ -758,32 +758,32 @@ private: // Sending related data
 
     /*volatile*/ duration m_tdSendInterval;      // Inter-packet time, in CPU clock cycles
 
-    /*volatile*/ duration m_tdSendTimeDiff;      // aggregate difference in inter-packet sending time
+    /*volatile*/ duration m_tdSendTimeDiff;      // Aggregate difference in inter-packet sending time
 
     volatile int m_iFlowWindowSize;              // Flow control window size
-    volatile double m_dCongestionWindow;         // congestion window size
+    volatile double m_dCongestionWindow;         // Congestion window size
 
 private: // Timers
-    /*volatile*/ time_point m_tsNextACKTime;    // Next ACK time, in CPU clock cycles, same below
-    /*volatile*/ time_point m_tsNextNAKTime;    // Next NAK time
+    /*volatile*/ time_point m_tsNextACKTime;     // Next ACK time, in CPU clock cycles, same below
+    /*volatile*/ time_point m_tsNextNAKTime;     // Next NAK time
 
-    /*volatile*/ duration   m_tdACKInterval;    // ACK interval
-    /*volatile*/ duration   m_tdNAKInterval;    // NAK interval
-    /*volatile*/ time_point m_tsLastRspTime;    // time stamp of last response from the peer
-    /*volatile*/ time_point m_tsLastRspAckTime; // time stamp of last ACK from the peer
-    /*volatile*/ time_point m_tsLastSndTime;    // time stamp of last data/ctrl sent (in system ticks)
-    time_point m_tsLastWarningTime;             // Last time that a warning message is sent
-    time_point m_tsLastReqTime;                 // last time when a connection request is sent
+    /*volatile*/ duration   m_tdACKInterval;     // ACK interval
+    /*volatile*/ duration   m_tdNAKInterval;     // NAK interval
+    /*volatile*/ time_point m_tsLastRspTime;     // Timestamp of last response from the peer
+    /*volatile*/ time_point m_tsLastRspAckTime;  // Timestamp of last ACK from the peer
+    /*volatile*/ time_point m_tsLastSndTime;     // Timestamp of last data/ctrl sent (in system ticks)
+    time_point m_tsLastWarningTime;              // Last time that a warning message is sent
+    time_point m_tsLastReqTime;                  // last time when a connection request is sent
     time_point m_tsRcvPeerStartTime;
-    time_point m_tsLingerExpiration;            // Linger expiration time (for GC to close a socket with data in sending buffer)
-    time_point m_tsLastAckTime;                 // Timestamp of last ACK
-    duration m_tdMinNakInterval;                // NAK timeout lower bound; too small value can cause unnecessary retransmission
-    duration m_tdMinExpInterval;                // timeout lower bound threshold: too small timeout can cause problem
+    time_point m_tsLingerExpiration;             // Linger expiration time (for GC to close a socket with data in sending buffer)
+    time_point m_tsLastAckTime;                  // Timestamp of last ACK
+    duration m_tdMinNakInterval;                 // NAK timeout lower bound; too small value can cause unnecessary retransmission
+    duration m_tdMinExpInterval;                 // Timeout lower bound threshold: too small timeout can cause problem
 
-    int m_iPktCount;                          // packet counter for ACK
-    int m_iLightACKCount;                     // light ACK counter
+    int m_iPktCount;                             // Packet counter for ACK
+    int m_iLightACKCount;                        // Light ACK counter
 
-    time_point m_tsNextSendTime;     // scheduled time of next packet sending
+    time_point m_tsNextSendTime;                 // Scheduled time of next packet sending
 
     volatile int32_t m_iSndLastFullAck;          // Last full ACK received
     volatile int32_t m_iSndLastAck;              // Last ACK received
@@ -843,17 +843,17 @@ private: // Timers
     int32_t m_iReXmitCount;                      // Re-Transmit Count since last ACK
 
 private: // Receiving related data
-    CRcvBuffer* m_pRcvBuffer;                    //< Receiver buffer
-    CRcvLossList* m_pRcvLossList;                //< Receiver loss list
-    std::deque<CRcvFreshLoss> m_FreshLoss;       //< Lost sequence already added to m_pRcvLossList, but not yet sent UMSG_LOSSREPORT for.
-    int m_iReorderTolerance;                     //< Current value of dynamic reorder tolerance
-    int m_iConsecEarlyDelivery;                  //< Increases with every OOO packet that came <TTL-2 time, resets with every increased reorder tolerance
-    int m_iConsecOrderedDelivery;                //< Increases with every packet coming in order or retransmitted, resets with every out-of-order packet
+    CRcvBuffer* m_pRcvBuffer;                    // Receiver buffer
+    CRcvLossList* m_pRcvLossList;                // Receiver loss list
+    std::deque<CRcvFreshLoss> m_FreshLoss;       // Lost sequence already added to m_pRcvLossList, but not yet sent UMSG_LOSSREPORT for.
+    int m_iReorderTolerance;                     // Current value of dynamic reorder tolerance
+    int m_iConsecEarlyDelivery;                  // Increases with every OOO packet that came <TTL-2 time, resets with every increased reorder tolerance
+    int m_iConsecOrderedDelivery;                // Increases with every packet coming in order or retransmitted, resets with every out-of-order packet
 
-    CACKWindow<1024> m_ACKWindow;                //< ACK history window
-    CPktTimeWindow<16, 64> m_RcvTimeWindow;      //< Packet arrival time window
+    CACKWindow<ACK_WND_SIZE> m_ACKWindow;        // ACK history window
+    CPktTimeWindow<16, 64> m_RcvTimeWindow;      // Packet arrival time window
 
-    int32_t m_iRcvLastAck;                       //< Last sent ACK
+    int32_t m_iRcvLastAck;                       // Last sent ACK
 #ifdef ENABLE_LOGGING
     int32_t m_iDebugPrevLastAck;
 #endif
@@ -869,10 +869,10 @@ private: // Receiving related data
     uint32_t m_uPeerSrtFlags;
 
     bool m_bTsbPd;                               // Peer sends TimeStamp-Based Packet Delivery Packets 
-    bool m_bGroupTsbPd;                          // TSBPD should be used for GROUP RECEIVER instead.
+    bool m_bGroupTsbPd;                          // TSBPD should be used for GROUP RECEIVER instead
 
     srt::sync::CThread m_RcvTsbPdThread;         // Rcv TsbPD Thread handle
-    srt::sync::Condition m_RcvTsbPdCond;         // TSBPD signals if reading is ready. Use together with m_RecvLock.
+    srt::sync::Condition m_RcvTsbPdCond;         // TSBPD signals if reading is ready. Use together with m_RecvLock
     bool m_bTsbPdAckWakeup;                      // Signal TsbPd thread on Ack sent
     srt::sync::Mutex m_RcvTsbPdStartupLock;      // Protects TSBPD thread creating and joining
 

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -77,7 +77,7 @@ void store(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t s
       r_iTail = (r_iTail + 1) % size;
 }
 
-int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack)
+int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack, const steady_clock::time_point& currtime)
 {
    // Head has not exceeded the physical boundary of the window
    if (r_iHead >= r_iTail)
@@ -91,7 +91,7 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
             r_ack = r_aSeq[i].iACK;
 
             // Calculate RTT estimate
-            const int rtt = count_microseconds(steady_clock::now() - r_aSeq[i].tsTimeStamp);
+            const int rtt = count_microseconds(currtime - r_aSeq[i].tsTimeStamp);
 
             if (i + 1 == r_iHead)
             {
@@ -120,7 +120,7 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
          r_ack = r_aSeq[j].iACK;
 
          // Calculate RTT estimate
-         const int rtt = count_microseconds(steady_clock::now() - r_aSeq[j].tsTimeStamp);
+         const int rtt = count_microseconds(currtime - r_aSeq[j].tsTimeStamp);
 
          if (j == r_iHead)
          {

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -79,19 +79,18 @@ void store(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t s
 
 int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack)
 {
+   // Head has not exceeded the physical boundary of the window
    if (r_iHead >= r_iTail)
    {
-      // Head has not exceeded the physical boundary of the window
-
       for (int i = r_iTail, n = r_iHead; i < n; ++ i)
       {
-         // looking for identical ACK Seq. No.
+         // Looking for an identical ACK Seq. No.
          if (seq == r_aSeq[i].iACKSeqNo)
          {
-            // return the Data ACK it carried
+            // Return the Data ACK it carried
             r_ack = r_aSeq[i].iACK;
 
-            // calculate RTT
+            // Calculate RTT estimate
             const int rtt = count_microseconds(steady_clock::now() - r_aSeq[i].tsTimeStamp);
 
             if (i + 1 == r_iHead)
@@ -106,21 +105,21 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
          }
       }
 
-      // Bad input, the ACK node has been overwritten
+      // The record about ACK is not found in the buffer, RTT can not be calculated
       return -1;
    }
 
    // Head has exceeded the physical window boundary, so it is behind tail
    for (int j = r_iTail, n = r_iHead + size; j < n; ++ j)
    {
-      // looking for indentical ACK seq. no.
+      // Looking for an identical ACK Seq. No.
       if (seq == r_aSeq[j % size].iACKSeqNo)
       {
-         // return Data ACK
+         // Return the Data ACK it carried
          j %= size;
          r_ack = r_aSeq[j].iACK;
 
-         // calculate RTT
+         // Calculate RTT estimate
          const int rtt = count_microseconds(steady_clock::now() - r_aSeq[j].tsTimeStamp);
 
          if (j == r_iHead)
@@ -135,9 +134,10 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
       }
    }
 
-   // bad input, the ACK node has been overwritten
+   // The record about ACK is not found in the buffer, RTT can not be calculated
    return -1;
 }
+
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -58,20 +58,20 @@ modified by
    #include <sys/time.h>
    #include <time.h>
 #endif
-#include "udt.h"
 #include "packet.h"
+#include "udt.h"
 
 namespace ACKWindowTools
 {
    struct Seq
    {
-       int32_t iACKSeqNo;       // Seq. No. for the ACK packet
-       int32_t iACK;            // Data Seq. No. carried by the ACK packet
-       srt::sync::steady_clock::time_point tsTimeStamp;      // The timestamp when the ACK was sent
+       int32_t iACKSeqNo;                                   // Seq. No. of the ACK packet
+       int32_t iACK;                                        // Data packet Seq. No. carried by the ACK packet
+       srt::sync::steady_clock::time_point tsTimeStamp;     // The timestamp when the ACK was sent
    };
 
    void store(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t ack);
-   int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack);
+   int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack, const srt::sync::steady_clock::time_point& currtime);
 }
 
 template <size_t SIZE>
@@ -89,22 +89,24 @@ public:
    ~CACKWindow() {}
 
       /// Write an ACK record into the window.
-      /// @param [in] seq ACK seq. no.
-      /// @param [in] ack DATA ACK no.
+      /// @param [in] seq Seq. No. of the ACK packet
+      /// @param [in] ack Data packet Seq. No. carried by the ACK packet
 
    void store(int32_t seq, int32_t ack)
    {
        return ACKWindowTools::store(m_aSeq, SIZE, m_iHead, m_iTail, seq, ack);
    }
 
-      /// Search the ACK-2 "seq" in the window, find out the DATA "ack" and caluclate RTT .
-      /// @param [in] seq ACK-2 seq. no.
-      /// @param [out] ack the DATA ACK no. that matches the ACK-2 no.
-      /// @return RTT.
+      /// Search the ACKACK "seq" in the window, find out the data packet "ack"
+      /// and calculate RTT estimate based on the ACK/ACKACK pair
+      /// @param [in] seq Seq. No. of the ACK packet carried within ACKACK
+      /// @param [out] ack Acknowledged data packet Seq. No. from the ACK packet that matches the ACKACK
+      /// @param [in] currtime The timestamp of ACKACK packet reception by the receiver
+      /// @return RTT
 
-   int acknowledge(int32_t seq, int32_t& r_ack)
+   int acknowledge(int32_t seq, int32_t& r_ack, const srt::sync::steady_clock::time_point& currtime)
    {
-       return ACKWindowTools::acknowledge(m_aSeq, SIZE, m_iHead, m_iTail, seq, r_ack);
+       return ACKWindowTools::acknowledge(m_aSeq, SIZE, m_iHead, m_iTail, seq, r_ack, currtime);
    }
 
 private:
@@ -112,7 +114,7 @@ private:
    typedef ACKWindowTools::Seq Seq;
 
    Seq m_aSeq[SIZE];
-   int m_iHead;                 // Pointer to the lastest ACK record
+   int m_iHead;                 // Pointer to the latest ACK record
    int m_iTail;                 // Pointer to the oldest ACK record
 
 private:
@@ -323,22 +325,22 @@ public:
    }
 
 private:
-   int m_aPktWindow[ASIZE];          // packet information window (inter-packet time)
-   int m_aBytesWindow[ASIZE];        // 
-   int m_iPktWindowPtr;         // position pointer of the packet info. window.
-   mutable srt::sync::Mutex m_lockPktWindow; // used to synchronize access to the packet window
+   int m_aPktWindow[ASIZE];                                 // Packet information window (inter-packet time)
+   int m_aBytesWindow[ASIZE];                               // 
+   int m_iPktWindowPtr;                                     // Position pointer of the packet info. window
+   mutable srt::sync::Mutex m_lockPktWindow;                // Used to synchronize access to the packet window
 
-   int m_aProbeWindow[PSIZE];        // record inter-packet time for probing packet pairs
-   int m_iProbeWindowPtr;       // position pointer to the probing window
-   mutable srt::sync::Mutex m_lockProbeWindow; // used to synchronize access to the probe window
+   int m_aProbeWindow[PSIZE];                               // Record inter-packet time for probing packet pairs
+   int m_iProbeWindowPtr;                                   // Position pointer to the probing window
+   mutable srt::sync::Mutex m_lockProbeWindow;              // Used to synchronize access to the probe window
 
-   int m_iLastSentTime;         // last packet sending time
-   int m_iMinPktSndInt;         // Minimum packet sending interval
+   int m_iLastSentTime;                                     // Last packet sending time
+   int m_iMinPktSndInt;                                     // Minimum packet sending interval
 
    srt::sync::steady_clock::time_point m_tsLastArrTime;      // last packet arrival time
-   srt::sync::steady_clock::time_point m_tsCurrArrTime;      // current packet arrival time
-   srt::sync::steady_clock::time_point m_tsProbeTime;        // arrival time of the first probing packet
-   int32_t m_Probe1Sequence;    // sequence number for which the arrival time was notified
+   srt::sync::steady_clock::time_point m_tsCurrArrTime;      // Current packet arrival time
+   srt::sync::steady_clock::time_point m_tsProbeTime;        // Arrival time of the first probing packet
+   int32_t m_Probe1Sequence;                                 // Sequence number for which the arrival time was notified
 
 private:
    CPktTimeWindow(const CPktTimeWindow&);

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -326,7 +326,7 @@ public:
 
 private:
    int m_aPktWindow[ASIZE];                                 // Packet information window (inter-packet time)
-   int m_aBytesWindow[ASIZE];                               // 
+   int m_aBytesWindow[ASIZE];
    int m_iPktWindowPtr;                                     // Position pointer of the packet info. window
    mutable srt::sync::Mutex m_lockPktWindow;                // Used to synchronize access to the packet window
 
@@ -337,10 +337,10 @@ private:
    int m_iLastSentTime;                                     // Last packet sending time
    int m_iMinPktSndInt;                                     // Minimum packet sending interval
 
-   srt::sync::steady_clock::time_point m_tsLastArrTime;      // last packet arrival time
-   srt::sync::steady_clock::time_point m_tsCurrArrTime;      // Current packet arrival time
-   srt::sync::steady_clock::time_point m_tsProbeTime;        // Arrival time of the first probing packet
-   int32_t m_Probe1Sequence;                                 // Sequence number for which the arrival time was notified
+   srt::sync::steady_clock::time_point m_tsLastArrTime;     // Last packet arrival time
+   srt::sync::steady_clock::time_point m_tsCurrArrTime;     // Current packet arrival time
+   srt::sync::steady_clock::time_point m_tsProbeTime;       // Arrival time of the first probing packet
+   int32_t m_Probe1Sequence;                                // Sequence number for which the arrival time was notified
 
 private:
    CPktTimeWindow(const CPktTimeWindow&);


### PR DESCRIPTION
(1) - This PR provides extended logs for negative or zero RTT estimate on the receiver side, former "IPE: ACK node overwritten message". See issue #253 for details.

The logs are now splitted into two cases:
- When the record about ACK is not found in the buffer,
- When the RTT estimate obtained by the receiver based on ACK/ACKACK pair is negative or zero.

This check happens upon ACKACK reception by the receiver.

The logs format is the following:

```
12:40:38.677155/SRT:RcvQ:w1*E:SRT.in: @577838857:IPE: The record about ACK is not found, RTT estimate at the receiver side can not be calculated (ACK number: 113, last ACK sent: 115, oldest ACK record: not yet available, RTT (EWMA): 21052)
```
```
12:40:38.677194/SRT:RcvQ:w1*E:SRT.in: @577838857:IPE: RTT estimate obtained by the receiver is negative or zero, there may have been a time shift (current time: 18705D 11:40:38.677154 [STDY], the time of sending ACK: not yet available, RTT estimate: 21015). The usage of monotonic clocks is recommended.
```

(2) - Additionally, the current time of ACKACK packet reception `currtime` is now passed to the `acknowledge` function (`window.cpp`) as an argument to make the RTT estimate calculation more precise.

The change has been tested [in the following way](https://github.com/Haivision/srt/issues/253#issuecomment-802807868).

**TODO**
- [x] In the first log, `oldest ACK record: not yet available`.
- [x] In the second log, `the time of sending ACK: not yet available`. The redesign of `acknowledge` function (`window.cpp`) is required to be able to extract this value from the buffer with ACK records.
- [ ] Is there a need to rename `currtime` argument in `acknowledge` function to something like `ACKACKReceptionTime`?
- [ ] The arguments names `seq` and `ack` used in `store` and `acknowledge` functions are difficult to read. I would suggest proper renaming: `seq` -> `ACKSeqNo` (as per `Seq` structure, meaning ACK packet Seq. No.), `ack` -> `AckPktSeqNo` (meaning acknowledged packet Seq. No.). In the `Seq` structure the renaming is also required: `iACK` -> `iAckPktSeqNo`.
- [ ] The function `int32_t CPacket::getAckSeqNo() const` (`packet.cpp`) probably needs renaming to `int32_t CPacket::getAckPktSeqNo() const`.