### PR TITLE
[core] Renamed m_iRTT variable to m_iSRTT

### DIFF
--- a/docs/API/statistics.md
+++ b/docs/API/statistics.md
@@ -539,21 +539,10 @@ at that moment.
 
 #### msRTT
 
-Calculated Round trip time (RTT), in milliseconds. Sender and Receiver. \
-The value is calculated by the receiver based on the incoming ACKACK control packets
-(used by sender to acknowledge ACKs from receiver).
+Smoothed round-trip time (SRTT), an exponentially-weighted moving average (EWMA) of an endpoint's RTT samples, in milliseconds.
+Available both for sender and receiver.
 
-The RTT (Round-Trip time) is the sum of two STT (Single-Trip time) 
-values, one from agent to peer, and one from peer to agent. Note that **the 
-measurement method is different than in TCP**. SRT measures only the "reverse
-RTT", that is, the time measured at the receiver between sending a `UMSG_ACK`
-message until receiving the sender's `UMSG_ACKACK` response message (with the
-same journal). This happens to be a little different from the "forward RTT"
-measured in TCP, which is the time between sending a data packet of a particular 
-sequence number and receiving `UMSG_ACK` with a sequence number that is later 
-by 1. Forward RTT isn't being measured or reported in SRT, although some
-research works have shown that these values, even though they should be the same,
-happen to differ; "reverse RTT" seems to be more optimistic.
+See [Section 4.10. Round-Trip Time Estimation](https://tools.ietf.org/html/draft-sharabayko-srt-00#section-4.10) of the [SRT RFC](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-00) and [[RFC6298] Paxson, V., Allman, M., Chu, J., and M. Sargent, "Computing TCP's Retransmission Timer"](https://datatracker.ietf.org/doc/html/rfc6298) for more details.
 
 #### mbpsBandwidth
 

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -50,14 +50,14 @@ using namespace std;
 CInfoBlock& CInfoBlock::copyFrom(const CInfoBlock& obj)
 {
    std::copy(obj.m_piIP, obj.m_piIP + 4, m_piIP);
-   m_iIPversion = obj.m_iIPversion;
-   m_ullTimeStamp = obj.m_ullTimeStamp;
-   m_iRTT = obj.m_iRTT;
-   m_iBandwidth = obj.m_iBandwidth;
-   m_iLossRate = obj.m_iLossRate;
+   m_iIPversion       = obj.m_iIPversion;
+   m_ullTimeStamp     = obj.m_ullTimeStamp;
+   m_iSRTT            = obj.m_iSRTT;
+   m_iBandwidth       = obj.m_iBandwidth;
+   m_iLossRate        = obj.m_iLossRate;
    m_iReorderDistance = obj.m_iReorderDistance;
-   m_dInterval = obj.m_dInterval;
-   m_dCWnd = obj.m_dCWnd;
+   m_dInterval        = obj.m_dInterval;
+   m_dCWnd            = obj.m_dCWnd;
 
    return *this;
 }
@@ -84,14 +84,14 @@ CInfoBlock* CInfoBlock::clone()
    CInfoBlock* obj = new CInfoBlock;
 
    std::copy(m_piIP, m_piIP + 4, obj->m_piIP);
-   obj->m_iIPversion = m_iIPversion;
-   obj->m_ullTimeStamp = m_ullTimeStamp;
-   obj->m_iRTT = m_iRTT;
-   obj->m_iBandwidth = m_iBandwidth;
-   obj->m_iLossRate = m_iLossRate;
+   obj->m_iIPversion       = m_iIPversion;
+   obj->m_ullTimeStamp     = m_ullTimeStamp;
+   obj->m_iSRTT            = m_iSRTT;
+   obj->m_iBandwidth       = m_iBandwidth;
+   obj->m_iLossRate        = m_iLossRate;
    obj->m_iReorderDistance = m_iReorderDistance;
-   obj->m_dInterval = m_dInterval;
-   obj->m_dCWnd = m_dCWnd;
+   obj->m_dInterval        = m_dInterval;
+   obj->m_dCWnd            = m_dCWnd;
 
    return obj;
 }

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -235,15 +235,15 @@ private:
 class CInfoBlock
 {
 public:
-   uint32_t m_piIP[4];		// IP address, machine read only, not human readable format
-   int m_iIPversion;   		// Address family: AF_INET or AF_INET6
-   uint64_t m_ullTimeStamp;	// last update time
-   int m_iRTT;			// RTT
-   int m_iBandwidth;		// estimated bandwidth
-   int m_iLossRate;		// average loss rate
-   int m_iReorderDistance;	// packet reordering distance
-   double m_dInterval;		// inter-packet time, congestion control
-   double m_dCWnd;		// congestion window size, congestion control
+   uint32_t m_piIP[4];        // IP address, machine read only, not human readable format.
+   int m_iIPversion;          // Address family: AF_INET or AF_INET6.
+   uint64_t m_ullTimeStamp;   // Last update time.
+   int m_iSRTT;               // Smoothed RTT.
+   int m_iBandwidth;          // Estimated link bandwidth.
+   int m_iLossRate;           // Average loss rate.
+   int m_iReorderDistance;    // Packet reordering distance.
+   double m_dInterval;        // Inter-packet time (Congestion Control).
+   double m_dCWnd;            // Congestion window size (Congestion Control).
 
 public:
    CInfoBlock() {} // NOTE: leaves uninitialized

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -284,7 +284,7 @@ enum ETransmissionEvent
 {
     TEV_INIT,       // --> After creation, and after any parameters were updated.
     TEV_ACK,        // --> When handling UMSG_ACK - older CCC:onAck()
-    TEV_ACKACK,     // --> UDT does only RTT sync, can be read from CUDT::RTT().
+    TEV_ACKACK,     // --> UDT does only RTT sync, can be read from CUDT::SRTT().
     TEV_LOSSREPORT, // --> When handling UMSG_LOSSREPORT - older CCC::onLoss()
     TEV_CHECKTIMER, // --> See TEV_CHT_REXMIT
     TEV_SEND,       // --> When the packet is scheduled for sending - older CCC::onPktSent

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -358,11 +358,11 @@ private:
                 }
                 else
                 {
-                    m_dPktSndPeriod = m_dCWndSize / (m_parent->RTT() + m_iRCInterval);
+                    m_dPktSndPeriod = m_dCWndSize / (m_parent->SRTT() + m_iRCInterval);
                     HLOGC(cclog.Debug, log << "FileCC: UPD (slowstart:ENDED) wndsize="
                         << m_dCWndSize << "/" << m_dMaxCWndSize
                         << " sndperiod=" << m_dPktSndPeriod << "us = wndsize/(RTT+RCIV) RTT="
-                        << m_parent->RTT() << " RCIV=" << m_iRCInterval);
+                        << m_parent->SRTT() << " RCIV=" << m_iRCInterval);
                 }
             }
             else
@@ -374,9 +374,9 @@ private:
         }
         else
         {
-            m_dCWndSize = m_parent->deliveryRate() / 1000000.0 * (m_parent->RTT() + m_iRCInterval) + 16;
+            m_dCWndSize = m_parent->deliveryRate() / 1000000.0 * (m_parent->SRTT() + m_iRCInterval) + 16;
             HLOGC(cclog.Debug, log << "FileCC: UPD (speed mode) wndsize="
-                << m_dCWndSize << "/" << m_dMaxCWndSize << " RTT = " << m_parent->RTT()
+                << m_dCWndSize << "/" << m_dMaxCWndSize << " RTT = " << m_parent->SRTT()
                 << " sndperiod=" << m_dPktSndPeriod << "us. deliverRate = "
                 << m_parent->deliveryRate() << " pkts/s)");
         }
@@ -481,9 +481,9 @@ private:
             }
             else
             {
-                m_dPktSndPeriod = m_dCWndSize / (m_parent->RTT() + m_iRCInterval);
+                m_dPktSndPeriod = m_dCWndSize / (m_parent->SRTT() + m_iRCInterval);
                 HLOGC(cclog.Debug, log << "FileCC: LOSS, SLOWSTART:OFF, sndperiod=" << m_dPktSndPeriod << "us AS wndsize/(RTT+RCIV) (RTT="
-                    << m_parent->RTT() << " RCIV=" << m_iRCInterval << ")");
+                    << m_parent->SRTT() << " RCIV=" << m_iRCInterval << ")");
             }
 
         }
@@ -491,7 +491,7 @@ private:
         m_bLoss = true;
 
         // TODO: const int pktsInFlight = CSeqNo::seqoff(m_iLastAck, m_parent->sndSeqNo());
-        const int pktsInFlight = m_parent->RTT() / m_dPktSndPeriod;
+        const int pktsInFlight = m_parent->SRTT() / m_dPktSndPeriod;
         const int numPktsLost = m_parent->sndLossLength();
         const int lost_pcent_x10 = pktsInFlight > 0 ? (numPktsLost * 1000) / pktsInFlight : 0;
 
@@ -581,9 +581,9 @@ private:
             }
             else
             {
-                m_dPktSndPeriod = m_dCWndSize / (m_parent->RTT() + m_iRCInterval);
+                m_dPktSndPeriod = m_dCWndSize / (m_parent->SRTT() + m_iRCInterval);
                 HLOGC(cclog.Debug, log << "FileCC: CHKTIMER, SLOWSTART:OFF, sndperiod=" << m_dPktSndPeriod << "us AS wndsize/(RTT+RCIV) (wndsize="
-                    << setprecision(6) << m_dCWndSize << " RTT=" << m_parent->RTT() << " RCIV=" << m_iRCInterval << ")");
+                    << setprecision(6) << m_dCWndSize << " RTT=" << m_parent->SRTT() << " RCIV=" << m_iRCInterval << ")");
             }
         }
         else

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -146,7 +146,7 @@ protected:
     //int m_iMSS;              // NOT REQUIRED. Use m_parent->MSS() instead.
     //int32_t m_iSndCurrSeqNo; // NOT REQUIRED. Use m_parent->sndSeqNo().
     //int m_iRcvRate;          // NOT REQUIRED. Use m_parent->deliveryRate() instead.
-    //int m_RTT;               // NOT REQUIRED. Use m_parent->RTT() instead.
+    //int m_RTT;               // NOT REQUIRED. Use m_parent->SRTT() instead.
     //char* m_pcParam;         // Used to access m_llMaxBw. Use m_parent->maxBandwidth() instead.
 
     // Constructor in protected section so that this class is semi-abstract.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -302,7 +302,7 @@ public: // internal API
     void sendSrtMsg(int cmd, uint32_t *srtdata_in = NULL, size_t srtlen_in = 0);
 
     bool        isOPT_TsbPd()                   const { return m_config.bTSBPD; }
-    int         RTT()                           const { return m_iRTT; }
+    int         RTT()                           const { return m_iSRTT; }
     int         RTTVar()                        const { return m_iRTTVar; }
     int32_t     sndSeqNo()                      const { return m_iSndCurrSeqNo; }
     int32_t     schedSeqNo()                    const { return m_iSndNextSeqNo; }
@@ -733,12 +733,12 @@ private:
 
     int m_iEXPCount;                             // Expiration counter
     int m_iBandwidth;                            // Estimated bandwidth, number of packets per second
-    int m_iRTT;                                  // Smoothed RTT (an exponentially-weighted moving average (EWMA)
+    int m_iSRTT;                                 // Smoothed RTT (an exponentially-weighted moving average (EWMA)
                                                  // of an endpoint's RTT samples), in microseconds
     int m_iRTTVar;                               // The variation in the RTT samples (RTT variance), in microseconds
     bool m_bIsFirstRTTReceived;                  // True if the first RTT sample was obtained from the ACK/ACKACK pair
                                                  // at the receiver side or received by the sender from an ACK packet.
-                                                 // It's used to reset the initial value of smoothed RTT (m_iRTT)
+                                                 // It's used to reset the initial value of smoothed RTT (m_iSRTT)
                                                  // at the beginning of transmission (including the one taken from
                                                  // cache). False by default.
     int m_iDeliveryRate;                         // Packet arrival rate at the receiver side

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -302,7 +302,7 @@ public: // internal API
     void sendSrtMsg(int cmd, uint32_t *srtdata_in = NULL, size_t srtlen_in = 0);
 
     bool        isOPT_TsbPd()                   const { return m_config.bTSBPD; }
-    int         RTT()                           const { return m_iSRTT; }
+    int         SRTT()                          const { return m_iSRTT; }
     int         RTTVar()                        const { return m_iRTTVar; }
     int32_t     sndSeqNo()                      const { return m_iSndCurrSeqNo; }
     int32_t     schedSeqNo()                    const { return m_iSndNextSeqNo; }

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -439,7 +439,7 @@ void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen SRT_ATR_UNUSED)
      * then (re-)send handshake request.
      */
     if (((m_SndKmMsg[0].iPeerRetry > 0) || (m_SndKmMsg[1].iPeerRetry > 0))
-        && ((m_SndKmLastTime + srt::sync::microseconds_from((m_parent->RTT() * 3)/2)) <= now))
+        && ((m_SndKmLastTime + srt::sync::microseconds_from((m_parent->SRTT() * 3)/2)) <= now))
     {
         for (int ki = 0; ki < 2; ki++)
         {

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2978,7 +2978,7 @@ public:
         m_fout << u.id() << ",";
         m_fout << weight << ",";
         m_fout << u.peerLatency_us() << ",";
-        m_fout << u.RTT() << ",";
+        m_fout << u.SRTT() << ",";
         m_fout << u.RTTVar() << ",";
         m_fout << stability_tmo_us << ",";
         m_fout << count_microseconds(currtime - u.lastRspTime()) << ",";
@@ -3039,7 +3039,7 @@ static int sendBackup_CheckRunningLinkStable(const CUDT& u, const srt::sync::ste
 
     const int64_t stability_tout_us = is_activation_phase
         ? initial_stabtout_us // activation phase
-        : min<int64_t>(max<int64_t>(min_stability_us, 2 * u.RTT() + 4 * u.RTTVar()), latency_us);
+        : min<int64_t>(max<int64_t>(min_stability_us, 2 * u.SRTT() + 4 * u.RTTVar()), latency_us);
     
     const steady_clock::time_point last_rsp = max(u.freshActivationStart(), u.lastRspTime());
     const steady_clock::duration td_response = currtime - last_rsp;


### PR DESCRIPTION
- Renamed `m_iRTT` variable to `m_iSRTT` so it reflects that the RTT estimate is a smoothed RTT, an exponentially-weighted moving average (EWMA) of an endpoint's RTT samples. SRTT means smoothed RTT (see [RFC6298](https://datatracker.ietf.org/doc/html/rfc6298) for the reference).
- Updated `msRTT` description in `docs/API/statistics.md`.