### PR TITLE
Moved some code from processCtrl to dedicated functions

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8399,6 +8399,19 @@ void CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
     }
 }
 
+void CUDT::processCtrlShutdown(const CPacket& ctrlpkt)
+{
+    m_bShutdown = true;
+    m_bClosing = true;
+    m_bBroken = true;
+    m_iBrokenCounter = 60;
+
+    // This does the same as it would happen on connection timeout,
+    // just we know about this state prematurely thanks to this message.
+    updateBrokenConnection();
+    completeBrokenConnectionDependencies(SRT_ECONNLOST); // LOCKS!
+}
+
 void CUDT::processCtrl(const CPacket &ctrlpkt)
 {
     // Just heard from the peer, reset the expiration count.
@@ -8443,15 +8456,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
         break;
 
     case UMSG_SHUTDOWN: // 101 - Shutdown
-        m_bShutdown      = true;
-        m_bClosing       = true;
-        m_bBroken        = true;
-        m_iBrokenCounter = 60;
-
-        // This does the same as it would happen on connection timeout,
-        // just we know about this state prematurely thanks to this message.
-        updateBrokenConnection();
-        completeBrokenConnectionDependencies(SRT_ECONNLOST); // LOCKS!
+        processCtrlShutdown(ctrlpkt);
         break;
 
     case UMSG_DROPREQ: // 111 - Msg drop request

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -973,6 +973,10 @@ private: // Generation and processing of packets
     /// @param ctrlpkt incoming shutdown packet
     void processCtrlShutdown(const CPacket& ctrlpkt);
 
+    /// @brief Process incoming user defined control packet
+    /// @param ctrlpkt incoming user defined packet
+    void processCtrlUserDefined(const CPacket& ctrlpkt);
+
     /// @brief Update sender's loss list on an incoming acknowledgement.
     /// @param ackdata_seqno    sequence number of a data packet being acknowledged
     void updateSndLossListOnACK(int32_t ackdata_seqno);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -969,6 +969,10 @@ private: // Generation and processing of packets
     /// @param ctrlpkt incoming drop request packet
     void processCtrlDropReq(const CPacket& ctrlpkt);
 
+    /// @brief Process incoming shutdown control packet
+    /// @param ctrlpkt incoming shutdown packet
+    void processCtrlShutdown(const CPacket& ctrlpkt);
+
     /// @brief Update sender's loss list on an incoming acknowledgement.
     /// @param ackdata_seqno    sequence number of a data packet being acknowledged
     void updateSndLossListOnACK(int32_t ackdata_seqno);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -943,13 +943,25 @@ private: // Generation and processing of packets
     ///
     /// @returns the nmber of packets sent.
     int  sendCtrlAck(CPacket& ctrlpkt, int size);
+    void sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& losslist);
 
     void processCtrl(const CPacket& ctrlpkt);
-    void sendLossReport(const std::vector< std::pair<int32_t, int32_t> >& losslist);
-    void processCtrlAck(const CPacket& ctrlpkt, const time_point &currtime);
+    
+    /// @brief Process incoming control ACK packet.
+    /// @param ctrlpkt incoming packet
+    /// @param currtime current clock time
+    void processCtrlAck(const CPacket& ctrlpkt, const time_point& currtime);
+
+    /// @brief Process incoming control ACKACK packet.
+    /// @param ctrlpkt incoming packet
+    /// @param tsArrival time when packet has arrived (used to calculate RTT)
+    void processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival);
+
+    /// @brief Process incoming loss report (NAK) packet.
+    /// @param ctrlpkt incoming NAK packet
     void processCtrlLossReport(const CPacket& ctrlpkt);
 
-    ///
+    /// @brief Update sender's loss list on an incoming acknowledgement.
     /// @param ackdata_seqno    sequence number of a data packet being acknowledged
     void updateSndLossListOnACK(int32_t ackdata_seqno);
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -965,6 +965,10 @@ private: // Generation and processing of packets
     /// @param ctrlpkt incoming HS packet
     void processCtrlHS(const CPacket& ctrlpkt);
 
+    /// @brief Process incoming drop request control packet
+    /// @param ctrlpkt incoming drop request packet
+    void processCtrlDropReq(const CPacket& ctrlpkt);
+
     /// @brief Update sender's loss list on an incoming acknowledgement.
     /// @param ackdata_seqno    sequence number of a data packet being acknowledged
     void updateSndLossListOnACK(int32_t ackdata_seqno);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -948,18 +948,22 @@ private: // Generation and processing of packets
     void processCtrl(const CPacket& ctrlpkt);
     
     /// @brief Process incoming control ACK packet.
-    /// @param ctrlpkt incoming packet
+    /// @param ctrlpkt incoming ACK packet
     /// @param currtime current clock time
     void processCtrlAck(const CPacket& ctrlpkt, const time_point& currtime);
 
     /// @brief Process incoming control ACKACK packet.
-    /// @param ctrlpkt incoming packet
+    /// @param ctrlpkt incoming ACKACK packet
     /// @param tsArrival time when packet has arrived (used to calculate RTT)
     void processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival);
 
     /// @brief Process incoming loss report (NAK) packet.
     /// @param ctrlpkt incoming NAK packet
     void processCtrlLossReport(const CPacket& ctrlpkt);
+
+    /// @brief Process incoming handshake control packet
+    /// @param ctrlpkt incoming HS packet
+    void processCtrlHS(const CPacket& ctrlpkt);
 
     /// @brief Update sender's loss list on an incoming acknowledgement.
     /// @param ackdata_seqno    sequence number of a data packet being acknowledged


### PR DESCRIPTION
Minor refactoring of `CUDT::processCtrl(..)` function:
- moved code to processCtrlAckAck
- moved code to processCtrlHS
- moved code to processCtrlDropReq
- moved code to processCtrlShutdown
- moved code to processCtrlUserDefined