### PR TITLE
[core] Added SRT_STATIC_ASSERT macro

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -78,12 +78,17 @@ modified by
    #define NET_ERROR WSAGetLastError()
 #endif
 
-
 #ifdef _DEBUG
 #include <assert.h>
 #define SRT_ASSERT(cond) assert(cond)
 #else
 #define SRT_ASSERT(cond)
+#endif
+
+#if HAVE_FULL_CXX11
+#define SRT_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#else
+#define SRT_STATIC_ASSERT(cond, msg)
 #endif
 
 #include <exception>


### PR DESCRIPTION
If C++11 is available, SRT_STATIC_ASSERT  maps to `static_assert`. Otherwise empty macro.

Extracting from #1857.