### PR TITLE
[core] Improved RTT estimation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ endforeach()
 # SRT_DEBUG_TLPKTDROP_DROPSEQ 1
 # SRT_DEBUG_SNDQ_HIGHRATE 1
 # SRT_DEBUG_BONDING_STATES 1
+# SRT_DEBUG_RTT 1                 /* RTT trace */
 # SRT_MAVG_SAMPLING_RATE 40       /* Max sampling rate */
 
 # option defaults

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4553,7 +4553,7 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
     if (m_pCache->lookup(&ib) >= 0)
     {
         m_iRTT       = ib.m_iRTT;
-        m_iRTTVar    = m_iRTT >> 1;
+        m_iRTTVar    = ib.m_iRTT / 2;
         m_iBandwidth = ib.m_iBandwidth;
     }
 
@@ -5457,7 +5457,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer,
     if (m_pCache->lookup(&ib) >= 0)
     {
         m_iRTT       = ib.m_iRTT;
-        m_iRTTVar    = m_iRTT >> 1;
+        m_iRTTVar    = ib.m_iRTT / 2;
         m_iBandwidth = ib.m_iBandwidth;
     }
 
@@ -5928,6 +5928,11 @@ bool CUDT::closeInternal()
         ib.m_iRTT       = m_iRTT;
         ib.m_iBandwidth = m_iBandwidth;
         m_pCache->update(&ib);
+
+#if SRT_DEBUG_RTT
+    s_rtt_trace.trace(steady_clock::now(), "Cache", -1, -1,
+                      m_bIsSmoothedRTTReset, -1, m_iRTT, -1);
+#endif
 
         m_bConnected = false;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1907,7 +1907,7 @@ private:
 
     void create_file()
     {
-        if (m_fout)
+        if (m_fout.is_open())
             return;
 
         std::string str_tnow = srt::sync::FormatTimeSys(srt::sync::steady_clock::now());
@@ -8199,9 +8199,6 @@ void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival
     // final smoothed RTT value.
     else
     {
-#if SRT_DEBUG_RTT
-        s_rtt_trace.trace(tsArrival, "ACKACK", rtt, m_bIsSmoothedRTTReset, m_iRTT, m_iRTTVar);
-#endif
         m_iRTT                = rtt;
         m_iRTTVar             = rtt / 2;
         m_bIsSmoothedRTTReset = true;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1905,8 +1905,9 @@ public:
 private:
     void print_header()
     {
-        //srt::sync::ScopedLock lck(m_mtx);
-        m_fout << "Timepoint_SYST,Timepoint_STDY,Event,usRTTSample,usRTTVarSample,IsSmoothedRTTReset,pktsRecvTotal,usSmoothedRTT,usRTTVar\n";
+        m_fout << "Timepoint_SYST,Timepoint_STDY,Event,usRTTSample,"
+                  "usRTTVarSample,IsSmoothedRTTReset,pktsRecvTotal,"
+                  "usSmoothedRTT,usRTTVar\n";
     }
 
     void create_file()

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8099,8 +8099,13 @@ void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point
         // consistent with the previous behavior.
         if (m_stats.recvTotal != 0)
         {
-            m_iRTTVar = avg_iir<4>(m_iRTTVar, abs(rtt - m_iRTT));
-            m_iRTT    = avg_iir<8>(m_iRTT, rtt);
+            // Ignore initial values which might arrive after smoothed RTT
+            // has been reset.
+            if (rtt != INITIAL_RTT && rttvar != INITIAL_RTTVAR)
+            {
+                m_iRTTVar = avg_iir<4>(m_iRTTVar, abs(rtt - m_iRTT));
+                m_iRTT    = avg_iir<8>(m_iRTT, rtt);
+            }
         }
         // In the case of unidirectional transmission, extract the values of
         // smoothed RTT and RTT variance from the ACK packet.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8228,8 +8228,8 @@ void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival
     }
 
 #if SRT_DEBUG_RTT
-    s_rtt_trace.trace(tsArrival, "ACKACK", rtt, m_iRTTVar,
-                      m_bIsSmoothedRTTReset, -1, m_iRTT, m_iRTTVar);
+    s_rtt_trace.trace(tsArrival, "ACKACK", rtt, -1, m_bIsSmoothedRTTReset,
+                      -1, m_iRTT, m_iRTTVar);
 #endif
 
     updateCC(TEV_ACKACK, EventVariant(ack));

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8123,7 +8123,7 @@ void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point
         }
     }
     // Reset the value of smoothed RTT to the first real RTT estimate extracted
-    // from an ACK after initialization (at the beginning of a transmission).
+    // from an ACK after initialization (at the beginning of transmission).
     // In case of resumed connection over the same network, the very first RTT
     // value sent within an ACK will be taken from cache and equal to previous
     // connection's final smoothed RTT value. The reception of such a value
@@ -8234,7 +8234,7 @@ void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival
         m_iRTT    = avg_iir<8>(m_iRTT, rtt);
     }
     // Reset the value of smoothed RTT on the first RTT sample after initialization
-    // (at the beginning of a transmission).
+    // (at the beginning of transmission).
     // In case of resumed connection over the same network, the initial RTT
     // value will be taken from cache and equal to previous connection's
     // final smoothed RTT value.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1890,6 +1890,7 @@ public:
         create_file();
         
         m_fout << srt::sync::FormatTimeSys(currtime) << ",";
+        m_fout << srt::sync::FormatTime(currtime) << ",";
         m_fout << event << ",";
         m_fout << rtt_sample_us << ",";
         m_fout << is_smoothed_rtt_reset << ",";
@@ -1902,7 +1903,7 @@ private:
     void print_header()
     {
         //srt::sync::ScopedLock lck(m_mtx);
-        m_fout << "Timepoint,Event,usRTTSample,IsSmoothedRttReset, usSmoothedRtt,usRttVar\n";
+        m_fout << "Timepoint_SYST,Timepoint_STDY,Event,usRTTSample,IsSmoothedRttReset, usSmoothedRtt,usRttVar\n";
     }
 
     void create_file()

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -744,10 +744,11 @@ private:
     int m_iRTT;                                  // Smoothed RTT (an exponentially-weighted moving average (EWMA)
                                                  // of an endpoint's RTT samples), in microseconds
     int m_iRTTVar;                               // The variation in the RTT samples (RTT variance), in microseconds
-    bool m_bIsFirstRTTReceived;                  // This variable is used to determine whether the first RTT sample were obtained
-                                                 // from the ACK/ACKACK pair at the receiver side or received by the sender from
-                                                 // an ACK packet. It's used to reset the value of smoothed RTT (m_iRTT) after 
-                                                 // initialization at the beginning of a transmission. False by default.
+    bool m_bIsFirstRTTReceived;                  // True if the first RTT sample was obtained from the ACK/ACKACK pair
+                                                 // at the receiver side or received by the sender from an ACK packet.
+                                                 // It's used to reset the initial value of smoothed RTT (m_iRTT)
+                                                 // at the beginning of transmission (including the one taken from
+                                                 // cache). False by default.
     int m_iDeliveryRate;                         // Packet arrival rate at the receiver side
     int m_iByteDeliveryRate;                     // Byte arrival rate at the receiver side
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -741,9 +741,13 @@ private:
 
     int m_iEXPCount;                             // Expiration counter
     int m_iBandwidth;                            // Estimated bandwidth, number of packets per second
-    int m_iRTT;                                  // RTT, in microseconds
-    int m_iRTTVar;                               // RTT variance
-    bool m_bIsSmoothedRTTReset;                  // If smoothed RTT has been reset after initialization
+    int m_iRTT;                                  // Smoothed RTT (an exponentially-weighted moving average (EWMA)
+                                                 // of an endpoint's RTT samples), in microseconds
+    int m_iRTTVar;                               // The variation in the RTT samples (RTT variance), in microseconds
+    bool m_bIsFirstRTTReceived;                  // This variable is used to determine whether the first RTT sample were obtained
+                                                 // from the ACK/ACKACK pair at the receiver side or received by the sender from
+                                                 // an ACK packet. It's used to reset the value of smoothed RTT (m_iRTT) after 
+                                                 // initialization at the beginning of a transmission. False by default.
     int m_iDeliveryRate;                         // Packet arrival rate at the receiver side
     int m_iByteDeliveryRate;                     // Byte arrival rate at the receiver side
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -267,13 +267,15 @@ public: // internal API
     //
     // NOTE: Use notation with X*1000*1000*... instead of
     // million zeros in a row.
-    static const int       COMM_RESPONSE_MAX_EXP                  = 16;
-    static const int       SRT_TLPKTDROP_MINTHRESHOLD_MS          = 1000;
-    static const uint64_t  COMM_KEEPALIVE_PERIOD_US               = 1*1000*1000;
-    static const int32_t   COMM_SYN_INTERVAL_US                   = 10*1000;
-    static const int       COMM_CLOSE_BROKEN_LISTENER_TIMEOUT_MS  = 3000;
-    static const uint16_t  MAX_WEIGHT                             = 32767;
-    static const size_t    ACK_WND_SIZE                           = 1024;
+    static const int       COMM_RESPONSE_MAX_EXP                 = 16;
+    static const int       SRT_TLPKTDROP_MINTHRESHOLD_MS         = 1000;
+    static const uint64_t  COMM_KEEPALIVE_PERIOD_US              = 1*1000*1000;
+    static const int32_t   COMM_SYN_INTERVAL_US                  = 10*1000;
+    static const int       COMM_CLOSE_BROKEN_LISTENER_TIMEOUT_MS = 3000;
+    static const uint16_t  MAX_WEIGHT                            = 32767;
+    static const size_t    ACK_WND_SIZE                          = 1024;
+    static const int       INITIAL_RTT                           = 10 * COMM_SYN_INTERVAL_US;
+    static const int       INITIAL_RTTVAR                        = INITIAL_RTT / 2;
 
     int handshakeVersion()
     {
@@ -741,6 +743,7 @@ private:
     int m_iBandwidth;                            // Estimated bandwidth, number of packets per second
     int m_iRTT;                                  // RTT, in microseconds
     int m_iRTTVar;                               // RTT variance
+    bool m_bIsSmoothedRTTReset;                  // If smoothed RTT has been reset after initialization
     int m_iDeliveryRate;                         // Packet arrival rate at the receiver side
     int m_iByteDeliveryRate;                     // Byte arrival rate at the receiver side
 


### PR DESCRIPTION
## Improvements Done 

Improved RTT estimation in the following way:
- On the receiver side, reset smoothed RTT to the very first RTT sample obtained from the ACK/ACKACK pair. At the beginning of a transmission, the value of smoothed RTT is either equal to `INITIAL_RTT = 100 ms`, or is taken from cache. It remains so until the very first ACKACK packet is received from the sender and triggers RTT sample calculation. At this moment, the smoothed RTT is reset to the very first RTT sample and the EWMA is applied further on the subsequent RTT samples.
- On the sender side, in the case of unidirectional transmission, the values of smoothed RTT and RTT variance are now extracted from the ACK packets. There is no more EWMA applied on the sender side to avoid double smoothing, see issue #782. 
   The initial values of RTT and RTT variance are either equal to `INITIAL_RTT = 100 ms` and `INITIAL_RTTVAR = 50 ms`, or taken from sender's cache. Upon ACK packet reception, they can be reset to the receiver's RTT and RTTVar extracted from the ACK if those values are taken from the receiver's cache. Initial values of 100 ms and 50 ms will be ignored. Receiver's cache is of a higher priority meaning that in case of both peers have cache, receiver's cache wins.
- On the sender side, in the case of bidirectional transmission, the double smoothing is still applied to be consistent with the previous behaviour. Additionally, initial RTT values of 100 ms are not taken into account when calculating smoothed average. In general, the case of bidirectional transmission requires further improvements and testing as more complicated use case. Currently, it's out of scope.
- The RTT trace log has been added to test the changes appropriately. Use `-DENFORCE_SRT_DEBUG_RTT=1` with `cmake` to activate it.

Fixes #782, #1769, #1818. 

## Test Cases

The tests were performed with the help of `srt-xtransmit` application with the following test parameters:
```
sendrate = 10 Mbps, RTT = 500 ms, latency = 2000 ms (4RTT), rcvbuf = 5625000 bytes
```
(see test case 6 from #1937).

The SRT library was built with the advanced RTT log plus the usage of monotonic clocks:
```
cmake -DENFORCE_SRT_DEBUG_RTT=1 -DENABLE_STDCXX_SYNC=ON ../
cmake —build ./
```

### Test Case 1. Unidirectional transmission. Initial values for smoothed RTT and RTTVar are applied on both sides.

```
_build_rtt/bin/srt-xtransmit receive "srt://:4200?latency=2000&rcvbuf=5625000" --enable-metrics --metricsfile metrics-rcv.csv --metricsfreq 100ms --statsfile stats-rcv.csv --statsfreq 100ms -v

_build_rtt/bin/srt-xtransmit generate srt://192.168.2.2:4200?latency=2000 --sendrate 10Mbps --duration 120s --enable-metrics --statsfile stats-snd.csv --statsfreq 100ms -v
```

### Test Case 2. Unidirectional transmission, resumed connection. Initial value for smoothed RTT is taken from cache.

#### 2.1. Sender-caller, receiver-listener, reconnection on the receiver side. The cache is available on the receiver side only.

```
_build_rtt/bin/srt-xtransmit receive "srt://:4200?latency=2000&rcvbuf=5625000" --enable-metrics --metricsfile metrics-rcv.csv --metricsfreq 100ms --statsfile stats-rcv.csv --statsfreq 100ms --reconnect --handle-sigint -v

_build_rtt/bin/srt-xtransmit generate srt://192.168.2.2:4200?latency=2000 --sendrate 10Mbps --duration 20s --enable-metrics --statsfile stats-snd.csv --statsfreq 100ms --handle-sigint -v
```

The logic of applying the values from cache works correct, however, during this test, I've faced the following bug #1958. 

The sender application has been restarted 4 times. As we can see from the first picture, for the first restart (see row 1859), the values of smoothed RTT and RTTVar are equal to the initial values of 100 ms and 50 ms, because the values from cache are not yet available. The socket is in process of closing, however it's not yet closed when the reconnection happens.

<img width="900" alt="Screenshot 2021-04-16 at 17 14 09" src="https://user-images.githubusercontent.com/41019697/115226779-eac08900-a10f-11eb-80d1-7e537a85a6a9.png">

As can be seen from the following pictures, when the second reconnection happens (see row 3717), the value from cache is available (500288), however this value isn't correct and actually taken from the very first session.

<img width="910" alt="Screenshot 2021-04-16 at 17 13 32" src="https://user-images.githubusercontent.com/41019697/115227619-fb253380-a110-11eb-8a68-bc09fd4bb44b.png">
<img width="910" alt="Screenshot 2021-04-16 at 17 16 40" src="https://user-images.githubusercontent.com/41019697/115227629-ff515100-a110-11eb-96a0-d481254992ad.png">

#### 2.2. Sender-listener, receiver-caller, reconnection on the sender side. The cache is available on the sender side only.

```
_build_rtt/bin/srt-xtransmit generate srt://:4200?latency=2000 --sendrate 10Mbps --duration 30s --enable-metrics --statsfile stats-snd.csv --statsfreq 100ms --reconnect --handle-sigint -v

_build_rtt/bin/srt-xtransmit receive "srt://192.168.2.1:4200?latency=2000&rcvbuf=5625000" --enable-metrics --metricsfile metrics-rcv.csv --metricsfreq 100ms --statsfile stats-rcv.csv --statsfreq 100ms --handle-sigint -v
```
Haven't faced the bug #1958 as in test case 2.1.

#### 2.3. Reconnection on both sides, the cache is available on both sides.

```
_build_rtt/bin/srt-xtransmit receive "srt://:4200?latency=2000&rcvbuf=5625000" --enable-metrics --metricsfile metrics-rcv.csv --metricsfreq 100ms --statsfile stats-rcv.csv --statsfreq 100ms --reconnect --handle-sigint -v

_build_rtt/bin/srt-xtransmit generate srt://192.168.2.2:4200?latency=2000 --sendrate 10Mbps --duration 20s --enable-metrics --statsfile stats-snd.csv --statsfreq 100ms --reconnect --handle-sigint -v
```
- [ ] Haven't been tested as this functionality is not available in `srt-xtransmit` application.

### Test Case 3. Bidirectional transmission.

[develop/generate-null-receiver](https://github.com/maxsharabayko/srt-xtransmit/tree/develop/generate-null-receiver) branch of `srt-xtransmit` was used to test the case of bidirectional transmission.

```
_build_rtt/bin/srt-xtransmit generate "srt://:4200?latency=2000&rcvbuf=5625000" --sendrate 1Mbps --duration 30s --statsfile generator-flop.csv --statsfreq 100ms -v

_build_rtt/bin/srt-xtransmit generate srt://192.168.2.2:4200?latency=2000 --sendrate 1Mbps --duration 30s --statsfile generator-flip.csv --statsfreq 100ms -v
```

The very first implementation showed that there was a variation in smoothed RTT and RTTVar at the beginning of a transmission. The screenshot below was taken on the caller side. In case of bidirectional transmission, at each peer we receive both ACK and ACKACK packets. The very first packet triggers the reset of smoothed RTT, however later there is still a chance to receive ACK packets with initial RTT value of 100 ms which will be taken into account while calculating smoothed average.
<img width="528" alt="bidirect_1st_version_flip" src="https://user-images.githubusercontent.com/41019697/115265246-5538ef80-a137-11eb-882e-ea9c644fb1dc.png">

In the improved version, these values are simply ignored.
<img width="543" alt="bidirect_improved_flip_caller" src="https://user-images.githubusercontent.com/41019697/115265329-68e45600-a137-11eb-94f8-10fe12e32abf.png">