### PR TITLE
[devel] Fixed wrong handling of no transmission in the test apps

### DIFF
--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -68,8 +68,10 @@ inline void SysCleanupNetwork() {}
 
 #ifdef _WIN32
 inline int SysError() { return ::GetLastError(); }
+const int SysAGAIN = WSAEWOULDBLOCK;
 #else
 inline int SysError() { return errno; }
+const int SysAGAIN = EAGAIN;
 #endif
 
 sockaddr_any CreateAddr(const std::string& name, unsigned short port = 0, int pref_family = AF_UNSPEC);

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -2905,7 +2905,6 @@ public:
         tv.tv_usec = 0;
         if (::setsockopt(m_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0)
             Error(SysError(), "Setting timeout for UDP");
-
     }
 
     MediaPacket Read(size_t chunk) override


### PR DESCRIPTION
Fixed #1872
1. Incorrect handling of the "again" situation after setting 1s timeout so that a check for interrupt can happen. This was resulting in phantom zero packets because the -1 result from `srt_recvmsg2` was not correctly handled.
2. Also added a timeout for UDP reading so that it can be correctly interrupted.