### PR TITLE
[docs] API-functions: pass optlen in srt_getsockopt

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -1558,24 +1558,29 @@ port number after it has been autoselected.
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)
 
 ---  
-  
+
 ### srt_getsockopt
 ### srt_getsockflag
-```
+
+```c++
 int srt_getsockopt(SRTSOCKET u, int level /*ignored*/, SRT_SOCKOPT opt, void* optval, int* optlen);
 int srt_getsockflag(SRTSOCKET u, SRT_SOCKOPT opt, void* optval, int* optlen);
 ```
 
-Gets the value of the given socket option (from a socket or a group). 
+Gets the value of the given socket option (from a socket or a group).
 
-The first version ([`srt_getsockopt`](#srt_getsockopt)) respects the BSD socket 
-API convention, although the "level" parameter is ignored. The second version 
+The first version ([`srt_getsockopt`](#srt_getsockopt)) follows the BSD socket
+API convention, although the "level" parameter is ignored. The second version
 ([`srt_getsockflag`](#srt_getsockflag)) omits the "level" parameter completely.
 
-Options correspond to various data types, so you need to know what data type is 
-assigned to a particular option, and to pass a variable of the appropriate data 
-type. Specifications are provided in the `apps/socketoptions.hpp` file at the 
-`srt_options` object declaration.
+Options correspond to various data types (see [API-socket-options.md](#API-socket-options.md)).
+A variable `oprval` of the appropriate data type has to be passed.
+The integer value of `optlen` should originally contain the size of `optval` type provided;
+on return, it will be set to the size of the value returned.
+For most options, it will be the size of an integer. Some option, however, use `bool`, `int64_t`, `string` etc. types
+(see [API-socket-options.md](#API-socket-options.md)).
+
+The application is responsible for allocating sufficient memory space pointed by `optval`.
 
 |      Returns                  |                                                           |
 |:----------------------------- |:--------------------------------------------------------- |
@@ -1586,7 +1591,7 @@ type. Specifications are provided in the `apps/socketoptions.hpp` file at the
 |:-------------------------------- |:---------------------------------------------- |
 | [`SRT_EINVSOCK`](#srt_einvsock)  | Socket [`u`](#u) indicates no valid socket ID  |
 | [`SRT_EINVOP`](#srt_einvop)      | Option `opt` indicates no valid option         |
-| <img width=240px height=1px/>    | <img width=710px height=1px/>                      |
+| <img width=240px height=1px/>    | <img width=710px height=1px/>                  |
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)
@@ -1595,19 +1600,19 @@ type. Specifications are provided in the `apps/socketoptions.hpp` file at the
 ### srt_setsockopt
 ### srt_setsockflag
 
-```
+```c++
 int srt_setsockopt(SRTSOCKET u, int level /*ignored*/, SRT_SOCKOPT opt, const void* optval, int optlen);
 int srt_setsockflag(SRTSOCKET u, SRT_SOCKOPT opt, const void* optval, int optlen);
 ```
 
-Sets a value for a socket option in the socket or group. 
+Sets a value for a socket option in the socket or group.
 
-The first version ([`srt_setsockopt`](#srt_setsockopt)) respects the BSD socket 
-API convention, although the "level" parameter is ignored. The second version 
+The first version ([`srt_setsockopt`](#srt_setsockopt)) follows the BSD socket
+API convention, although the "level" parameter is ignored. The second version
 ([`srt_setsockflag`](#srt_setsockflag)) omits the "level" parameter completely.
 
-Options correspond to various data types, so you need to know what data type is 
-assigned to a particular option, and to pass a variable of the appropriate data 
+Options correspond to various data types, so you need to know what data type is
+assigned to a particular option, and to pass a variable of the appropriate data
 type with the option value to be set.
 
 Please note that some of the options can only be set on sockets or only on
@@ -1619,14 +1624,16 @@ are then derived by the member sockets.
 | `SRT_ERROR`                   | (-1) in case of error, otherwise 0              |
 | <img width=240px height=1px/> | <img width=710px height=1px/>                   |
 
-|       Errors                    |                                               |
-|:------------------------------- |:--------------------------------------------- |
-| [`SRT_EINVSOCK`](#srt_einvsock) | Socket [`u`](#u) indicates no valid socket ID |
-| [`SRT_EINVOP`](#srt_einvop)     | Option `opt` indicates no valid option        |
+|       Errors                        |                                               |
+|:----------------------------------- |:--------------------------------------------- |
+| [`SRT_EINVSOCK`](#srt_einvsock)     | Socket [`u`](#u) indicates no valid socket ID |
+| [`SRT_EINVPARAM`](#srt_einvparam)   | Option `opt` indicates no valid option        |
+| [`SRT_EBOUNDSOCK`](#srt_eboundsock) | Tried to set an option with PRE_BIND restriction on a bound socket. |
+| [`SRT_ECONNSOCK`](#srt_econnsock)   | Tried to set an option with PRE_BIND or PRE restriction on a socket in connecting/listening/connected state. |
 | <img width=240px height=1px/>   | <img width=710px height=1px/>                 |
 
-**NOTE*: Various other errors may result from problems when setting a 
-specific option (see option description for details).
+**NOTE*: Various other errors may result from problems when setting a
+specific option (see option description in [API-socket-options.md](#API-socket-options.md) for details).
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -1633,7 +1633,7 @@ are then derived by the member sockets.
 | <img width=240px height=1px/>   | <img width=710px height=1px/>                 |
 
 **NOTE*: Various other errors may result from problems when setting a
-specific option (see option description in [API-socket-options.md](#API-socket-options.md) for details).
+specific option (see option description in [API-socket-options.md](./API-socket-options.md) for details).
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -1580,7 +1580,7 @@ on return, it will be set to the size of the value returned.
 For most options, it will be the size of an integer. Some options, however, use types `bool`, `int64_t`, `C string`, etc.
 (see [API-socket-options.md](./API-socket-options.md#sockopt_types)).
 
-The application is responsible for allocating sufficient memory space pointed by `optval`.
+The application is responsible for allocating sufficient memory space as defined and pointed to by `optval`.
 
 |      Returns                  |                                                           |
 |:----------------------------- |:--------------------------------------------------------- |

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -1573,12 +1573,12 @@ The first version ([`srt_getsockopt`](#srt_getsockopt)) follows the BSD socket
 API convention, although the "level" parameter is ignored. The second version
 ([`srt_getsockflag`](#srt_getsockflag)) omits the "level" parameter completely.
 
-Options correspond to various data types (see [API-socket-options.md](#API-socket-options.md)).
-A variable `oprval` of the appropriate data type has to be passed.
-The integer value of `optlen` should originally contain the size of `optval` type provided;
+Options correspond to various data types (see [API-socket-options.md](./API-socket-options.md)).
+A variable `optval` of the appropriate data type has to be passed.
+The integer value of `optlen` should originally contain the size of the `optval` type provided;
 on return, it will be set to the size of the value returned.
-For most options, it will be the size of an integer. Some option, however, use `bool`, `int64_t`, `string` etc. types
-(see [API-socket-options.md](#API-socket-options.md)).
+For most options, it will be the size of an integer. Some options, however, use types `bool`, `int64_t`, `C string`, etc.
+(see [API-socket-options.md](./API-socket-options.md#sockopt_types)).
 
 The application is responsible for allocating sufficient memory space pointed by `optval`.
 

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -7,31 +7,32 @@ to the system `setsockopt/getsockopt` functions.
 - [Getting and Setting Options](#getting-and-setting-options)
 - [List of Options](#list-of-options)
 
-## Types Used in Socket Options
+## Types Used in Socket Options <a name="sockopt_types"></a>
 
 Possible types of socket options are:
 
-- `int32_t` - This type can usually be treated as an `int` equivalent since it 
-does not change size on 64-bit systems. For clarity, options use this fixed size 
-integer. In some cases the value is expressed using an enumeration type (see below).
+- `int32_t` - a 32-bit integer. On most systems similar to `int`.
+In some cases the value is expressed using an enumeration type
+(see [Enumeration types...](#enumeration_types) section below).
 
-- `int64_t` - Some options need the parameter specified as 64-bit integer.
+- `int64_t` - a 64-bit integer.
 
-- `bool` - Requires the use of a boolean type (`<stdbool.h>` for C, or built-in
+- `bool` - a Boolean type (`<stdbool.h>` for C, or built-in
 for C++). When *setting* an option, passing the value through an `int` type is
-also properly recognized. When *getting* an option, however, you should use the
-`bool` type, although you can risk passing a variable of `int` type initialized
-with 0 and then checking if the resulting value is equal to 0 (just don't compare
-the result with 1).
+also properly recognized. When *getting* an option, however, the`bool` type
+should be used. It is also possible to pass a variable of `int` type initialized
+with 0 and then comparing the resulting value with 0 (just don't compare
+the result with 1 or `true`).
 
-- `string` - When *setting* an option, pass the character array pointer as value
-and the string length as length. When *getting*, pass an array of sufficient size
-(as specified in the size variable). Every option with this type that can be
-read should specify the maximum length of that array.
+- `string` - a C string. When *setting* an option, a `const char*` character array pointer
+is expected to be passed in `optval` and the array length in `optlen` **without the terminating NULL character**.
+When *getting*, an array is expected to be passed in `optval` with a
+sufficient size **with an extra space for the terminating NULL character** provided in `optlen`.
+The return value of `optlen` does not count the terminating NULL character.
 
 - `linger` - Linger structure. Used exclusively with `SRTO_LINGER`.
 
-### Enumeration Types Used in Options
+### Enumeration Types Used in Options <a name="enumeration_types"></a>
 
 #### `SRT_TRANSTYPE`
 


### PR DESCRIPTION
Improved the documentation of `srt_getsockopt(..)` advising to pass the size of `optval` in `optlen`.
The first step towards #1819 (checking `optlen` provided in `srt_getsockopt(..)`).

Also defines missing error codes for `srt_setsockopt(..)` function.

Added some guidelines for handling C string type options.

Depends on #1939: PRE restriction in "listening" state.