### PR TITLE
[core] Fixed DROPREQ on NAK behind SndLastDataAck

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -183,7 +183,7 @@ void CSndBuffer::addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl)
     int32_t&  w_msgno   = w_mctrl.msgno;
     int32_t&  w_seqno   = w_mctrl.pktseq;
     int64_t& w_srctime  = w_mctrl.srctime;
-    int&      w_ttl     = w_mctrl.msgttl;
+    const int& ttl      = w_mctrl.msgttl;
     int       size      = len / m_iMSS;
     if ((len % m_iMSS) != 0)
         size++;
@@ -254,7 +254,7 @@ void CSndBuffer::addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl)
         s->m_llSourceTime_us = w_srctime;
         s->m_tsOriginTime = time;
         s->m_tsRexmitTime = time_point();
-        s->m_iTTL = w_ttl;
+        s->m_iTTL = ttl;
         // Rewrite the actual sending time back into w_srctime
         // so that the calling facilities can reuse it
         if (!w_srctime)
@@ -542,6 +542,7 @@ int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time
     // if found block is stale
     // (This is for messages that have declared TTL - messages that fail to be sent
     // before the TTL defined time comes, will be dropped).
+
     if ((p->m_iTTL >= 0) && (count_milliseconds(steady_clock::now() - p->m_tsOriginTime) > p->m_iTTL))
     {
         int32_t msgno = p->getMsgSeq();

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8848,9 +8848,10 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
             // No matter whether this is right or not (maybe the attack case should be
             // considered, and some LOSSREPORT flood prevention), send the drop request
             // to the peer.
-            int32_t seqpair[2];
-            seqpair[0] = w_packet.m_iSeqNo;
-            seqpair[1] = m_iSndLastDataAck;
+            int32_t seqpair[2] = {
+                w_packet.m_iSeqNo,
+                CSeqNo::decseq(m_iSndLastDataAck)
+            };
 
             HLOGC(qrlog.Debug, log << "PEER reported LOSS not from the sending buffer - requesting DROP: "
                     << "msg=" << MSGNO_SEQ::unwrap(w_packet.m_iMsgNo) << " SEQ:"

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8852,6 +8852,7 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
                 w_packet.m_iSeqNo,
                 CSeqNo::decseq(m_iSndLastDataAck)
             };
+            w_packet.m_iMsgNo = 0; // Message number is not known, setting all 32 bits to 0.
 
             HLOGC(qrlog.Debug, log << "PEER reported LOSS not from the sending buffer - requesting DROP: "
                     << "msg=" << MSGNO_SEQ::unwrap(w_packet.m_iMsgNo) << " SEQ:"

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -863,7 +863,7 @@ SRT_API       int srt_setsockflag  (SRTSOCKET u, SRT_SOCKOPT opt, const void* op
 typedef struct SRT_MsgCtrl_
 {
    int flags;            // Left for future
-   int msgttl;           // TTL for a message, default -1 (no TTL limitation)
+   int msgttl;           // TTL for a message (millisec), default -1 (no TTL limitation)
    int inorder;          // Whether a message is allowed to supersede partially lost one. Unused in stream and live mode.
    int boundary;         // 0:mid pkt, 1(01b):end of frame, 2(11b):complete frame, 3(10b): start of frame
    int64_t srctime;      // source time since epoch (usec), 0: use internal time (sender)


### PR DESCRIPTION
The range pair of `UMSG_DROPREQ` must be [low, high] instead of [low, high).
`m_iSndLastDataAck` is the very first packet that is present in the sender buffer (first packet after ACK). Therefore it should not be included in the range for dropping.


Revealed while reviewing #2003.
Related to #1910.