### PR TITLE
Added script to build the Windows installer for SRT libraries

### DIFF
--- a/scripts/win-installer/.gitignore
+++ b/scripts/win-installer/.gitignore
@@ -1,0 +1,10 @@
+tmp
+installers
+*.exe
+*~
+~*
+.#*
+*.bak
+*.autosave
+.DS_Store
+._*

--- a/scripts/win-installer/README.md
+++ b/scripts/win-installer/README.md
@@ -1,0 +1,33 @@
+## SRT Static Libraries Installer for Windows
+
+This directory contains scripts to build a binary installer for
+libsrt on Windows systems for Visual Studio applications using SRT.
+
+### Building Windows applications with libsrt
+
+After installing the libsrt binary, an environment variable named `LIBSRT` is
+defined to the installation root (typically `C:\Program Files (x86)\libsrt`).
+
+In this directory, there is a Visual Studio property file named `libsrt.props`.
+Simply reference this property file in your Visual Studio project to use libsrt.
+
+You can also do that manually by editing the application project file (the XML
+file named with a `.vcxproj` extension). Add the following line just before
+the end of the file:
+
+~~~
+  <Import Project="$(LIBSRT)\libsrt.props"/>
+~~~
+
+### Building the installer
+
+The first two steps need to be executed once only. Only the last step needs
+to be repeated each time a new version of libsrt is available.
+
+- Prerequisite 1: Install OpenSSL for Windows, both 64 and 32 bits.
+  This can be done automatically by running the PowerShell script `install-openssl.ps1`.
+- Prerequisite 2: Install NSIS, the NullSoft Installation Scripting system.
+  This can be done automatically by running the PowerShell script `install-nsis.ps1`.
+- Build the libsrt installer by running the PowerShell script `build-win-installer.ps1`.
+
+The installer is then available in the directory `installers`.

--- a/scripts/win-installer/build-win-intaller.ps1
+++ b/scripts/win-installer/build-win-intaller.ps1
@@ -56,7 +56,7 @@ function Exit-Script([string]$Message = "")
 {
     $Code = 0
     if ($Message -ne "") {
-        Write-Host "ERROR: $Message"
+        Write-Output "ERROR: $Message"
         $Code = 1
     }
     if (-not $NoPause) {

--- a/scripts/win-installer/build-win-intaller.ps1
+++ b/scripts/win-installer/build-win-intaller.ps1
@@ -1,0 +1,212 @@
+﻿#-----------------------------------------------------------------------------
+#
+#  SRT - Secure, Reliable, Transport
+#  Copyright (c) 2021, Thierry Lelegard
+# 
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#-----------------------------------------------------------------------------
+
+<#
+ .SYNOPSIS
+
+  Build the SRT static libraries installer for Windows.
+
+ .PARAMETER Version
+
+  Use the specified string as version number from libsrt. By default, if
+  the current commit has a tag, use that tag (initial 'v' removed). Otherwise,
+  the defaut version is a detailed version number (most recent version, number
+  of commits since then, short commit SHA).
+
+ .PARAMETER NoPause
+
+  Do not wait for the user to press <enter> at end of execution. By default,
+  execute a "pause" instruction at the end of execution, which is useful
+  when the script was run from Windows Explorer.
+
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [switch]$NoPause = $false
+)
+Write-Output "Building the SRT static libraries installer for Windows"
+
+# Directory containing this script:
+$ScriptDir = $PSScriptRoot
+
+# The root of the srt repository is two levels up.
+$RepoDir = (Split-Path -Parent (Split-Path -Parent $ScriptDir))
+
+# Output directory for final installers:
+$OutDir = "$ScriptDir\installers"
+
+# Temporary directory for build operations:
+$TmpDir = "$ScriptDir\tmp"
+
+
+#-----------------------------------------------------------------------------
+# A function to exit this script with optional error message, using -NoPause
+#-----------------------------------------------------------------------------
+
+function Exit-Script([string]$Message = "")
+{
+    $Code = 0
+    if ($Message -ne "") {
+        Write-Host "ERROR: $Message"
+        $Code = 1
+    }
+    if (-not $NoPause) {
+        pause
+    }
+    exit $Code
+}
+
+
+#-----------------------------------------------------------------------------
+# Build SRT version strings
+#-----------------------------------------------------------------------------
+
+# By default, let git format a decent version number.
+if (-not $Version) {
+    $Version = (git describe --tags ) -replace '-g','-'
+}
+$Version = $Version -replace '^v',''
+
+# Split version string in pieces and make sure to get at least four elements.
+$VField = ($Version -split "[-\. ]") + @("0", "0", "0", "0") | Select-String -Pattern '^\d*$'
+$VersionInfo = "$($VField[0]).$($VField[1]).$($VField[2]).$($VField[3])"
+
+Write-Output "SRT version: $Version"
+Write-Output "Windows version info: $VersionInfo"
+
+
+#-----------------------------------------------------------------------------
+# Initialization phase, verify prerequisites
+#-----------------------------------------------------------------------------
+
+# Locate OpenSSL root from local installation.
+$SslRoot = @{
+    "x64" = "C:\Program Files\OpenSSL-Win64";
+    "Win32" = "C:\Program Files (x86)\OpenSSL-Win32"
+}
+
+# Verify OpenSSL directories.
+$Missing = 0
+foreach ($file in @($SslRoot["x64"], $SslRoot["Win32"])) {
+    if (-not (Test-Path $file)) {
+        Write-Output "**** Missing $file"
+        $Missing = $Missing + 1
+    }
+}
+if ($Missing -gt 0) {
+    Exit-Script "Missing $Missing OpenSSL files, use install-openssl.ps1 to install OpenSSL"
+}
+
+# Locate MSBuild and CMake, regardless of Visual Studio version.
+Write-Output "Searching MSBuild ..."
+$MSRoots = @("C:\Program Files*\MSBuild", "C:\Program Files*\Microsoft Visual Studio", "C:\Program Files*\CMake*")
+$MSBuild = Get-ChildItem -Recurse -Path $MSRoots -Include MSBuild.exe -ErrorAction Ignore |
+    ForEach-Object { (Get-Command $_).FileVersionInfo } |
+    Sort-Object -Unique -Property FileVersion |
+    ForEach-Object { $_.FileName} |
+    Select-Object -Last 1
+if (-not $MSBuild) {
+    Exit-Script "MSBuild not found"
+}
+
+Write-Output "Searching CMake ..."
+$CMake = Get-ChildItem -Recurse -Path $MSRoots -Include cmake.exe -ErrorAction Ignore |
+    ForEach-Object { (Get-Command $_).FileVersionInfo } |
+    Sort-Object -Unique -Property FileVersion |
+    ForEach-Object { $_.FileName} |
+    Select-Object -Last 1
+if (-not $CMake) {
+    Exit-Script "CMake not found, check option 'C++ CMake tools for Windows' in Visual Studio installer"
+}
+
+# Locate NSIS, the Nullsoft Scriptable Installation System.
+Write-Output "Searching NSIS ..."
+$NSIS = Get-Item "C:\Program Files*\NSIS\makensis.exe" | ForEach-Object { $_.FullName} | Select-Object -Last 1
+if (-not $NSIS) {
+    Exit-Script "NSIS not found, use install-nsis.ps1 to install NSIS"
+}
+
+Write-Output "MSBuild: $MSBuild"
+Write-Output "CMake: $CMake"
+Write-Output "NSIS: $NSIS"
+
+# Create the directories for builds when necessary.
+[void](New-Item -Path $TmpDir -ItemType Directory -Force)
+[void](New-Item -Path $OutDir -ItemType Directory -Force)
+
+
+#-----------------------------------------------------------------------------
+# Configure and build SRT library using CMake on two architectures.
+#-----------------------------------------------------------------------------
+
+foreach ($Platform in @("x64", "Win32")) {
+
+    # Build directory. Cleanup to force a fresh cmake config.
+    $BuildDir = "$TmpDir\build.$Platform"
+    Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $BuildDir
+    [void](New-Item -Path $BuildDir -ItemType Directory -Force)
+
+    # Run CMake.
+    Write-Output "Configuring build for platform $Platform ..."
+    $SRoot = $SslRoot[$Platform]
+    & $CMake -S $RepoDir -B $BuildDir -A $Platform `
+        -DENABLE_STDCXX_SYNC=ON `
+        -DOPENSSL_ROOT_DIR="$SRoot" `
+        -DOPENSSL_LIBRARIES="$SRoot\lib\libssl_static.lib;$SRoot\lib\libcrypto_static.lib" `
+        -DOPENSSL_INCLUDE_DIR="$SRoot\include"
+
+    # Patch version string in version.h
+    Get-Content "$BuildDir\version.h" |
+        ForEach-Object {
+            $_ -replace "#define *SRT_VERSION_STRING .*","#define SRT_VERSION_STRING `"$Version`""
+        } |
+        Out-File "$BuildDir\version.new" -Encoding ascii
+    Move-Item "$BuildDir\version.new" "$BuildDir\version.h" -Force
+
+    # Compile SRT.
+    Write-Output "Building for platform $Platform ..."
+    foreach ($Conf in @("Release", "Debug")) {
+        & $MSBuild "$BuildDir\SRT.sln" /nologo /maxcpucount /property:Configuration=$Conf /property:Platform=$Platform /target:srt_static
+    }
+}
+
+# Verify the presence of compiled libraries.
+Write-Output "Checking compiled libraries ..."
+$Missing = 0
+foreach ($Conf in @("Release", "Debug")) {
+    foreach ($Platform in @("x64", "Win32")) {
+        $Path = "$TmpDir\build.$Platform\$Conf\srt_static.lib"
+        if (-not (Test-Path $Path)) {
+            Write-Output "**** Missing $Path"
+            $Missing = $Missing + 1
+        }
+    }
+}
+if ($Missing -gt 0) {
+    Exit-Script "Missing $Missing files"
+}
+
+
+#-----------------------------------------------------------------------------
+# Build the binary installer.
+#-----------------------------------------------------------------------------
+
+Write-Output "Building installer ..."
+& $NSIS /V2 `
+    /DVersion="$Version" `
+    /DVersionInfo="$VersionInfo" `
+    /DOutDir="$OutDir" `
+    /DBuildRoot="$TmpDir" `
+    /DRepoDir="$RepoDir" `
+    "$ScriptDir\libsrt.nsi" 
+
+Exit-Script

--- a/scripts/win-installer/install-nsis.ps1
+++ b/scripts/win-installer/install-nsis.ps1
@@ -44,7 +44,7 @@ function Exit-Script([string]$Message = "")
 {
     $Code = 0
     if ($Message -ne "") {
-        Write-Host "ERROR: $Message"
+        Write-Output "ERROR: $Message"
         $Code = 1
     }
     if (-not $NoPause) {

--- a/scripts/win-installer/install-nsis.ps1
+++ b/scripts/win-installer/install-nsis.ps1
@@ -1,0 +1,122 @@
+﻿#-----------------------------------------------------------------------------
+#
+#  SRT - Secure, Reliable, Transport
+#  Copyright (c) 2021, Thierry Lelegard
+# 
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#-----------------------------------------------------------------------------
+
+<#
+ .SYNOPSIS
+
+  Download, expand and install NSIS, the NullSoft Installer Scripting.
+
+ .PARAMETER ForceDownload
+
+  Force a download even if NSIS is already downloaded.
+
+ .PARAMETER NoInstall
+
+  Do not install the NSIS package. By default, NSIS is installed.
+
+ .PARAMETER NoPause
+
+  Do not wait for the user to press <enter> at end of execution. By default,
+  execute a "pause" instruction at the end of execution, which is useful
+  when the script was run from Windows Explorer.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+param(
+    [switch]$ForceDownload = $false,
+    [switch]$NoInstall = $false,
+    [switch]$NoPause = $false
+)
+
+Write-Output "NSIS download and installation procedure"
+$NSISPage = "https://nsis.sourceforge.io/Download"
+$FallbackURL = "http://prdownloads.sourceforge.net/nsis/nsis-3.05-setup.exe?download"
+
+# A function to exit this script.
+function Exit-Script([string]$Message = "")
+{
+    $Code = 0
+    if ($Message -ne "") {
+        Write-Host "ERROR: $Message"
+        $Code = 1
+    }
+    if (-not $NoPause) {
+        pause
+    }
+    exit $Code
+}
+
+# Local file names.
+$RootDir = $PSScriptRoot
+$TmpDir = "$RootDir\tmp"
+
+# Create the directory for external products when necessary.
+[void] (New-Item -Path $TmpDir -ItemType Directory -Force)
+
+# Without this, Invoke-WebRequest is awfully slow.
+$ProgressPreference = 'SilentlyContinue'
+
+# Get the HTML page for NSIS downloads.
+$status = 0
+$message = ""
+$Ref = $null
+try {
+    $response = Invoke-WebRequest -UseBasicParsing -UserAgent Download -Uri $NSISPage
+    $status = [int] [Math]::Floor($response.StatusCode / 100)
+}
+catch {
+    $message = $_.Exception.Message
+}
+
+if ($status -ne 1 -and $status -ne 2) {
+    # Error fetch NSIS download page.
+    if ($message -eq "" -and (Test-Path variable:response)) {
+        Write-Output "Status code $($response.StatusCode), $($response.StatusDescription)"
+    }
+    else {
+        Write-Output "#### Error accessing ${NSISPage}: $message"
+    }
+}
+else {
+    # Parse HTML page to locate the latest installer.
+    $Ref = $response.Links.href | Where-Object { $_ -like "*/nsis-*-setup.exe?download" } | Select-Object -First 1
+}
+
+if (-not $Ref) {
+    # Could not find a reference to NSIS installer.
+    $Url = [System.Uri]$FallbackURL
+}
+else {
+    # Build the absolute URL's from base URL (the download page) and href links.
+    $Url = New-Object -TypeName 'System.Uri' -ArgumentList ([System.Uri]$NSISPage, $Ref)
+}
+
+$InstallerName = (Split-Path -Leaf $Url.LocalPath)
+$InstallerPath = "$TmpDir\$InstallerName"
+
+# Download installer
+if (-not $ForceDownload -and (Test-Path $InstallerPath)) {
+    Write-Output "$InstallerName already downloaded, use -ForceDownload to download again"
+}
+else {
+    Write-Output "Downloading $Url ..."
+    Invoke-WebRequest -UseBasicParsing -UserAgent Download -Uri $Url -OutFile $InstallerPath
+    if (-not (Test-Path $InstallerPath)) {
+        Exit-Script "$Url download failed"
+    }
+}
+
+# Install NSIS
+if (-not $NoInstall) {
+    Write-Output "Installing $InstallerName"
+    Start-Process -FilePath $InstallerPath -ArgumentList @("/S") -Wait
+}
+
+Exit-Script

--- a/scripts/win-installer/install-openssl.ps1
+++ b/scripts/win-installer/install-openssl.ps1
@@ -1,0 +1,119 @@
+﻿#-----------------------------------------------------------------------------
+#
+#  SRT - Secure, Reliable, Transport
+#  Copyright (c) 2021, Thierry Lelegard
+# 
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+#-----------------------------------------------------------------------------
+
+<#
+ .SYNOPSIS
+
+  Download, expand and install OpenSSL for Windows.
+
+ .PARAMETER ForceDownload
+
+  Force a download even if the OpenSSL installers are already downloaded.
+
+ .PARAMETER NoInstall
+
+  Do not install the OpenSSL packages. By default, OpenSSL is installed.
+
+ .PARAMETER NoPause
+
+  Do not wait for the user to press <enter> at end of execution. By default,
+  execute a "pause" instruction at the end of execution, which is useful
+  when the script was run from Windows Explorer.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+param(
+    [switch]$ForceDownload = $false,
+    [switch]$NoInstall = $false,
+    [switch]$NoPause = $false
+)
+
+Write-Output "OpenSSL download and installation procedure"
+$OpenSSLHomePage = "http://slproweb.com/products/Win32OpenSSL.html"
+
+# A function to exit this script.
+function Exit-Script([string]$Message = "")
+{
+    $Code = 0
+    if ($Message -ne "") {
+        Write-Host "ERROR: $Message"
+        $Code = 1
+    }
+    if (-not $NoPause) {
+        pause
+    }
+    exit $Code
+}
+
+# Local file names.
+$RootDir = $PSScriptRoot
+$TmpDir = "$RootDir\tmp"
+
+# Create the directory for external products when necessary.
+[void] (New-Item -Path $TmpDir -ItemType Directory -Force)
+
+# Without this, Invoke-WebRequest is awfully slow.
+$ProgressPreference = 'SilentlyContinue'
+
+# Get the HTML page for OpenSSL downloads.
+$status = 0
+$message = ""
+try {
+    $response = Invoke-WebRequest -UseBasicParsing -UserAgent Download -Uri $OpenSSLHomePage
+    $status = [int] [Math]::Floor($response.StatusCode / 100)
+}
+catch {
+    $message = $_.Exception.Message
+}
+if ($status -ne 1 -and $status -ne 2) {
+    if ($message -eq "" -and (Test-Path variable:response)) {
+        Exit-Script "Status code $($response.StatusCode), $($response.StatusDescription)"
+    }
+    else {
+        Exit-Script "#### Error accessing ${OpenSSLHomePage}: $message"
+    }
+}
+
+# Parse HTML page to locate the latest MSI files.
+$Ref32 = $response.Links.href | Where-Object { $_ -like "*/Win32OpenSSL-*.msi" } | Select-Object -First 1
+$Ref64 = $response.Links.href | Where-Object { $_ -like "*/Win64OpenSSL-*.msi" } | Select-Object -First 1
+
+# Build the absolute URL's from base URL (the download page) and href links.
+$Url32 = New-Object -TypeName 'System.Uri' -ArgumentList ([System.Uri]$OpenSSLHomePage, $Ref32)
+$Url64 = New-Object -TypeName 'System.Uri' -ArgumentList ([System.Uri]$OpenSSLHomePage, $Ref64)
+
+# Download and install one MSI package.
+function Download-Install([string]$Url)
+{
+    $MsiName = (Split-Path -Leaf $Url.toString())
+    $MsiPath = "$TmpDir\$MsiName"
+
+    if (-not $ForceDownload -and (Test-Path $MsiPath)) {
+        Write-Output "$MsiName already downloaded, use -ForceDownload to download again"
+    }
+    else {
+        Write-Output "Downloading $Url ..."
+        Invoke-WebRequest -UseBasicParsing -UserAgent Download -Uri $Url -OutFile $MsiPath
+    }
+
+    if (-not (Test-Path $MsiPath)) {
+        Exit-Script "$Url download failed"
+    }
+
+    if (-not $NoInstall) {
+        Write-Output "Installing $MsiName"
+        Start-Process msiexec.exe -ArgumentList @("/i", $MsiPath, "/qn", "/norestart") -Wait
+    }
+}
+
+# Download and install the two MSI packages.
+Download-Install $Url32
+Download-Install $Url64
+Exit-Script

--- a/scripts/win-installer/install-openssl.ps1
+++ b/scripts/win-installer/install-openssl.ps1
@@ -43,7 +43,7 @@ function Exit-Script([string]$Message = "")
 {
     $Code = 0
     if ($Message -ne "") {
-        Write-Host "ERROR: $Message"
+        Write-Output "ERROR: $Message"
         $Code = 1
     }
     if (-not $NoPause) {

--- a/scripts/win-installer/libsrt.nsi
+++ b/scripts/win-installer/libsrt.nsi
@@ -1,0 +1,217 @@
+;-----------------------------------------------------------------------------
+;
+; SRT - Secure, Reliable, Transport
+; Copyright (c) 2021, Thierry Lelegard
+; 
+; This Source Code Form is subject to the terms of the Mozilla Public
+; License, v. 2.0. If a copy of the MPL was not distributed with this
+; file, You can obtain one at http://mozilla.org/MPL/2.0/.
+;
+;-----------------------------------------------------------------------------
+;
+; NSIS script to build the SRT binary installer for Windows.
+; Do not invoke NSIS directly, use PowerShell script build-win-installer.ps1
+; to ensure that all parameters are properly passed.
+;
+;-----------------------------------------------------------------------------
+
+Name "SRT"
+Caption "SRT Libraries Installer"
+
+!verbose push
+!verbose 0
+!include "MUI2.nsh"
+!include "Sections.nsh"
+!include "TextFunc.nsh"
+!include "FileFunc.nsh"
+!include "WinMessages.nsh"
+!include "x64.nsh"
+!verbose pop
+
+!define ProductName "libsrt"
+!define Build32Dir  "${BuildRoot}\build.Win32"
+!define Build64Dir  "${BuildRoot}\build.x64"
+!define SSL32Dir    "C:\Program Files (x86)\OpenSSL-Win32"
+!define SSL64Dir    "C:\Program Files\OpenSSL-Win64"
+
+; Installer file information.
+VIProductVersion ${VersionInfo}
+VIAddVersionKey ProductName "${ProductName}"
+VIAddVersionKey ProductVersion "${Version}"
+VIAddVersionKey Comments "The SRT static libraries for Visual C++ on Windows"
+VIAddVersionKey CompanyName "Haivision"
+VIAddVersionKey LegalCopyright "Copyright (c) 2021 Haivision Systems Inc."
+VIAddVersionKey FileVersion "${VersionInfo}"
+VIAddVersionKey FileDescription "SRT Installer"
+
+; Name of binary installer file.
+OutFile "${OutDir}\${ProductName}-${Version}.exe"
+
+; Generate a Unicode installer (default is ANSI).
+Unicode true
+
+; Registry key for environment variables
+!define EnvironmentKey '"SYSTEM\CurrentControlSet\Control\Session Manager\Environment"'
+
+; Registry entry for product info and uninstallation info.
+!define ProductKey "Software\${ProductName}"
+!define UninstallKey "Software\Microsoft\Windows\CurrentVersion\Uninstall\${ProductName}"
+
+; Use XP manifest.
+XPStyle on
+
+; Request administrator privileges for Windows Vista and higher.
+RequestExecutionLevel admin
+
+; "Modern User Interface" (MUI) settings.
+!define MUI_ABORTWARNING
+
+; Default installation folder.
+InstallDir "$PROGRAMFILES\${ProductName}"
+
+; Get installation folder from registry if available from a previous installation.
+InstallDirRegKey HKLM "${ProductKey}" "InstallDir"
+
+; Installer pages.
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+
+; Uninstaller pages.
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+; Languages.
+!insertmacro MUI_LANGUAGE "English"
+
+; Installation initialization.
+function .onInit
+    ; In 64-bit installers, don't use registry redirection.
+    ${If} ${RunningX64}
+        SetRegView 64
+    ${EndIf}
+functionEnd
+
+; Uninstallation initialization.
+function un.onInit
+    ; In 64-bit installers, don't use registry redirection.
+    ${If} ${RunningX64}
+        SetRegView 64
+    ${EndIf}
+functionEnd
+
+; Installation section
+Section "Install"
+
+    ; Work on "all users" context, not current user.
+    SetShellVarContext all
+
+    ; Delete obsolete files from previous versions.
+    Delete "$INSTDIR\LICENSE.pthread.txt"
+    Delete "$INSTDIR\include\srt\srt4udt.h"
+    Delete "$INSTDIR\include\srt\udt.h"
+    Delete "$INSTDIR\lib\Release-x64\pthread.lib"
+    Delete "$INSTDIR\lib\Release-Win32\pthread.lib"
+    Delete "$INSTDIR\lib\Debug-x64\srt.pdb"
+    Delete "$INSTDIR\lib\Debug-x64\pthread.pdb"
+    Delete "$INSTDIR\lib\Debug-x64\pthread.lib"
+    Delete "$INSTDIR\lib\Debug-Win32\srt.pdb"
+    Delete "$INSTDIR\lib\Debug-Win32\pthread.pdb"
+    Delete "$INSTDIR\lib\Debug-Win32\pthread.lib"
+
+    SetOutPath "$INSTDIR"
+    File /oname=LICENSE.txt "${RepoDir}\LICENSE"
+    File "libsrt.props"
+
+    ; Header files.
+    CreateDirectory "$INSTDIR\include\srt"
+    SetOutPath "$INSTDIR\include\srt"
+    File "${RepoDir}\srtcore\logging_api.h"
+    File "${RepoDir}\srtcore\platform_sys.h"
+    File "${RepoDir}\srtcore\srt.h"
+    File "${Build64Dir}\version.h"
+
+    CreateDirectory "$INSTDIR\include\win"
+    SetOutPath "$INSTDIR\include\win"
+    File "${RepoDir}\common\win\syslog_defs.h"
+
+    ; Libraries.
+    CreateDirectory "$INSTDIR\lib"
+    
+    CreateDirectory "$INSTDIR\lib\Release-x64"
+    SetOutPath "$INSTDIR\lib\Release-x64"
+    File /oname=srt.lib       "${Build64Dir}\Release\srt_static.lib"
+    File /oname=libcrypto.lib "${SSL64Dir}\lib\VC\static\libcrypto64MD.lib"
+    File /oname=libssl.lib    "${SSL64Dir}\lib\VC\static\libssl64MD.lib"
+
+    CreateDirectory "$INSTDIR\lib\Debug-x64"
+    SetOutPath "$INSTDIR\lib\Debug-x64"
+    File /oname=srt.lib       "${Build64Dir}\Debug\srt_static.lib"
+    File /oname=libcrypto.lib "${SSL64Dir}\lib\VC\static\libcrypto64MDd.lib"
+    File /oname=libssl.lib    "${SSL64Dir}\lib\VC\static\libssl64MDd.lib"
+
+    CreateDirectory "$INSTDIR\lib\Release-Win32"
+    SetOutPath "$INSTDIR\lib\Release-Win32"
+    File /oname=srt.lib       "${Build32Dir}\Release\srt_static.lib"
+    File /oname=libcrypto.lib "${SSL32Dir}\lib\VC\static\libcrypto32MD.lib"
+    File /oname=libssl.lib    "${SSL32Dir}\lib\VC\static\libssl32MD.lib"
+
+    CreateDirectory "$INSTDIR\lib\Debug-Win32"
+    SetOutPath "$INSTDIR\lib\Debug-Win32"
+    File /oname=srt.lib       "${Build32Dir}\Debug\srt_static.lib"
+    File /oname=libcrypto.lib "${SSL32Dir}\lib\VC\static\libcrypto32MDd.lib"
+    File /oname=libssl.lib    "${SSL32Dir}\lib\VC\static\libssl32MDd.lib"
+
+    ; Add an environment variable to installation root.
+    WriteRegStr HKLM ${EnvironmentKey} "LIBSRT" "$INSTDIR"
+
+    ; Store installation folder in registry.
+    WriteRegStr HKLM "${ProductKey}" "InstallDir" $INSTDIR
+
+    ; Create uninstaller
+    WriteUninstaller "$INSTDIR\Uninstall.exe"
+ 
+    ; Declare uninstaller in "Add/Remove Software" control panel
+    WriteRegStr HKLM "${UninstallKey}" "DisplayName" "${ProductName}"
+    WriteRegStr HKLM "${UninstallKey}" "Publisher" "Haivision"
+    WriteRegStr HKLM "${UninstallKey}" "URLInfoAbout" "https://github.com/Haivision/srt"
+    WriteRegStr HKLM "${UninstallKey}" "DisplayVersion" "${Version}"
+    WriteRegStr HKLM "${UninstallKey}" "DisplayIcon" "$INSTDIR\Uninstall.exe"
+    WriteRegStr HKLM "${UninstallKey}" "UninstallString" "$INSTDIR\Uninstall.exe"
+
+    ; Get estimated size of installed files
+    ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+    IntFmt $0 "0x%08X" $0
+    WriteRegDWORD HKLM "${UninstallKey}" "EstimatedSize" "$0"
+
+    ; Notify applications of environment modifications
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+SectionEnd
+
+; Uninstallation section
+Section "Uninstall"
+
+    ; Work on "all users" context, not current user.
+    SetShellVarContext all
+
+    ; Get installation folder from registry
+    ReadRegStr $0 HKLM "${ProductKey}" "InstallDir"
+
+    ; Delete product registry entries
+    DeleteRegKey HKCU "${ProductKey}"
+    DeleteRegKey HKLM "${ProductKey}"
+    DeleteRegKey HKLM "${UninstallKey}"
+    DeleteRegValue HKLM ${EnvironmentKey} "LIBSRT"
+
+    ; Delete product files.
+    RMDir /r "$0\include"
+    RMDir /r "$0\lib"
+    Delete "$0\libsrt.props"
+    Delete "$0\LICENSE*"
+    Delete "$0\Uninstall.exe"
+    RMDir "$0"
+
+    ; Notify applications of environment modifications
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+SectionEnd

--- a/scripts/win-installer/libsrt.props
+++ b/scripts/win-installer/libsrt.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Visual Studio or MSBuild property file to use SRT static library -->
+
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Compilation and link options -->
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(LIBSRT)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>srt.lib;libssl.lib;libcrypto.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(LIBSRT)\lib\$(Configuration)-$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+
+</Project>


### PR DESCRIPTION
See the scripts/win-installer/README.md file for details.

The Windows installer for SRT is currently managed in a [separate project](https://github.com/tsduck/srt-win-installer) in the context of the [TSDuck project](https://tsduck.io). It was proposed as a contribution in issue #1068. This pull request follows @maxsharabayko's request in the same issue.
