### PR TITLE
[core] WIP: Extending ACK with RCV drop total

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -829,8 +829,10 @@ void CUDT::clearData()
         m_stats.traceBelatedTime                                                  = 0.0;
         m_stats.traceRcvBelated                                                   = 0;
 
+        m_stats.sndRcvDropTotal = 0;
         m_stats.sndDropTotal = 0;
         m_stats.traceSndDrop = 0;
+        m_stats.traceSndRcvDrop = 0;
         m_stats.rcvDropTotal = 0;
         m_stats.traceRcvDrop = 0;
 
@@ -7079,6 +7081,7 @@ void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
     if (clear)
     {
         m_stats.traceSndDrop           = 0;
+        m_stats.traceSndRcvDrop        = 0;
         m_stats.traceRcvDrop           = 0;
         m_stats.traceSndBytesDrop      = 0;
         m_stats.traceRcvBytesDrop      = 0;
@@ -7706,8 +7709,20 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
             else if (m_uPeerSrtVersion >= SrtVersion(1, 0, 3))
             {
                 // Normal, currently expected version.
-                data[ACKD_RCVRATE] = rcvRate; // bytes/sec
-                ctrlsz = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER101;
+                data[ACKD_RCVRATE] = rcvRate;                                     // bytes/sec
+                ctrlsz = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER143;
+            }
+            else if (m_uPeerSrtVersion >= SrtVersion(1, 4, 3) && m_bPeerTLPktDrop && m_bPeerTsbPd)
+            {
+                enterCS(m_StatsLock);
+                const int64_t dropTotal = m_stats.rcvDropTotal;
+                leaveCS(m_StatsLock);
+                // Normal, currently expected version.
+                data[ACKD_RCVRATE] = rcvRate;                   // bytes/sec
+
+                // TODO: only include this field if dropTotal was updated
+                data[ACKD_RCVDROP_TOTAL] = (unsigned)dropTotal; // truncation is allowed and must be handled by ACK-receiver
+                ctrlsz = ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_VER143;
             }
             // ELSE: leave the buffer with ...UDTBASE size.
 
@@ -8014,6 +8029,18 @@ void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point
         m_iBandwidth        = avg_iir<8>(m_iBandwidth, bandwidth);
         m_iDeliveryRate     = avg_iir<8>(m_iDeliveryRate, pktps);
         m_iByteDeliveryRate = avg_iir<8>(m_iByteDeliveryRate, bytesps);
+
+        // TODO: or maybe == ?
+        if (acksize >= ACKD_TOTAL_SIZE_VER143)
+        {
+            const unsigned uRcvDropTotal = ackdata[ACKD_RCVDROP_TOTAL];
+            enterCS(m_StatsLock);
+            const int64_t prevTotalDrop = m_stats.sndRcvDropTotal;
+            // TODO: handle possible uint32_t overflow here
+            m_stats.sndRcvDropTotal = uRcvDropTotal;
+            m_stats.traceSndRcvDrop += uRcvDropTotal - prevTotalDrop;
+            leaveCS(m_StatsLock);
+        }
         // XXX not sure if ACKD_XMRATE is of any use. This is simply
         // calculated as ACKD_BANDWIDTH * m_iMaxSRTPayloadSize.
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -110,6 +110,10 @@ enum AckDataItem
                      // XXX NOTE: field number 7 may be used for something in future, need to confirm destruction of all !compat 1.0.2 version
 
     ACKD_TOTAL_SIZE_VER102 = 8, // 32
+
+    ACKD_RCVDROP_TOTAL = 7,
+    ACKD_TOTAL_SIZE_VER143 = 8, // 32
+
 // FEATURE BLOCKED. Probably not to be restored.
 //  ACKD_ACKBITMAP = 8,
     ACKD_TOTAL_SIZE = ACKD_TOTAL_SIZE_VER102 // length = 32 (or more)
@@ -1003,6 +1007,7 @@ private: // Trace
         int sentNAKTotal;                   // total number of sent NAK packets
         int recvNAKTotal;                   // total number of received NAK packets
         int sndDropTotal;
+        int64_t sndRcvDropTotal;            // total number of packets dropped by the receiver, and known to the sender (via ACK packets)
         int rcvDropTotal;
         uint64_t bytesSentTotal;            // total number of bytes sent,  including retransmissions
         uint64_t bytesSentUniqTotal;        // total number of bytes sent,  including retransmissions
@@ -1035,6 +1040,7 @@ private: // Trace
         int sentNAK;                        // number of NAKs sent in the last trace interval
         int recvNAK;                        // number of NAKs received in the last trace interval
         int traceSndDrop;
+        int traceSndRcvDrop;                // number of packets dropped by the receiver, and known to the sender (via ACK packets)
         int traceRcvDrop;
         int traceRcvRetrans;
         int traceReorderDistance;


### PR DESCRIPTION
**Problem:** Sender does not know if and how many packets are being dropped by the receiver. SRT receiver, dropping a packet, just sends a regular ACK control packet, as if it had received them.

**Proposed Solution**: Extend ACK control packet to contain information about the number of packets dropped by the receiver: "Total Dropped Packets Count" field.

```
    0                   1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+- SRT Header +-+-+-+-+-+-+-+-+-+-+-+-+-+
0  |1|        Control Type         |           Reserved            |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
1  |                    Acknowledgement Number                     |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
2  |                           Timestamp                           |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
3  |                     Destination Socket ID                     |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+- CIF -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
4  |            Last Acknowledged Packet Sequence Number           |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
5  |                              RTT                              |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
6  |                          RTT Variance                         |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
7  |                     Available Buffer Size                     |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
8  |                     Packets Receiving Rate                    |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
9  |                     Estimated Link Capacity                   |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
10 |                         Receiving Rate                        |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
11 |                   Total Dropped Packets Count                 | <-- PROPOSED FIELD!!!
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

**Total Dropped Packets Count** - the total number of packets dropped by the receiver
from the start of receiving. Only sent if differs from the previous value,
sent in previous ACK packets, that were acknowledged by the sender (ACKACK).
In other words, included in ACK packet until ACKACK is received acknowledging that the sender has received this number of dropped packets.

Older SRT versions will ignore this field (maximum size is not restricted). Also receiver knows sender’s SRT version, and can only send an extended ACK packet for newer versions.
ACKACK control packet: no changes are required. The structure remains the same.

### TODO

- [ ] Add API statistics (note that extending statistics API breaks ABI compatibility between versions).
- [ ] Do not include the **Total Dropped Packets Count** field if the value hasn't changed and the previous value was already received by sender (receiver got ACACK for ACK with that value).
- [ ] Handle possible `uint32_t` overflow on the sender side.