### PR TITLE
[apps] Changed the default log level to Warn

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -290,7 +290,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         PrintOptionHelp(o_statsout,  "<filename>", "output stats to file");
         PrintOptionHelp(o_statspf,   "<format=default>", "stats printing format {json, csv, default}");
         PrintOptionHelp(o_statsfull, "", "full counters in stats-report (prints total statistics)");
-        PrintOptionHelp(o_loglevel,  "<level=error>", "log level {fatal,error,info,note,warning}");
+        PrintOptionHelp(o_loglevel,  "<level=warn>", "log level {fatal,error,warn,note,info,debug}");
         PrintOptionHelp(o_logfa,     "<fas>", "log functional area (see '-h logging' for more info)");
         //PrintOptionHelp(o_log_internal, "", "use internal logger");
         PrintOptionHelp(o_logfile, "<filename="">", "write logs to file");
@@ -345,7 +345,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
     }
 
     cfg.full_stats   = OptionPresent(params, o_statsfull);
-    cfg.loglevel     = SrtParseLogLevel(Option<OutString>(params, "error", o_loglevel));
+    cfg.loglevel     = SrtParseLogLevel(Option<OutString>(params, "warn", o_loglevel));
     cfg.logfas       = SrtParseLogFA(Option<OutString>(params, "", o_logfa));
     cfg.log_internal = OptionPresent(params, o_log_internal);
     cfg.logfile      = Option<OutString>(params, o_logfile);

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -369,7 +369,7 @@ shell (using **"** **"** quotes or backslash).
 - **-statsout** - SRT statistics output: filename. Without this option specified, the statistics will be printed to the standard output.
 - **-pf**, **-statspf** - SRT statistics print format. Values: json, csv, default. After a comma, options can be specified (e.g. "json,pretty").
 - **-s**, **-stats**, **-stats-report-frequency** - The frequency of SRT statistics collection, based on the number of packets.
-- **-loglevel** - lowest logging level for SRT, one of: *fatal, error, warning, note, debug* (default: *error*)
+- **-loglevel** - lowest logging level for SRT, one of: *fatal, error, warn, note, debug* (default: *warn*)
 - **-logfa, -lfa** - selected FAs in SRT to be logged (default: all are enabled). See the list of FAs running `-help:logging`.
 - **-logfile:logs.txt** - Output of logs is written to file logs.txt instead of being printed to `stderr`.
 - **-help, -h** - Show help.


### PR DESCRIPTION
Some error messages were downgraded to "warn" level in some previous PRs (#1271 May 8, 2020). SRT v1.4.2 and above.
For example, the "No room to store incoming packet.." has the "warn" level ([see here](https://github.com/Haivision/srt/blob/v1.4.3-rc.0/srtcore/core.cpp#L9326)).

By default, `srt-live-transmit` shows only error messages, which makes some important logs invisible.
This PR changes the default log level of `srt-live-transmit` to "warn".