### PR TITLE
[core] Fixed getting SRTO_TLPKTDROP: return config value until connected.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -610,7 +610,11 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_TLPKTDROP:
-        *(bool *)optval = m_bTLPktDrop;
+        if (m_bConnected)
+            *(bool *)optval = m_bTLPktDrop;
+        else
+            *(bool *)optval = m_config.bTLPktDrop;
+
         optlen          = sizeof(bool);
         break;
 


### PR DESCRIPTION
Returning configuration value of `SRTO_TLPKTDROP` if a socket is not yet connected.

_A reopening of #1943, which was mistakenly created from fork's master._