### PR TITLE
Build Fix.

### DIFF
--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -210,4 +210,6 @@ bool CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer);
 inline void PacketFilter::feedSource(CPacket& w_packet) { SRT_ASSERT(m_filter); return m_filter->feedSource((w_packet)); }
 inline SRT_ARQLevel PacketFilter::arqLevel() { SRT_ASSERT(m_filter); return m_filter->arqLevel(); }
 
+bool ParseFilterConfig(std::string s, SrtFilterConfig& out, PacketFilter::Factory** ppf);
+
 #endif


### PR DESCRIPTION
`bool ParseFilterConfig()` 3 parameter version is called in `srtcore/socketconfig.h:1072`, but there is no prototype defined for it. This causes build failures with toolchains that do not auto-create an `int ParseFilterConfig()` for calls to undefined functions. This could also cause ABI issues if `sizeof(bool) != sizeof(int)` causing potential memory access violations.