### PR TITLE
[core] New API function srt_clock_type()

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -2650,16 +2650,16 @@ Get the type of clock used internally by SRT to be used only for informtational 
 Using any time source except for [`srt_time_now()`](#srt_time_now) and [`srt_connection_time(SRTSOCKET)`](#srt_connection_time)
 to timestamp packets submitted to SRT is not recommended and must be done with awareness and at your own risk.
 
-| Returns | `SRT_SYNC_CLOCK_TYPE`                    | Description                                |
-| :------ | :--------------------------------------- | :------------------------------------------|
-| 0       | `SRT_SYNC_CLOCK_TYPE_STDCXX_STEADY`      | C++11 `std::chrono::steady_clock`          |
-| 1       | `SRT_SYNC_CLOCK_TYPE_GETTIME_MONOTONIC`  | `clock_gettime` with `CLOCK_MONOTONIC`     |
-| 2       | `SRT_SYNC_CLOCK_TYPE_WINQPC`             | Windows `QueryPerformanceCounter(..)`      |
-| 3       | `SRT_SYNC_CLOCK_TYPE_MACH_ABSTIME`       | `mach_absolute_time()`                     |
-| 4       | `SRT_SYNC_CLOCK_TYPE_POSIX_GETTIMEOFDAY` | POSIX `gettimeofday(..)`                   |
-| 5       | `SRT_SYNC_CLOCK_TYPE_AMD64_RDTSC`        | `asm("rdtsc" ..)`                          |
-| 6       | `SRT_SYNC_CLOCK_TYPE_IA32_RDTSC`         | `asm volatile("rdtsc" ..)`                 |
-| 7       | `SRT_SYNC_CLOCK_TYPE_IA64_ITC`           | `asm("mov %0=ar.itc" ..)`                  |
+| Returns | Clock Type                          | Description                                |
+| :------ | :---------------------------------- | :------------------------------------------|
+| 0       | `SRT_SYNC_CLOCK_STDCXX_STEADY`      | C++11 `std::chrono::steady_clock`          |
+| 1       | `SRT_SYNC_CLOCK_GETTIME_MONOTONIC`  | `clock_gettime` with `CLOCK_MONOTONIC`     |
+| 2       | `SRT_SYNC_CLOCK_WINQPC`             | Windows `QueryPerformanceCounter(..)`      |
+| 3       | `SRT_SYNC_CLOCK_MACH_ABSTIME`       | `mach_absolute_time()`                     |
+| 4       | `SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY` | POSIX `gettimeofday(..)`                   |
+| 5       | `SRT_SYNC_CLOCK_AMD64_RDTSC`        | `asm("rdtsc" ..)`                          |
+| 6       | `SRT_SYNC_CLOCK_IA32_RDTSC`         | `asm volatile("rdtsc" ..)`                 |
+| 7       | `SRT_SYNC_CLOCK_IA64_ITC`           | `asm("mov %0=ar.itc" ..)`                  |
 
 |       Errors                      |                                                            |
 |:--------------------------------- |:---------------------------------------------------------- |

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -135,6 +135,7 @@
 |:------------------------------------------------- |:-------------------------------------------------------------------------------------------------------------- |
 | [srt_time_now](#srt_time_now)                     | Get time in microseconds elapsed since epoch using SRT internal clock <br/> (steady or monotonic clock)              |
 | [srt_connection_time](#srt_connection_time)       | Get connection time in microseconds elapsed since epoch using SRT internal clock <br/> (steady or monotonic clock)   |
+| [srt_clock_type](#srt_clock_type)                 | Get the type of clock used internally by SRT                                                                   |
 | <img width=290px height=1px/>                     | <img width=720px height=1px/>                                                                                  |
 
 <h3 id="diagnostics">Diagnostics</h3>
@@ -2639,7 +2640,36 @@ and `msTimeStamp` value of the `SRT_TRACEBSTATS` (see [SRT Statistics](statistic
 
 ---
   
+### srt_clock_type
 
+```c
+int srt_clock_type(void);
+```
+
+Get the type of clock used internally by SRT to be used only for informtational peurpose.
+Using any time source except for [`srt_time_now()`](#srt_time_now) and [`srt_connection_time(SRTSOCKET)`](#srt_connection_time)
+to timestamp packets submitted to SRT is not recommended and must be done with awareness and at your own risk.
+
+| Returns | `SRT_SYNC_CLOCK_TYPE`                    | Description                                |
+| :------ | :--------------------------------------- | :------------------------------------------|
+| 0       | `SRT_SYNC_CLOCK_TYPE_STDCXX_STEADY`      | C++11 `std::chrono::steady_clock`          |
+| 1       | `SRT_SYNC_CLOCK_TYPE_GETTIME_MONOTONIC`  | `clock_gettime` with `CLOCK_MONOTONIC`     |
+| 2       | `SRT_SYNC_CLOCK_TYPE_WINQPC`             | Windows `QueryPerformanceCounter(..)`      |
+| 3       | `SRT_SYNC_CLOCK_TYPE_MACH_ABSTIME`       | `mach_absolute_time()`                     |
+| 4       | `SRT_SYNC_CLOCK_TYPE_POSIX_GETTIMEOFDAY` | POSIX `gettimeofday(..)`                   |
+| 5       | `SRT_SYNC_CLOCK_TYPE_AMD64_RDTSC`        | `asm("rdtsc" ..)`                          |
+| 6       | `SRT_SYNC_CLOCK_TYPE_IA32_RDTSC`         | `asm volatile("rdtsc" ..)`                 |
+| 7       | `SRT_SYNC_CLOCK_TYPE_IA64_ITC`           | `asm("mov %0=ar.itc" ..)`                  |
+
+|       Errors                      |                                                            |
+|:--------------------------------- |:---------------------------------------------------------- |
+| None                              |                                                            |
+| <img width=240px height=1px/>     | <img width=710px height=1px/>                      |
+
+  
+[:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)
+
+---
 
 
 ## Diagnostics

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -1007,7 +1007,7 @@ enum SRT_SYNC_CLOCK_TYPE
     SRT_SYNC_CLOCK_TYPE_IA64_ITC           = 7
 };
 
-SRT_API int srt_clock_type();
+SRT_API int srt_clock_type(void);
 
 #ifdef __cplusplus
 }

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -995,17 +995,15 @@ SRT_API int64_t srt_time_now(void);
 
 SRT_API int64_t srt_connection_time(SRTSOCKET sock);
 
-enum SRT_SYNC_CLOCK_TYPE
-{
-    SRT_SYNC_CLOCK_TYPE_STDCXX_STEADY      = 0, // C++11 std::chrono::steady_clock
-    SRT_SYNC_CLOCK_TYPE_GETTIME_MONOTONIC  = 1, // clock_gettime with CLOCK_MONOTONIC
-    SRT_SYNC_CLOCK_TYPE_WINQPC             = 2,
-    SRT_SYNC_CLOCK_TYPE_MACH_ABSTIME       = 3,
-    SRT_SYNC_CLOCK_TYPE_POSIX_GETTIMEOFDAY = 4,
-    SRT_SYNC_CLOCK_TYPE_AMD64_RDTSC        = 5,
-    SRT_SYNC_CLOCK_TYPE_IA32_RDTSC         = 6,
-    SRT_SYNC_CLOCK_TYPE_IA64_ITC           = 7
-};
+// Possible internal clock types
+#define SRT_SYNC_CLOCK_STDCXX_STEADY      0 // C++11 std::chrono::steady_clock
+#define SRT_SYNC_CLOCK_GETTIME_MONOTONIC  1 // clock_gettime with CLOCK_MONOTONIC
+#define SRT_SYNC_CLOCK_WINQPC             2
+#define SRT_SYNC_CLOCK_MACH_ABSTIME       3
+#define SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY 4
+#define SRT_SYNC_CLOCK_AMD64_RDTSC        5
+#define SRT_SYNC_CLOCK_IA32_RDTSC         6
+#define SRT_SYNC_CLOCK_IA64_ITC           7
 
 SRT_API int srt_clock_type(void);
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -995,6 +995,20 @@ SRT_API int64_t srt_time_now(void);
 
 SRT_API int64_t srt_connection_time(SRTSOCKET sock);
 
+enum SRT_SYNC_CLOCK_TYPE
+{
+    SRT_SYNC_CLOCK_TYPE_STDCXX_STEADY      = 0, // C++11 std::chrono::steady_clock
+    SRT_SYNC_CLOCK_TYPE_GETTIME_MONOTONIC  = 1, // clock_gettime with CLOCK_MONOTONIC
+    SRT_SYNC_CLOCK_TYPE_WINQPC             = 2,
+    SRT_SYNC_CLOCK_TYPE_MACH_ABSTIME       = 3,
+    SRT_SYNC_CLOCK_TYPE_POSIX_GETTIMEOFDAY = 4,
+    SRT_SYNC_CLOCK_TYPE_AMD64_RDTSC        = 5,
+    SRT_SYNC_CLOCK_TYPE_IA32_RDTSC         = 6,
+    SRT_SYNC_CLOCK_TYPE_IA64_ITC           = 7
+};
+
+SRT_API int srt_clock_type();
+
 #ifdef __cplusplus
 }
 #endif

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -410,4 +410,9 @@ int64_t srt_connection_time(SRTSOCKET sock)
     return CUDT::socketStartTime(sock);
 }
 
+int srt_clock_type()
+{
+    return SRT_SYNC_CLOCK;
+}
+
 }

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -11,16 +11,6 @@
 #ifndef INC_SRT_SYNC_H
 #define INC_SRT_SYNC_H
 
-// Possible internal clock types
-#define SRT_SYNC_CLOCK_STDCXX_STEADY      0 // C++11 std::chrono::steady_clock
-#define SRT_SYNC_CLOCK_GETTIME_MONOTONIC  1 // clock_gettime with CLOCK_MONOTONIC
-#define SRT_SYNC_CLOCK_WINQPC             2
-#define SRT_SYNC_CLOCK_MACH_ABSTIME       3
-#define SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY 4
-#define SRT_SYNC_CLOCK_AMD64_RDTSC        5
-#define SRT_SYNC_CLOCK_IA32_RDTSC         6
-#define SRT_SYNC_CLOCK_IA64_ITC           7
-
 #include <cstdlib>
 #include <limits>
 #ifdef ENABLE_STDCXX_SYNC


### PR DESCRIPTION
Adds `int srt_clock_type(void)` API function to determine in runtime the internal clock type used by SRT library.

Possible return values:
```c++
#define SRT_SYNC_CLOCK_STDCXX_STEADY      0 // C++11 std::chrono::steady_clock
#define SRT_SYNC_CLOCK_GETTIME_MONOTONIC  1 // clock_gettime with CLOCK_MONOTONIC
#define SRT_SYNC_CLOCK_WINQPC             2
#define SRT_SYNC_CLOCK_MACH_ABSTIME       3
#define SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY 4
#define SRT_SYNC_CLOCK_AMD64_RDTSC        5
#define SRT_SYNC_CLOCK_IA32_RDTSC         6
#define SRT_SYNC_CLOCK_IA64_ITC           7
```

Defines are used instead of enum to allow possible inclusion of `SRT_INTERNAL_CLOCK_VERSION` in `version.h` to determine the clock type at the compilation time.

Fixes #1702

### TODO

- [x] **docs:** add function description to the API-functions.md.