### PR TITLE
SRTO_FC socket option: minimum allowed value is 32

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -219,7 +219,7 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_MAXBW`](#SRTO_MAXBW)                            |       | post     | `int64_t` | B/s     | -1            | -1..     | RW  | GSD   |
 | [`SRTO_MESSAGEAPI`](#SRTO_MESSAGEAPI)                  | 1.3.0 | pre      | `bool`    |         | true          |          | W   | GSD   |
 | [`SRTO_MININPUTBW`](#SRTO_MININPUTBW)                  | 1.4.3 | post     | `int64_t` | B/s     | 0             | 0..      | RW  | GSD   |
-| [`SRTO_MINVERSION`](#SRTO_MINVERSION)                  | 1.3.0 | pre      | `int32_t` | version | 0             | *        | W   | GSD   |
+| [`SRTO_MINVERSION`](#SRTO_MINVERSION)                  | 1.3.0 | pre      | `int32_t` | version | 0x010000      | *        | RW  | GSD   |
 | [`SRTO_MSS`](#SRTO_MSS)                                |       | pre      | `int32_t` | bytes   | 1500          | 76..     | RW  | GSD   |
 | [`SRTO_NAKREPORT`](#SRTO_NAKREPORT)                    | 1.1.0 | pre      | `bool`    |         |  *            |          | RW  | GSD+  |
 | [`SRTO_OHEADBW`](#SRTO_OHEADBW)                        | 1.0.5 | post     | `int32_t` | %       | 25            | 5..100   | RW  | GSD   |
@@ -784,11 +784,13 @@ SCTP protocol.
 
 | OptName              | Since | Restrict | Type       |  Units  | Default  | Range  | Dir | Entity |
 | -------------------- | ----- | -------- | ---------- | ------- | -------- | ------ | --- | ------ |
-| `SRTO_MINVERSION`    | 1.3.0 | pre      | `int32_t`  | version | 0        | *      | W   | GSD    |
+| `SRTO_MINVERSION`    | 1.3.0 | pre      | `int32_t`  | version | 0x010000 | *      | RW  | GSD    |
 
 The minimum SRT version that is required from the peer. A connection to a
 peer that does not satisfy the minimum version requirement will be rejected.
 See [`SRTO_VERSION`](#SRTO_VERSION) for the version format.
+
+The default value is 0x010000 (SRT v1.0.0).
 
 [Return to list](#list-of-options)
 

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -414,11 +414,15 @@ struct CSrtConfigSetter<SRTO_FC>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        int fc = cast_optval<int>(optval, optlen);
-        if (fc < 1)
+        using namespace srt_logging;
+        const int fc = cast_optval<int>(optval, optlen);
+        if (fc < co.DEF_MIN_FLIGHT_PKT)
+        {
+            LOGC(kmlog.Error, log << "SRTO_FC: minimum allowed value is 32 (provided: " << fc << ")");
             throw CUDTException(MJ_NOTSUP, MN_INVAL);
+        }
 
-        co.iFlightFlagSize = std::max(fc, +co.DEF_MIN_FLIGHT_PKT);
+        co.iFlightFlagSize = fc;
     }
 };
 


### PR DESCRIPTION
1. The minimum allowed value of `SRTO_FC` socket option is 32.
This PR makes `srt_setsockopt` to set the `SRT_EINVPARAM` and return `SRT_ERROR` if the lower value is supplied.
Previous SRT versions (v1.4.2 and below) return `SRT_SUCCESS`, but reset `SRTO_FC` to 32.

2. Documentation for `SRTO_FC` is improved.
3. Fix: `SRTO_MINVERSION` is also readable.
4. Fix: SRTO_MINVERSION default value is 1.0.0
