### PR TITLE
Update srt-live-transmit.md

### DIFF
--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -314,7 +314,7 @@ All other parameters are SRT socket options. The following have the following va
 | `nakreport`          | `bool`           | `SRTO_NAKREPORT`          | Enables/disables periodic NAK reports |
 | `oheadbw`            | 5..100           | `SRTO_OHEADBW`            | limits bandwidth overhead, percents |
 | `packetfilter`       | `string`         | `SRTO_PACKETFILTER`       | Set up the packet filter. |
-| `passphrase`         | `string`         | `SRTO_PASSPHRASE`         | Password for the encrypted transmission. |
+| `passphrase`         | `string`         | `SRTO_PASSPHRASE`         | Password for the encrypted transmission. (must be 10 to 79 characters) |
 | `payloadsize`        | 0..              | `SRTO_PAYLOADSIZE`        | Maximum payload size. |
 | `pbkeylen`           | {16, 24, 32}     | `SRTO_PBKEYLEN`           | Crypto key length in bytes. |
 | `peeridletimeo`      | `ms`             | `SRTO_PEERIDLETIMEO`      | Peer idle timeout. |


### PR DESCRIPTION
Was testing around with using the passphrase option in SRT, and could not get it working at first, turned out to be due to a too short password. This is described in https://github.com/Haivision/srt/blob/944287050f58a7901d485c21f75bf636742f3fdd/srtcore/srt.h#L213 but would be better to communicate this in the README as well.