### PR TITLE
[core] Added Clang TSA attributes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ option(USE_BUSY_WAITING "Enable more accurate sending times at a cost of potenti
 option(USE_GNUSTL "Get c++ library/headers from the gnustl.pc" OFF)
 option(ENABLE_SOCK_CLOEXEC "Enable setting SOCK_CLOEXEC on a socket" ON)
 
+option(ENABLE_CLANG_TSA "Enable Clang Thread Safety Analysis" OFF)
+
 set(TARGET_srt "srt" CACHE STRING "The name for the SRT library")
 
 # Use application-defined group reader
@@ -632,6 +634,11 @@ if (ENABLE_THREAD_CHECK)
 		-DFUGU_PLATFORM=1
 		-I${WITH_THREAD_CHECK_INCLUDEDIR}
 	)
+endif()
+
+if (ENABLE_CLANG_TSA)
+	list(APPEND SRT_EXTRA_CFLAGS "-Wthread-safety")
+	message(STATUS "Clang TSA: Enabled")
 endif()
 
 if (ENABLE_PROFILE)

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -131,8 +131,11 @@ struct LogConfig
     {
     }
 
-    void lock() ACQUIRE(mutex) { mutex.lock(); }
-    void unlock() RELEASE(mutex) { mutex.unlock(); }
+    SRT_ATTR_ACQUIRE(mutex)
+    void lock() { mutex.lock(); }
+
+    SRT_ATTR_RELEASE(mutex)
+    void unlock() { mutex.unlock(); }
 };
 
 // The LogDispatcher class represents the object that is responsible for

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -131,8 +131,8 @@ struct LogConfig
     {
     }
 
-    void lock() { mutex.lock(); }
-    void unlock() { mutex.unlock(); }
+    void lock() ACQUIRE(mutex) { mutex.lock(); }
+    void unlock() RELEASE(mutex) { mutex.unlock(); }
 };
 
 // The LogDispatcher class represents the object that is responsible for

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -41,7 +41,7 @@
    #include <stdint.h>
    #include <inttypes.h>
    #if defined(_MSC_VER)
-      #pragma warning(disable:4251)
+      #pragma warning(disable: 4251 26812)
    #endif
 #else
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -961,7 +961,7 @@ typedef struct SRT_EPOLL_EVENT_STR
     int       events; // SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR
 #ifdef __cplusplus
     SRT_EPOLL_EVENT_STR(SRTSOCKET s, int ev): fd(s), events(ev) {}
-    SRT_EPOLL_EVENT_STR() {} // NOTE: allows singular values, no init.
+    SRT_EPOLL_EVENT_STR(): fd(-1), events(0) {} // NOTE: allows singular values, no init.
 #endif
 } SRT_EPOLL_EVENT;
 SRT_API int srt_epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);

--- a/srtcore/srt_attr_defs.h
+++ b/srtcore/srt_attr_defs.h
@@ -1,0 +1,89 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2019 Haivision Systems Inc.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+/*****************************************************************************
+The file contains various planform and compiler dependent attribute definitions
+used by SRT library internally.
+
+1. Attributes for thread safety analysis
+   - Clang (https://clang.llvm.org/docs/ThreadSafetyAnalysis.html#mutexheader).
+   - Other compilers: none.
+
+ *****************************************************************************/
+
+#ifndef INC_SRT_ATTR_DEFS_H
+#define INC_SRT_ATTR_DEFS_H
+
+#if defined(__clang__)
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
+#else
+#define THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
+#endif
+
+#define CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY \
+  THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define PT_GUARDED_BY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
+
+#define ACQUIRED_BEFORE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
+
+#define ACQUIRED_AFTER(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
+
+#define REQUIRES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define REQUIRES_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define ACQUIRE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
+
+#define RELEASE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define RELEASE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
+
+#define RELEASE_GENERIC(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(release_generic_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
+
+#define TRY_ACQUIRE_SHARED(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define ASSERT_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
+
+#define ASSERT_SHARED_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
+
+#define RETURN_CAPABILITY(x) \
+  THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+  THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+#endif // INC_SRT_ATTR_DEFS_H

--- a/srtcore/srt_attr_defs.h
+++ b/srtcore/srt_attr_defs.h
@@ -20,70 +20,100 @@ used by SRT library internally.
 #ifndef INC_SRT_ATTR_DEFS_H
 #define INC_SRT_ATTR_DEFS_H
 
+#if _MSC_VER >= 1920
+// In case of MSVC these attributes have to preceed the attributed objects (variable, function).
+// E.g. SRT_ATTR_GUARDED_BY(mtx) int object;
+// It is tricky to annotate e.g. the following function, as clang complaints it does not know 'm'.
+// SRT_ATTR_EXCLUDES(m) SRT_ATTR_ACQUIRE(m)
+// inline void enterCS(Mutex& m) { m.lock(); }
+#define SRT_ATTR_CAPABILITY(expr)
+#define SRT_ATTR_SCOPED_CAPABILITY
+#define SRT_ATTR_GUARDED_BY(expr) _Guarded_by_(expr)
+#define SRT_ATTR_PT_GUARDED_BY(expr)
+#define SRT_ATTR_ACQUIRED_BEFORE(...)
+#define SRT_ATTR_ACQUIRED_AFTER(...)
+#define SRT_ATTR_REQUIRES(expr) _Requires_lock_held_(expr)
+#define SRT_ATTR_REQUIRES_SHARED(...)
+#define SRT_ATTR_ACQUIRE(expr) _Acquires_nonreentrant_lock_(expr)
+#define SRT_ATTR_ACQUIRE_SHARED(...)
+#define SRT_ATTR_RELEASE(expr) _Releases_lock_(expr)
+#define SRT_ATTR_RELEASE_SHARED(...)
+#define SRT_ATTR_RELEASE_GENERIC(...)
+#define SRT_ATTR_TRY_ACQUIRE(...) _Acquires_nonreentrant_lock_(expr)
+#define SRT_ATTR_TRY_ACQUIRE_SHARED(...)
+#define SRT_ATTR_EXCLUDES(...)
+#define SRT_ATTR_ASSERT_CAPABILITY(expr)
+#define SRT_ATTR_ASSERT_SHARED_CAPABILITY(x)
+#define SRT_ATTR_RETURN_CAPABILITY(x)
+#define SRT_ATTR_NO_THREAD_SAFETY_ANALYSIS
+#else
+
 #if defined(__clang__)
 #define THREAD_ANNOTATION_ATTRIBUTE__(x)   __attribute__((x))
 #else
 #define THREAD_ANNOTATION_ATTRIBUTE__(x)   // no-op
 #endif
 
-#define CAPABILITY(x) \
+#define SRT_ATTR_CAPABILITY(x) \
   THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
 
-#define SCOPED_CAPABILITY \
+#define SRT_ATTR_SCOPED_CAPABILITY \
   THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
 
-#define GUARDED_BY(x) \
+#define SRT_ATTR_GUARDED_BY(x) \
   THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
 
-#define PT_GUARDED_BY(x) \
+#define SRT_ATTR_PT_GUARDED_BY(x) \
   THREAD_ANNOTATION_ATTRIBUTE__(pt_guarded_by(x))
 
-#define ACQUIRED_BEFORE(...) \
+#define SRT_ATTR_ACQUIRED_BEFORE(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(acquired_before(__VA_ARGS__))
 
-#define ACQUIRED_AFTER(...) \
+#define SRT_ATTR_ACQUIRED_AFTER(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
 
-#define REQUIRES(...) \
+#define SRT_ATTR_REQUIRES(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
 
-#define REQUIRES_SHARED(...) \
+#define SRT_ATTR_REQUIRES_SHARED(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(requires_shared_capability(__VA_ARGS__))
 
-#define ACQUIRE(...) \
+#define SRT_ATTR_ACQUIRE(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
 
-#define ACQUIRE_SHARED(...) \
+#define SRT_ATTR_ACQUIRE_SHARED(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(acquire_shared_capability(__VA_ARGS__))
 
-#define RELEASE(...) \
+#define SRT_ATTR_RELEASE(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
 
-#define RELEASE_SHARED(...) \
+#define SRT_ATTR_RELEASE_SHARED(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(release_shared_capability(__VA_ARGS__))
 
-#define RELEASE_GENERIC(...) \
+#define SRT_ATTR_RELEASE_GENERIC(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(release_generic_capability(__VA_ARGS__))
 
-#define TRY_ACQUIRE(...) \
+#define SRT_ATTR_TRY_ACQUIRE(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_capability(__VA_ARGS__))
 
-#define TRY_ACQUIRE_SHARED(...) \
+#define SRT_ATTR_TRY_ACQUIRE_SHARED(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(try_acquire_shared_capability(__VA_ARGS__))
 
-#define EXCLUDES(...) \
+#define SRT_ATTR_EXCLUDES(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
 
-#define ASSERT_CAPABILITY(x) \
+#define SRT_ATTR_ASSERT_CAPABILITY(x) \
   THREAD_ANNOTATION_ATTRIBUTE__(assert_capability(x))
 
-#define ASSERT_SHARED_CAPABILITY(x) \
+#define SRT_ATTR_ASSERT_SHARED_CAPABILITY(x) \
   THREAD_ANNOTATION_ATTRIBUTE__(assert_shared_capability(x))
 
-#define RETURN_CAPABILITY(x) \
+#define SRT_ATTR_RETURN_CAPABILITY(x) \
   THREAD_ANNOTATION_ATTRIBUTE__(lock_returned(x))
 
-#define NO_THREAD_SAFETY_ANALYSIS \
+#define SRT_ATTR_NO_THREAD_SAFETY_ANALYSIS \
   THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+#endif // not _MSC_VER
 
 #endif // INC_SRT_ATTR_DEFS_H

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -22,7 +22,6 @@
 #define SRT_SYNC_CLOCK_STR "STDCXX_STEADY"
 #else
 #include <pthread.h>
-#include "srt_attr_defs.h"
 
 // Defile clock type to use
 #ifdef IA32
@@ -51,6 +50,7 @@
 #endif // ENABLE_STDCXX_SYNC
 
 #include "utilities.h"
+#include "srt_attr_defs.h"
 
 class CUDTException;    // defined in common.h
 

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -244,22 +244,27 @@ srt::sync::UniqueLock::UniqueLock(Mutex& m)
 
 srt::sync::UniqueLock::~UniqueLock()
 {
-    unlock();
+    if (m_iLocked == 0)
+    {
+        unlock();
+    }
 }
 
 void srt::sync::UniqueLock::lock()
 {
-    if (m_iLocked == -1)
-        m_iLocked = m_Mutex.lock();
+    if (m_iLocked != -1)
+        throw CThreadException(MJ_SYSTEMRES, MN_THREAD, 0);
+
+    m_iLocked = m_Mutex.lock();
 }
 
 void srt::sync::UniqueLock::unlock()
 {
-    if (m_iLocked == 0)
-    {
-        m_Mutex.unlock();
-        m_iLocked = -1;
-    }
+    if (m_iLocked != 0)
+        throw CThreadException(MJ_SYSTEMRES, MN_THREAD, 0);
+
+    m_Mutex.unlock();
+    m_iLocked = -1;
 }
 
 srt::sync::Mutex* srt::sync::UniqueLock::mutex()

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -70,10 +70,10 @@ modified by
 #include "srt.h"
 
 /*
-* SRT_ENABLE_THREADCHECK (THIS IS SET IN MAKEFILE NOT HERE)
+* SRT_ENABLE_THREADCHECK IS SET IN MAKEFILE, NOT HERE
 */
 #if defined(SRT_ENABLE_THREADCHECK)
-#include <threadcheck.h>
+#include "threadcheck.h"
 #else
 #define THREAD_STATE_INIT(name)
 #define THREAD_EXIT()


### PR DESCRIPTION
- Added Clang TSA attributes to run static analysis.
- Added CMake build option ENABLE_CLANG_TSA (disabled by default).
- `srt::sync::UniqueLock` now throws an exception from unlock and lock.

See also:
- [Thread Safety Analysis](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html);
- [CLang Annotations](https://clang-analyzer.llvm.org/annotations.html#attr_nonnull);
- [Abseil thread annotations](https://abseil.io/docs/cpp/guides/synchronization).