### PR TITLE
[core] Fixed wrong limitation on SRTO_FC option. Fixed documentation.

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -394,7 +394,7 @@ Possible values are those defined in `SRT_EPOLL_OPT` enum (a combination of
 | ----------------- | ----- | -------- | --------- | ------ | -------- | ------ | --- | ------ |
 | `SRTO_FC`         |       | pre      | `int32_t` | pkts   | 25600    | 32..   | RW  | GSD    |
 
-Flight Flag Size (maximum number of bytes that can be sent without
+Flight Flag Size (maximum number of packets that can be sent without
 being acknowledged)
 
 [Return to list](#list-of-options)

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -418,7 +418,7 @@ struct CSrtConfigSetter<SRTO_FC>
         if (fc < 1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL);
 
-        co.iFlightFlagSize = std::min(fc, +co.DEF_MAX_FLIGHT_PKT);
+        co.iFlightFlagSize = std::max(fc, +co.DEF_MAX_FLIGHT_PKT);
     }
 };
 

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -185,7 +185,7 @@ struct CSrtConfig: CSrtMuxerConfig
     static const uint32_t COMM_DEF_STABILITY_TIMEOUT_US = 80 * 1000;
 
     // Mimimum recv flight flag size is 32 packets
-    static const int    DEF_MAX_FLIGHT_PKT = 32;
+    static const int    DEF_MIN_FLIGHT_PKT = 32;
     static const size_t MAX_SID_LENGTH     = 512;
     static const size_t MAX_PFILTER_LENGTH = 64;
     static const size_t MAX_CONG_LENGTH    = 16;
@@ -418,7 +418,7 @@ struct CSrtConfigSetter<SRTO_FC>
         if (fc < 1)
             throw CUDTException(MJ_NOTSUP, MN_INVAL);
 
-        co.iFlightFlagSize = std::max(fc, +co.DEF_MAX_FLIGHT_PKT);
+        co.iFlightFlagSize = std::max(fc, +co.DEF_MIN_FLIGHT_PKT);
     }
 };
 
@@ -447,11 +447,10 @@ struct CSrtConfigSetter<SRTO_RCVBUF>
         // Mimimum recv buffer size is 32 packets
         const int mssin_size = co.iMSS - CPacket::UDP_HDR_SIZE;
 
-        // XXX This magic 32 deserves some constant
-        if (val > mssin_size * co.DEF_MAX_FLIGHT_PKT)
+        if (val > mssin_size * co.DEF_MIN_FLIGHT_PKT)
             co.iRcvBufSize = val / mssin_size;
         else
-            co.iRcvBufSize = co.DEF_MAX_FLIGHT_PKT;
+            co.iRcvBufSize = co.DEF_MIN_FLIGHT_PKT;
 
         // recv buffer MUST not be greater than FC size
         if (co.iRcvBufSize > co.iFlightFlagSize)


### PR DESCRIPTION
Fixes #1898

Problem: 32 is to be the minimum allowed value for `SRTO_FC`, so a maximum out of 32 and the given one should be used.

Also the constant should use MIN, not MAX, as this is the minimum allowed value.

Documentation: the unit for SRTO_FC is packet, so it should be fixed that this is the maximum number of PACKETS that can be sent without acknowledgement.