### PR TITLE
Drift Tracer: taking RTT into account

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1764,10 +1764,11 @@ void CRcvBuffer::setRcvTsbPdMode(const steady_clock::time_point& timebase, const
 }
 
 bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t                  timestamp_us,
+                                        int                       rtt,
                                         steady_clock::duration&   w_udrift,
                                         steady_clock::time_point& w_newtimebase)
 {
-    return m_tsbpd.addDriftSample(timestamp_us, w_udrift, w_newtimebase);
+    return m_tsbpd.addDriftSample(timestamp_us, rtt, w_udrift, w_newtimebase);
 }
 
 int CRcvBuffer::readMsg(char* data, int len)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -399,6 +399,7 @@ public:
     /// @param [out] w_udrift current drift value
     /// @param [out] w_newtimebase current TSBPD base time
     bool addRcvTsbPdDriftSample(uint32_t          timestamp,
+                                int               rtt,
                                 duration&         w_udrift,
                                 time_point&       w_newtimebase);
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8263,7 +8263,7 @@ void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival
         steady_clock::duration udrift(0);
         steady_clock::time_point newtimebase;
         const bool drift_updated ATR_UNUSED = m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(),
-            (udrift), (newtimebase));
+            rtt, (udrift), (newtimebase));
 #if ENABLE_EXPERIMENTAL_BONDING
         if (drift_updated && m_parent->m_GroupOf)
         {

--- a/srtcore/tsbpd_time.h
+++ b/srtcore/tsbpd_time.h
@@ -30,7 +30,8 @@ class CTsbpdTime
 
 public:
     CTsbpdTime()
-        : m_bTsbPdMode(false)
+        : m_iFirstRTT(-1)
+        , m_bTsbPdMode(false)
         , m_tdTsbPdDelay(0)
         , m_bTsbPdWrapCheck(false)
     {
@@ -61,13 +62,17 @@ public:
 
     /// @brief Add new drift sample from an ACK-ACKACK pair.
     /// ACKACK packets are sent immediately (except for UDP buffering).
+    /// Therefore their timestamp roughly corresponds to the time of sending
+    /// and can be used to estimate clock drift.
     /// 
     /// @param [in] pktTimestamp Timestamp of the arrived ACKACK packet.
+    /// @param [in] usRTTSample RTT sample from an ACK-ACKACK pair.
     /// @param [out] w_udrift Current clock drift value.
     /// @param [out] w_newtimebase Current TSBPD base time.
     /// 
     /// @return true if TSBPD base time has changed, false otherwise.
     bool addDriftSample(uint32_t                  pktTimestamp,
+                        int                       usRTTSample,
                         steady_clock::duration&   w_udrift,
                         steady_clock::time_point& w_newtimebase);
 
@@ -116,8 +121,9 @@ public:
     void getInternalTimeBase(time_point& w_tb, bool& w_wrp, duration& w_udrift) const;
 
 private:
-    bool       m_bTsbPdMode;      //< Rreceiver buffering and TSBPD is active when true.
-    duration   m_tdTsbPdDelay;    //< Negotiated buffering delay.
+    int        m_iFirstRTT;       // First measured RTT sample.
+    bool       m_bTsbPdMode;      // Receiver buffering and TSBPD is active when true.
+    duration   m_tdTsbPdDelay;    // Negotiated buffering delay.
 
     /// @brief Local time base for TsbPd.
     /// @note m_tsTsbPdTimeBase is changed in the following cases:

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -791,11 +791,13 @@ public:
         m_qDriftSum += driftval;
         ++m_uDriftSpan;
 
+        // I moved it here to calculate accumulated overdrift.
+        if (CLEAR_ON_UPDATE)
+            m_qOverdrift = 0;
+
         if (m_uDriftSpan < MAX_SPAN)
             return false;
 
-        if (CLEAR_ON_UPDATE)
-            m_qOverdrift = 0;
 
         // Calculate the median of all drift values.
         // In most cases, the divisor should be == MAX_SPAN.


### PR DESCRIPTION
RTT sample is now taken into account in drift calculations.

### Drift Estimation

TSBPD time base is the base time difference between the local clock of the receiver, and the clock used by the sender to timestamp packets being sent.
It is first initialized with the reception of the conclusion handshake as follows:
```
usTsbpdTimeBase = Tnow - usPktTimeStamp,
```
where `Tnow` is the time the HS packet is received (current time), `usPktTimeStamp` is the timestamp set on the packet.

For any further packet with its `usPktTimeStamp` corresponding to the sending time (only true for control packets), It is assumed that:
```
Tnow = usTsbpdTimeBase + usPktTimeStamp
```

Any consistent difference is caused by the drift of the two clocks (SND and RCV).

Therefore, drift is measured on every incoming ACKACK control packet as:
```
DriftSample = Tnow - (usTsbpdTimeBase + usPktTimeStamp).
```

However, the formula does not take possible network delay change into account. Longer or shorter journeys on the net result is a shift of the arrival time.

### Taking RTT Sample into Account

RTT sample is measured on every ACK-ACKACK pair. Therefore, it is available at the time of drift sample estimation. RTT sample can be used to estimate the change in one-way network delay (SND->RCV) as:
```
usRTTDelta = usRTTSample - usRTT0,
```

where RTT0 is the first know RTT sample. Ideally, it should be estimated at the handshaking stage, but this is not yet implemented. The very first RTT measurement is taken instead with an assumption that it is close to the initial RTT.

Thus, `usRTTDelta / 2` is assumed to roughly correspond to the change of the one-way network delay. This is of course close to the actual value for symmetric networks, but might be far from the truth for asymmetric networks. However, it is the best guess available.
So, **this PR changes drift sample estimation to:**

```
DriftSample = Tnow - (usTsbpdTimeBase + usPktTimeStamp) - usRTTDelta / 2.
```

### Notes

Fixes #753, #984.
Refactoring extracted to PR #1968. TSBPD and clock drift tracing logic are moved to a separate class `CTsbpdTime`. It should also provide a cleaner update of #1964.

### TODO

- [x] Split PR into two commits: 1) refactoring (`CTsbpdTime`), 2) RTT usage in Drift.
- [x] Provide description of changes.
- [x] Provide test results.