### PR TITLE
[core] SRTO_CONGESTION: Check optlen in getsockopt

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -694,6 +694,9 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_CONGESTION:
+        if (size_t(optlen) < m_config.sCongestion.size() + 1)
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+
         strcpy((char *)optval, m_config.sCongestion.c_str());
         optlen = (int) m_config.sCongestion.size();
         break;


### PR DESCRIPTION
Return an error if `optlen` passed in `srt_getsockopt(..)` for `SRTO_CONGESTION` is not big enough to fit the string value of an option (effectively four chars + one null-terminating character).