### PR TITLE
[core] const SrtOptionAction

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -216,7 +216,7 @@ struct SrtOptionAction
     }
 };
 
-const SrtOptionAction g_sockopt_action;
+const SrtOptionAction s_sockopt_action;
 
 } // namespace srt
 
@@ -304,9 +304,9 @@ CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
     m_config            = ancestor.m_config;
     // Reset values that shall not be derived to default ones.
     // These declarations should be consistent with SRTO_R_PRIVATE flag.
-    for (size_t i = 0; i < Size(g_sockopt_action.flags); ++i)
+    for (size_t i = 0; i < Size(s_sockopt_action.flags); ++i)
     {
-        const string* pdef = map_getp(g_sockopt_action.private_default, SRT_SOCKOPT(i));
+        const string* pdef = map_getp(s_sockopt_action.private_default, SRT_SOCKOPT(i));
         if (pdef)
         {
             try
@@ -349,12 +349,12 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-    // Match check (confirm optName as index for g_sockopt_action)
+    // Match check (confirm optName as index for s_sockopt_action)
     if (int(optName) < 0 || int(optName) >= int(SRTO_E_SIZE))
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
     // Restriction check
-    const int oflags = g_sockopt_action.flags[optName];
+    const int oflags = s_sockopt_action.flags[optName];
 
     ScopedLock cg (m_ConnectionLock);
     ScopedLock sendguard (m_SendLock);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -210,8 +210,9 @@ struct SrtOptionAction
         // passed to a setting function.
         private_default[SRTO_STREAMID] = string();
     }
-}
-srt_options_action;
+};
+
+static const SrtOptionAction s_srt_option_action;
 
 
 void CUDT::construct()
@@ -297,9 +298,9 @@ CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
     m_config            = ancestor.m_config;
     // Reset values that shall not be derived to default ones.
     // These declarations should be consistent with SRTO_R_PRIVATE flag.
-    for (size_t i = 0; i < Size(srt_options_action.flags); ++i)
+    for (size_t i = 0; i < Size(s_srt_option_action.flags); ++i)
     {
-        string* pdef = map_getp(srt_options_action.private_default, SRT_SOCKOPT(i));
+        const string* pdef = map_getp(s_srt_option_action.private_default, SRT_SOCKOPT(i));
         if (pdef)
         {
             try
@@ -342,12 +343,12 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-    // Match check (confirm optName as index for srt_options_action)
+    // Match check (confirm optName as index for s_srt_option_action)
     if (int(optName) < 0 || int(optName) >= int(SRTO_E_SIZE))
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
     // Restriction check
-    const int oflags = srt_options_action.flags[optName];
+    const int oflags = s_srt_option_action.flags[optName];
 
     ScopedLock cg (m_ConnectionLock);
     ScopedLock sendguard (m_SendLock);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -130,10 +130,14 @@ extern const SRT_SOCKOPT srt_post_opt_list [SRT_SOCKOPT_NPOST] = {
     SRTO_LOSSMAXTTL
 };
 
-static const int32_t
+const int32_t
     SRTO_R_PREBIND = BIT(0), //< cannot be modified after srt_bind()
     SRTO_R_PRE = BIT(1),     //< cannot be modified after connection is established
     SRTO_POST_SPEC = BIT(2); //< executes some action after setting the option
+
+
+namespace srt
+{
 
 struct SrtOptionAction
 {
@@ -212,7 +216,9 @@ struct SrtOptionAction
     }
 };
 
-static const SrtOptionAction s_srt_option_action;
+const SrtOptionAction g_sockopt_action;
+
+} // namespace srt
 
 
 void CUDT::construct()
@@ -298,9 +304,9 @@ CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
     m_config            = ancestor.m_config;
     // Reset values that shall not be derived to default ones.
     // These declarations should be consistent with SRTO_R_PRIVATE flag.
-    for (size_t i = 0; i < Size(s_srt_option_action.flags); ++i)
+    for (size_t i = 0; i < Size(g_sockopt_action.flags); ++i)
     {
-        const string* pdef = map_getp(s_srt_option_action.private_default, SRT_SOCKOPT(i));
+        const string* pdef = map_getp(g_sockopt_action.private_default, SRT_SOCKOPT(i));
         if (pdef)
         {
             try
@@ -343,12 +349,12 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-    // Match check (confirm optName as index for s_srt_option_action)
+    // Match check (confirm optName as index for g_sockopt_action)
     if (int(optName) < 0 || int(optName) >= int(SRTO_E_SIZE))
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
     // Restriction check
-    const int oflags = s_srt_option_action.flags[optName];
+    const int oflags = g_sockopt_action.flags[optName];
 
     ScopedLock cg (m_ConnectionLock);
     ScopedLock sendguard (m_SendLock);

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -123,11 +123,11 @@ static int count_subsecond_precision(int64_t ticks_per_us)
     return signs;
 }
 
-const int64_t g_clock_ticks_per_us = get_cpu_frequency();
+const int64_t s_clock_ticks_per_us = get_cpu_frequency();
 
-const int g_clock_subsecond_precision = count_subsecond_precision(g_clock_ticks_per_us);
+const int s_clock_subsecond_precision = count_subsecond_precision(s_clock_ticks_per_us);
 
-int clockSubsecondPrecision() { return g_clock_subsecond_precision; }
+int clockSubsecondPrecision() { return s_clock_subsecond_precision; }
 
 } // namespace sync
 } // namespace srt
@@ -167,32 +167,32 @@ srt::sync::TimePoint<srt::sync::steady_clock> srt::sync::steady_clock::now()
 
 int64_t srt::sync::count_microseconds(const steady_clock::duration& t)
 {
-    return t.count() / g_clock_ticks_per_us;
+    return t.count() / s_clock_ticks_per_us;
 }
 
 int64_t srt::sync::count_milliseconds(const steady_clock::duration& t)
 {
-    return t.count() / g_clock_ticks_per_us / 1000;
+    return t.count() / s_clock_ticks_per_us / 1000;
 }
 
 int64_t srt::sync::count_seconds(const steady_clock::duration& t)
 {
-    return t.count() / g_clock_ticks_per_us / 1000000;
+    return t.count() / s_clock_ticks_per_us / 1000000;
 }
 
 srt::sync::steady_clock::duration srt::sync::microseconds_from(int64_t t_us)
 {
-    return steady_clock::duration(t_us * g_clock_ticks_per_us);
+    return steady_clock::duration(t_us * s_clock_ticks_per_us);
 }
 
 srt::sync::steady_clock::duration srt::sync::milliseconds_from(int64_t t_ms)
 {
-    return steady_clock::duration((1000 * t_ms) * g_clock_ticks_per_us);
+    return steady_clock::duration((1000 * t_ms) * s_clock_ticks_per_us);
 }
 
 srt::sync::steady_clock::duration srt::sync::seconds_from(int64_t t_s)
 {
-    return steady_clock::duration((1000000 * t_s) * g_clock_ticks_per_us);
+    return steady_clock::duration((1000000 * t_s) * s_clock_ticks_per_us);
 }
 
 srt::sync::Mutex::Mutex()

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -38,7 +38,7 @@ namespace srt
 namespace sync
 {
 
-void rdtsc(uint64_t& x)
+static void rdtsc(uint64_t& x)
 {
 #if SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_IA32_RDTSC
     uint32_t lval, hval;
@@ -123,11 +123,11 @@ static int count_subsecond_precision(int64_t ticks_per_us)
     return signs;
 }
 
-static const int64_t s_clock_ticks_per_us = get_cpu_frequency();
+const int64_t g_clock_ticks_per_us = get_cpu_frequency();
 
-static const int s_clock_subsecond_precision = count_subsecond_precision(s_clock_ticks_per_us);
+const int g_clock_subsecond_precision = count_subsecond_precision(g_clock_ticks_per_us);
 
-int clockSubsecondPrecision() { return s_clock_subsecond_precision; }
+int clockSubsecondPrecision() { return g_clock_subsecond_precision; }
 
 } // namespace sync
 } // namespace srt
@@ -167,32 +167,32 @@ srt::sync::TimePoint<srt::sync::steady_clock> srt::sync::steady_clock::now()
 
 int64_t srt::sync::count_microseconds(const steady_clock::duration& t)
 {
-    return t.count() / s_clock_ticks_per_us;
+    return t.count() / g_clock_ticks_per_us;
 }
 
 int64_t srt::sync::count_milliseconds(const steady_clock::duration& t)
 {
-    return t.count() / s_clock_ticks_per_us / 1000;
+    return t.count() / g_clock_ticks_per_us / 1000;
 }
 
 int64_t srt::sync::count_seconds(const steady_clock::duration& t)
 {
-    return t.count() / s_clock_ticks_per_us / 1000000;
+    return t.count() / g_clock_ticks_per_us / 1000000;
 }
 
 srt::sync::steady_clock::duration srt::sync::microseconds_from(int64_t t_us)
 {
-    return steady_clock::duration(t_us * s_clock_ticks_per_us);
+    return steady_clock::duration(t_us * g_clock_ticks_per_us);
 }
 
 srt::sync::steady_clock::duration srt::sync::milliseconds_from(int64_t t_ms)
 {
-    return steady_clock::duration((1000 * t_ms) * s_clock_ticks_per_us);
+    return steady_clock::duration((1000 * t_ms) * g_clock_ticks_per_us);
 }
 
 srt::sync::steady_clock::duration srt::sync::seconds_from(int64_t t_s)
 {
-    return steady_clock::duration((1000000 * t_s) * s_clock_ticks_per_us);
+    return steady_clock::duration((1000000 * t_s) * g_clock_ticks_per_us);
 }
 
 srt::sync::Mutex::Mutex()


### PR DESCRIPTION
Minor changes: made `srt_options_action` constant. Renamed to `s_srt_option_action`.
The prefix `s_` is intended to depict internal (static) linkage.

- [C++ Core Guidelines I.2](https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#i2-avoid-non-const-global-variables) - Avoid non-const global variables
- [C++ Core Guidelines C.7](https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#c7-dont-define-a-class-or-enum-and-declare-a-variable-of-its-type-in-the-same-statement): Don't define a class or enum and declare a variable of its type in the same statement