### PR TITLE
[test] Fixed usage of _S symbol as UDL

### DIFF
--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -4,6 +4,7 @@
 #include "srt.h"
 #include "netinet_any.h"
 
+#undef _S
 inline std::string operator "" _S(const char* src, std::size_t)
 {
     return std::string(src);


### PR DESCRIPTION
On some platforms `_S` is defined as a macro and causes a build break.