### PR TITLE
Fixing srt_getsockopt for bool socket options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,9 +88,9 @@ script:
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ./test-srt --gtest_filter="-TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6*";
-        source ./scripts/collect-gcov.sh;
       fi
     - if (( "$RUN_CODECOV" )); then
+        source ./scripts/collect-gcov.sh;
         bash <(curl -s https://codecov.io/bash);
       fi
     - if (( "$RUN_SONARCUBE" )); then

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -405,11 +405,13 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SNDSYN:
-        cast_set_optval(optval, optlen, m_config.bSynSending);
+        *(bool *)optval = m_config.bSynSending;
+        optlen          = sizeof(bool);
         break;
 
     case SRTO_RCVSYN:
-        cast_set_optval(optval, optlen, m_config.bSynRecving);
+        *(bool *)optval = m_config.bSynRecving;
+        optlen          = sizeof(bool);
         break;
 
     case SRTO_ISN:
@@ -451,7 +453,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_RENDEZVOUS:
-        cast_set_optval(optval, optlen, m_config.bRendezvous);
+        *(bool *)optval = m_config.bRendezvous;
+        optlen          = sizeof(bool);
         break;
 
     case SRTO_SNDTIMEO:
@@ -465,7 +468,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_REUSEADDR:
-        cast_set_optval(optval, optlen, m_config.bReuseAddr);
+        *(bool *)optval = m_config.bReuseAddr;
+        optlen          = sizeof(bool);
         break;
 
     case SRTO_MAXBW:
@@ -575,11 +579,13 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SENDER:
-        cast_set_optval(optval, optlen, m_config.bDataSender);
+        *(bool *)optval = m_config.bDataSender;
+        optlen             = sizeof(bool);
         break;
 
     case SRTO_TSBPDMODE:
-        cast_set_optval(optval, optlen, m_config.bTSBPD);
+        *(bool *)optval = m_config.bTSBPD;
+        optlen             = sizeof(bool);
         break;
 
     case SRTO_LATENCY:
@@ -601,8 +607,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_TLPKTDROP:
-        // TODO: Why not m_config.bTLPktDrop until connected?
-        cast_set_optval(optval, optlen, m_bTLPktDrop);
+        *(bool *)optval = m_bTLPktDrop;
+        optlen          = sizeof(bool);
         break;
 
     case SRTO_SNDDROPDELAY:
@@ -650,7 +656,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_NAKREPORT:
-        cast_set_optval(optval, optlen, m_config.bRcvNakReport);
+        *(bool *)optval = m_config.bRcvNakReport;
+        optlen          = sizeof(bool);
         break;
 
     case SRTO_VERSION:
@@ -669,7 +676,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_DRIFTTRACER:
-        cast_set_optval(optval, optlen, m_config.bDriftTracer);
+        *(bool*)optval = m_config.bDriftTracer;
+        optlen         = sizeof(bool);
         break;
 
     case SRTO_MINVERSION:
@@ -691,7 +699,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_MESSAGEAPI:
-        cast_set_optval(optval, optlen, m_config.bMessageAPI);
+        optlen          = sizeof(bool);
+        *(bool *)optval = m_config.bMessageAPI;
         break;
 
     case SRTO_PAYLOADSIZE:
@@ -712,7 +721,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 #endif
 
     case SRTO_ENFORCEDENCRYPTION:
-        cast_set_optval(optval, optlen, m_config.bEnforcedEnc);
+        optlen          = sizeof(bool);
+        *(bool *)optval = m_config.bEnforcedEnc;
         break;
 
     case SRTO_IPV6ONLY:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -579,13 +579,13 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SENDER:
-        *(int32_t *)optval = m_config.bDataSender;
-        optlen             = sizeof(int32_t);
+        *(bool *)optval = m_config.bDataSender;
+        optlen             = sizeof(bool);
         break;
 
     case SRTO_TSBPDMODE:
-        *(int32_t *)optval = m_config.bTSBPD;
-        optlen             = sizeof(int32_t);
+        *(bool *)optval = m_config.bTSBPD;
+        optlen             = sizeof(bool);
         break;
 
     case SRTO_LATENCY:
@@ -676,8 +676,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_DRIFTTRACER:
-        *(int*)optval = m_config.bDriftTracer;
-        optlen        = sizeof(int);
+        *(bool*)optval = m_config.bDriftTracer;
+        optlen         = sizeof(bool);
         break;
 
     case SRTO_MINVERSION:
@@ -721,8 +721,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 #endif
 
     case SRTO_ENFORCEDENCRYPTION:
-        optlen             = sizeof(int32_t); // also with TSBPDMODE and SENDER
-        *(int32_t *)optval = m_config.bEnforcedEnc;
+        optlen          = sizeof(bool);
+        *(bool *)optval = m_config.bEnforcedEnc;
         break;
 
     case SRTO_IPV6ONLY:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -405,13 +405,11 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SNDSYN:
-        *(bool *)optval = m_config.bSynSending;
-        optlen          = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bSynSending);
         break;
 
     case SRTO_RCVSYN:
-        *(bool *)optval = m_config.bSynRecving;
-        optlen          = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bSynRecving);
         break;
 
     case SRTO_ISN:
@@ -453,8 +451,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_RENDEZVOUS:
-        *(bool *)optval = m_config.bRendezvous;
-        optlen          = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bRendezvous);
         break;
 
     case SRTO_SNDTIMEO:
@@ -468,8 +465,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_REUSEADDR:
-        *(bool *)optval = m_config.bReuseAddr;
-        optlen          = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bReuseAddr);
         break;
 
     case SRTO_MAXBW:
@@ -579,13 +575,11 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_SENDER:
-        *(bool *)optval = m_config.bDataSender;
-        optlen             = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bDataSender);
         break;
 
     case SRTO_TSBPDMODE:
-        *(bool *)optval = m_config.bTSBPD;
-        optlen             = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bTSBPD);
         break;
 
     case SRTO_LATENCY:
@@ -607,8 +601,8 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_TLPKTDROP:
-        *(bool *)optval = m_bTLPktDrop;
-        optlen          = sizeof(bool);
+        // TODO: Why not m_config.bTLPktDrop until connected?
+        cast_set_optval(optval, optlen, m_bTLPktDrop);
         break;
 
     case SRTO_SNDDROPDELAY:
@@ -656,8 +650,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_NAKREPORT:
-        *(bool *)optval = m_config.bRcvNakReport;
-        optlen          = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bRcvNakReport);
         break;
 
     case SRTO_VERSION:
@@ -676,8 +669,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_DRIFTTRACER:
-        *(bool*)optval = m_config.bDriftTracer;
-        optlen         = sizeof(bool);
+        cast_set_optval(optval, optlen, m_config.bDriftTracer);
         break;
 
     case SRTO_MINVERSION:
@@ -699,8 +691,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_MESSAGEAPI:
-        optlen          = sizeof(bool);
-        *(bool *)optval = m_config.bMessageAPI;
+        cast_set_optval(optval, optlen, m_config.bMessageAPI);
         break;
 
     case SRTO_PAYLOADSIZE:
@@ -721,8 +712,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 #endif
 
     case SRTO_ENFORCEDENCRYPTION:
-        optlen          = sizeof(bool);
-        *(bool *)optval = m_config.bEnforcedEnc;
+        cast_set_optval(optval, optlen, m_config.bEnforcedEnc);
         break;
 
     case SRTO_IPV6ONLY:

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -390,39 +390,6 @@ inline bool cast_optval(const void* optval, int optlen)
     return false;
 }
 
-/// @brief Sets optval and optlen to the value provided and its type size
-/// @tparam T value type (int, bool, etc.)
-/// @param[in,out] optval will be set to the value provided
-/// @param[in,out] optlen the length of the optval, will be set according to type T
-/// @param[in] value The value to be set in optval 
-template <typename T>
-inline void cast_set_optval(void* optval, int& optlen, const T& value)
-{
-    *reinterpret_cast<T*>(optval) = value;
-    optlen = sizeof(T);
-}
-
-template <>
-inline void cast_set_optval(void* optval, int& optlen, const bool& value)
-{
-    using namespace srt_logging;
-    if (optlen == 0 || optlen == sizeof(bool))
-    {
-        *reinterpret_cast<bool*>(optval) = value;
-        optlen = sizeof(bool);
-    }
-    else if (optlen >= sizeof(int))
-    {
-        *reinterpret_cast<int*>(optval) = value;
-        optlen = sizeof(int);
-    }
-    else
-    {
-        LOGC(kmlog.Error, log << "Wrong optlen provided: expecting 0,1 (bool) or 4 (int)");
-        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-    }
-}
-
 template<>
 struct CSrtConfigSetter<SRTO_MSS>
 {

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -390,6 +390,39 @@ inline bool cast_optval(const void* optval, int optlen)
     return false;
 }
 
+/// @brief Sets optval and optlen to the value provided and its type size
+/// @tparam T value type (int, bool, etc.)
+/// @param[in,out] optval will be set to the value provided
+/// @param[in,out] optlen the length of the optval, will be set according to type T
+/// @param[in] value The value to be set in optval 
+template <typename T>
+inline void cast_set_optval(void* optval, int& optlen, const T& value)
+{
+    *reinterpret_cast<T*>(optval) = value;
+    optlen = sizeof(T);
+}
+
+template <>
+inline void cast_set_optval(void* optval, int& optlen, const bool& value)
+{
+    using namespace srt_logging;
+    if (optlen == 0 || optlen == sizeof(bool))
+    {
+        *reinterpret_cast<bool*>(optval) = value;
+        optlen = sizeof(bool);
+    }
+    else if (optlen >= sizeof(int))
+    {
+        *reinterpret_cast<int*>(optval) = value;
+        optlen = sizeof(int);
+    }
+    else
+    {
+        LOGC(kmlog.Error, log << "Wrong optlen provided: expecting 0,1 (bool) or 4 (int)");
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    }
+}
+
 template<>
 struct CSrtConfigSetter<SRTO_MSS>
 {

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -277,10 +277,10 @@ public:
     bool GetEnforcedEncryption(PEER_TYPE peer_type)
     {
         const SRTSOCKET socket = peer_type == PEER_CALLER ? m_caller_socket : m_listener_socket;
-        int value = -1;
-        int value_len = sizeof value;
-        EXPECT_EQ(srt_getsockopt(socket, 0, SRTO_ENFORCEDENCRYPTION, (void*)&value, &value_len), SRT_SUCCESS);
-        return value ? true : false;
+        bool optval;
+        int  optlen = sizeof optval;
+        EXPECT_EQ(srt_getsockopt(socket, 0, SRTO_ENFORCEDENCRYPTION, (void*)&optval, &optlen), SRT_SUCCESS);
+        return optval ? true : false;
     }
 
 
@@ -503,8 +503,8 @@ private:
 
     int       m_pollid          = 0;
 
-    const int s_yes = 1;
-    const int s_no  = 0;
+    const bool s_yes = true;
+    const bool s_no  = false;
 
     const bool          m_is_tracing = false;
     static const char*  m_km_state[];


### PR DESCRIPTION
In `srt_getsockopt(..)` API function these `bool` socket options were actually using `int` type when casting the `optval`, which may lead to writing outsize the memory of the `optval` when `bool` is provided.
- `SRTO_SENDER`
- `SRTO_TSBPDMODE`
- `SRTO_DRIFTTRACER`
- `SRTO_ENFORCEDENCRYPTION`

This PR changes types to `bool` if `optlen` is zero of `sizeof(bool)`, otherwise casts to `int`.

### ABI Change

Fixing cast to bool is the lesser evil compared to potential outside-of-memory writing.
This change however affects SRT API a bit and might lead to certain upgrading difficulties.
Both FFMpeg and GStreamer should not get into trouble with this change, as they only get the value of `SRTO_PAYLOADSIZE`.

Still, the output `optlen` should provide a hint of how many bytes were actually set by `srt_getsockopt(..)` function.

Note that the type used to set those `bool` options is still `int` there, as both `int` and `bool` types are supported in `srt_setsockopt(..)`.

### TODO

- [x] Consider if this breaks ABI compatibility with previous SRT versions
- [x] Check `srt_getopt` for `SRTO_TLPKTDROP`: does not use the value from config (to be addressed separately).