### PR TITLE
[core] Added srt::sync::genRandomInt(..)

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -194,22 +194,7 @@ m_bGCStatus(false),
 m_ClosedSockets()
 {
    // Socket ID MUST start from a random value
-   // Note. Don't use CTimer here, because s_UDTUnited is a static instance of CUDTUnited
-   // with dynamic initialization (calling this constructor), while CTimer has
-   // a static member s_ullCPUFrequency with dynamic initialization.
-   // The order of initialization is not guaranteed.
-   timeval t;
-
-   gettimeofday(&t, 0);
-   srand((unsigned int)t.tv_usec);
-
-   const double rand1_0 = double(rand())/RAND_MAX;
-
-   // Motivation: in case when rand() returns the value equal to RAND_MAX,
-   // rand1_0 == 1, so the below formula will be
-   // 1 + (MAX_SOCKET_VAL-1) * 1 = 1 + MAX_SOCKET_VAL - 1 = MAX_SOCKET_VAL
-   // which is the highest allowed value for the socket.
-   m_SocketIDGenerator = 1 + int((MAX_SOCKET_VAL-1) * rand1_0);
+   m_SocketIDGenerator = genRandomInt(1, MAX_SOCKET_VAL);
    m_SocketIDGenerator_init = m_SocketIDGenerator;
 
    // XXX An unlikely exception thrown from the below calls

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -562,12 +562,6 @@ int CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
 
     if (!packet.isControl())
     {
-        if (dcounter == 0)
-        {
-            timeval tv;
-            gettimeofday(&tv, 0);
-            srand(tv.tv_usec & 0xFFFF);
-        }
         ++dcounter;
 
         if (flwcounter)
@@ -581,7 +575,7 @@ int CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
         if (dcounter > 8)
         {
             // Make a random number in the range between 8 and 24
-            int rnd = rand() % 16 + SRT_TEST_FAKE_LOSS;
+            const int rnd = srt::sync::getRandomInt(8, 24);
 
             if (dcounter > rnd)
             {

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -525,11 +525,9 @@ private:
 
             m_iLastDecSeq = m_parent->sndSeqNo();
 
-            // remove global synchronization using randomization
-            srand(m_iLastDecSeq);
-            m_iDecRandom = (int)ceil(m_iAvgNAKNum * (double(rand()) / RAND_MAX));
-            if (m_iDecRandom < 1)
-                m_iDecRandom = 1;
+            // remove global synchronization using randomization.
+            m_iDecRandom = genRandomInt(1, m_iAvgNAKNum);
+            SRT_ASSERT(m_iDecRandom >= 1);
             HLOGC(cclog.Debug, log << "FileCC: LOSS:NEW lseqno=" << lossbegin
                 << ", lastsentseqno=" << m_iLastDecSeq
                 << ", seqdiff=" << CSeqNo::seqoff(m_iLastDecSeq, lossbegin)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -401,9 +401,7 @@ public: // internal API
     static int32_t generateISN()
     {
         using namespace srt::sync;
-        // Random Initial Sequence Number (normal mode)
-        srand((unsigned) count_microseconds(steady_clock::now().time_since_epoch()));
-        return (int32_t)(CSeqNo::m_iMaxSeqNo * (double(rand()) / RAND_MAX));
+        return genRandomInt(0, CSeqNo::m_iMaxSeqNo);
     }
 
     // For SRT_tsbpdLoop

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -30,7 +30,7 @@
    #include <ws2ipdef.h>
    #include <windows.h>
 
-#ifndef __MINGW__
+#ifndef __MINGW32__
    #include <intrin.h>
 #endif
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -35,7 +35,7 @@ written by
 
 
 #ifdef _WIN32
-   #ifndef __MINGW__
+   #ifndef __MINGW32__
       // Explicitly define 32-bit and 64-bit numbers
       typedef __int32 int32_t;
       typedef __int64 int64_t;
@@ -56,7 +56,7 @@ written by
       #else
          #define SRT_API
       #endif
-   #else // __MINGW__
+   #else // __MINGW32__
       #define SRT_API
    #endif
 #else
@@ -152,7 +152,7 @@ typedef int32_t SRTSOCKET;
 static const int32_t SRTGROUP_MASK = (1 << 30);
 
 #ifdef _WIN32
-   #ifndef __MINGW__
+   #ifndef __MINGW32__
       typedef SOCKET SYSSOCKET;
    #else
       typedef int SYSSOCKET;

--- a/srtcore/srt_compat.h
+++ b/srtcore/srt_compat.h
@@ -22,7 +22,7 @@ written by
 
 #ifndef SRT_API
 #ifdef _WIN32
-   #ifndef __MINGW__
+   #ifndef __MINGW32__
       #ifdef SRT_DYNAMIC
          #ifdef SRT_EXPORTS
             #define SRT_API __declspec(dllexport)

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -18,11 +18,18 @@
 #include "logging.h"
 #include "common.h"
 
+// HAVE_CXX11 is defined in utilities.h, included with common.h. 
+// The following conditional inclusion must go after common.h.
+#if HAVE_CXX11 
+#include <random>
+#endif
+
 namespace srt_logging
 {
     extern Logger inlog;
 }
 using namespace srt_logging;
+using namespace std;
 
 namespace srt
 {
@@ -265,5 +272,79 @@ void srt::sync::CGlobEvent::triggerEvent()
 bool srt::sync::CGlobEvent::waitForEvent()
 {
     return g_Sync.lock_wait_for(milliseconds_from(10));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// Random
+//
+////////////////////////////////////////////////////////////////////////////////
+
+namespace srt
+{
+#if HAVE_CXX11
+static std::random_device& randomDevice()
+{
+    static std::random_device s_RandomDevice;
+    return s_RandomDevice;
+}
+#elif defined(_WIN32) && defined(__MINGW32__)
+static void initRandSeed()
+{
+    const int64_t seed = sync::steady_clock::now().time_since_epoch().count();
+    srand((unsigned int) seed);
+}
+static pthread_once_t s_InitRandSeedOnce = PTHREAD_ONCE_INIT;
+#else
+
+static unsigned int genRandSeed()
+{
+    // Duration::count() does not depend on any global objects,
+    // therefore it is preferred over count)microseconds(..).
+    const int64_t seed = sync::steady_clock::now().time_since_epoch().count();
+    return (unsigned int) seed;
+}
+
+static unsigned int* getRandSeed()
+{
+    static unsigned int s_uRandSeed = genRandSeed();
+    return &s_uRandSeed;
+}
+
+#endif
+}
+
+int srt::sync::genRandomInt(int minVal, int maxVal)
+{
+    // This Meyers singleton initialization is thread-safe since C++11, but is not thread-safe in C++03.
+    // A mutex to protect simulteneout access to the random device.
+    // Thread-local storage could be used here instead to store the seed / random device.
+    // However the generator is not used often (Initial Socket ID, Initial sequence number, FileCC),
+    // so sharing a single seed among threads should not impact the performance.
+    static sync::Mutex s_mtxRandomDevice;
+    sync::ScopedLock lck(s_mtxRandomDevice);
+#if HAVE_CXX11
+    uniform_int_distribution<> dis(minVal, maxVal); 
+    return dis(randomDevice());
+#else
+#if defined(__MINGW32__)
+    // No rand_r(..) for MinGW.
+    pthread_once(&s_InitRandSeedOnce, initRandSeed);
+    // rand() returns a pseudo-random integer in the range 0 to RAND_MAX inclusive
+    // (i.e., the mathematical range [0, RAND_MAX]). 
+    // Therefore, rand_0_1 belongs to [0.0, 1.0].
+    const double rand_0_1 = double(rand()) / RAND_MAX;
+#else // not __MINGW32__
+    // rand_r(..) returns a pseudo-random integer in the range 0 to RAND_MAX inclusive
+    // (i.e., the mathematical range [0, RAND_MAX]). 
+    // Therefore, rand_0_1 belongs to [0.0, 1.0].
+    const double rand_0_1 = double(rand_r(getRandSeed())) / RAND_MAX;
+#endif
+
+    // Map onto [minVal, maxVal].
+    // Note. The probablity to get maxVal as the result is minuscule.
+    const int res = minVal + static_cast<int>((maxVal - minVal) * rand_0_1);
+    return res;
+#endif // HAVE_CXX11
 }
 

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -227,7 +227,7 @@ bool srt::sync::CTimer::sleep_until(TimePoint<steady_clock> tp)
         __asm__ volatile ("nop 0; nop 0; nop 0; nop 0; nop 0;");
 #elif AMD64
         __asm__ volatile ("nop; nop; nop; nop; nop;");
-#elif defined(_WIN32) && !defined(__MINGW__)
+#elif defined(_WIN32) && !defined(__MINGW32__)
         __nop();
         __nop();
         __nop();

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -835,6 +835,18 @@ void SetThreadLocalError(const CUDTException& e);
 /// @returns CUDTException pointer
 CUDTException& GetThreadLocalError();
 
+////////////////////////////////////////////////////////////////////////////////
+//
+// Random distribution functions.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+/// Generate a uniform-distributed random integer from [minVal; maxVal].
+/// If HAVE_CXX11, uses std::uniform_distribution(std::random_device).
+/// @param[in] minVal minimum allowed value of the resulting random number.
+/// @param[in] maxVal maximum allowed value of the resulting random number.
+int genRandomInt(int minVal, int maxVal);
+
 } // namespace sync
 } // namespace srt
 

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -82,20 +82,12 @@ modified by
 #define INCREMENT_THREAD_ITERATIONS()
 #endif
 
-/* Obsolete way to define MINGW */
-#ifndef __MINGW__
-#if defined(__MINGW32__) || defined(__MINGW64__)
-#define __MINGW__ 1
-#endif
-#endif
-
 #ifdef __cplusplus
 #include <fstream>
 #include <set>
 #include <string>
 #include <vector>
 #endif
-
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -34,7 +34,6 @@ written by
 #define ATR_UNUSED
 #define ATR_DEPRECATED
 #endif
-
 #if defined(__cplusplus) && __cplusplus > 199711L
 #define HAVE_CXX11 1
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -157,6 +157,27 @@ TEST(SyncDuration, OperatorMultIntEq)
     EXPECT_EQ(count_milliseconds(a), 7000);
 }
 
+TEST(SyncRandom, GenRandomInt)
+{
+    vector<int> mn(64);
+
+    for (int i = 0; i < 2048; ++i)
+    {
+        const int rand_val = genRandomInt(0, 63);
+        ASSERT_GE(rand_val, 0);
+        ASSERT_LE(rand_val, 63);
+        ++mn[rand_val];
+    }
+
+    // Uncomment to see the distribution.
+    // for (size_t i = 0; i < mn.size(); ++i)
+    // {
+    //     cout << i << '\t';
+    //     for (int j=0; j<mn[i]; ++j) cout << '*';
+    //     cout << '\n';
+    // }
+}
+
 /*****************************************************************************/
 /*
  * TimePoint tests


### PR DESCRIPTION
## 1. Fixed MinGW Build

_Commit no. 1._
Previously a custom definition `__MINGW__` was defined in `udt.h`. However, `udt.h`. was not included in every source file, which uses `__MINGW__` preprocessor definition, **including `srt.h`**.

According to [this table](http://beefchunk.com/documentation/lang/c/pre-defined-c/precomp.html) MinGW defines `__MINGW32__` preprocessor definition.
Now simply using `__MINGW32__` preprocessor definition in relevant places.

## 2. Thread-Safe Random

_Commit no. 2._
POSIX `rand()` is not thread safe.
This PR makes use of `rand_r(unsigned int *seed)` instead.
- C++11 enabled: `std::random_device` and `std::uniform_ditribution`;
- C++03 mode: a thread-safe `rand_r(unsigned int *seed)` is used instead.
- MinGW: still uses `rand()` as there is no `rand_r(..)` available.

### TODO

- [x] Maybe use thread-local seed? - Not using as random is not called that often. The most often series of calls would happen in case of congestion in file transfer configuration.
- [x] No `rand_r` on MinGW? - using `rand()`.

Fixes #1825.
Maybe improves the situation with #1838.