### PR TITLE
[apps] Removed trailing comma in JSON stats

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -552,7 +552,7 @@ public:
         }
 
         // Close the general category entity
-        output << "}," << pretty_cr << endl;
+        output << "}" << pretty_cr << endl;
 
         return output.str();
     }


### PR DESCRIPTION
Removed trailing comma in JSON stats.
It was mistakenly added in PR #1743. 
SRT v1.4.2 didn't have the trailing comma, [see here](https://github.com/Haivision/srt/blob/v1.4.2/apps/apputil.cpp#L391).

**SRT version affected**: v1.4.3.

Fixes #1975.