### PR TITLE
Fix use-after-free in rendezvous queue

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1009,11 +1009,6 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
                 LinkStatusInfo fi = {i->m_pUDT, i->m_iID, ccerror, i->m_PeerAddr, -1};
                 ufailed.push_back(fi);
 
-                /*
-                 * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
-                 * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
-                 * and may crash here on next pass.
-                 */
                 // i_next was preincremented, but this is guaranteed to point to
                 // the element next to erased one.
                 i_next = m_lRendezvousID.erase(i);
@@ -1100,7 +1095,13 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
     for (vector<LinkStatusInfo>::iterator i = ufailed.begin(); i != ufailed.end(); ++i)
     {
         HLOGC(cnlog.Debug, log << "updateConnStatus: COMPLETING dep objects update on failed @" << i->id);
+        /*
+         * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
+         * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
+         * and may crash on next pass.
+         */
         i->u->m_bConnecting = false;
+        remove(i->u->m_SocketID);
 
         // DO NOT close the socket here because in this case it might be
         // unable to get status from at the right moment. Also only member


### PR DESCRIPTION
./test-srt  --gtest_filter=TestEnforcedEncryption.CASE_B_2_NonBlocking*

==24654==ERROR: AddressSanitizer: heap-use-after-free on address 0x62a000000f40 at pc 0x000109e6c756 bp 0x700000512550 sp 0x700000512548
READ of size 8 at 0x62a000000f40 thread T6
    #0 0x109e6c755 in srt::sync::TimePoint<srt::sync::steady_clock>::TimePoint(srt::sync::TimePoint<srt::sync::steady_clock> const&) sync.h:189
    #1 0x109df3f6c in srt::sync::TimePoint<srt::sync::steady_clock>::TimePoint(srt::sync::TimePoint<srt::sync::steady_clock> const&) sync.h:190
    #2 0x10a1f0bfb in CRendezvousQueue::updateConnStatus(EReadStatus, EConnectStatus, CPacket const&) queue.cpp:949
    #3 0x10a1fa38a in CRcvQueue::worker(void*) queue.cpp:1337
    #4 0x7fff2032c94f in _pthread_start+0xdf (libsystem_pthread.dylib:x86_64+0x694f)
    #5 0x7fff2032847a in thread_start+0xe (libsystem_pthread.dylib:x86_64+0x247a)