### PR TITLE
Fixed nonblocking client example

### DIFF
--- a/examples/example-client-nonblock.c
+++ b/examples/example-client-nonblock.c
@@ -31,7 +31,7 @@ int main(int argc, char** argv)
 {
     int ss, st;
     struct sockaddr_in sa;
-    int yes = 1;
+    const int no = 0;
     const char message [] = "This message should be sent to the other side";
 
     if (argc != 3) {
@@ -66,8 +66,8 @@ int main(int argc, char** argv)
     }
 
     printf("srt setsockflag\n");
-    if (SRT_ERROR == srt_setsockflag(ss, SRTO_RCVSYN, &yes, sizeof yes)
-        || SRT_ERROR == srt_setsockflag(ss, SRTO_SNDSYN, &yes, sizeof yes))
+    if (SRT_ERROR == srt_setsockflag(ss, SRTO_RCVSYN, &no, sizeof no)
+        || SRT_ERROR == srt_setsockflag(ss, SRTO_SNDSYN, &no, sizeof no))
     {
         fprintf(stderr, "SRTO_SNDSYN or SRTO_RCVSYN: %s\n", srt_getlasterror_str());
         return 1;

--- a/examples/example-client-nonblock.c
+++ b/examples/example-client-nonblock.c
@@ -101,7 +101,7 @@ int main(int argc, char** argv)
         SRT_SOCKSTATUS state = srt_getsockstate(ss);
         if (state != SRTS_CONNECTED || rlen > 0) // rlen > 0 - an error notification
         {
-            fprintf(stderr, "srt_epoll_wait: %s\n", srt_getlasterror_str());
+            fprintf(stderr, "srt_epoll_wait: reject reason %s\n", srt_rejectreason_str(srt_getrejectreason(rready)));
             return 1;
         }
 


### PR DESCRIPTION
`SRTO_RCVSYN` and `SRTO_SNDSYN` were wrongfully set to `1` instead of `0`, as noticed by @nobodyintheworld in [this comment](https://github.com/Haivision/srt/pull/1746#issuecomment-828903129).