### PR TITLE
Made CEpoll::m_EPollLock mutable

### DIFF
--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -808,7 +808,7 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
     return 0;
 }
 
-bool CEPoll::empty(CEPollDesc& d)
+bool CEPoll::empty(const CEPollDesc& d) const
 {
     ScopedLock lg (m_EPollLock);
     return d.watch_empty();

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -425,7 +425,7 @@ public: // for CUDTUnited API
    int swait(CEPollDesc& d, fmap_t& st, int64_t msTimeOut, bool report_by_exception = true);
 
    /// Empty subscription check - for internal use only.
-   bool empty(CEPollDesc& d);
+   bool empty(const CEPollDesc& d) const;
 
    /// Reports which events are ready on the given socket.
    /// @param mp socket event map retirned by `swait`
@@ -486,7 +486,7 @@ private:
    srt::sync::Mutex m_SeedLock;
 
    std::map<int, CEPollDesc> m_mPolls;       // all epolls
-   srt::sync::Mutex m_EPollLock;
+   mutable srt::sync::Mutex m_EPollLock;
 };
 
 #if ENABLE_HEAVY_LOGGING

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -4193,7 +4193,7 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
         // is performed, and this one will result in none-write-ready, this will
         // be fixed just after returning from this function.
 
-        ready_again = ready_again | d->ps->writeReady();
+        ready_again = ready_again || d->ps->writeReady();
     }
     w_mc.grpdata_size = i;
 


### PR DESCRIPTION
Two minor fixes in this Pr (in separate commits):
1. Made `CEpoll::m_EPollLock` mutable. `CEpoll::empty(..)` now has a const qualifier.
2. `sendBackup`: use logical OR instead of bitwise

Closes #1847