### PR TITLE
[core] SocketData moved to group_common.h (REFAX)

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1417,7 +1417,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
         // Do it after setting all stored options, as some of them may
         // influence some group data.
 
-        CUDTGroup::SocketData data = g.prepareData(ns);
+        srt::groups::SocketData data = srt::groups::prepareSocketData(ns);
         if (targets[tii].token != -1)
         {
             // Reuse the token, if specified by the caller
@@ -3237,7 +3237,7 @@ int CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
         s->m_GroupOf = g;
         return 0;
     }
-    s->m_GroupMemberData = g->add(g->prepareData(s));
+    s->m_GroupMemberData = g->add(srt::groups::prepareSocketData(s));
     s->m_GroupOf = g;
 
     return 0;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3228,7 +3228,7 @@ int CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
     // Check if the socket already is in the group
-    CUDTGroup::SocketData* f;
+    srt::groups::SocketData* f;
     if (g->contains(socket, (f)))
     {
         // XXX This is internal error. Report it, but continue

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -117,8 +117,8 @@ public:
 
    SRTSOCKET m_PeerID;                       //< peer socket ID
 #if ENABLE_EXPERIMENTAL_BONDING
-   CUDTGroup::SocketData* m_GroupMemberData; //< Pointer to group member data, or NULL if not a group member
-   CUDTGroup* m_GroupOf;                     //< Group this socket is a member of, or NULL if it isn't
+   srt::groups::SocketData* m_GroupMemberData; //< Pointer to group member data, or NULL if not a group member
+   CUDTGroup* m_GroupOf;                       //< Group this socket is a member of, or NULL if it isn't
 #endif
 
    int32_t m_iISN;                           //< initial sequence number, used to tell different connection from same IP:port

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -79,6 +79,7 @@ modified by
 #endif
 
 using namespace std;
+using namespace srt;
 using namespace srt::sync;
 using namespace srt_logging;
 
@@ -3130,7 +3131,7 @@ SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t l
         return 0;
     }
 
-    s->m_GroupMemberData = gp->add(gp->prepareData(s));
+    s->m_GroupMemberData = gp->add(groups::prepareSocketData(s));
     s->m_GroupOf = gp;
 
     // Record the remote address in the group data.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3020,7 +3020,7 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
             return false;
         }
 
-        CUDTGroup::SocketData* f = m_parent->m_GroupMemberData;
+        srt::groups::SocketData* f = m_parent->m_GroupMemberData;
 
         f->weight = link_weight;
         f->agent = m_parent->m_SelfAddr;
@@ -3119,7 +3119,7 @@ SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t l
     // Copy of addSocketToGroup. No idea how many parts could be common, not much.
 
     // Check if the socket already is in the group
-    CUDTGroup::SocketData* f;
+    srt::groups::SocketData* f;
     if (gp->contains(m_SocketID, (f)))
     {
         // XXX This is internal error. Report it, but continue
@@ -4550,7 +4550,7 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
 
             HLOGC(cnlog.Debug, log << "group: Socket @" << m_parent->m_SocketID << " fresh connected, setting IDLE");
 
-            CUDTGroup::SocketData* gi       = m_parent->m_GroupMemberData;
+            srt::groups::SocketData* gi       = m_parent->m_GroupMemberData;
             gi->sndstate   = SRT_GST_IDLE;
             gi->rcvstate   = SRT_GST_IDLE;
             gi->laststatus = SRTS_CONNECTED;
@@ -9294,7 +9294,7 @@ int CUDT::processData(CUnit* in_unit)
     if (m_parent->m_GroupOf)
     {
         ScopedLock protect_group_existence (s_UDTUnited.m_GlobControlLock);
-        CUDTGroup::SocketData* gi = m_parent->m_GroupMemberData;
+        srt::groups::SocketData* gi = m_parent->m_GroupMemberData;
 
         // This check is needed as after getting the lock the socket
         // could be potentially removed. It is however granted that as long
@@ -9793,7 +9793,7 @@ CUDT::loss_seqs_t CUDT::defaultPacketArrival(void* vself, CPacket& pkt)
 
     if (self->m_parent->m_GroupOf)
     {
-        CUDTGroup::SocketData* gi = self->m_parent->m_GroupMemberData;
+        srt::groups::SocketData* gi = self->m_parent->m_GroupMemberData;
         if (gi->rcvstate < SRT_GST_RUNNING) // PENDING or IDLE, tho PENDING is unlikely
         {
             HLOGC(qrlog.Debug, log << "defaultPacketArrival: IN-GROUP rcv state transition to RUNNING. NOT checking for loss");

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -28,6 +28,7 @@ sync.cpp
 
 SOURCES - ENABLE_EXPERIMENTAL_BONDING
 group.cpp
+group_common.cpp
 
 SOURCES - !ENABLE_STDCXX_SYNC
 sync_posix.cpp
@@ -73,3 +74,4 @@ window.h
 
 PRIVATE HEADERS - ENABLE_EXPERIMENTAL_BONDING
 group.h
+group_common.h

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -244,41 +244,6 @@ CUDTGroup::SocketData* CUDTGroup::add(SocketData data)
     return &*end;
 }
 
-CUDTGroup::SocketData CUDTGroup::prepareData(CUDTSocket* s)
-{
-    // This uses default SRT_GST_BROKEN because when the group operation is done,
-    // then the SRT_GST_IDLE state automatically turns into SRT_GST_RUNNING. This is
-    // recognized as an initial state of the fresh added socket to the group,
-    // so some "initial configuration" must be done on it, after which it's
-    // turned into SRT_GST_RUNNING, that is, it's treated as all others. When
-    // set to SRT_GST_BROKEN, this socket is disregarded. This socket isn't cleaned
-    // up, however, unless the status is simultaneously SRTS_BROKEN.
-
-    // The order of operations is then:
-    // - add the socket to the group in this "broken" initial state
-    // - connect the socket (or get it extracted from accept)
-    // - update the socket state (should be SRTS_CONNECTED)
-    // - once the connection is established (may take time with connect), set SRT_GST_IDLE
-    // - the next operation of send/recv will automatically turn it into SRT_GST_RUNNING
-    SocketData sd = {
-        s->m_SocketID,
-        s,
-        -1,
-        SRTS_INIT,
-        SRT_GST_BROKEN,
-        SRT_GST_BROKEN,
-        -1,
-        -1,
-        sockaddr_any(),
-        sockaddr_any(),
-        false,
-        false,
-        false,
-        0 // weight
-    };
-    return sd;
-}
-
 CUDTGroup::CUDTGroup(SRT_GROUP_TYPE gtype)
     : m_pGlobal(&CUDT::s_UDTUnited)
     , m_GroupID(-1)

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -107,8 +107,6 @@ public:
     CUDTGroup(SRT_GROUP_TYPE);
     ~CUDTGroup();
 
-    static SocketData prepareData(CUDTSocket* s);
-
     SocketData* add(SocketData data);
 
     struct HaveID

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -19,6 +19,7 @@ Written by
 #include "srt.h"
 #include "common.h"
 #include "packet.h"
+#include "group_common.h"
 
 #if ENABLE_HEAVY_LOGGING
 const char* const srt_log_grp_state[] = {"PENDING", "IDLE", "RUNNING", "BROKEN"};
@@ -31,6 +32,7 @@ class CUDTGroup
     typedef srt::sync::steady_clock::time_point time_point;
     typedef srt::sync::steady_clock::duration   duration;
     typedef srt::sync::steady_clock             steady_clock;
+    typedef srt::groups::SocketData             SocketData;
 
 public:
     typedef SRT_MEMBERSTATUS GroupState;
@@ -56,26 +58,6 @@ public:
 
     static int32_t s_tokenGen;
     static int32_t genToken() { ++s_tokenGen; if (s_tokenGen < 0) s_tokenGen = 0; return s_tokenGen;}
-
-    struct SocketData
-    {
-        SRTSOCKET      id;
-        CUDTSocket*    ps;
-        int            token;
-        SRT_SOCKSTATUS laststatus;
-        GroupState     sndstate;
-        GroupState     rcvstate;
-        int            sndresult;
-        int            rcvresult;
-        sockaddr_any   agent;
-        sockaddr_any   peer;
-        bool           ready_read;
-        bool           ready_write;
-        bool           ready_error;
-
-        // Configuration
-        uint16_t weight;
-    };
 
     struct ConfigItem
     {

--- a/srtcore/group_common.cpp
+++ b/srtcore/group_common.cpp
@@ -1,0 +1,62 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2021 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+ /*****************************************************************************
+ Written by
+    Haivision Systems Inc.
+ *****************************************************************************/
+
+#include "platform_sys.h"
+
+#include "group_common.h"
+#include "api.h"
+
+namespace srt
+{
+    namespace groups
+    {
+
+        SocketData prepareSocketData(CUDTSocket* s)
+        {
+            // This uses default SRT_GST_BROKEN because when the group operation is done,
+            // then the SRT_GST_IDLE state automatically turns into SRT_GST_RUNNING. This is
+            // recognized as an initial state of the fresh added socket to the group,
+            // so some "initial configuration" must be done on it, after which it's
+            // turned into SRT_GST_RUNNING, that is, it's treated as all others. When
+            // set to SRT_GST_BROKEN, this socket is disregarded. This socket isn't cleaned
+            // up, however, unless the status is simultaneously SRTS_BROKEN.
+
+            // The order of operations is then:
+            // - add the socket to the group in this "broken" initial state
+            // - connect the socket (or get it extracted from accept)
+            // - update the socket state (should be SRTS_CONNECTED)
+            // - once the connection is established (may take time with connect), set SRT_GST_IDLE
+            // - the next operation of send/recv will automatically turn it into SRT_GST_RUNNING
+            SocketData sd = {
+                s->m_SocketID,
+                s,
+                -1,
+                SRTS_INIT,
+                SRT_GST_BROKEN,
+                SRT_GST_BROKEN,
+                -1,
+                -1,
+                sockaddr_any(),
+                sockaddr_any(),
+                false,
+                false,
+                false,
+                0 // weight
+            };
+            return sd;
+        }
+
+    } // namespace groups
+} // namespace srt

--- a/srtcore/group_common.h
+++ b/srtcore/group_common.h
@@ -1,0 +1,60 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2021 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+ /*****************************************************************************
+ Written by
+    Haivision Systems Inc.
+ *****************************************************************************/
+
+#ifndef INC_SRT_GROUP_COMMON_H
+#define INC_SRT_GROUP_COMMON_H
+
+#include "srt.h"
+#include "common.h"
+#include "core.h"
+
+#include <list>
+
+namespace srt
+{
+    namespace groups
+    {
+        typedef SRT_MEMBERSTATUS GroupState;
+
+        struct SocketData
+        {
+            SRTSOCKET      id; // same as ps->m_SocketID
+            CUDTSocket*    ps;
+            int            token;
+            SRT_SOCKSTATUS laststatus;
+            GroupState     sndstate;
+            GroupState     rcvstate;
+            int            sndresult;
+            int            rcvresult;
+            sockaddr_any   agent;
+            sockaddr_any   peer;
+            bool           ready_read;
+            bool           ready_write;
+            bool           ready_error;
+
+            // Configuration
+            uint16_t       weight;
+        };
+
+        SocketData prepareSocketData(CUDTSocket* s);
+
+        typedef std::list<SocketData> group_t;
+        typedef group_t::iterator     gli_t;
+
+    } // namespace groups
+} // namespace srt
+
+
+#endif // INC_SRT_GROUP_COMMON_H


### PR DESCRIPTION
Minor refactoring, extracted from PR #1857. Will be used in the updated main/backup code.

`CUDTGroup::SocketData` is moved to a separate file `group_common.h` under `srt::groups` namespace.