### PR TITLE
[core] Improved 'no room to store' log message

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1769,7 +1769,7 @@ string CRcvBuffer::strFullnessState(const time_point& tsNow) const
     stringstream ss;
 
     ss << "Space avail " << getAvailBufSize() << "/" << m_iSize;
-    ss << ". Packets ACKed: " << bufstate.iNumAcknowledged;
+    ss << " pkts. Packets ACKed: " << bufstate.iNumAcknowledged;
     if (!is_zero(bufstate.tsStart) && !is_zero(bufstate.tsLastAck))
     {
         ss << " (TSBPD ready in ";

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1768,7 +1768,8 @@ string CRcvBuffer::strFullnessState(const time_point& tsNow) const
     const ReadingState bufstate = debugGetReadingState();
     stringstream ss;
 
-    ss << "Packets ACKed: " << bufstate.iNumAcknowledged;
+    ss << "Space avail " << getAvailBufSize() << "/" << m_iSize;
+    ss << ". Packets ACKed: " << bufstate.iNumAcknowledged;
     if (!is_zero(bufstate.tsStart) && !is_zero(bufstate.tsLastAck))
     {
         ss << " (TSBPD ready in ";

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1722,6 +1722,47 @@ unsigned CRcvBuffer::getRcvAvgPayloadSize() const
     return m_uAvgPayloadSz;
 }
 
+CRcvBuffer::ReadingState CRcvBuffer::debugGetReadingState() const
+{
+    ReadingState readstate;
+
+    readstate.numAcknowledged = 0;
+    readstate.numUnacknowledged = m_iMaxPos;
+
+    if ((NULL != m_pUnit[m_iStartPos]) && (m_pUnit[m_iStartPos]->m_iFlag == CUnit::GOOD))
+    {
+        if (m_tsbpd.isEnabled())
+            readstate.tsStart = m_tsbpd.getPktTsbPdTime(m_pUnit[m_iStartPos]->m_Packet.getMsgTimeStamp());
+
+        readstate.numAcknowledged = m_iLastAckPos > m_iStartPos
+            ? m_iLastAckPos - m_iStartPos
+            : m_iLastAckPos + (m_iSize - m_iStartPos);
+    }
+
+    // All further stats are valid if TSBPD is enabled.
+    if (!m_tsbpd.isEnabled())
+        return readstate;
+
+    // m_iLastAckPos points to the first unacknowledged packet
+    const int iLastAckPos = (m_iLastAckPos - 1) % m_iSize;
+    if (m_iLastAckPos != m_iStartPos && (NULL != m_pUnit[iLastAckPos]) && (m_pUnit[iLastAckPos]->m_iFlag == CUnit::GOOD))
+    {
+        readstate.tsLastAck = m_tsbpd.getPktTsbPdTime(m_pUnit[iLastAckPos]->m_Packet.getMsgTimeStamp());
+    }
+
+    const int iEndPos = (m_iLastAckPos + m_iMaxPos - 1) % m_iSize;
+    if (m_iMaxPos == 0)
+    {
+        readstate.tsEnd = readstate.tsLastAck;
+    }
+    else if ((NULL != m_pUnit[iEndPos]) && (m_pUnit[iEndPos]->m_iFlag == CUnit::GOOD))
+    {
+        readstate.tsEnd = m_tsbpd.getPktTsbPdTime(m_pUnit[iEndPos]->m_Packet.getMsgTimeStamp());
+    }
+
+    return readstate;
+}
+
 void CRcvBuffer::dropMsg(int32_t msgno, bool using_rexmit_flag)
 {
     for (int i = m_iStartPos, n = shift(m_iLastAckPos, m_iMaxPos); i != n; i = shiftFwd(i))

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -348,6 +348,18 @@ public:
     /// @return size (bytes) of payload size
     unsigned getRcvAvgPayloadSize() const;
 
+
+    struct ReadingState
+    {
+        time_point tsStart;
+        time_point tsLastAck;
+        time_point tsEnd;
+        int numAcknowledged;
+        int numUnacknowledged;
+    };
+
+    ReadingState debugGetReadingState() const;
+
     /// Mark the message to be dropped from the message list.
     /// @param [in] msgno message number.
     /// @param [in] using_rexmit_flag whether the MSGNO field uses rexmit flag (if not, one more bit is part of the

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -348,17 +348,20 @@ public:
     /// @return size (bytes) of payload size
     unsigned getRcvAvgPayloadSize() const;
 
-
     struct ReadingState
     {
         time_point tsStart;
         time_point tsLastAck;
         time_point tsEnd;
-        int numAcknowledged;
-        int numUnacknowledged;
+        int iNumAcknowledged;
+        int iNumUnacknowledged;
     };
 
     ReadingState debugGetReadingState() const;
+
+    /// Form a string of the current buffer fullness state.
+    /// number of packets acknowledged, TSBPD readiness, etc.
+    std::string strFullnessState(const time_point& tsNow) const;
 
     /// Mark the message to be dropped from the message list.
     /// @param [in] msgno message number.
@@ -474,6 +477,7 @@ private:
     bool getRcvReadyMsg(time_point& w_tsbpdtime, int32_t& w_curpktseq, int upto);
 
 public:
+    /// @brief Get clock drift in microseconds.
     int64_t getDrift() const { return m_tsbpd.drift(); }
 
 public:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9622,38 +9622,12 @@ int CUDT::processData(CUnit* in_unit)
                 }
                 else
                 {
-#if ENABLE_LOGGING
-                    const time_point curtime = steady_clock::now();
-                    const CRcvBuffer::ReadingState bufstate = m_pRcvBuffer->debugGetReadingState();
-                    stringstream ss;
-
-                    ss << "Packets ACKed: " << bufstate.numAcknowledged;
-                    if (!is_zero(bufstate.tsStart) && !is_zero(bufstate.tsLastAck))
-                    {
-                        ss << " (TSBPD ready in ";
-                        ss << count_milliseconds(bufstate.tsStart - curtime);
-                        ss << " : ";
-                        ss << count_milliseconds(bufstate.tsLastAck - curtime);
-                        ss << " ms)";
-                    }
-
-                    ss << ", not ACKed: " << bufstate.numUnacknowledged;
-                    if (!is_zero(bufstate.tsStart) && !is_zero(bufstate.tsEnd))
-                    {
-                        ss << ", timespan ";
-                        ss << count_milliseconds(bufstate.tsEnd - bufstate.tsStart);
-                        ss << " ms";
-                    }
-
                     LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet: insert offset " << offset
                         << ", space avail " << avail_bufsize
                         << " (pkt.seq=" << rpkt.m_iSeqNo
                         << ", ack.seq=" << m_iRcvLastSkipAck
-                        << "). " << ss.str()
-                        << ". " SRT_SYNC_CLOCK_STR
-                        << " drift=" << m_pRcvBuffer->getDrift()
+                        << "). " << m_pRcvBuffer->strFullnessState(steady_clock::now())
                     );
-#endif
 
                     return -1;
                 }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9622,12 +9622,39 @@ int CUDT::processData(CUnit* in_unit)
                 }
                 else
                 {
-                    LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet: offset="
-                            << offset << " avail=" << avail_bufsize
-                            << " ack.seq=" << m_iRcvLastSkipAck << " pkt.seq=" << rpkt.m_iSeqNo
-                            << " rcv-remain=" << m_pRcvBuffer->debugGetSize()
-                            << " drift=" << m_pRcvBuffer->getDrift()
-                        );
+#if ENABLE_LOGGING
+                    const time_point curtime = steady_clock::now();
+                    const CRcvBuffer::ReadingState bufstate = m_pRcvBuffer->debugGetReadingState();
+                    stringstream ss;
+
+                    ss << "Packets ACKed: " << bufstate.numAcknowledged;
+                    if (!is_zero(bufstate.tsStart) && !is_zero(bufstate.tsLastAck))
+                    {
+                        ss << " (TSBPD ready in ";
+                        ss << count_milliseconds(bufstate.tsStart - curtime);
+                        ss << " : ";
+                        ss << count_milliseconds(bufstate.tsLastAck - curtime);
+                        ss << " ms)";
+                    }
+
+                    ss << ", not ACKed: " << bufstate.numUnacknowledged;
+                    if (!is_zero(bufstate.tsStart) && !is_zero(bufstate.tsEnd))
+                    {
+                        ss << ", timespan ";
+                        ss << count_milliseconds(bufstate.tsEnd - bufstate.tsStart);
+                        ss << " ms. ";
+                    }
+
+                    LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet: insert offset " << offset
+                        << ", space avail " << avail_bufsize
+                        << " (pkt.seq=" << rpkt.m_iSeqNo
+                        << ", ack.seq=" << m_iRcvLastSkipAck
+                        << "). " << ss.str()
+                        << SRT_SYNC_CLOCK_STR
+                        << " drift=" << m_pRcvBuffer->getDrift()
+                    );
+#endif
+
                     return -1;
                 }
             }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9642,7 +9642,7 @@ int CUDT::processData(CUnit* in_unit)
                     {
                         ss << ", timespan ";
                         ss << count_milliseconds(bufstate.tsEnd - bufstate.tsStart);
-                        ss << " ms.";
+                        ss << " ms";
                     }
 
                     LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet: insert offset " << offset

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9642,7 +9642,7 @@ int CUDT::processData(CUnit* in_unit)
                     {
                         ss << ", timespan ";
                         ss << count_milliseconds(bufstate.tsEnd - bufstate.tsStart);
-                        ss << " ms. ";
+                        ss << " ms.";
                     }
 
                     LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet: insert offset " << offset
@@ -9650,7 +9650,7 @@ int CUDT::processData(CUnit* in_unit)
                         << " (pkt.seq=" << rpkt.m_iSeqNo
                         << ", ack.seq=" << m_iRcvLastSkipAck
                         << "). " << ss.str()
-                        << SRT_SYNC_CLOCK_STR
+                        << ". " SRT_SYNC_CLOCK_STR
                         << " drift=" << m_pRcvBuffer->getDrift()
                     );
 #endif

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9622,11 +9622,9 @@ int CUDT::processData(CUnit* in_unit)
                 }
                 else
                 {
-                    LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet: insert offset " << offset
-                        << ", space avail " << avail_bufsize
-                        << " (pkt.seq=" << rpkt.m_iSeqNo
-                        << ", ack.seq=" << m_iRcvLastSkipAck
-                        << "). " << m_pRcvBuffer->strFullnessState(steady_clock::now())
+                    LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet seqno " << rpkt.m_iSeqNo
+                        << ", insert offset " << offset << ". "
+                        << m_pRcvBuffer->strFullnessState(steady_clock::now())
                     );
 
                     return -1;


### PR DESCRIPTION
### Problem Statement

The current "no room to store incoming packet" log message format does not provide enough hints to define the reason.

```shell
SRT.qr: @246279816:No room to store incoming packet: offset=1 avail=1
        ack.seq=864548218 pkt.seq=864548219 rcv-remain=25598 drift=-768
```

### Proposed Log Message

**Log level: warning** (as before).

1) Example log message when the app is not reading fast enough:

```shell
No room to store incoming packet seqno 1887365986, insert offset 1711. Space avail 190/849 pkts.
    Packets ACKed: 658 (TSBPD ready in -1680 : -1219 ms), not ACKed: 0, timespan 460 ms. STDCXX_STEADY drift 0 ms.
```
TSBPD ready in -1680 : -1219 ms indicates that there are 658 packets available for reading for already at least 1.6 seconds.

2) Example log message when there is almost nothing for the app to read, and not enough receiver buffer. Knowing the configured `SRT_RCVLATENCY` is 1s, it can be seen the timestamp of the receiver buffer is less (593 ms). The first packet can be read only in 383 ms, which means the current target buffering delay is 593 + 383 = 976ms.
```
No room to store incoming packet seqno 2027222264, insert offset 0. Space avail 0/849 pkts.
    Packets ACKed: 848 (TSBPD ready in 383 : 977 ms), not ACKed: 0, timespan 593 ms. STDCXX_STEADY drift 0 ms.
```

Related issue #409

### Possible Reasons for Not Enough Room

Possible reasons for not having enough room for an incoming packet are the following.

#### 1. Receiving Application Is Not Reading

Data is available to be read from SRT socket, but the application is not reading or not reading fast enough. Excessive data is accumulated in the receiver buffer (above the buffering latency).

**Need** a way to tell how many packets are available for reading (including TSBPD readiness).

#### 2.  TSBPD-related:

SRT receiving application is reading fast enough, but there is not enough space to apply the buffering latency for the incoming bitrate.

Possible reasons:

1. Wrong configuration of the receiver buffer size. Must be at least `(latency_ms + rtt_ms / 2) * bps / 1000 / 8`.
2. RTT on the link has decreased -> buffering more than `SRTO_RCVLATENCY`.
3. DriftTracer changed the TSBPD base time, thus changing the buffering delay.

The actual receiver buffer timespan (`stats.msRcvBuf` + 10ms of unACKed packets) should roughly correspond to the `SRTO_RCVLATENCY`.
**Need** a way to tell how many packets (in ms timespan) are not yet available for reading.