### PR TITLE
[core] Fixed type conversion build warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,20 +23,24 @@ matrix:
         - os: linux
           env:
           - BUILD_TYPE=Debug
-          - BUILD_OPTS='-DENABLE_CODE_COVERAGE=ON -DENABLE_EXPERIMENTAL_BONDING=ON'
+          - BUILD_OPTS='-DENABLE_CODE_COVERAGE=ON -DENABLE_EXPERIMENTAL_BONDING=ON -DCMAKE_CXX_FLAGS="-Werror"'
           - RUN_SONARCUBE=1
           - RUN_CODECOV=1
         - env:
           - BUILD_TYPE=Debug
-          - BUILD_OPTS='-DENABLE_LOGGING=OFF -DENABLE_MONOTONIC_CLOCK=ON -DENABLE_EXPERIMENTAL_BONDING=ON'
+          - BUILD_OPTS='-DENABLE_LOGGING=OFF -DENABLE_MONOTONIC_CLOCK=ON -DENABLE_EXPERIMENTAL_BONDING=ON -DCMAKE_CXX_FLAGS="-Werror"'
         - os: linux
           env: BUILD_TYPE=Release
         - os: osx
           osx_image: xcode11.1
-          env: BUILD_TYPE=Debug
+          env:
+          - BUILD_TYPE=Debug
+          - BUILD_OPTS='-DCMAKE_CXX_FLAGS="-Werror"'
         - os: osx
           osx_image: xcode11.1
-          env: BUILD_TYPE=Release
+          env:
+          - BUILD_TYPE=Release
+          - BUILD_OPTS='-DCMAKE_CXX_FLAGS="-Werror"'
         - os: linux
           compiler: x86_64-w64-mingw32-g++
           addons:

--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -701,10 +701,10 @@ unique_ptr<Medium> TcpMedium::Accept()
 
     // Configure 1s timeout
     timeval timeout_1s { 1, 0 };
-    int st = setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout_1s, sizeof timeout_1s);
+    int st SRT_ATR_UNUSED = setsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (char*)&timeout_1s, sizeof timeout_1s);
     timeval re;
     socklen_t size = sizeof re;
-    int st2 = getsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (char*)&re, &size);
+    int st2 SRT_ATR_UNUSED = getsockopt(s, SOL_SOCKET, SO_RCVTIMEO, (char*)&re, &size);
 
     LOGP(applog.Debug, "Setting SO_RCVTIMEO to @", m_socket, ": ", st == -1 ? "FAILED" : "SUCCEEDED",
             ", read-back value: ", st2 == -1 ? int64_t(-1) : (int64_t(re.tv_sec)*1000000 + re.tv_usec)/1000, "ms");

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -56,7 +56,7 @@ public:
     SRTSOCKET Socket() const { return m_sock; }
     SRTSOCKET Listener() const { return m_bindsock; }
 
-    virtual void Close();
+    void Close();
 
 protected:
 
@@ -109,7 +109,6 @@ public:
 
     bool IsOpen() override { return IsUsable(); }
     bool End() override { return IsBroken(); }
-    void Close() override { return SrtCommon::Close(); }
 
     SRTSOCKET GetSRTSocket() const override
     { 
@@ -137,7 +136,6 @@ public:
     int Write(const char* data, size_t size, int64_t src_time, ostream &out_stats = cout) override;
     bool IsOpen() override { return IsUsable(); }
     bool Broken() override { return IsBroken(); }
-    void Close() override { return SrtCommon::Close(); }
 
     size_t Still() override
     {
@@ -181,18 +179,8 @@ public:
     string m_host;
     int m_port = 0;
 
-
     SrtModel(string host, int port, map<string,string> par);
     void Establish(std::string& name);
-
-    void Close()
-    {
-        if (m_sock != SRT_INVALID_SOCK)
-        {
-            srt_close(m_sock);
-            m_sock = SRT_INVALID_SOCK;
-        }
-    }
 };
 
 

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1768,8 +1768,8 @@ steady_clock::time_point CRcvBuffer::getTsbPdTimeBase(uint32_t timestamp_us)
         {
             carryover = int64_t(CPacket::MAX_TIMESTAMP) + 1;
         }
-        //
-        else if ((timestamp_us >= TSBPD_WRAP_PERIOD) && (timestamp_us <= (TSBPD_WRAP_PERIOD * 2)))
+        // timestamp_us >= TSBPD_WRAP_PERIOD
+        else if (timestamp_us <= (TSBPD_WRAP_PERIOD * 2))
         {
             /* Exiting wrap check period (if for packet delivery head) */
             m_bTsbPdWrapCheck = false;

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -183,8 +183,9 @@ void CChannel::createSocket(int family)
 
     if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {
-        int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY,
+        const int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY,
                 (const char*) &m_mcfg.iIpV6Only, sizeof m_mcfg.iIpV6Only);
+#if ENABLE_LOGGING
         if (res == -1)
         {
             int err = errno;
@@ -192,6 +193,7 @@ void CChannel::createSocket(int family)
             LOGC(kmlog.Error, log << "::setsockopt: failed to set IPPROTO_IPV6/IPV6_V6ONLY = "
                     << m_mcfg.iIpV6Only << ": " << SysStrError(err, msg, 159));
         }
+#endif // ENABLE_LOGGING
     }
 
 }
@@ -352,9 +354,11 @@ void CChannel::setUDPSockOpt()
           if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_BINDTODEVICE,
                       m_mcfg.sBindToDevice.c_str(), m_mcfg.sBindToDevice.size()))
           {
+#if ENABLE_LOGGING
               char buf[255];
               const char* err = SysStrError(NET_ERROR, buf, 255);
               LOGC(kmlog.Error, log << "setsockopt(SRTO_BINDTODEVICE): " << err);
+#endif // ENABLE_LOGGING
               throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
           }
       }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -364,7 +364,7 @@ public: // internal API
 
     int minSndSize(int len = 0) const
     {
-        const int ps = maxPayloadSize();
+        const int ps = (int) maxPayloadSize();
         if (len == 0) // wierd, can't use non-static data member as default argument!
             len = ps;
         return m_config.bMessageAPI ? (len+ps-1)/ps : 1;
@@ -379,7 +379,7 @@ public: // internal API
         // So, this can be simply defined as: TS = (RTS - STS) % (MAX_TIMESTAMP+1)
         // XXX Would be nice to check if local_time > m_tsStartTime,
         // otherwise it may go unnoticed with clock skew.
-        return srt::sync::count_microseconds(from_time - m_stats.tsStartTime);
+        return (int32_t) srt::sync::count_microseconds(from_time - m_stats.tsStartTime);
     }
 
     void setPacketTS(CPacket& p, const time_point& local_time)
@@ -400,17 +400,9 @@ public: // internal API
     {
         using namespace srt::sync;
         // Random Initial Sequence Number (normal mode)
-        srand(count_microseconds(steady_clock::now().time_since_epoch()));
+        srand((unsigned) count_microseconds(steady_clock::now().time_since_epoch()));
         return (int32_t)(CSeqNo::m_iMaxSeqNo * (double(rand()) / RAND_MAX));
     }
-
-    // XXX See CUDT::tsbpd() to see how to implement it. This should
-    // do the same as TLPKTDROP feature when skipping packets that are agreed
-    // to be lost. Note that this is predicted to be called with TSBPD off.
-    // This is to be exposed for the application so that it can require this
-    // sequence to be skipped, if that packet has been otherwise arrived through
-    // a different channel.
-    void skipIncoming(int32_t seq);
 
     // For SRT_tsbpdLoop
     static CUDTUnited* uglobal() { return &s_UDTUnited; } // needed by tsbpdLoop
@@ -669,7 +661,7 @@ private:
 
     int sndSpaceLeft()
     {
-        return sndBuffersLeft() * maxPayloadSize();
+        return static_cast<int>(sndBuffersLeft() * maxPayloadSize());
     }
 
     int sndBuffersLeft()

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -147,8 +147,8 @@ void CUDTGroup::debugMasterData(SRTSOCKET slave)
     // time when the connection process is done, until the first reading/writing happens.
     ScopedLock cg(m_GroupLock);
 
-    SRTSOCKET mpeer;
-    steady_clock::time_point start_time;
+    IF_LOGGING(SRTSOCKET mpeer);
+    IF_LOGGING(steady_clock::time_point start_time);
 
     bool found = false;
 
@@ -159,8 +159,8 @@ void CUDTGroup::debugMasterData(SRTSOCKET slave)
             // Found it. Get the socket's peer's ID and this socket's
             // Start Time. Once it's delivered, this can be used to calculate
             // the Master-to-Slave start time difference.
-            mpeer = gi->ps->m_PeerID;
-            start_time    = gi->ps->core().socketStartTime();
+            IF_LOGGING(mpeer = gi->ps->m_PeerID);
+            IF_LOGGING(start_time = gi->ps->core().socketStartTime());
             HLOGC(gmlog.Debug,
                   log << "getMasterData: found RUNNING master @" << gi->id << " - reporting master's peer $" << mpeer
                       << " starting at " << FormatTime(start_time));
@@ -185,8 +185,8 @@ void CUDTGroup::debugMasterData(SRTSOCKET slave)
             // Found it. Get the socket's peer's ID and this socket's
             // Start Time. Once it's delivered, this can be used to calculate
             // the Master-to-Slave start time difference.
-            mpeer = gi->ps->core().m_PeerID;
-            start_time    = gi->ps->core().socketStartTime();
+            IF_LOGGING(mpeer = gi->ps->core().m_PeerID);
+            IF_LOGGING(start_time    = gi->ps->core().socketStartTime());
             HLOGC(gmlog.Debug,
                     log << "getMasterData: found IDLE/PENDING master @" << gi->id << " - reporting master's peer $" << mpeer
                     << " starting at " << FormatTime(start_time));
@@ -203,7 +203,7 @@ void CUDTGroup::debugMasterData(SRTSOCKET slave)
     {
         // The returned master_st is the master's start time. Calculate the
         // differene time.
-        steady_clock::duration master_tdiff = m_tsStartTime - start_time;
+        IF_LOGGING(steady_clock::duration master_tdiff = m_tsStartTime - start_time);
         LOGC(cnlog.Debug, log << CONID() << "FOUND GROUP MASTER LINK: peer=$" << mpeer
                 << " - start time diff: " << FormatDuration<DUNIT_S>(master_tdiff));
     }

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -66,6 +66,8 @@ written by
 // Usage: LOGP(gglog.Debug, param1, param2, param3);
 #define LOGP(logdes, ...) if (logdes.CheckEnabled()) logdes.printloc(__FILE__, __LINE__, __FUNCTION__,##__VA_ARGS__)
 
+#define IF_LOGGING(instr) instr
+
 #if ENABLE_HEAVY_LOGGING
 
 #define HLOGC LOGC
@@ -95,6 +97,7 @@ written by
 #define HLOGP(...)
 
 #define IF_HEAVY_LOGGING(instr) (void)0
+#define IF_LOGGING(instr) (void)0
 
 #endif
 

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -146,7 +146,7 @@ public:
 
         memcpy(stor, s, length);
         stor[length] = 0;
-        len          = length;
+        len          = (int) length;
         return true;
     }
 
@@ -945,8 +945,8 @@ struct CSrtConfigSetter<SRTO_PAYLOADSIZE>
                 throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
             }
 
-            size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
-            if (val > efc_max_payload_size)
+            const size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - fc.extra_size;
+            if (size_t(val) > efc_max_payload_size)
             {
                 LOGC(aclog.Error,
                      log << "SRTO_PAYLOADSIZE: value exceeds SRT_LIVE_MAX_PLSIZE decreased by " << fc.extra_size

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -218,7 +218,7 @@ public:
        m_tsCurrArrTime = srt::sync::steady_clock::now();
 
        // record the packet interval between the current and the last one
-       m_aPktWindow[m_iPktWindowPtr] = srt::sync::count_microseconds(m_tsCurrArrTime - m_tsLastArrTime);
+       m_aPktWindow[m_iPktWindowPtr] = (int) srt::sync::count_microseconds(m_tsCurrArrTime - m_tsLastArrTime);
        m_aBytesWindow[m_iPktWindowPtr] = pktsz;
 
        // the window is logically circular


### PR DESCRIPTION
- [core] Fixed some minor build and static analyzer warnings.
- [build] Added `-Werror` flag to Linux and macOS CI builds on Travis.
- [apps] Fixed virtual call from a destructor. Virtual functions should not be invoked from a constructor or destructor of the same class. Confusingly, virtual functions are resolved statically (not dynamically) in constructors and destructors for the same class.