### PR TITLE
[core] Removed unnecessary lock that could cause a deadlock

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1668,7 +1668,6 @@ bool CUDT::createSrtHandshake(
     if (have_group)
     {
         // NOTE: See information about mutex ordering in api.h
-        ScopedLock grd (m_parent->m_ControlLock); // Required to make sure 
         ScopedLock gdrg (s_UDTUnited.m_GlobControlLock);
         if (!m_parent->m_GroupOf)
         {


### PR DESCRIPTION
Removed the lock for CUDTSocket::m_ControlLock that breaks the ordering against m_ConnectionLock (which may lead to a deadlock, which was also experienced in some tests). This lock is likely not necessary provided that m_GlobControlLock is also applied.