### PR TITLE
Placing some SRT classes inside 'srt' namespace

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -83,7 +83,7 @@ using namespace srt::sync;
 extern LogConfig srt_logger_config;
 
 
-void CUDTSocket::construct()
+void srt::CUDTSocket::construct()
 {
 #if ENABLE_EXPERIMENTAL_BONDING
    m_GroupOf = NULL;
@@ -94,7 +94,7 @@ void CUDTSocket::construct()
    setupMutex(m_ControlLock, "Control");
 }
 
-CUDTSocket::~CUDTSocket()
+srt::CUDTSocket::~CUDTSocket()
 {
 
    delete m_pUDT;
@@ -106,7 +106,7 @@ CUDTSocket::~CUDTSocket()
 }
 
 
-SRT_SOCKSTATUS CUDTSocket::getStatus()
+SRT_SOCKSTATUS srt::CUDTSocket::getStatus()
 {
     // TTL in CRendezvousQueue::updateConnStatus() will set m_bConnecting to false.
     // Although m_Status is still SRTS_CONNECTING, the connection is in fact to be closed due to TTL expiry.
@@ -124,7 +124,7 @@ SRT_SOCKSTATUS CUDTSocket::getStatus()
 }
 
 // [[using locked(m_GlobControlLock)]]
-void CUDTSocket::breakSocket_LOCKED()
+void srt::CUDTSocket::breakSocket_LOCKED()
 {
     // This function is intended to be called from GC,
     // under a lock of m_GlobControlLock. 
@@ -135,7 +135,7 @@ void CUDTSocket::breakSocket_LOCKED()
     setClosed();
 }
 
-void CUDTSocket::setClosed()
+void srt::CUDTSocket::setClosed()
 {
     m_Status = SRTS_CLOSED;
 
@@ -146,14 +146,14 @@ void CUDTSocket::setClosed()
     m_tsClosureTimeStamp = steady_clock::now();
 }
 
-void CUDTSocket::setBrokenClosed()
+void srt::CUDTSocket::setBrokenClosed()
 {
     m_pUDT->m_iBrokenCounter = 60;
     m_pUDT->m_bBroken = true;
     setClosed();
 }
 
-bool CUDTSocket::readReady()
+bool srt::CUDTSocket::readReady()
 {
     if (m_pUDT->m_bConnected && m_pUDT->m_pRcvBuffer->isRcvDataReady())
         return true;
@@ -165,33 +165,33 @@ bool CUDTSocket::readReady()
     return broken();
 }
 
-bool CUDTSocket::writeReady() const
+bool srt::CUDTSocket::writeReady() const
 {
     return (m_pUDT->m_bConnected
                 && (m_pUDT->m_pSndBuffer->getCurrBufSize() < m_pUDT->m_config.iSndBufSize))
         || broken();
 }
 
-bool CUDTSocket::broken() const
+bool srt::CUDTSocket::broken() const
 {
     return m_pUDT->m_bBroken || !m_pUDT->m_bConnected;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-CUDTUnited::CUDTUnited():
-m_Sockets(),
-m_GlobControlLock(),
-m_IDLock(),
-m_mMultiplexer(),
-m_MultiplexerLock(),
-m_pCache(NULL),
-m_bClosing(false),
-m_GCStopCond(),
-m_InitLock(),
-m_iInstanceCount(0),
-m_bGCStatus(false),
-m_ClosedSockets()
+srt::CUDTUnited::CUDTUnited():
+    m_Sockets(),
+    m_GlobControlLock(),
+    m_IDLock(),
+    m_mMultiplexer(),
+    m_MultiplexerLock(),
+    m_pCache(NULL),
+    m_bClosing(false),
+    m_GCStopCond(),
+    m_InitLock(),
+    m_iInstanceCount(0),
+    m_bGCStatus(false),
+    m_ClosedSockets()
 {
    // Socket ID MUST start from a random value
    m_SocketIDGenerator = genRandomInt(1, MAX_SOCKET_VAL);
@@ -207,7 +207,7 @@ m_ClosedSockets()
    m_pCache = new CCache<CInfoBlock>;
 }
 
-CUDTUnited::~CUDTUnited()
+srt::CUDTUnited::~CUDTUnited()
 {
     // Call it if it wasn't called already.
     // This will happen at the end of main() of the application,
@@ -224,7 +224,7 @@ CUDTUnited::~CUDTUnited()
     delete m_pCache;
 }
 
-std::string CUDTUnited::CONID(SRTSOCKET sock)
+string srt::CUDTUnited::CONID(SRTSOCKET sock)
 {
     if ( sock == 0 )
         return "";
@@ -234,7 +234,7 @@ std::string CUDTUnited::CONID(SRTSOCKET sock)
     return os.str();
 }
 
-int CUDTUnited::startup()
+int srt::CUDTUnited::startup()
 {
    ScopedLock gcinit(m_InitLock);
 
@@ -277,7 +277,7 @@ int CUDTUnited::startup()
    return 0;
 }
 
-int CUDTUnited::cleanup()
+int srt::CUDTUnited::cleanup()
 {
    // IMPORTANT!!!
    // In this function there must be NO LOGGING AT ALL.  This function may
@@ -324,7 +324,7 @@ int CUDTUnited::cleanup()
    return 0;
 }
 
-SRTSOCKET CUDTUnited::generateSocketID(bool for_group)
+SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
 {
     ScopedLock guard(m_IDLock);
 
@@ -426,7 +426,7 @@ SRTSOCKET CUDTUnited::generateSocketID(bool for_group)
     return sockval;
 }
 
-SRTSOCKET CUDTUnited::newSocket(CUDTSocket** pps)
+SRTSOCKET srt::CUDTUnited::newSocket(CUDTSocket** pps)
 {
    // XXX consider using some replacement of std::unique_ptr
    // so that exceptions will clean up the object without the
@@ -484,7 +484,7 @@ SRTSOCKET CUDTUnited::newSocket(CUDTSocket** pps)
    return ns->m_SocketID;
 }
 
-int CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
+int srt::CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
         CHandShake& w_hs, int& w_error, CUDT*& w_acpu)
 {
    CUDTSocket* ns = NULL;
@@ -852,12 +852,12 @@ ERR_ROLLBACK:
 }
 
 // static forwarder
-int CUDT::installAcceptHook(SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
+int srt::CUDT::installAcceptHook(SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
 {
     return s_UDTUnited.installAcceptHook(lsn, hook, opaq);
 }
 
-int CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
+int srt::CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
 {
     try
     {
@@ -873,12 +873,12 @@ int CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* h
     return 0;
 }
 
-int CUDT::installConnectHook(SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq)
+int srt::CUDT::installConnectHook(SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq)
 {
     return s_UDTUnited.installConnectHook(lsn, hook, opaq);
 }
 
-int CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_callback_fn* hook, void* opaq)
+int srt::CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_callback_fn* hook, void* opaq)
 {
     try
     {
@@ -902,7 +902,7 @@ int CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_callback_fn* h
     return 0;
 }
 
-SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
+SRT_SOCKSTATUS srt::CUDTUnited::getStatus(const SRTSOCKET u)
 {
     // protects the m_Sockets structure
     ScopedLock cg(m_GlobControlLock);
@@ -919,7 +919,7 @@ SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
     return i->second->getStatus();
 }
 
-int CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
+int srt::CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
 {
    ScopedLock cg(s->m_ControlLock);
 
@@ -937,7 +937,7 @@ int CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
    return 0;
 }
 
-int CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
+int srt::CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
 {
    ScopedLock cg(s->m_ControlLock);
 
@@ -966,7 +966,7 @@ int CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
    return 0;
 }
 
-int CUDTUnited::listen(const SRTSOCKET u, int backlog)
+int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
 {
    if (backlog <= 0)
       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -1012,7 +1012,7 @@ int CUDTUnited::listen(const SRTSOCKET u, int backlog)
    return 0;
 }
 
-SRTSOCKET CUDTUnited::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut)
+SRTSOCKET srt::CUDTUnited::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut)
 {
     CEPollDesc* ed = 0;
     int eid = m_EPoll.create(&ed);
@@ -1056,7 +1056,7 @@ SRTSOCKET CUDTUnited::accept_bond(const SRTSOCKET listeners [], int lsize, int64
     return accept(lsn, ((sockaddr*)&dummy), (&outlen));
 }
 
-SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_addrlen)
+SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_addrlen)
 {
    if (pw_addr && !pw_addrlen)
    {
@@ -1190,7 +1190,7 @@ SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_
    return u;
 }
 
-int CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int namelen)
+int srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int namelen)
 {
     // Here both srcname and tarname must be specified
     if (!srcname || !tarname || size_t(namelen) < sizeof (sockaddr_in))
@@ -1235,7 +1235,7 @@ int CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* ta
     return connectIn(s, target_addr, SRT_SEQNO_NONE);
 }
 
-int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
+int srt::CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
     sockaddr_any target_addr(name, namelen);
     if (target_addr.len == 0)
@@ -1266,7 +1266,7 @@ int CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, in
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-int CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* gd)
+int srt::CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* gd)
 {
     int gstat = groupConnect(pg, gd, 1);
     if (gstat == -1)
@@ -1286,7 +1286,7 @@ int CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* gd)
 }
 
 // [[using assert(pg->m_iBusy > 0)]]
-int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int arraysize)
+int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int arraysize)
 {
     CUDTGroup& g = *pg;
     SRT_ASSERT(g.m_iBusy > 0);
@@ -1822,7 +1822,7 @@ int CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int ar
 #endif
 
 
-int CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_t forced_isn)
+int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_t forced_isn)
 {
    ScopedLock cg(s->m_ControlLock);
    // a socket can "connect" only if it is in the following states:
@@ -1892,7 +1892,7 @@ int CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_
 }
 
 
-int CUDTUnited::close(const SRTSOCKET u)
+int srt::CUDTUnited::close(const SRTSOCKET u)
 {
 #if ENABLE_EXPERIMENTAL_BONDING
     if (u & SRTGROUP_MASK)
@@ -1911,7 +1911,7 @@ int CUDTUnited::close(const SRTSOCKET u)
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-void CUDTUnited::deleteGroup(CUDTGroup* g)
+void srt::CUDTUnited::deleteGroup(CUDTGroup* g)
 {
     using srt_logging::gmlog;
 
@@ -1920,7 +1920,7 @@ void CUDTUnited::deleteGroup(CUDTGroup* g)
 }
 
 // [[using locked(m_GlobControlLock)]]
-void CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
+void srt::CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
 {
     SRT_ASSERT(g->groupEmpty());
 
@@ -1960,7 +1960,7 @@ void CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
 }
 #endif
 
-int CUDTUnited::close(CUDTSocket* s)
+int srt::CUDTUnited::close(CUDTSocket* s)
 {
    HLOGC(smlog.Debug, log << s->m_pUDT->CONID() << " CLOSE. Acquiring control lock");
 
@@ -2118,7 +2118,7 @@ int CUDTUnited::close(CUDTSocket* s)
    return 0;
 }
 
-void CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
+void srt::CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
 {
    if (!pw_name || !pw_namelen)
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -2142,7 +2142,7 @@ void CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_namel
    *pw_namelen = len;
 }
 
-void CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
+void srt::CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
 {
    if (!pw_name || !pw_namelen)
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -2166,7 +2166,7 @@ void CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_namel
    *pw_namelen = len;
 }
 
-int CUDTUnited::select(
+int srt::CUDTUnited::select(
    UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout)
 {
    const steady_clock::time_point entertime = steady_clock::now();
@@ -2276,7 +2276,7 @@ int CUDTUnited::select(
    return count;
 }
 
-int CUDTUnited::selectEx(
+int srt::CUDTUnited::selectEx(
    const vector<SRTSOCKET>& fds,
    vector<SRTSOCKET>* readfds,
    vector<SRTSOCKET>* writefds,
@@ -2350,17 +2350,17 @@ int CUDTUnited::selectEx(
    return count;
 }
 
-int CUDTUnited::epoll_create()
+int srt::CUDTUnited::epoll_create()
 {
    return m_EPoll.create();
 }
 
-int CUDTUnited::epoll_clear_usocks(int eid)
+int srt::CUDTUnited::epoll_clear_usocks(int eid)
 {
     return m_EPoll.clear_usocks(eid);
 }
 
-int CUDTUnited::epoll_add_usock(
+int srt::CUDTUnited::epoll_add_usock(
    const int eid, const SRTSOCKET u, const int* events)
 {
    int ret = -1;
@@ -2390,27 +2390,27 @@ int CUDTUnited::epoll_add_usock(
 // NOTE: WILL LOCK (serially):
 // - CEPoll::m_EPollLock
 // - CUDT::m_RecvLock
-int CUDTUnited::epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, const int* events)
+int srt::CUDTUnited::epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, const int* events)
 {
     int ret = m_EPoll.update_usock(eid, s->m_SocketID, events);
     s->m_pUDT->addEPoll(eid);
     return ret;
 }
 
-int CUDTUnited::epoll_add_ssock(
+int srt::CUDTUnited::epoll_add_ssock(
    const int eid, const SYSSOCKET s, const int* events)
 {
    return m_EPoll.add_ssock(eid, s, events);
 }
 
-int CUDTUnited::epoll_update_ssock(
+int srt::CUDTUnited::epoll_update_ssock(
    const int eid, const SYSSOCKET s, const int* events)
 {
    return m_EPoll.update_ssock(eid, s, events);
 }
 
 template <class EntityType>
-int CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
+int srt::CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
 {
     // XXX Not sure if this is anyhow necessary because setting readiness
     // to false doesn't actually trigger any action. Further research needed.
@@ -2432,19 +2432,19 @@ int CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
 }
 
 // Needed internal access!
-int CUDTUnited::epoll_remove_socket_INTERNAL(const int eid, CUDTSocket* s)
+int srt::CUDTUnited::epoll_remove_socket_INTERNAL(const int eid, CUDTSocket* s)
 {
     return epoll_remove_entity(eid, s->m_pUDT);
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-int CUDTUnited::epoll_remove_group_INTERNAL(const int eid, CUDTGroup* g)
+int srt::CUDTUnited::epoll_remove_group_INTERNAL(const int eid, CUDTGroup* g)
 {
     return epoll_remove_entity(eid, g);
 }
 #endif
 
-int CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
+int srt::CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
 {
    CUDTSocket* s = 0;
 
@@ -2470,12 +2470,12 @@ int CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
    return m_EPoll.update_usock(eid, u, &no_events);
 }
 
-int CUDTUnited::epoll_remove_ssock(const int eid, const SYSSOCKET s)
+int srt::CUDTUnited::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
    return m_EPoll.remove_ssock(eid, s);
 }
 
-int CUDTUnited::epoll_uwait(
+int srt::CUDTUnited::epoll_uwait(
    const int eid,
    SRT_EPOLL_EVENT* fdsSet,
    int fdsSize, 
@@ -2484,17 +2484,17 @@ int CUDTUnited::epoll_uwait(
    return m_EPoll.uwait(eid, fdsSet, fdsSize, msTimeOut);
 }
 
-int32_t CUDTUnited::epoll_set(int eid, int32_t flags)
+int32_t srt::CUDTUnited::epoll_set(int eid, int32_t flags)
 {
     return m_EPoll.setflags(eid, flags);
 }
 
-int CUDTUnited::epoll_release(const int eid)
+int srt::CUDTUnited::epoll_release(const int eid)
 {
    return m_EPoll.release(eid);
 }
 
-CUDTSocket* CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling erh)
+srt::CUDTSocket* srt::CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling erh)
 {
     ScopedLock cg (m_GlobControlLock);
     CUDTSocket* s = locateSocket_LOCKED(u);
@@ -2509,7 +2509,7 @@ CUDTSocket* CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling erh)
 }
 
 // [[using locked(m_GlobControlLock)]];
-CUDTSocket* CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
+srt::CUDTSocket* srt::CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
 {
     sockets_t::iterator i = m_Sockets.find(u);
 
@@ -2522,7 +2522,7 @@ CUDTSocket* CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-CUDTGroup* CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling erh)
+srt::CUDTGroup* srt::CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling erh)
 {
    ScopedLock cg (m_GlobControlLock);
 
@@ -2539,7 +2539,7 @@ CUDTGroup* CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling erh)
    return i->second;
 }
 
-CUDTGroup* CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
+srt::CUDTGroup* srt::CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
 {
    ScopedLock cg (m_GlobControlLock);
    CUDTGroup* g = s->m_GroupOf;
@@ -2553,7 +2553,7 @@ CUDTGroup* CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
 }
 #endif
 
-CUDTSocket* CUDTUnited::locatePeer(
+srt::CUDTSocket* srt::CUDTUnited::locatePeer(
    const sockaddr_any& peer,
    const SRTSOCKET id,
    int32_t isn)
@@ -2582,7 +2582,7 @@ CUDTSocket* CUDTUnited::locatePeer(
    return NULL;
 }
 
-void CUDTUnited::checkBrokenSockets()
+void srt::CUDTUnited::checkBrokenSockets()
 {
    ScopedLock cg(m_GlobControlLock);
 
@@ -2724,7 +2724,7 @@ void CUDTUnited::checkBrokenSockets()
 }
 
 // [[using locked(m_GlobControlLock)]]
-void CUDTUnited::removeSocket(const SRTSOCKET u)
+void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
 {
    sockets_t::iterator i = m_ClosedSockets.find(u);
 
@@ -2829,7 +2829,7 @@ void CUDTUnited::removeSocket(const SRTSOCKET u)
    }
 }
 
-void CUDTUnited::updateMux(
+void srt::CUDTUnited::updateMux(
    CUDTSocket* s, const sockaddr_any& addr, const UDPSOCKET* udpsock /*[[nullable]]*/)
 {
    ScopedLock cg(m_GlobControlLock);
@@ -2943,7 +2943,7 @@ void CUDTUnited::updateMux(
 // exists, otherwise the dispatching procedure wouldn't even call this
 // function. By historical reasons there's also a fallback for a case when the
 // multiplexer wasn't found by id, the search by port number continues.
-bool CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
+bool srt::CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
 {
    ScopedLock cg(m_GlobControlLock);
    const int port = ls->m_SelfAddr.hport();
@@ -3026,7 +3026,7 @@ bool CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
    return false;
 }
 
-void* CUDTUnited::garbageCollect(void* p)
+void* srt::CUDTUnited::garbageCollect(void* p)
 {
    CUDTUnited* self = (CUDTUnited*)p;
 
@@ -3108,17 +3108,17 @@ void* CUDTUnited::garbageCollect(void* p)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-int CUDT::startup()
+int srt::CUDT::startup()
 {
    return s_UDTUnited.startup();
 }
 
-int CUDT::cleanup()
+int srt::CUDT::cleanup()
 {
    return s_UDTUnited.cleanup();
 }
 
-SRTSOCKET CUDT::socket()
+SRTSOCKET srt::CUDT::socket()
 {
    if (!s_UDTUnited.m_bGCStatus)
       s_UDTUnited.startup();
@@ -3147,12 +3147,12 @@ SRTSOCKET CUDT::socket()
    }
 }
 
-CUDT::APIError::APIError(const CUDTException& e)
+srt::CUDT::APIError::APIError(const CUDTException& e)
 {
     SetThreadLocalError(e);
 }
 
-CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
+srt::CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
 {
     SetThreadLocalError(CUDTException(mj, mn, syserr));
 }
@@ -3162,7 +3162,7 @@ CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
 // This doesn't have argument of GroupType due to header file conflicts.
 
 // [[using locked(s_UDTUnited.m_GlobControlLock)]]
-CUDTGroup& CUDT::newGroup(const int type)
+srt::CUDTGroup& srt::CUDT::newGroup(const int type)
 {
     const SRTSOCKET id = s_UDTUnited.generateSocketID(true);
 
@@ -3170,7 +3170,7 @@ CUDTGroup& CUDT::newGroup(const int type)
     return s_UDTUnited.addGroup(id, SRT_GROUP_TYPE(type)).set_id(id);
 }
 
-SRTSOCKET CUDT::createGroup(SRT_GROUP_TYPE gt)
+SRTSOCKET srt::CUDT::createGroup(SRT_GROUP_TYPE gt)
 {
     // Doing the same lazy-startup as with srt_create_socket()
     if (!s_UDTUnited.m_bGCStatus)
@@ -3199,7 +3199,7 @@ SRTSOCKET CUDT::createGroup(SRT_GROUP_TYPE gt)
 }
 
 
-int CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
+int srt::CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
 {
     // Check if socket and group have been set correctly.
     int32_t sid = socket & ~SRTGROUP_MASK;
@@ -3253,7 +3253,7 @@ int CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
 
 // dead function as for now. This is only for non-managed
 // groups.
-int CUDT::removeSocketFromGroup(SRTSOCKET socket)
+int srt::CUDT::removeSocketFromGroup(SRTSOCKET socket)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(socket);
     if (!s)
@@ -3270,7 +3270,7 @@ int CUDT::removeSocketFromGroup(SRTSOCKET socket)
 
 // [[using locked(m_ControlLock)]]
 // [[using locked(CUDT::s_UDTUnited.m_GlobControlLock)]]
-void CUDTSocket::removeFromGroup(bool broken)
+void srt::CUDTSocket::removeFromGroup(bool broken)
 {
     CUDTGroup* g = m_GroupOf;
     if (g)
@@ -3299,7 +3299,7 @@ void CUDTSocket::removeFromGroup(bool broken)
     }
 }
 
-SRTSOCKET CUDT::getGroupOfSocket(SRTSOCKET socket)
+SRTSOCKET srt::CUDT::getGroupOfSocket(SRTSOCKET socket)
 {
     // Lock this for the whole function as we need the group
     // to persist the call.
@@ -3311,7 +3311,7 @@ SRTSOCKET CUDT::getGroupOfSocket(SRTSOCKET socket)
     return s->m_GroupOf->id();
 }
 
-int CUDT::configureGroup(SRTSOCKET groupid, const char* str)
+int srt::CUDT::configureGroup(SRTSOCKET groupid, const char* str)
 {
     if ( (groupid & SRTGROUP_MASK) == 0)
     {
@@ -3327,7 +3327,7 @@ int CUDT::configureGroup(SRTSOCKET groupid, const char* str)
     return k.group->configure(str);
 }
 
-int CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize)
+int srt::CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize)
 {
     if ((groupid & SRTGROUP_MASK) == 0 || !psize)
     {
@@ -3345,7 +3345,7 @@ int CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psiz
 }
 #endif
 
-int CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
+int srt::CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
 {
    try
    {
@@ -3381,7 +3381,7 @@ int CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
    }
 }
 
-int CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
+int srt::CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
 {
     try
     {
@@ -3407,7 +3407,7 @@ int CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
     }
 }
 
-int CUDT::listen(SRTSOCKET u, int backlog)
+int srt::CUDT::listen(SRTSOCKET u, int backlog)
 {
    try
    {
@@ -3429,7 +3429,7 @@ int CUDT::listen(SRTSOCKET u, int backlog)
    }
 }
 
-SRTSOCKET CUDT::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut)
+SRTSOCKET srt::CUDT::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut)
 {
    try
    {
@@ -3454,7 +3454,7 @@ SRTSOCKET CUDT::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msT
    }
 }
 
-SRTSOCKET CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
+SRTSOCKET srt::CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
 {
    try
    {
@@ -3479,7 +3479,7 @@ SRTSOCKET CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
    }
 }
 
-int CUDT::connect(
+int srt::CUDT::connect(
     SRTSOCKET u, const sockaddr* name, const sockaddr* tname, int namelen)
 {
    try
@@ -3503,7 +3503,7 @@ int CUDT::connect(
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-int CUDT::connectLinks(SRTSOCKET grp,
+int srt::CUDT::connectLinks(SRTSOCKET grp,
         SRT_SOCKGROUPCONFIG targets [], int arraysize)
 {
     if (arraysize <= 0)
@@ -3537,7 +3537,7 @@ int CUDT::connectLinks(SRTSOCKET grp,
 }
 #endif
 
-int CUDT::connect(
+int srt::CUDT::connect(
    SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
    try
@@ -3560,7 +3560,7 @@ int CUDT::connect(
    }
 }
 
-int CUDT::close(SRTSOCKET u)
+int srt::CUDT::close(SRTSOCKET u)
 {
    try
    {
@@ -3578,7 +3578,7 @@ int CUDT::close(SRTSOCKET u)
    }
 }
 
-int CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
+int srt::CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
 {
    try
    {
@@ -3597,7 +3597,7 @@ int CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
    }
 }
 
-int CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
+int srt::CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
 {
    try
    {
@@ -3616,7 +3616,7 @@ int CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
    }
 }
 
-int CUDT::getsockopt(
+int srt::CUDT::getsockopt(
    SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_optval, int* pw_optlen)
 {
     if (!pw_optval || !pw_optlen)
@@ -3651,7 +3651,7 @@ int CUDT::getsockopt(
     }
 }
 
-int CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, int optlen)
+int srt::CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, int optlen)
 {
    if (!optval)
        return APIError(MJ_NOTSUP, MN_INVAL, 0);
@@ -3683,7 +3683,7 @@ int CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, 
    }
 }
 
-int CUDT::send(SRTSOCKET u, const char* buf, int len, int)
+int srt::CUDT::send(SRTSOCKET u, const char* buf, int len, int)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     return sendmsg2(u, buf, len, (mctrl));
@@ -3691,7 +3691,7 @@ int CUDT::send(SRTSOCKET u, const char* buf, int len, int)
 
 // --> CUDT::recv moved down
 
-int CUDT::sendmsg(
+int srt::CUDT::sendmsg(
    SRTSOCKET u, const char* buf, int len, int ttl, bool inorder,
    int64_t srctime)
 {
@@ -3702,7 +3702,7 @@ int CUDT::sendmsg(
     return sendmsg2(u, buf, len, (mctrl));
 }
 
-int CUDT::sendmsg2(
+int srt::CUDT::sendmsg2(
    SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
 {
    try
@@ -3733,14 +3733,14 @@ int CUDT::sendmsg2(
    }
 }
 
-int CUDT::recv(SRTSOCKET u, char* buf, int len, int)
+int srt::CUDT::recv(SRTSOCKET u, char* buf, int len, int)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     int ret = recvmsg2(u, buf, len, (mctrl));
     return ret;
 }
 
-int CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
+int srt::CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     int ret = recvmsg2(u, buf, len, (mctrl));
@@ -3748,7 +3748,7 @@ int CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
     return ret;
 }
 
-int CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
+int srt::CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
 {
    try
    {
@@ -3774,7 +3774,7 @@ int CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
    }
 }
 
-int64_t CUDT::sendfile(
+int64_t srt::CUDT::sendfile(
    SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
 {
    try
@@ -3798,7 +3798,7 @@ int64_t CUDT::sendfile(
    }
 }
 
-int64_t CUDT::recvfile(
+int64_t srt::CUDT::recvfile(
    SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
 {
    try
@@ -3817,7 +3817,7 @@ int64_t CUDT::recvfile(
    }
 }
 
-int CUDT::select(
+int srt::CUDT::select(
    int,
    UDT::UDSET* readfds,
    UDT::UDSET* writefds,
@@ -3849,7 +3849,7 @@ int CUDT::select(
    }
 }
 
-int CUDT::selectEx(
+int srt::CUDT::selectEx(
    const vector<SRTSOCKET>& fds,
    vector<SRTSOCKET>* readfds,
    vector<SRTSOCKET>* writefds,
@@ -3881,7 +3881,7 @@ int CUDT::selectEx(
    }
 }
 
-int CUDT::epoll_create()
+int srt::CUDT::epoll_create()
 {
    try
    {
@@ -3899,7 +3899,7 @@ int CUDT::epoll_create()
    }
 }
 
-int CUDT::epoll_clear_usocks(int eid)
+int srt::CUDT::epoll_clear_usocks(int eid)
 {
    try
    {
@@ -3917,7 +3917,7 @@ int CUDT::epoll_clear_usocks(int eid)
    }
 }
 
-int CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
+int srt::CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
 {
    try
    {
@@ -3935,7 +3935,7 @@ int CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
    }
 }
 
-int CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
+int srt::CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
    try
    {
@@ -3953,7 +3953,7 @@ int CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
    }
 }
 
-int CUDT::epoll_update_usock(
+int srt::CUDT::epoll_update_usock(
    const int eid, const SRTSOCKET u, const int* events)
 {
    try
@@ -3972,7 +3972,7 @@ int CUDT::epoll_update_usock(
    }
 }
 
-int CUDT::epoll_update_ssock(
+int srt::CUDT::epoll_update_ssock(
    const int eid, const SYSSOCKET s, const int* events)
 {
    try
@@ -3992,7 +3992,7 @@ int CUDT::epoll_update_ssock(
 }
 
 
-int CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
+int srt::CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
 {
    try
    {
@@ -4010,7 +4010,7 @@ int CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
    }
 }
 
-int CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
+int srt::CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
    try
    {
@@ -4028,7 +4028,7 @@ int CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
    }
 }
 
-int CUDT::epoll_wait(
+int srt::CUDT::epoll_wait(
    const int eid,
    set<SRTSOCKET>* readfds,
    set<SRTSOCKET>* writefds,
@@ -4053,7 +4053,7 @@ int CUDT::epoll_wait(
    }
 }
 
-int CUDT::epoll_uwait(
+int srt::CUDT::epoll_uwait(
    const int eid,
    SRT_EPOLL_EVENT* fdsSet,
    int fdsSize,
@@ -4075,7 +4075,7 @@ int CUDT::epoll_uwait(
    }
 }
 
-int32_t CUDT::epoll_set(
+int32_t srt::CUDT::epoll_set(
    const int eid,
    int32_t flags)
 {
@@ -4095,7 +4095,7 @@ int32_t CUDT::epoll_set(
    }
 }
 
-int CUDT::epoll_release(const int eid)
+int srt::CUDT::epoll_release(const int eid)
 {
    try
    {
@@ -4113,12 +4113,12 @@ int CUDT::epoll_release(const int eid)
    }
 }
 
-CUDTException& CUDT::getlasterror()
+CUDTException& srt::CUDT::getlasterror()
 {
    return GetThreadLocalError();
 }
 
-int CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
+int srt::CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
 {
 #if ENABLE_EXPERIMENTAL_BONDING
    if (u & SRTGROUP_MASK)
@@ -4144,7 +4144,7 @@ int CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-int CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
+int srt::CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
 {
    try
    {
@@ -4167,7 +4167,7 @@ int CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
 }
 #endif
 
-CUDT* CUDT::getUDTHandle(SRTSOCKET u)
+srt::CUDT* srt::CUDT::getUDTHandle(SRTSOCKET u)
 {
    try
    {
@@ -4187,7 +4187,7 @@ CUDT* CUDT::getUDTHandle(SRTSOCKET u)
    }
 }
 
-vector<SRTSOCKET> CUDT::existingSockets()
+vector<SRTSOCKET> srt::CUDT::existingSockets()
 {
     vector<SRTSOCKET> out;
     for (CUDTUnited::sockets_t::iterator i = s_UDTUnited.m_Sockets.begin();
@@ -4198,7 +4198,7 @@ vector<SRTSOCKET> CUDT::existingSockets()
     return out;
 }
 
-SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
+SRT_SOCKSTATUS srt::CUDT::getsockstate(SRTSOCKET u)
 {
    try
    {
@@ -4225,7 +4225,6 @@ SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
    }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace UDT
@@ -4233,64 +4232,64 @@ namespace UDT
 
 int startup()
 {
-   return CUDT::startup();
+   return srt::CUDT::startup();
 }
 
 int cleanup()
 {
-   return CUDT::cleanup();
+   return srt::CUDT::cleanup();
 }
 
 int bind(SRTSOCKET u, const struct sockaddr* name, int namelen)
 {
-   return CUDT::bind(u, name, namelen);
+   return srt::CUDT::bind(u, name, namelen);
 }
 
 int bind2(SRTSOCKET u, UDPSOCKET udpsock)
 {
-   return CUDT::bind(u, udpsock);
+   return srt::CUDT::bind(u, udpsock);
 }
 
 int listen(SRTSOCKET u, int backlog)
 {
-   return CUDT::listen(u, backlog);
+   return srt::CUDT::listen(u, backlog);
 }
 
 SRTSOCKET accept(SRTSOCKET u, struct sockaddr* addr, int* addrlen)
 {
-   return CUDT::accept(u, addr, addrlen);
+   return srt::CUDT::accept(u, addr, addrlen);
 }
 
 int connect(SRTSOCKET u, const struct sockaddr* name, int namelen)
 {
-   return CUDT::connect(u, name, namelen, SRT_SEQNO_NONE);
+   return srt::CUDT::connect(u, name, namelen, SRT_SEQNO_NONE);
 }
 
 int close(SRTSOCKET u)
 {
-   return CUDT::close(u);
+   return srt::CUDT::close(u);
 }
 
 int getpeername(SRTSOCKET u, struct sockaddr* name, int* namelen)
 {
-   return CUDT::getpeername(u, name, namelen);
+   return srt::CUDT::getpeername(u, name, namelen);
 }
 
 int getsockname(SRTSOCKET u, struct sockaddr* name, int* namelen)
 {
-   return CUDT::getsockname(u, name, namelen);
+   return srt::CUDT::getsockname(u, name, namelen);
 }
 
 int getsockopt(
    SRTSOCKET u, int level, SRT_SOCKOPT optname, void* optval, int* optlen)
 {
-   return CUDT::getsockopt(u, level, optname, optval, optlen);
+   return srt::CUDT::getsockopt(u, level, optname, optval, optlen);
 }
 
 int setsockopt(
    SRTSOCKET u, int level, SRT_SOCKOPT optname, const void* optval, int optlen)
 {
-   return CUDT::setsockopt(u, level, optname, optval, optlen);
+   return srt::CUDT::setsockopt(u, level, optname, optval, optlen);
 }
 
 // DEVELOPER API
@@ -4298,17 +4297,17 @@ int setsockopt(
 int connect_debug(
    SRTSOCKET u, const struct sockaddr* name, int namelen, int32_t forced_isn)
 {
-   return CUDT::connect(u, name, namelen, forced_isn);
+   return srt::CUDT::connect(u, name, namelen, forced_isn);
 }
 
 int send(SRTSOCKET u, const char* buf, int len, int flags)
 {
-   return CUDT::send(u, buf, len, flags);
+   return srt::CUDT::send(u, buf, len, flags);
 }
 
 int recv(SRTSOCKET u, char* buf, int len, int flags)
 {
-   return CUDT::recv(u, buf, len, flags);
+   return srt::CUDT::recv(u, buf, len, flags);
 }
 
 
@@ -4316,18 +4315,18 @@ int sendmsg(
    SRTSOCKET u, const char* buf, int len, int ttl, bool inorder,
    int64_t srctime)
 {
-   return CUDT::sendmsg(u, buf, len, ttl, inorder, srctime);
+   return srt::CUDT::sendmsg(u, buf, len, ttl, inorder, srctime);
 }
 
 int recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
 {
-   return CUDT::recvmsg(u, buf, len, srctime);
+   return srt::CUDT::recvmsg(u, buf, len, srctime);
 }
 
 int recvmsg(SRTSOCKET u, char* buf, int len)
 {
    int64_t srctime;
-   return CUDT::recvmsg(u, buf, len, srctime);
+   return srt::CUDT::recvmsg(u, buf, len, srctime);
 }
 
 int64_t sendfile(
@@ -4337,7 +4336,7 @@ int64_t sendfile(
    int64_t size,
    int block)
 {
-   return CUDT::sendfile(u, ifs, offset, size, block);
+   return srt::CUDT::sendfile(u, ifs, offset, size, block);
 }
 
 int64_t recvfile(
@@ -4347,7 +4346,7 @@ int64_t recvfile(
    int64_t size,
    int block)
 {
-   return CUDT::recvfile(u, ofs, offset, size, block);
+   return srt::CUDT::recvfile(u, ofs, offset, size, block);
 }
 
 int64_t sendfile2(
@@ -4358,7 +4357,7 @@ int64_t sendfile2(
    int block)
 {
    fstream ifs(path, ios::binary | ios::in);
-   int64_t ret = CUDT::sendfile(u, ifs, *offset, size, block);
+   int64_t ret = srt::CUDT::sendfile(u, ifs, *offset, size, block);
    ifs.close();
    return ret;
 }
@@ -4371,7 +4370,7 @@ int64_t recvfile2(
    int block)
 {
    fstream ofs(path, ios::binary | ios::out);
-   int64_t ret = CUDT::recvfile(u, ofs, *offset, size, block);
+   int64_t ret = srt::CUDT::recvfile(u, ofs, *offset, size, block);
    ofs.close();
    return ret;
 }
@@ -4383,7 +4382,7 @@ int select(
    UDSET* exceptfds,
    const struct timeval* timeout)
 {
-   return CUDT::select(nfds, readfds, writefds, exceptfds, timeout);
+   return srt::CUDT::select(nfds, readfds, writefds, exceptfds, timeout);
 }
 
 int selectEx(
@@ -4393,47 +4392,47 @@ int selectEx(
    vector<SRTSOCKET>* exceptfds,
    int64_t msTimeOut)
 {
-   return CUDT::selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
+   return srt::CUDT::selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
 }
 
 int epoll_create()
 {
-   return CUDT::epoll_create();
+   return srt::CUDT::epoll_create();
 }
 
 int epoll_clear_usocks(int eid)
 {
-    return CUDT::epoll_clear_usocks(eid);
+    return srt::CUDT::epoll_clear_usocks(eid);
 }
 
 int epoll_add_usock(int eid, SRTSOCKET u, const int* events)
 {
-   return CUDT::epoll_add_usock(eid, u, events);
+   return srt::CUDT::epoll_add_usock(eid, u, events);
 }
 
 int epoll_add_ssock(int eid, SYSSOCKET s, const int* events)
 {
-   return CUDT::epoll_add_ssock(eid, s, events);
+   return srt::CUDT::epoll_add_ssock(eid, s, events);
 }
 
 int epoll_update_usock(int eid, SRTSOCKET u, const int* events)
 {
-   return CUDT::epoll_update_usock(eid, u, events);
+   return srt::CUDT::epoll_update_usock(eid, u, events);
 }
 
 int epoll_update_ssock(int eid, SYSSOCKET s, const int* events)
 {
-   return CUDT::epoll_update_ssock(eid, s, events);
+   return srt::CUDT::epoll_update_ssock(eid, s, events);
 }
 
 int epoll_remove_usock(int eid, SRTSOCKET u)
 {
-   return CUDT::epoll_remove_usock(eid, u);
+   return srt::CUDT::epoll_remove_usock(eid, u);
 }
 
 int epoll_remove_ssock(int eid, SYSSOCKET s)
 {
-   return CUDT::epoll_remove_ssock(eid, s);
+   return srt::CUDT::epoll_remove_ssock(eid, s);
 }
 
 int epoll_wait(
@@ -4444,33 +4443,8 @@ int epoll_wait(
    set<SYSSOCKET>* lrfds,
    set<SYSSOCKET>* lwfds)
 {
-   return CUDT::epoll_wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
+   return srt::CUDT::epoll_wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
 }
-
-/*
-
-#define SET_RESULT(val, num, fds, it) \
-   if (val != NULL) \
-   { \
-      if (val->empty()) \
-      { \
-         if (num) *num = 0; \
-      } \
-      else \
-      { \
-         if (*num > static_cast<int>(val->size())) \
-            *num = val->size(); \
-         int count = 0; \
-         for (it = val->begin(); it != val->end(); ++ it) \
-         { \
-            if (count >= *num) \
-               break; \
-            fds[count ++] = *it; \
-         } \
-      } \
-   }
-
-*/
 
 template <class SOCKTYPE>
 inline void set_result(set<SOCKTYPE>* val, int* num, SOCKTYPE* fds)
@@ -4524,7 +4498,7 @@ int epoll_wait2(
    if ((lwfds != NULL) && (lwnum != NULL))
       lwval = &lwset;
 
-   int ret = CUDT::epoll_wait(eid, rval, wval, msTimeOut, lrval, lwval);
+   int ret = srt::CUDT::epoll_wait(eid, rval, wval, msTimeOut, lrval, lwval);
    if (ret > 0)
    {
       //set<SRTSOCKET>::const_iterator i;
@@ -4544,32 +4518,32 @@ int epoll_wait2(
 
 int epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
-   return CUDT::epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
+   return srt::CUDT::epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
 }
 
 int epoll_release(int eid)
 {
-   return CUDT::epoll_release(eid);
+   return srt::CUDT::epoll_release(eid);
 }
 
 ERRORINFO& getlasterror()
 {
-   return CUDT::getlasterror();
+   return srt::CUDT::getlasterror();
 }
 
 int getlasterror_code()
 {
-   return CUDT::getlasterror().getErrorCode();
+   return srt::CUDT::getlasterror().getErrorCode();
 }
 
 const char* getlasterror_desc()
 {
-   return CUDT::getlasterror().getErrorMessage();
+   return srt::CUDT::getlasterror().getErrorMessage();
 }
 
 int getlasterror_errno()
 {
-   return CUDT::getlasterror().getErrno();
+   return srt::CUDT::getlasterror().getErrno();
 }
 
 // Get error string of a given error code
@@ -4581,12 +4555,12 @@ const char* geterror_desc(int code, int err)
 
 int bstats(SRTSOCKET u, SRT_TRACEBSTATS* perf, bool clear)
 {
-   return CUDT::bstats(u, perf, clear);
+   return srt::CUDT::bstats(u, perf, clear);
 }
 
 SRT_SOCKSTATUS getsockstate(SRTSOCKET u)
 {
-   return CUDT::getsockstate(u);
+   return srt::CUDT::getsockstate(u);
 }
 
 } // namespace UDT

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -72,6 +72,8 @@ modified by
 // Please refer to structure and locking information provided in the
 // docs/dev/low-level-info.md document.
 
+namespace srt {
+
 class CUDT;
 
 class CUDTSocket
@@ -107,7 +109,7 @@ public:
    /// of sockets in order to prevent other methods from accessing invalid address.
    /// A timer is started and the socket will be removed after approximately
    /// 1 second (see CUDTUnited::checkBrokenSockets()).
-   srt::sync::steady_clock::time_point m_tsClosureTimeStamp;
+   sync::steady_clock::time_point m_tsClosureTimeStamp;
 
    sockaddr_any m_SelfAddr;                  //< local address of the socket
    sockaddr_any m_PeerAddr;                  //< peer address of the socket
@@ -117,7 +119,7 @@ public:
 
    SRTSOCKET m_PeerID;                       //< peer socket ID
 #if ENABLE_EXPERIMENTAL_BONDING
-   srt::groups::SocketData* m_GroupMemberData; //< Pointer to group member data, or NULL if not a group member
+   groups::SocketData* m_GroupMemberData; //< Pointer to group member data, or NULL if not a group member
    CUDTGroup* m_GroupOf;                       //< Group this socket is a member of, or NULL if it isn't
 #endif
 
@@ -125,10 +127,10 @@ public:
 
    CUDT* m_pUDT;                             //< pointer to the UDT entity
 
-   std::set<SRTSOCKET> m_QueuedSockets;    //< set of connections waiting for accept()
+   std::set<SRTSOCKET> m_QueuedSockets;      //< set of connections waiting for accept()
 
-   srt::sync::Condition m_AcceptCond;        //< used to block "accept" call
-   srt::sync::Mutex m_AcceptLock;            //< mutex associated to m_AcceptCond
+   sync::Condition m_AcceptCond;             //< used to block "accept" call
+   sync::Mutex m_AcceptLock;                 //< mutex associated to m_AcceptCond
 
    unsigned int m_uiBackLog;                 //< maximum number of connections in queue
 
@@ -143,9 +145,9 @@ public:
    // When deleting, you simply "unsubscribe" yourself from the multiplexer, which
    // will unref it and remove the list element by the iterator kept by the
    // socket.
-   int m_iMuxID;                             //< multiplexer ID
+   int m_iMuxID;                        //< multiplexer ID
 
-   srt::sync::Mutex m_ControlLock;           //< lock this socket exclusively for control APIs: bind/listen/connect
+   sync::Mutex m_ControlLock;           //< lock this socket exclusively for control APIs: bind/listen/connect
 
    CUDT& core() { return *m_pUDT; }
 
@@ -346,12 +348,12 @@ private:
    groups_t m_Groups;
 #endif
 
-   srt::sync::Mutex m_GlobControlLock;               // used to synchronize UDT API
+   sync::Mutex m_GlobControlLock;               // used to synchronize UDT API
 
-   srt::sync::Mutex m_IDLock;                        // used to synchronize ID generation
+   sync::Mutex m_IDLock;                        // used to synchronize ID generation
 
-   SRTSOCKET m_SocketIDGenerator;                    // seed to generate a new unique socket ID
-   SRTSOCKET m_SocketIDGenerator_init;               // Keeps track of the very first one
+   SRTSOCKET m_SocketIDGenerator;               // seed to generate a new unique socket ID
+   SRTSOCKET m_SocketIDGenerator_init;          // Keeps track of the very first one
 
    std::map<int64_t, std::set<SRTSOCKET> > m_PeerRec;// record sockets from peers to avoid repeated connection request, int64_t = (socker_id << 30) + isn
 
@@ -394,7 +396,7 @@ private:
                // We have a guarantee that if `group` was set
                // as non-NULL here, it is also acquired and will not
                // be deleted until this busy flag is set back to false.
-               srt::sync::ScopedLock cgroup (*group->exp_groupLock());
+               sync::ScopedLock cgroup (*group->exp_groupLock());
                group->apiRelease();
                // Only now that the group lock is lifted, can the
                // group be now deleted and this pointer potentially dangling
@@ -408,21 +410,21 @@ private:
 
 private:
    std::map<int, CMultiplexer> m_mMultiplexer;		// UDP multiplexer
-   srt::sync::Mutex            m_MultiplexerLock;
+   sync::Mutex            m_MultiplexerLock;
 
 private:
    CCache<CInfoBlock>* m_pCache;			// UDT network information cache
 
 private:
    volatile bool m_bClosing;
-   srt::sync::Mutex m_GCStopLock;
-   srt::sync::Condition m_GCStopCond;
+   sync::Mutex m_GCStopLock;
+   sync::Condition m_GCStopCond;
 
-   srt::sync::Mutex m_InitLock;
+   sync::Mutex m_InitLock;
    int m_iInstanceCount;				// number of startup() called by application
    bool m_bGCStatus;					// if the GC thread is working (true)
 
-   srt::sync::CThread m_GCThread;
+   sync::CThread m_GCThread;
    static void* garbageCollect(void*);
 
    sockets_t m_ClosedSockets;   // temporarily store closed sockets
@@ -439,5 +441,7 @@ private:
    CUDTUnited(const CUDTUnited&);
    CUDTUnited& operator=(const CUDTUnited&);
 };
+
+} // namespace srt
 
 #endif

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -61,6 +61,7 @@ modified by
 
 using namespace std;
 using namespace srt_logging;
+using namespace srt;
 using namespace srt::sync;
 
 // You can change this value at build config by using "ENFORCE" options.
@@ -317,7 +318,7 @@ void CSndBuffer::updateInputRate(const steady_clock::time_point& time, int pkts,
     if (early_update || period_us > m_InRatePeriod)
     {
         // Required Byte/sec rate (payload + headers)
-        m_iInRateBytesCount += (m_iInRatePktsCount * CPacket::SRT_DATA_HDR_SIZE);
+        m_iInRateBytesCount += (m_iInRatePktsCount * srt::CPacket::SRT_DATA_HDR_SIZE);
         m_iInRateBps = (int)(((int64_t)m_iInRateBytesCount * 1000000) / period_us);
         HLOGC(bslog.Debug,
               log << "updateInputRate: pkts:" << m_iInRateBytesCount << " bytes:" << m_iInRatePktsCount
@@ -410,7 +411,7 @@ steady_clock::time_point CSndBuffer::getSourceTime(const CSndBuffer::Block& bloc
     return block.m_tsOriginTime;
 }
 
-int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime, int kflgs)
+int CSndBuffer::readData(srt::CPacket& w_packet, steady_clock::time_point& w_srctime, int kflgs)
 {
     // No data to read
     if (m_pCurrBlock == m_pLastBlock)
@@ -511,7 +512,7 @@ int32_t CSndBuffer::getMsgNoAt(const int offset)
     return p->getMsgSeq();
 }
 
-int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time_point& w_srctime, int& w_msglen)
+int CSndBuffer::readData(const int offset, srt::CPacket& w_packet, steady_clock::time_point& w_srctime, int& w_msglen)
 {
     int32_t& msgno_bitset = w_packet.m_iMsgNo;
 
@@ -926,7 +927,7 @@ int CRcvBuffer::readBuffer(char* data, int len)
             return -1;
         }
 
-        const CPacket& pkt = m_pUnit[p]->m_Packet;
+        const srt::CPacket& pkt = m_pUnit[p]->m_Packet;
 
         if (bTsbPdEnabled)
         {
@@ -995,7 +996,7 @@ int CRcvBuffer::readBufferToFile(fstream& ofs, int len)
             continue;
         }
 
-        const CPacket& pkt = m_pUnit[p]->m_Packet;
+        const srt::CPacket& pkt = m_pUnit[p]->m_Packet;
 
 #if ENABLE_LOGGING
         trace_seq = pkt.getSeqNo();
@@ -1435,7 +1436,7 @@ bool CRcvBuffer::isRcvDataReady(steady_clock::time_point& w_tsbpdtime, int32_t& 
 
     if (m_tsbpd.isEnabled())
     {
-        const CPacket* pkt = getRcvReadyPacket(seqdistance);
+        const srt::CPacket* pkt = getRcvReadyPacket(seqdistance);
         if (!pkt)
         {
             HLOGC(brlog.Debug, log << "isRcvDataReady: packet NOT extracted.");
@@ -1572,7 +1573,7 @@ void CRcvBuffer::reportBufferStats() const
     uint64_t lower_time = low_ts;
 
     if (lower_time > upper_time)
-        upper_time += uint64_t(CPacket::MAX_TIMESTAMP) + 1;
+        upper_time += uint64_t(srt::CPacket::MAX_TIMESTAMP) + 1;
 
     int32_t timespan = upper_time - lower_time;
     int     seqspan  = 0;

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -145,7 +145,7 @@ public:
     /// @param [out] origintime origin time stamp of the message
     /// @param [in] kflags Odd|Even crypto key flag
     /// @return Actual length of data read.
-    int readData(CPacket& w_packet, time_point& w_origintime, int kflgs);
+    int readData(srt::CPacket& w_packet, time_point& w_origintime, int kflgs);
 
     /// Find data position to pack a DATA packet for a retransmission.
     /// @param [out] data the pointer to the data position.
@@ -154,7 +154,7 @@ public:
     /// @param [out] origintime origin time stamp of the message
     /// @param [out] msglen length of the message
     /// @return Actual length of data read.
-    int readData(const int offset, CPacket& w_packet, time_point& w_origintime, int& w_msglen);
+    int readData(const int offset, srt::CPacket& w_packet, time_point& w_origintime, int& w_msglen);
 
     /// Get the time of the last retransmission (if any) of the DATA packet.
     /// @param [in] offset offset from the last ACK point (backward sequence number difference)
@@ -288,7 +288,7 @@ public:
     /// Construct the buffer.
     /// @param [in] queue  CUnitQueue that actually holds the units (packets)
     /// @param [in] bufsize_pkts in units (packets)
-    CRcvBuffer(CUnitQueue* queue, int bufsize_pkts = DEFAULT_SIZE);
+    CRcvBuffer(srt::CUnitQueue* queue, int bufsize_pkts = DEFAULT_SIZE);
     ~CRcvBuffer();
 
 public:
@@ -296,7 +296,7 @@ public:
     /// @param [in] unit pointer to a data unit containing new packet
     /// @param [in] offset offset from last ACK point.
     /// @return 0 is success, -1 if data is repeated.
-    int addData(CUnit* unit, int offset);
+    int addData(srt::CUnit* unit, int offset);
 
     /// Read data into a user buffer.
     /// @param [in] data pointer to user buffer.
@@ -402,7 +402,7 @@ public:
 
     bool     isRcvDataReady();
     bool     isRcvDataAvailable() { return m_iLastAckPos != m_iStartPos; }
-    CPacket* getRcvReadyPacket(int32_t seqdistance);
+    srt::CPacket* getRcvReadyPacket(int32_t seqdistance);
 
     /// Set TimeStamp-Based Packet Delivery Rx Mode
     /// @param [in] timebase localtime base (uSec) of packet time stamps including buffering delay
@@ -462,7 +462,7 @@ private:
     /// data.
     size_t freeUnitAt(size_t p)
     {
-        CUnit* u       = m_pUnit[p];
+        srt::CUnit* u  = m_pUnit[p];
         m_pUnit[p]     = NULL;
         size_t rmbytes = u->m_Packet.getLength();
         m_pUnitQueue->makeUnitFree(u);
@@ -528,9 +528,9 @@ private:
     }
 
 private:
-    CUnit**     m_pUnit;      // Array of pointed units collected in the buffer
+    srt::CUnit** m_pUnit;      // Array of pointed units collected in the buffer
     const int   m_iSize;      // Size of the internal array of CUnit* items
-    CUnitQueue* m_pUnitQueue; // the shared unit queue
+    srt::CUnitQueue* m_pUnitQueue; // the shared unit queue
 
     int m_iStartPos;   // HEAD: first packet available for reading
     int m_iLastAckPos; // the last ACKed position (exclusive), follows the last readable

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -53,7 +53,7 @@ modified by
 #include "platform_sys.h"
 
 #include <iostream>
-#include <iomanip> // Logging 
+#include <iomanip> // Logging
 #include <srt_compat.h>
 #include <csignal>
 
@@ -65,34 +65,30 @@ modified by
 #include "utilities.h"
 
 #ifdef _WIN32
-    typedef int socklen_t;
+typedef int socklen_t;
 #endif
 
 using namespace std;
 using namespace srt_logging;
 
-namespace srt {
+namespace srt
+{
 
 #ifdef _WIN32
-    // use INVALID_SOCKET, as provided
+// use INVALID_SOCKET, as provided
 #else
-    static const int INVALID_SOCKET = -1;
+static const int INVALID_SOCKET = -1;
 #endif
 
 #if ENABLE_SOCK_CLOEXEC
 #ifndef _WIN32
 
-#if defined(_AIX) || \
-    defined(__APPLE__) || \
-    defined(__DragonFly__) || \
-    defined(__FreeBSD__) || \
-    defined(__FreeBSD_kernel__) || \
-    defined(__linux__) || \
-    defined(__OpenBSD__) || \
-    defined(__NetBSD__)
+#if defined(_AIX) || defined(__APPLE__) || defined(__DragonFly__) || defined(__FreeBSD__) ||                           \
+    defined(__FreeBSD_kernel__) || defined(__linux__) || defined(__OpenBSD__) || defined(__NetBSD__)
 
 // Set the CLOEXEC flag using ioctl() function
-static int set_cloexec(int fd, int set) {
+static int set_cloexec(int fd, int set)
+{
     int r;
 
     do
@@ -106,7 +102,8 @@ static int set_cloexec(int fd, int set) {
 }
 #else
 // Set the CLOEXEC flag using fcntl() function
-static int set_cloexec(int fd, int set) {
+static int set_cloexec(int fd, int set)
+{
     int flags;
     int r;
 
@@ -141,13 +138,11 @@ static int set_cloexec(int fd, int set) {
 } // namespace srt
 
 srt::CChannel::CChannel()
-    :m_iSocket(INVALID_SOCKET)
+    : m_iSocket(INVALID_SOCKET)
 {
 }
 
-srt::CChannel::~CChannel()
-{
-}
+srt::CChannel::~CChannel() {}
 
 void srt::CChannel::createSocket(int family)
 {
@@ -158,14 +153,14 @@ void srt::CChannel::createSocket(int family)
     m_iSocket = ::socket(family, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
     if (m_iSocket == INVALID_SOCKET)
     {
-        m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
+        m_iSocket    = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
         cloexec_flag = true;
     }
 #else
-    m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
+    m_iSocket    = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
     cloexec_flag = true;
 #endif
-#else // ENABLE_SOCK_CLOEXEC
+#else  // ENABLE_SOCK_CLOEXEC
     m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
 #endif // ENABLE_SOCK_CLOEXEC
 
@@ -174,10 +169,12 @@ void srt::CChannel::createSocket(int family)
 
 #if ENABLE_SOCK_CLOEXEC
 #ifdef _WIN32
-    // XXX ::SetHandleInformation(hInputWrite, HANDLE_FLAG_INHERIT, 0)
+        // XXX ::SetHandleInformation(hInputWrite, HANDLE_FLAG_INHERIT, 0)
 #else
-    if (cloexec_flag) {
-        if (0 != set_cloexec(m_iSocket, 1)) {
+    if (cloexec_flag)
+    {
+        if (0 != set_cloexec(m_iSocket, 1))
+        {
             throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
         }
     }
@@ -186,19 +183,19 @@ void srt::CChannel::createSocket(int family)
 
     if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
     {
-        const int res ATR_UNUSED = ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY,
-                (const char*) &m_mcfg.iIpV6Only, sizeof m_mcfg.iIpV6Only);
+        const int res ATR_UNUSED =
+            ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&m_mcfg.iIpV6Only, sizeof m_mcfg.iIpV6Only);
 #if ENABLE_LOGGING
         if (res == -1)
         {
-            int err = errno;
+            int  err = errno;
             char msg[160];
-            LOGC(kmlog.Error, log << "::setsockopt: failed to set IPPROTO_IPV6/IPV6_V6ONLY = "
-                    << m_mcfg.iIpV6Only << ": " << SysStrError(err, msg, 159));
+            LOGC(kmlog.Error,
+                 log << "::setsockopt: failed to set IPPROTO_IPV6/IPV6_V6ONLY = " << m_mcfg.iIpV6Only << ": "
+                     << SysStrError(err, msg, 159));
         }
 #endif // ENABLE_LOGGING
     }
-
 }
 
 void srt::CChannel::open(const sockaddr_any& addr)
@@ -219,14 +216,14 @@ void srt::CChannel::open(int family)
 {
     createSocket(family);
 
-    //sendto or WSASendTo will also automatically bind the socket
-    addrinfo hints;
+    // sendto or WSASendTo will also automatically bind the socket
+    addrinfo  hints;
     addrinfo* res;
 
     memset(&hints, 0, sizeof(struct addrinfo));
 
-    hints.ai_flags = AI_PASSIVE;
-    hints.ai_family = family;
+    hints.ai_flags    = AI_PASSIVE;
+    hints.ai_family   = family;
     hints.ai_socktype = SOCK_DGRAM;
 
     const int eai = ::getaddrinfo(NULL, "0", &hints, &res);
@@ -248,7 +245,7 @@ void srt::CChannel::open(int family)
         ::freeaddrinfo(res);
         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
     }
-    m_BindAddr = sockaddr_any(res->ai_addr, (sockaddr_any::len_t) res->ai_addrlen);
+    m_BindAddr = sockaddr_any(res->ai_addr, (sockaddr_any::len_t)res->ai_addrlen);
 
     ::freeaddrinfo(res);
 
@@ -261,159 +258,169 @@ void srt::CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
 {
     // The getsockname() call is done before calling it and the
     // result is placed into udpsocks_addr.
-    m_iSocket = udpsock;
+    m_iSocket  = udpsock;
     m_BindAddr = udpsocks_addr;
     setUDPSockOpt();
 }
 
 void srt::CChannel::setUDPSockOpt()
 {
-   #if defined(BSD) || TARGET_OS_MAC
-      // BSD system will fail setsockopt if the requested buffer size exceeds system maximum value
-      int maxsize = 64000;
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*) &m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize))
-         ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*) &maxsize, sizeof maxsize);
-      if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize))
-         ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*) &maxsize, sizeof maxsize);
-   #else
-      // for other systems, if requested is greated than maximum, the maximum value will be automactally used
-      if ((0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*) &m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize)) ||
-          (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*) &m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize)))
-         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-   #endif
-
-      if (m_mcfg.iIpTTL != -1)
-      {
-          if (m_BindAddr.family() == AF_INET)
-          {
-              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*) &m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
-                  throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-          }
-          else
-          {
-              // If IPv6 address is unspecified, set BOTH IP_TTL and IPV6_UNICAST_HOPS.
-
-              // For specified IPv6 address, set IPV6_UNICAST_HOPS ONLY UNLESS it's an IPv4-mapped-IPv6
-              if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
-              {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char*) &m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
-                  {
-                      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-                  }
-              }
-              // For specified IPv6 address, set IP_TTL ONLY WHEN it's an IPv4-mapped-IPv6
-              if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
-              {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*) &m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
-                  {
-                      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-                  }
-              }
-          }
-      }
-
-      if (m_mcfg.iIpToS != -1)
-      {
-          if (m_BindAddr.family() == AF_INET)
-          {
-              if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*) &m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
-                  throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-          }
-          else
-          {
-              // If IPv6 address is unspecified, set BOTH IP_TOS and IPV6_TCLASS.
-
-#ifdef IPV6_TCLASS
-              // For specified IPv6 address, set IPV6_TCLASS ONLY UNLESS it's an IPv4-mapped-IPv6
-              if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
-              {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (const char*) &m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
-                  {
-                      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-                  }
-              }
+#if defined(BSD) || TARGET_OS_MAC
+    // BSD system will fail setsockopt if the requested buffer size exceeds system maximum value
+    int maxsize = 64000;
+    if (0 != ::setsockopt(
+                 m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize))
+        ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&maxsize, sizeof maxsize);
+    if (0 != ::setsockopt(
+                 m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize))
+        ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&maxsize, sizeof maxsize);
+#else
+    // for other systems, if requested is greated than maximum, the maximum value will be automactally used
+    if ((0 !=
+         ::setsockopt(
+             m_iSocket, SOL_SOCKET, SO_RCVBUF, (const char*)&m_mcfg.iUDPRcvBufSize, sizeof m_mcfg.iUDPRcvBufSize)) ||
+        (0 != ::setsockopt(
+                  m_iSocket, SOL_SOCKET, SO_SNDBUF, (const char*)&m_mcfg.iUDPSndBufSize, sizeof m_mcfg.iUDPSndBufSize)))
+        throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 #endif
 
-              // For specified IPv6 address, set IP_TOS ONLY WHEN it's an IPv4-mapped-IPv6
-              if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
-              {
-                  if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*) &m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
-                  {
-                      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-                  }
-              }
-          }
-      }
+    if (m_mcfg.iIpTTL != -1)
+    {
+        if (m_BindAddr.family() == AF_INET)
+        {
+            if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*)&m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
+                throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+        }
+        else
+        {
+            // If IPv6 address is unspecified, set BOTH IP_TTL and IPV6_UNICAST_HOPS.
+
+            // For specified IPv6 address, set IPV6_UNICAST_HOPS ONLY UNLESS it's an IPv4-mapped-IPv6
+            if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) ||
+                !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
+            {
+                if (0 !=
+                    ::setsockopt(
+                        m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (const char*)&m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
+                {
+                    throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+                }
+            }
+            // For specified IPv6 address, set IP_TTL ONLY WHEN it's an IPv4-mapped-IPv6
+            if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
+            {
+                if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (const char*)&m_mcfg.iIpTTL, sizeof m_mcfg.iIpTTL))
+                {
+                    throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+                }
+            }
+        }
+    }
+
+    if (m_mcfg.iIpToS != -1)
+    {
+        if (m_BindAddr.family() == AF_INET)
+        {
+            if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*)&m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
+                throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+        }
+        else
+        {
+            // If IPv6 address is unspecified, set BOTH IP_TOS and IPV6_TCLASS.
+
+#ifdef IPV6_TCLASS
+            // For specified IPv6 address, set IPV6_TCLASS ONLY UNLESS it's an IPv4-mapped-IPv6
+            if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) ||
+                !IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
+            {
+                if (0 != ::setsockopt(
+                             m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (const char*)&m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
+                {
+                    throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+                }
+            }
+#endif
+
+            // For specified IPv6 address, set IP_TOS ONLY WHEN it's an IPv4-mapped-IPv6
+            if (IN6_IS_ADDR_UNSPECIFIED(&m_BindAddr.sin6.sin6_addr) || IN6_IS_ADDR_V4MAPPED(&m_BindAddr.sin6.sin6_addr))
+            {
+                if (0 != ::setsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (const char*)&m_mcfg.iIpToS, sizeof m_mcfg.iIpToS))
+                {
+                    throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+                }
+            }
+        }
+    }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-      if (!m_mcfg.sBindToDevice.empty())
-      {
-          if (m_BindAddr.family() != AF_INET)
-          {
-              LOGC(kmlog.Error, log << "SRTO_BINDTODEVICE can only be set with AF_INET connections");
-              throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-          }
+    if (!m_mcfg.sBindToDevice.empty())
+    {
+        if (m_BindAddr.family() != AF_INET)
+        {
+            LOGC(kmlog.Error, log << "SRTO_BINDTODEVICE can only be set with AF_INET connections");
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+        }
 
-          if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_BINDTODEVICE,
-                      m_mcfg.sBindToDevice.c_str(), m_mcfg.sBindToDevice.size()))
-          {
+        if (0 != ::setsockopt(
+                     m_iSocket, SOL_SOCKET, SO_BINDTODEVICE, m_mcfg.sBindToDevice.c_str(), m_mcfg.sBindToDevice.size()))
+        {
 #if ENABLE_LOGGING
-              char buf[255];
-              const char* err = SysStrError(NET_ERROR, buf, 255);
-              LOGC(kmlog.Error, log << "setsockopt(SRTO_BINDTODEVICE): " << err);
+            char        buf[255];
+            const char* err = SysStrError(NET_ERROR, buf, 255);
+            LOGC(kmlog.Error, log << "setsockopt(SRTO_BINDTODEVICE): " << err);
 #endif // ENABLE_LOGGING
-              throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
-          }
-      }
+            throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+        }
+    }
 #endif
 
 #ifdef UNIX
-   // Set non-blocking I/O
-   // UNIX does not support SO_RCVTIMEO
-   int opts = ::fcntl(m_iSocket, F_GETFL);
-   if (-1 == ::fcntl(m_iSocket, F_SETFL, opts | O_NONBLOCK))
-      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+    // Set non-blocking I/O
+    // UNIX does not support SO_RCVTIMEO
+    int opts = ::fcntl(m_iSocket, F_GETFL);
+    if (-1 == ::fcntl(m_iSocket, F_SETFL, opts | O_NONBLOCK))
+        throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 #elif defined(_WIN32)
-   u_long nonBlocking = 1;
-   if (0 != ioctlsocket (m_iSocket, FIONBIO, &nonBlocking))
-      throw CUDTException (MJ_SETUP, MN_NORES, NET_ERROR);
+    u_long nonBlocking = 1;
+    if (0 != ioctlsocket(m_iSocket, FIONBIO, &nonBlocking))
+        throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 #else
-   timeval tv;
-   tv.tv_sec = 0;
-#if defined (BSD) || TARGET_OS_MAC
-   // Known BSD bug as the day I wrote this code.
-   // A small time out value will cause the socket to block forever.
-   tv.tv_usec = 10000;
+    timeval tv;
+    tv.tv_sec = 0;
+#if defined(BSD) || TARGET_OS_MAC
+    // Known BSD bug as the day I wrote this code.
+    // A small time out value will cause the socket to block forever.
+    tv.tv_usec = 10000;
 #else
-   tv.tv_usec = 100;
+    tv.tv_usec = 100;
 #endif
-   // Set receiving time-out value
-   if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv, sizeof(timeval)))
-      throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+    // Set receiving time-out value
+    if (0 != ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof(timeval)))
+        throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 #endif
 }
 
 void srt::CChannel::close() const
 {
-   #ifndef _WIN32
-      ::close(m_iSocket);
-   #else
-      ::closesocket(m_iSocket);
-   #endif
+#ifndef _WIN32
+    ::close(m_iSocket);
+#else
+    ::closesocket(m_iSocket);
+#endif
 }
 
 int srt::CChannel::getSndBufSize()
 {
-   socklen_t size = (socklen_t) sizeof m_mcfg.iUDPSndBufSize;
-   ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*) &m_mcfg.iUDPSndBufSize, &size);
-   return m_mcfg.iUDPSndBufSize;
+    socklen_t size = (socklen_t)sizeof m_mcfg.iUDPSndBufSize;
+    ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*)&m_mcfg.iUDPSndBufSize, &size);
+    return m_mcfg.iUDPSndBufSize;
 }
 
 int srt::CChannel::getRcvBufSize()
 {
-   socklen_t size = (socklen_t) sizeof m_mcfg.iUDPRcvBufSize;
-   ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*) &m_mcfg.iUDPRcvBufSize, &size);
-   return m_mcfg.iUDPRcvBufSize;
+    socklen_t size = (socklen_t)sizeof m_mcfg.iUDPRcvBufSize;
+    ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*)&m_mcfg.iUDPRcvBufSize, &size);
+    return m_mcfg.iUDPRcvBufSize;
 }
 
 void srt::CChannel::setConfig(const CSrtMuxerConfig& config)
@@ -423,50 +430,50 @@ void srt::CChannel::setConfig(const CSrtMuxerConfig& config)
 
 int srt::CChannel::getIpTTL() const
 {
-   if (m_iSocket == INVALID_SOCKET)
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    if (m_iSocket == INVALID_SOCKET)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   socklen_t size = (socklen_t) sizeof m_mcfg.iIpTTL;
-   if (m_BindAddr.family() == AF_INET)
-   {
-      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (char*) &m_mcfg.iIpTTL, &size);
-   }
-   else if (m_BindAddr.family() == AF_INET6)
-   {
-      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (char*) &m_mcfg.iIpTTL, &size);
-   }
-   else
-   {
-       // If family is unspecified, the socket probably doesn't exist.
-       LOGC(kmlog.Error, log << "IPE: CChannel::getIpTTL called with unset family");
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-   }
-   return m_mcfg.iIpTTL;
+    socklen_t size = (socklen_t)sizeof m_mcfg.iIpTTL;
+    if (m_BindAddr.family() == AF_INET)
+    {
+        ::getsockopt(m_iSocket, IPPROTO_IP, IP_TTL, (char*)&m_mcfg.iIpTTL, &size);
+    }
+    else if (m_BindAddr.family() == AF_INET6)
+    {
+        ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_UNICAST_HOPS, (char*)&m_mcfg.iIpTTL, &size);
+    }
+    else
+    {
+        // If family is unspecified, the socket probably doesn't exist.
+        LOGC(kmlog.Error, log << "IPE: CChannel::getIpTTL called with unset family");
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    }
+    return m_mcfg.iIpTTL;
 }
 
 int srt::CChannel::getIpToS() const
 {
-   if (m_iSocket == INVALID_SOCKET)
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    if (m_iSocket == INVALID_SOCKET)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   socklen_t size = (socklen_t) sizeof m_mcfg.iIpToS;
-   if (m_BindAddr.family() == AF_INET)
-   {
-      ::getsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (char*) &m_mcfg.iIpToS, &size);
-   }
-   else if (m_BindAddr.family() == AF_INET6)
-   {
+    socklen_t size = (socklen_t)sizeof m_mcfg.iIpToS;
+    if (m_BindAddr.family() == AF_INET)
+    {
+        ::getsockopt(m_iSocket, IPPROTO_IP, IP_TOS, (char*)&m_mcfg.iIpToS, &size);
+    }
+    else if (m_BindAddr.family() == AF_INET6)
+    {
 #ifdef IPV6_TCLASS
-      ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (char*) &m_mcfg.iIpToS, &size);
+        ::getsockopt(m_iSocket, IPPROTO_IPV6, IPV6_TCLASS, (char*)&m_mcfg.iIpToS, &size);
 #endif
-   }
-   else
-   {
-       // If family is unspecified, the socket probably doesn't exist.
-       LOGC(kmlog.Error, log << "IPE: CChannel::getIpToS called with unset family");
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-   }
-   return m_mcfg.iIpToS;
+    }
+    else
+    {
+        // If family is unspecified, the socket probably doesn't exist.
+        LOGC(kmlog.Error, log << "IPE: CChannel::getIpToS called with unset family");
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    }
+    return m_mcfg.iIpToS;
 }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
@@ -478,7 +485,7 @@ bool srt::CChannel::getBind(char* dst, size_t len)
     // Try to obtain it directly from the function. If not possible,
     // then return from internal data.
     socklen_t length = len;
-    int res = ::getsockopt(m_iSocket, SOL_SOCKET, SO_BINDTODEVICE, dst, &length);
+    int       res    = ::getsockopt(m_iSocket, SOL_SOCKET, SO_BINDTODEVICE, dst, &length);
     if (res == -1)
         return false; // Happens on Linux v < 3.8
 
@@ -492,8 +499,8 @@ int srt::CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
 {
 #if defined(unix) || defined(__APPLE__)
     int value = 0;
-    int res = ::ioctl(m_iSocket, type, &value);
-    if ( res != -1 )
+    int res   = ::ioctl(m_iSocket, type, &value);
+    if (res != -1)
         return value;
 #endif
     return -1;
@@ -502,10 +509,10 @@ int srt::CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
 int srt::CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNUSED) const
 {
 #if defined(unix) || defined(__APPLE__)
-    int value = 0;
-    socklen_t len = sizeof (int);
-    int res = ::getsockopt(m_iSocket, level, option, &value, &len);
-    if ( res != -1 )
+    int       value = 0;
+    socklen_t len   = sizeof(int);
+    int       res   = ::getsockopt(m_iSocket, level, option, &value, &len);
+    if (res != -1)
         return value;
 #endif
     return -1;
@@ -517,26 +524,23 @@ void srt::CChannel::getSockAddr(sockaddr_any& w_addr) const
     // space to copy the socket name, it doesn't have to be correlated
     // with the address family. So the maximum space for any name,
     // regardless of the family, does the job.
-    socklen_t namelen = (socklen_t) w_addr.storage_size();
+    socklen_t namelen = (socklen_t)w_addr.storage_size();
     ::getsockname(m_iSocket, (w_addr.get()), (&namelen));
     w_addr.len = namelen;
 }
 
 void srt::CChannel::getPeerAddr(sockaddr_any& w_addr) const
 {
-    socklen_t namelen = (socklen_t) w_addr.storage_size();
+    socklen_t namelen = (socklen_t)w_addr.storage_size();
     ::getpeername(m_iSocket, (w_addr.get()), (&namelen));
     w_addr.len = namelen;
 }
 
-
 int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
 {
-    HLOGC(kslog.Debug, log << "CChannel::sendto: SENDING NOW DST=" << addr.str()
-        << " target=@" << packet.m_iID
-        << " size=" << packet.getLength()
-        << " pkt.ts=" << packet.m_iTimeStamp
-        << " " << packet.Info());
+    HLOGC(kslog.Debug,
+          log << "CChannel::sendto: SENDING NOW DST=" << addr.str() << " target=@" << packet.m_iID
+              << " size=" << packet.getLength() << " pkt.ts=" << packet.m_iTimeStamp << " " << packet.Info());
 
 #ifdef SRT_TEST_FAKE_LOSS
 
@@ -546,18 +550,18 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
 #undef FAKELOSS_STRING
 #undef FAKELOSS_WRAP
 
-    static int dcounter = 0;
+    static int dcounter   = 0;
     static int flwcounter = 0;
 
     struct FakelossConfig
     {
-        pair<int,int> config;
+        pair<int, int> config;
         FakelossConfig(const char* f)
         {
             vector<string> out;
             Split(f, '+', back_inserter(out));
 
-            config.first = atoi(out[0].c_str());
+            config.first  = atoi(out[0].c_str());
             config.second = out.size() > 1 ? atoi(out[1].c_str()) : 8;
         }
     };
@@ -571,7 +575,9 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
         {
             // This is a counter of how many packets in a row shall be lost
             --flwcounter;
-            HLOGC(kslog.Debug, log << "CChannel: TEST: FAKE LOSS OF %" << packet.getSeqNo() << " (" << flwcounter << " more to drop)");
+            HLOGC(kslog.Debug,
+                  log << "CChannel: TEST: FAKE LOSS OF %" << packet.getSeqNo() << " (" << flwcounter
+                      << " more to drop)");
             return packet.getLength(); // fake successful sendinf
         }
 
@@ -583,7 +589,9 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
             if (dcounter > rnd)
             {
                 dcounter = 1;
-                HLOGC(kslog.Debug, log << "CChannel: TEST: FAKE LOSS OF %" << packet.getSeqNo() << " (will drop " << fakeloss.config.first << " more)");
+                HLOGC(kslog.Debug,
+                      log << "CChannel: TEST: FAKE LOSS OF %" << packet.getSeqNo() << " (will drop "
+                          << fakeloss.config.first << " more)");
                 flwcounter = fakeloss.config.first;
                 return packet.getLength(); // fake successful sendinf
             }
@@ -592,51 +600,51 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
 
 #endif
 
-   // convert control information into network order
-   packet.toNL();
+    // convert control information into network order
+    packet.toNL();
 
-   #ifndef _WIN32
-      msghdr mh;
-      mh.msg_name = (sockaddr*)&addr;
-      mh.msg_namelen = addr.size();
-      mh.msg_iov = (iovec*)packet.m_PacketVector;
-      mh.msg_iovlen = 2;
-      mh.msg_control = NULL;
-      mh.msg_controllen = 0;
-      mh.msg_flags = 0;
+#ifndef _WIN32
+    msghdr mh;
+    mh.msg_name       = (sockaddr*)&addr;
+    mh.msg_namelen    = addr.size();
+    mh.msg_iov        = (iovec*)packet.m_PacketVector;
+    mh.msg_iovlen     = 2;
+    mh.msg_control    = NULL;
+    mh.msg_controllen = 0;
+    mh.msg_flags      = 0;
 
-      const int res = ::sendmsg(m_iSocket, &mh, 0);
-   #else
-      DWORD size = (DWORD) (CPacket::HDR_SIZE + packet.getLength());
-      int addrsize = addr.size();
-      int res = ::WSASendTo(m_iSocket, (LPWSABUF)packet.m_PacketVector, 2, &size, 0, addr.get(), addrsize, NULL, NULL);
-      res = (0 == res) ? size : -1;
-   #endif
+    const int res = ::sendmsg(m_iSocket, &mh, 0);
+#else
+    DWORD size     = (DWORD)(CPacket::HDR_SIZE + packet.getLength());
+    int   addrsize = addr.size();
+    int   res = ::WSASendTo(m_iSocket, (LPWSABUF)packet.m_PacketVector, 2, &size, 0, addr.get(), addrsize, NULL, NULL);
+    res       = (0 == res) ? size : -1;
+#endif
 
-   packet.toHL();
+    packet.toHL();
 
-   return res;
+    return res;
 }
 
 EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
 {
-    EReadStatus status = RST_OK;
-    int msg_flags = 0;
-    int recv_size = -1;
+    EReadStatus status    = RST_OK;
+    int         msg_flags = 0;
+    int         recv_size = -1;
 
 #if defined(UNIX) || defined(_WIN32)
-    fd_set set;
+    fd_set  set;
     timeval tv;
     FD_ZERO(&set);
     FD_SET(m_iSocket, &set);
-    tv.tv_sec  = 0;
-    tv.tv_usec = 10000;
-    const int select_ret = ::select((int) m_iSocket + 1, &set, NULL, &set, &tv);
+    tv.tv_sec            = 0;
+    tv.tv_usec           = 10000;
+    const int select_ret = ::select((int)m_iSocket + 1, &set, NULL, &set, &tv);
 #else
-    const int select_ret = 1;   // the socket is expected to be in the blocking mode itself
+    const int select_ret = 1; // the socket is expected to be in the blocking mode itself
 #endif
 
-    if (select_ret == 0)   // timeout
+    if (select_ret == 0) // timeout
     {
         w_packet.setLength(-1);
         return RST_AGAIN;
@@ -646,13 +654,13 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
     if (select_ret > 0)
     {
         msghdr mh;
-        mh.msg_name = (w_addr.get());
-        mh.msg_namelen = w_addr.size();
-        mh.msg_iov = (w_packet.m_PacketVector);
-        mh.msg_iovlen = 2;
-        mh.msg_control = NULL;
+        mh.msg_name       = (w_addr.get());
+        mh.msg_namelen    = w_addr.size();
+        mh.msg_iov        = (w_packet.m_PacketVector);
+        mh.msg_iovlen     = 2;
+        mh.msg_control    = NULL;
         mh.msg_controllen = 0;
-        mh.msg_flags = 0;
+        mh.msg_flags      = 0;
 
         recv_size = ::recvmsg(m_iSocket, (&mh), 0);
         msg_flags = mh.msg_flags;
@@ -683,7 +691,8 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
     if (select_ret == -1 || recv_size == -1)
     {
         const int err = NET_ERROR;
-        if (err == EAGAIN || err == EINTR || err == ECONNREFUSED) // For EAGAIN, this isn't an error, just a useless call.
+        if (err == EAGAIN || err == EINTR ||
+            err == ECONNREFUSED) // For EAGAIN, this isn't an error, just a useless call.
         {
             status = RST_AGAIN;
         }
@@ -713,16 +722,23 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
     // value one Windows than 0, unless this procedure below is rewritten
     // to use WSARecvMsg().
 
-    int recv_ret = SOCKET_ERROR;
-    DWORD flag = 0;
+    int   recv_ret = SOCKET_ERROR;
+    DWORD flag     = 0;
 
-    if (select_ret > 0)     // the total number of socket handles that are ready
+    if (select_ret > 0) // the total number of socket handles that are ready
     {
-        DWORD size = (DWORD) (CPacket::HDR_SIZE + w_packet.getLength());
-        int addrsize = w_addr.size();
+        DWORD size     = (DWORD)(CPacket::HDR_SIZE + w_packet.getLength());
+        int   addrsize = w_addr.size();
 
-        recv_ret = ::WSARecvFrom(m_iSocket, ((LPWSABUF)w_packet.m_PacketVector), 2,
-                (&size), (&flag), (w_addr.get()), (&addrsize), NULL, NULL);
+        recv_ret = ::WSARecvFrom(m_iSocket,
+                                 ((LPWSABUF)w_packet.m_PacketVector),
+                                 2,
+                                 (&size),
+                                 (&flag),
+                                 (w_addr.get()),
+                                 (&addrsize),
+                                 NULL,
+                                 NULL);
         if (recv_ret == 0)
             recv_size = size;
     }
@@ -737,16 +753,9 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
         // WSAETIMEDOUT, which isn't mentioned in the documentation of WSARecvFrom at all.
         //
         // These below errors are treated as "fatal", all others are treated as "again".
-        static const int fatals [] =
-        {
-            WSAEFAULT,
-            WSAEINVAL,
-            WSAENETDOWN,
-            WSANOTINITIALISED,
-            WSA_OPERATION_ABORTED
-        };
+        static const int  fatals[]   = {WSAEFAULT, WSAEINVAL, WSAENETDOWN, WSANOTINITIALISED, WSA_OPERATION_ABORTED};
         static const int* fatals_end = fatals + Size(fatals);
-        const int err = NET_ERROR;
+        const int         err        = NET_ERROR;
         if (std::find(fatals, fatals_end, err) != fatals_end)
         {
             HLOGC(krlog.Debug, log << CONID() << "(sys)WSARecvFrom: " << SysStrError(err) << " [" << err << "]");
@@ -765,12 +774,12 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
         msg_flags = 1;
 #endif
 
-
     // Sanity check for a case when it didn't fill in even the header
     if (size_t(recv_size) < CPacket::HDR_SIZE)
     {
         status = RST_AGAIN;
-        HLOGC(krlog.Debug, log << CONID() << "POSSIBLE ATTACK: received too short packet with " << recv_size << " bytes");
+        HLOGC(krlog.Debug,
+              log << CONID() << "POSSIBLE ATTACK: received too short packet with " << recv_size << " bytes");
         goto Return_error;
     }
 
@@ -791,10 +800,11 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
     // When this happens, then you have at best a fragment of the buffer and it's
     // useless anyway. This is solved by dropping the packet and fake that no
     // packet was received, so the packet will be then retransmitted.
-    if ( msg_flags != 0 )
+    if (msg_flags != 0)
     {
-        HLOGC(krlog.Debug, log << CONID() << "NET ERROR: packet size=" << recv_size
-            << " msg_flags=0x" << hex << msg_flags << ", possibly MSG_TRUNC (0x" << hex << int(MSG_TRUNC) << ")");
+        HLOGC(krlog.Debug,
+              log << CONID() << "NET ERROR: packet size=" << recv_size << " msg_flags=0x" << hex << msg_flags
+                  << ", possibly MSG_TRUNC (0x" << hex << int(MSG_TRUNC) << ")");
         status = RST_AGAIN;
         goto Return_error;
     }
@@ -803,21 +813,21 @@ EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) con
 
     // convert back into local host order
     // XXX use NtoHLA().
-    //for (int i = 0; i < 4; ++ i)
+    // for (int i = 0; i < 4; ++ i)
     //   w_packet.m_nHeader[i] = ntohl(w_packet.m_nHeader[i]);
     {
         uint32_t* p = w_packet.m_nHeader;
-        for (size_t i = 0; i < SRT_PH_E_SIZE; ++ i)
+        for (size_t i = 0; i < SRT_PH_E_SIZE; ++i)
         {
             *p = ntohl(*p);
-            ++ p;
+            ++p;
         }
     }
 
     if (w_packet.isControl())
     {
-        for (size_t j = 0, n = w_packet.getLength() / sizeof (uint32_t); j < n; ++ j)
-            *((uint32_t *)w_packet.m_pcData + j) = ntohl(*((uint32_t *)w_packet.m_pcData + j));
+        for (size_t j = 0, n = w_packet.getLength() / sizeof(uint32_t); j < n; ++j)
+            *((uint32_t*)w_packet.m_pcData + j) = ntohl(*((uint32_t*)w_packet.m_pcData + j));
     }
 
     return RST_OK;

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -71,6 +71,8 @@ modified by
 using namespace std;
 using namespace srt_logging;
 
+namespace srt {
+
 #ifdef _WIN32
     // use INVALID_SOCKET, as provided
 #else
@@ -136,17 +138,18 @@ static int set_cloexec(int fd, int set) {
 #endif // if defined(_AIX) ...
 #endif // ifndef _WIN32
 #endif // if ENABLE_CLOEXEC
+} // namespace srt
 
-CChannel::CChannel()
+srt::CChannel::CChannel()
     :m_iSocket(INVALID_SOCKET)
 {
 }
 
-CChannel::~CChannel()
+srt::CChannel::~CChannel()
 {
 }
 
-void CChannel::createSocket(int family)
+void srt::CChannel::createSocket(int family)
 {
 #if ENABLE_SOCK_CLOEXEC
     bool cloexec_flag = false;
@@ -198,7 +201,7 @@ void CChannel::createSocket(int family)
 
 }
 
-void CChannel::open(const sockaddr_any& addr)
+void srt::CChannel::open(const sockaddr_any& addr)
 {
     createSocket(addr.family());
     socklen_t namelen = addr.size();
@@ -212,7 +215,7 @@ void CChannel::open(const sockaddr_any& addr)
     setUDPSockOpt();
 }
 
-void CChannel::open(int family)
+void srt::CChannel::open(int family)
 {
     createSocket(family);
 
@@ -254,7 +257,7 @@ void CChannel::open(int family)
     setUDPSockOpt();
 }
 
-void CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
+void srt::CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
 {
     // The getsockname() call is done before calling it and the
     // result is placed into udpsocks_addr.
@@ -263,7 +266,7 @@ void CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
     setUDPSockOpt();
 }
 
-void CChannel::setUDPSockOpt()
+void srt::CChannel::setUDPSockOpt()
 {
    #if defined(BSD) || TARGET_OS_MAC
       // BSD system will fail setsockopt if the requested buffer size exceeds system maximum value
@@ -390,7 +393,7 @@ void CChannel::setUDPSockOpt()
 #endif
 }
 
-void CChannel::close() const
+void srt::CChannel::close() const
 {
    #ifndef _WIN32
       ::close(m_iSocket);
@@ -399,26 +402,26 @@ void CChannel::close() const
    #endif
 }
 
-int CChannel::getSndBufSize()
+int srt::CChannel::getSndBufSize()
 {
    socklen_t size = (socklen_t) sizeof m_mcfg.iUDPSndBufSize;
    ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*) &m_mcfg.iUDPSndBufSize, &size);
    return m_mcfg.iUDPSndBufSize;
 }
 
-int CChannel::getRcvBufSize()
+int srt::CChannel::getRcvBufSize()
 {
    socklen_t size = (socklen_t) sizeof m_mcfg.iUDPRcvBufSize;
    ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*) &m_mcfg.iUDPRcvBufSize, &size);
    return m_mcfg.iUDPRcvBufSize;
 }
 
-void CChannel::setConfig(const CSrtMuxerConfig& config)
+void srt::CChannel::setConfig(const CSrtMuxerConfig& config)
 {
     m_mcfg = config;
 }
 
-int CChannel::getIpTTL() const
+int srt::CChannel::getIpTTL() const
 {
    if (m_iSocket == INVALID_SOCKET)
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -441,7 +444,7 @@ int CChannel::getIpTTL() const
    return m_mcfg.iIpTTL;
 }
 
-int CChannel::getIpToS() const
+int srt::CChannel::getIpToS() const
 {
    if (m_iSocket == INVALID_SOCKET)
        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -467,7 +470,7 @@ int CChannel::getIpToS() const
 }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-bool CChannel::getBind(char* dst, size_t len)
+bool srt::CChannel::getBind(char* dst, size_t len)
 {
     if (m_iSocket == INVALID_SOCKET)
         return false; // No socket to get data from
@@ -485,7 +488,7 @@ bool CChannel::getBind(char* dst, size_t len)
 }
 #endif
 
-int CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
+int srt::CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
 {
 #if defined(unix) || defined(__APPLE__)
     int value = 0;
@@ -496,7 +499,7 @@ int CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
     return -1;
 }
 
-int CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNUSED) const
+int srt::CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNUSED) const
 {
 #if defined(unix) || defined(__APPLE__)
     int value = 0;
@@ -508,7 +511,7 @@ int CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNUSED) 
     return -1;
 }
 
-void CChannel::getSockAddr(sockaddr_any& w_addr) const
+void srt::CChannel::getSockAddr(sockaddr_any& w_addr) const
 {
     // The getsockname function requires only to have enough target
     // space to copy the socket name, it doesn't have to be correlated
@@ -519,7 +522,7 @@ void CChannel::getSockAddr(sockaddr_any& w_addr) const
     w_addr.len = namelen;
 }
 
-void CChannel::getPeerAddr(sockaddr_any& w_addr) const
+void srt::CChannel::getPeerAddr(sockaddr_any& w_addr) const
 {
     socklen_t namelen = (socklen_t) w_addr.storage_size();
     ::getpeername(m_iSocket, (w_addr.get()), (&namelen));
@@ -527,7 +530,7 @@ void CChannel::getPeerAddr(sockaddr_any& w_addr) const
 }
 
 
-int CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
+int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
 {
     HLOGC(kslog.Debug, log << "CChannel::sendto: SENDING NOW DST=" << addr.str()
         << " target=@" << packet.m_iID
@@ -615,7 +618,7 @@ int CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
    return res;
 }
 
-EReadStatus CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
+EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
 {
     EReadStatus status = RST_OK;
     int msg_flags = 0;

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -59,107 +59,107 @@ modified by
 #include "socketconfig.h"
 #include "netinet_any.h"
 
-namespace srt {
+namespace srt
+{
 
 class CChannel
 {
-   void createSocket(int family);
+    void createSocket(int family);
+
 public:
+    // XXX There's currently no way to access the socket ID set for
+    // whatever the channel is currently working for. Required to find
+    // some way to do this, possibly by having a "reverse pointer".
+    // Currently just "unimplemented".
+    std::string CONID() const { return ""; }
 
-   // XXX There's currently no way to access the socket ID set for
-   // whatever the channel is currently working for. Required to find
-   // some way to do this, possibly by having a "reverse pointer".
-   // Currently just "unimplemented".
-   std::string CONID() const { return ""; }
+    CChannel();
+    ~CChannel();
 
-   CChannel();
-   ~CChannel();
+    /// Open a UDP channel.
+    /// @param [in] addr The local address that UDP will use.
 
-      /// Open a UDP channel.
-      /// @param [in] addr The local address that UDP will use.
+    void open(const sockaddr_any& addr);
 
-   void open(const sockaddr_any& addr);
+    void open(int family);
 
-   void open(int family);
+    /// Open a UDP channel based on an existing UDP socket.
+    /// @param [in] udpsock UDP socket descriptor.
 
-      /// Open a UDP channel based on an existing UDP socket.
-      /// @param [in] udpsock UDP socket descriptor.
+    void attach(UDPSOCKET udpsock, const sockaddr_any& adr);
 
-   void attach(UDPSOCKET udpsock, const sockaddr_any& adr);
+    /// Disconnect and close the UDP entity.
 
-      /// Disconnect and close the UDP entity.
+    void close() const;
 
-   void close() const;
+    /// Get the UDP sending buffer size.
+    /// @return Current UDP sending buffer size.
 
-      /// Get the UDP sending buffer size.
-      /// @return Current UDP sending buffer size.
+    int getSndBufSize();
 
-   int getSndBufSize();
+    /// Get the UDP receiving buffer size.
+    /// @return Current UDP receiving buffer size.
 
-      /// Get the UDP receiving buffer size.
-      /// @return Current UDP receiving buffer size.
+    int getRcvBufSize();
 
-   int getRcvBufSize();
+    /// Query the socket address that the channel is using.
+    /// @param [out] addr pointer to store the returned socket address.
 
-      /// Query the socket address that the channel is using.
-      /// @param [out] addr pointer to store the returned socket address.
+    void getSockAddr(sockaddr_any& addr) const;
 
-   void getSockAddr(sockaddr_any& addr) const;
+    /// Query the peer side socket address that the channel is connect to.
+    /// @param [out] addr pointer to store the returned socket address.
 
-      /// Query the peer side socket address that the channel is connect to.
-      /// @param [out] addr pointer to store the returned socket address.
+    void getPeerAddr(sockaddr_any& addr) const;
 
-   void getPeerAddr(sockaddr_any& addr) const;
+    /// Send a packet to the given address.
+    /// @param [in] addr pointer to the destination address.
+    /// @param [in] packet reference to a CPacket entity.
+    /// @return Actual size of data sent.
 
-      /// Send a packet to the given address.
-      /// @param [in] addr pointer to the destination address.
-      /// @param [in] packet reference to a CPacket entity.
-      /// @return Actual size of data sent.
+    int sendto(const sockaddr_any& addr, srt::CPacket& packet) const;
 
-   int sendto(const sockaddr_any& addr, srt::CPacket& packet) const;
+    /// Receive a packet from the channel and record the source address.
+    /// @param [in] addr pointer to the source address.
+    /// @param [in] packet reference to a CPacket entity.
+    /// @return Actual size of data received.
 
-      /// Receive a packet from the channel and record the source address.
-      /// @param [in] addr pointer to the source address.
-      /// @param [in] packet reference to a CPacket entity.
-      /// @return Actual size of data received.
+    EReadStatus recvfrom(sockaddr_any& addr, srt::CPacket& packet) const;
 
-   EReadStatus recvfrom(sockaddr_any& addr, srt::CPacket& packet) const;
+    void setConfig(const CSrtMuxerConfig& config);
 
-   void setConfig(const CSrtMuxerConfig& config);
+    /// Get the IP TTL.
+    /// @param [in] ttl IP Time To Live.
+    /// @return TTL.
 
-      /// Get the IP TTL.
-      /// @param [in] ttl IP Time To Live.
-      /// @return TTL.
+    int getIpTTL() const;
 
-   int getIpTTL() const;
+    /// Get the IP Type of Service.
+    /// @return ToS.
 
-      /// Get the IP Type of Service.
-      /// @return ToS.
-
-   int getIpToS() const;
+    int getIpToS() const;
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-   bool getBind(char* dst, size_t len);
+    bool getBind(char* dst, size_t len);
 #endif
 
-   int ioctlQuery(int type) const;
-   int sockoptQuery(int level, int option) const;
+    int ioctlQuery(int type) const;
+    int sockoptQuery(int level, int option) const;
 
-   const sockaddr* bindAddress() { return m_BindAddr.get(); }
-   const sockaddr_any& bindAddressAny() { return m_BindAddr; }
-
-private:
-   void setUDPSockOpt();
+    const sockaddr*     bindAddress() { return m_BindAddr.get(); }
+    const sockaddr_any& bindAddressAny() { return m_BindAddr; }
 
 private:
+    void setUDPSockOpt();
 
-   UDPSOCKET m_iSocket;                 // socket descriptor
+private:
+    UDPSOCKET m_iSocket; // socket descriptor
 
-   // Mutable because when querying original settings
-   // this comprises the cache for extracted values,
-   // although the object itself isn't considered modified.
-   mutable CSrtMuxerConfig m_mcfg; // Note: ReuseAddr is unused and ineffective.
-   sockaddr_any m_BindAddr;
+    // Mutable because when querying original settings
+    // this comprises the cache for extracted values,
+    // although the object itself isn't considered modified.
+    mutable CSrtMuxerConfig m_mcfg; // Note: ReuseAddr is unused and ineffective.
+    sockaddr_any            m_BindAddr;
 };
 
 } // namespace srt

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -59,6 +59,8 @@ modified by
 #include "socketconfig.h"
 #include "netinet_any.h"
 
+namespace srt {
+
 class CChannel
 {
    void createSocket(int family);
@@ -114,14 +116,14 @@ public:
       /// @param [in] packet reference to a CPacket entity.
       /// @return Actual size of data sent.
 
-   int sendto(const sockaddr_any& addr, CPacket& packet) const;
+   int sendto(const sockaddr_any& addr, srt::CPacket& packet) const;
 
       /// Receive a packet from the channel and record the source address.
       /// @param [in] addr pointer to the source address.
       /// @param [in] packet reference to a CPacket entity.
       /// @return Actual size of data received.
 
-   EReadStatus recvfrom(sockaddr_any& addr, CPacket& packet) const;
+   EReadStatus recvfrom(sockaddr_any& addr, srt::CPacket& packet) const;
 
    void setConfig(const CSrtMuxerConfig& config);
 
@@ -160,5 +162,6 @@ private:
    sockaddr_any m_BindAddr;
 };
 
+} // namespace srt
 
 #endif

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -70,6 +70,7 @@ modified by
 
 #include <srt_compat.h> // SysStrError
 
+using namespace srt;
 using namespace srt::sync;
 
 namespace srt_logging {

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -311,7 +311,9 @@ enum EInitEvent
     TEV_INIT_OHEADBW
 };
 
-class CPacket;
+namespace srt {
+    class CPacket;
+}
 
 // XXX Use some more standard less hand-crafted solution, if possible
 // XXX Consider creating a mapping between TEV_* values and associated types,
@@ -322,7 +324,7 @@ struct EventVariant
     enum Type {UNDEFINED, PACKET, ARRAY, ACK, STAGE, INIT} type;
     union U
     {
-        const CPacket* packet;
+        const srt::CPacket* packet;
         int32_t ack;
         struct
         {
@@ -341,7 +343,7 @@ struct EventVariant
     // Note: UNDEFINED and ARRAY don't have assignment operator.
     // For ARRAY you'll use 'set' function. For UNDEFINED there's nothing.
 
-    explicit EventVariant(const CPacket* arg)
+    explicit EventVariant(const srt::CPacket* arg)
     {
         type = PACKET;
         u.packet = arg;
@@ -430,7 +432,7 @@ class EventArgType;
 // use a full-templated version. TBD.
 template<> struct EventVariant::VariantFor<EventVariant::PACKET>
 {
-    typedef const CPacket* type;
+    typedef const srt::CPacket* type;
     static type U::*field() {return &U::packet;}
 };
 
@@ -1406,7 +1408,7 @@ inline std::string SrtVersionString(int version)
     return buf;
 }
 
-bool SrtParseConfig(std::string s, SrtConfig& w_config);
+bool SrtParseConfig(std::string s, srt::SrtConfig& w_config);
 
 struct PacketMetric
 {

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -34,6 +34,7 @@
 #include "logging.h"
 
 using namespace std;
+using namespace srt;
 using namespace srt::sync;
 using namespace srt_logging;
 

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -16,10 +16,12 @@
 #include <string>
 #include <utility>
 
-class CUDT;
+namespace srt {
+    class CUDT;
+}
 class SrtCongestionControlBase;
 
-typedef SrtCongestionControlBase* srtcc_create_t(CUDT* parent);
+typedef SrtCongestionControlBase* srtcc_create_t(srt::CUDT* parent);
 
 class SrtCongestion
 {
@@ -97,7 +99,7 @@ public:
     // in appropriate time. It should select appropriate
     // congctl basing on the value in selector, then
     // pin oneself in into CUDT for receiving event signals.
-    bool configure(CUDT* parent);
+    bool configure(srt::CUDT* parent);
 
     // This function will intentionally delete the contained object.
     // This makes future calls to ready() return false. Calling
@@ -129,13 +131,15 @@ public:
     };
 };
 
-class CPacket;
+namespace srt {
+    class CPacket;
+}
 
 class SrtCongestionControlBase
 {
 protected:
     // Here can be some common fields
-    CUDT* m_parent;
+    srt::CUDT* m_parent;
 
     double m_dPktSndPeriod;
     double m_dCWndSize;
@@ -150,7 +154,7 @@ protected:
     //char* m_pcParam;         // Used to access m_llMaxBw. Use m_parent->maxBandwidth() instead.
 
     // Constructor in protected section so that this class is semi-abstract.
-    SrtCongestionControlBase(CUDT* parent);
+    SrtCongestionControlBase(srt::CUDT* parent);
 public:
 
     // This could be also made abstract, but this causes a linkage
@@ -192,7 +196,7 @@ public:
     // Arg 2: value calculated out of CUDT's m_config.llInputBW and m_config.iOverheadBW.
     virtual void updateBandwidth(int64_t, int64_t) {}
 
-    virtual bool needsQuickACK(const CPacket&)
+    virtual bool needsQuickACK(const srt::CPacket&)
     {
         return false;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -83,10 +83,12 @@ using namespace srt;
 using namespace srt::sync;
 using namespace srt_logging;
 
-CUDTUnited CUDT::s_UDTUnited;
+namespace srt {
+    CUDTUnited CUDT::s_UDTUnited;
+}
 
-const SRTSOCKET UDT::INVALID_SOCK = CUDT::INVALID_SOCK;
-const int       UDT::ERROR        = CUDT::ERROR;
+const SRTSOCKET UDT::INVALID_SOCK = srt::CUDT::INVALID_SOCK;
+const int       UDT::ERROR        = srt::CUDT::ERROR;
 
 //#define SRT_CMD_HSREQ       1           /* SRT Handshake Request (sender) */
 #define SRT_CMD_HSREQ_MINSZ 8 /* Minumum Compatible (1.x.x) packet size (bytes) */
@@ -221,7 +223,7 @@ const SrtOptionAction s_sockopt_action;
 } // namespace srt
 
 
-void CUDT::construct()
+void srt::CUDT::construct()
 {
     m_pSndBuffer           = NULL;
     m_pRcvBuffer           = NULL;
@@ -271,7 +273,7 @@ void CUDT::construct()
     // m_cbPacketArrival.set(this, &CUDT::defaultPacketArrival);
 }
 
-CUDT::CUDT(CUDTSocket* parent): m_parent(parent)
+srt::CUDT::CUDT(CUDTSocket* parent): m_parent(parent)
 {
     construct();
 
@@ -294,7 +296,7 @@ CUDT::CUDT(CUDTSocket* parent): m_parent(parent)
 
 }
 
-CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
+srt::CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
 {
     construct();
 
@@ -330,7 +332,7 @@ CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
     m_pCache = ancestor.m_pCache;
 }
 
-CUDT::~CUDT()
+srt::CUDT::~CUDT()
 {
     // release mutex/condtion variables
     destroySynch();
@@ -344,7 +346,7 @@ CUDT::~CUDT()
     delete m_pRNode;
 }
 
-void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
+void srt::CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
 {
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -403,7 +405,7 @@ void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     }
 }
 
-void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
+void srt::CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 {
     ScopedLock cg(m_ConnectionLock);
 
@@ -782,7 +784,7 @@ void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 
 
 #if ENABLE_EXPERIMENTAL_BONDING
-SRT_ERRNO CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
+SRT_ERRNO srt::CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
 {
     SRT_SOCKOPT this_opt = SRTO_VERSION;
     for (size_t i = 0; i < opt.options.size(); ++i)
@@ -796,7 +798,7 @@ SRT_ERRNO CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
 }
 #endif
 
-bool CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
+bool srt::CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
 {
     CUDT *that = getUDTHandle(u);
     if (!that)
@@ -812,7 +814,7 @@ bool CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
     return true;
 }
 
-std::string CUDT::getstreamid(SRTSOCKET u)
+string srt::CUDT::getstreamid(SRTSOCKET u)
 {
     CUDT *that = getUDTHandle(u);
     if (!that)
@@ -823,7 +825,7 @@ std::string CUDT::getstreamid(SRTSOCKET u)
 
 // XXX REFACTOR: Make common code for CUDT constructor and clearData,
 // possibly using CUDT::construct.
-void CUDT::clearData()
+void srt::CUDT::clearData()
 {
     // Initial sequence number, loss, acknowledgement, etc.
     int udpsize = m_config.iMSS - CPacket::UDP_HDR_SIZE;
@@ -912,7 +914,7 @@ void CUDT::clearData()
     m_tsRcvPeerStartTime = steady_clock::time_point();
 }
 
-void CUDT::open()
+void srt::CUDT::open()
 {
     ScopedLock cg(m_ConnectionLock);
 
@@ -965,7 +967,7 @@ void CUDT::open()
     m_bOpened = true;
 }
 
-void CUDT::setListenState()
+void srt::CUDT::setListenState()
 {
     ScopedLock cg(m_ConnectionLock);
 
@@ -986,7 +988,7 @@ void CUDT::setListenState()
     m_bListening = true;
 }
 
-size_t CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, int hs_version)
+size_t srt::CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, int hs_version)
 {
     if (srtlen < SRT_HS_E_SIZE)
     {
@@ -1014,7 +1016,7 @@ size_t CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, 
     }
 }
 
-size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
+size_t srt::CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
 {
     // INITIATOR sends HSREQ.
 
@@ -1077,7 +1079,7 @@ size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unu
     return 3;
 }
 
-size_t CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
+size_t srt::CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
 {
     // Setting m_tsRcvPeerStartTime is done in processSrtMsg_HSREQ(), so
     // this condition will be skipped only if this function is called without
@@ -1185,7 +1187,7 @@ size_t CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unu
     return 3;
 }
 
-size_t CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
+size_t srt::CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
 {
     size_t srtlen = fillSrtHandshake(srtdata, size, cmd, handshakeVersion());
     HLOGF(cnlog.Debug,
@@ -1201,7 +1203,7 @@ size_t CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
     return srtlen;
 }
 
-void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
+void srt::CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
 {
     CPacket srtpkt;
     int32_t srtcmd = (int32_t)cmd;
@@ -1259,7 +1261,7 @@ void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
     }
 }
 
-size_t CUDT::fillHsExtConfigString(uint32_t* pcmdspec, int cmd, const string& str)
+size_t srt::CUDT::fillHsExtConfigString(uint32_t* pcmdspec, int cmd, const string& str)
 {
     uint32_t* space = pcmdspec + 1;
     size_t wordsize         = (str.size() + 3) / 4;
@@ -1278,7 +1280,7 @@ size_t CUDT::fillHsExtConfigString(uint32_t* pcmdspec, int cmd, const string& st
 #if ENABLE_EXPERIMENTAL_BONDING
 // [[using locked(m_parent->m_ControlLock)]]
 // [[using locked(s_UDTUnited.m_GlobControlLock)]]
-size_t CUDT::fillHsExtGroup(uint32_t* pcmdspec)
+size_t srt::CUDT::fillHsExtGroup(uint32_t* pcmdspec)
 {
     SRT_ASSERT(m_parent->m_GroupOf != NULL);
     uint32_t* space = pcmdspec + 1;
@@ -1320,7 +1322,7 @@ size_t CUDT::fillHsExtGroup(uint32_t* pcmdspec)
 }
 #endif
 
-size_t CUDT::fillHsExtKMREQ(uint32_t* pcmdspec, size_t ki)
+size_t srt::CUDT::fillHsExtKMREQ(uint32_t* pcmdspec, size_t ki)
 {
     uint32_t* space = pcmdspec + 1;
 
@@ -1349,7 +1351,7 @@ size_t CUDT::fillHsExtKMREQ(uint32_t* pcmdspec, size_t ki)
     return ra_size;
 }
 
-size_t CUDT::fillHsExtKMRSP(uint32_t* pcmdspec, const uint32_t* kmdata, size_t kmdata_wordsize)
+size_t srt::CUDT::fillHsExtKMRSP(uint32_t* pcmdspec, const uint32_t* kmdata, size_t kmdata_wordsize)
 {
     uint32_t* space = pcmdspec + 1;
     const uint32_t failure_kmrsp[] = {SRT_KM_S_UNSECURED};
@@ -1396,7 +1398,7 @@ size_t CUDT::fillHsExtKMRSP(uint32_t* pcmdspec, const uint32_t* kmdata, size_t k
 // PREREQUISITE:
 // pkt must be set the buffer and configured for UMSG_HANDSHAKE.
 // Note that this function replaces also serialization for the HSv4.
-bool CUDT::createSrtHandshake(
+bool srt::CUDT::createSrtHandshake(
         int             srths_cmd,
         int             srtkm_cmd,
         const uint32_t* kmdata,
@@ -1939,7 +1941,7 @@ RttTracer s_rtt_trace;
 #endif
 
 
-bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
+bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
 {
     uint32_t *srtdata = (uint32_t *)ctrlpkt->m_pcData;
     size_t    len     = ctrlpkt->getLength();
@@ -2021,7 +2023,7 @@ bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
     return true;
 }
 
-int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
+int srt::CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
 {
     // Set this start time in the beginning, regardless as to whether TSBPD is being
     // used or not. This must be done in the Initiator as well as Responder.
@@ -2235,7 +2237,7 @@ int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t 
     return SRT_CMD_HSRSP;
 }
 
-int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
+int srt::CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
 {
     // XXX Check for mis-version
     // With HSv4 we accept only version less than 1.3.0
@@ -2381,7 +2383,7 @@ int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t 
 }
 
 // This function is called only when the URQ_CONCLUSION handshake has been received from the peer.
-bool CUDT::interpretSrtHandshake(const CHandShake& hs,
+bool srt::CUDT::interpretSrtHandshake(const CHandShake& hs,
                                  const CPacket&    hspkt,
                                  uint32_t*         out_data,
                                  size_t*           pw_len)
@@ -2894,7 +2896,7 @@ bool CUDT::interpretSrtHandshake(const CHandShake& hs,
     return true;
 }
 
-bool CUDT::checkApplyFilterConfig(const std::string &confstr)
+bool srt::CUDT::checkApplyFilterConfig(const std::string &confstr)
 {
     SrtFilterConfig cfg;
     if (!ParseFilterConfig(confstr, (cfg)))
@@ -2976,7 +2978,7 @@ bool CUDT::checkApplyFilterConfig(const std::string &confstr)
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UNUSED, int hsreq_type_cmd SRT_ATR_UNUSED)
+bool srt::CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UNUSED, int hsreq_type_cmd SRT_ATR_UNUSED)
 {
     // `data_size` isn't checked because we believe it's checked earlier.
     // Also this code doesn't predict to get any other format than the official one,
@@ -3147,7 +3149,7 @@ bool CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_ATR_UN
 // exclusively on the listener side (HSD_RESPONDER, HSv5+).
 
 // [[using locked(s_UDTUnited.m_GlobControlLock)]]
-SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t link_flags)
+SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t link_flags)
 {
     // Note: This function will lock pg->m_GroupLock!
 
@@ -3245,7 +3247,7 @@ SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t l
     return gp->id();
 }
 
-void CUDT::synchronizeWithGroup(CUDTGroup* gp)
+void srt::CUDT::synchronizeWithGroup(CUDTGroup* gp)
 {
     ScopedLock gl (*gp->exp_groupLock());
 
@@ -3344,7 +3346,7 @@ void CUDT::synchronizeWithGroup(CUDTGroup* gp)
 }
 #endif
 
-void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
+void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 {
     ScopedLock cg (m_ConnectionLock);
 
@@ -3723,7 +3725,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 }
 
 // Asynchronous connection
-EConnectStatus CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEPT
+EConnectStatus srt::CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEPT
 {
     EConnectStatus cst = CONN_CONTINUE;
     CUDTException  e;
@@ -3740,7 +3742,7 @@ EConnectStatus CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEP
     return cst;
 }
 
-bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
+bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
                                       EConnectStatus      cst,
                                       const CPacket&      response,
                                       const sockaddr_any& serv_addr)
@@ -3834,7 +3836,7 @@ bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
     return status;
 }
 
-void CUDT::cookieContest()
+void srt::CUDT::cookieContest()
 {
     if (m_SrtHsSide != HSD_DRAW)
         return;
@@ -3899,7 +3901,7 @@ void CUDT::cookieContest()
 // - There's no KMX (including first responder's handshake in rendezvous). This writes 0 to w_kmdatasize.
 // - The encryption status is failure. Respond with fail code and w_kmdatasize = 1.
 // - The last KMX was successful. Respond with the original kmdata and their size in w_kmdatasize.
-EConnectStatus CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatasize)
+EConnectStatus srt::CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatasize)
 {
     // If the last CONCLUSION message didn't contain the KMX extension, there's
     // no key recorded yet, so it can't be extracted. Mark this w_kmdatasize empty though.
@@ -3973,7 +3975,7 @@ EConnectStatus CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatasize)
     return CONN_ACCEPT;
 }
 
-EConnectStatus CUDT::processRendezvous(
+EConnectStatus srt::CUDT::processRendezvous(
     const CPacket& response, const sockaddr_any& serv_addr,
     EReadStatus rst, CPacket& w_reqpkt)
 {
@@ -4243,7 +4245,7 @@ EConnectStatus CUDT::processRendezvous(
 }
 
 // [[using locked(m_ConnectionLock)]];
-EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTException* eout) ATR_NOEXCEPT
+EConnectStatus srt::CUDT::processConnectResponse(const CPacket& response, CUDTException* eout) ATR_NOEXCEPT
 {
     // NOTE: ASSUMED LOCK ON: m_ConnectionLock.
 
@@ -4475,7 +4477,7 @@ EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTExcepti
     return postConnect(response, false, eout);
 }
 
-bool CUDT::applyResponseSettings() ATR_NOEXCEPT
+bool srt::CUDT::applyResponseSettings() ATR_NOEXCEPT
 {
     if (!m_ConnRes.valid())
     {
@@ -4505,7 +4507,7 @@ bool CUDT::applyResponseSettings() ATR_NOEXCEPT
     return true;
 }
 
-EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTException *eout) ATR_NOEXCEPT
+EConnectStatus srt::CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTException *eout) ATR_NOEXCEPT
 {
     if (m_ConnRes.m_iVersion < HS_VERSION_SRT1)
         m_tsRcvPeerStartTime = steady_clock::time_point(); // will be set correctly in SRT HS.
@@ -4713,7 +4715,7 @@ EConnectStatus CUDT::postConnect(const CPacket &response, bool rendezvous, CUDTE
     return CONN_ACCEPT;
 }
 
-void CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t typefield)
+void srt::CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t typefield)
 {
     int enc_flags = SrtHSRequest::SRT_HSTYPE_ENCFLAGS::unwrap(typefield);
 
@@ -4759,7 +4761,7 @@ void CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t ty
 }
 
 // Rendezvous
-void CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_extension, bool& w_needs_hsrsp)
+void srt::CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_extension, bool& w_needs_hsrsp)
 {
     UDTRequestType req           = m_ConnRes.m_iReqType;
     int            hs_flags      = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
@@ -5123,7 +5125,7 @@ void CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_extens
  * This thread runs only if TsbPd mode is enabled
  * Hold received packets until its time to 'play' them, at PktTimeStamp + TsbPdDelay.
  */
-void *CUDT::tsbpd(void *param)
+void * srt::CUDT::tsbpd(void *param)
 {
     CUDT *self = (CUDT *)param;
 
@@ -5332,7 +5334,7 @@ void *CUDT::tsbpd(void *param)
     return NULL;
 }
 
-void CUDT::updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno)
+void srt::CUDT::updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno)
 {
     /* Update drop/skip stats */
     enterCS(m_StatsLock);
@@ -5347,7 +5349,7 @@ void CUDT::updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno)
     dropFromLossLists(lastack, CSeqNo::decseq(skiptoseqno)); //remove(from,to-inclusive)
 }
 
-bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout)
+bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout)
 {
     // This will be lazily created due to being the common
     // code with HSv5 rendezvous, in which this will be run
@@ -5409,7 +5411,7 @@ bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUD
     return true;
 }
 
-void CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
+void srt::CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
 {
     // this is a reponse handshake
     w_hs.m_iReqType        = URQ_CONCLUSION;
@@ -5428,7 +5430,7 @@ void CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
     CIPAddress::ntop(peer, (w_hs.m_piPeerIP));
 }
 
-void CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& w_hs)
+void srt::CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& w_hs)
 {
     HLOGC(cnlog.Debug, log << "acceptAndRespond: setting up data according to handshake");
 
@@ -5610,7 +5612,7 @@ void CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer,
 // be created, as this happens before the completion of the connection (and
 // therefore configuration of the crypter object), which can only take place upon
 // reception of CONCLUSION response from the listener.
-bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
+bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
 {
     // Lazy initialization
     if (m_pCryptoControl)
@@ -5636,7 +5638,7 @@ bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     return m_pCryptoControl->init(side, bidirectional);
 }
 
-SRT_REJECT_REASON CUDT::setupCC()
+SRT_REJECT_REASON srt::CUDT::setupCC()
 {
     // Prepare configuration object,
     // Create the CCC object and configure it.
@@ -5719,7 +5721,7 @@ SRT_REJECT_REASON CUDT::setupCC()
     return SRT_REJ_UNKNOWN;
 }
 
-void CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timebase)
+void srt::CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timebase)
 {
     // Do a fast pre-check first - this simply declares that agent uses HSv5
     // and the legacy SRT Handshake is not to be done. Second check is whether
@@ -5769,7 +5771,7 @@ void CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timebase)
     sendSrtMsg(SRT_CMD_HSREQ);
 }
 
-void CUDT::checkSndTimers(Whether2RegenKm regen)
+void srt::CUDT::checkSndTimers(Whether2RegenKm regen)
 {
     if (m_SrtHsSide == HSD_INITIATOR)
     {
@@ -5797,7 +5799,7 @@ void CUDT::checkSndTimers(Whether2RegenKm regen)
     }
 }
 
-void CUDT::addressAndSend(CPacket& w_pkt)
+void srt::CUDT::addressAndSend(CPacket& w_pkt)
 {
     w_pkt.m_iID        = m_PeerID;
     setPacketTS(w_pkt, steady_clock::now());
@@ -5811,7 +5813,7 @@ void CUDT::addressAndSend(CPacket& w_pkt)
 }
 
 // [[using maybe_locked(m_GlobControlLock, if called from GC)]]
-bool CUDT::closeInternal()
+bool srt::CUDT::closeInternal()
 {
     // NOTE: this function is called from within the garbage collector thread.
 
@@ -5987,7 +5989,7 @@ bool CUDT::closeInternal()
     return true;
 }
 
-int CUDT::receiveBuffer(char *data, int len)
+int srt::CUDT::receiveBuffer(char *data, int len)
 {
     if (!m_CongCtl->checkTransArgs(SrtCongestion::STA_BUFFER, SrtCongestion::STAD_RECV, data, len, SRT_MSGTTL_INF, false))
         throw CUDTException(MJ_NOTSUP, MN_INVALBUFFERAPI, 0);
@@ -6112,7 +6114,7 @@ int CUDT::receiveBuffer(char *data, int len)
 
 // [[using maybe_locked(CUDTGroup::m_GroupLock, m_parent->m_GroupOf != NULL)]];
 // [[using locked(m_SendLock)]];
-void CUDT::checkNeedDrop(bool& w_bCongestion)
+void srt::CUDT::checkNeedDrop(bool& w_bCongestion)
 {
     if (!m_bPeerTLPktDrop)
         return;
@@ -6209,7 +6211,7 @@ void CUDT::checkNeedDrop(bool& w_bCongestion)
     }
 }
 
-int CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, int64_t srctime)
+int srt::CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, int64_t srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     mctrl.msgttl      = msttl;
@@ -6221,7 +6223,7 @@ int CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, int64_t sr
 // [[using maybe_locked(CUDTGroup::m_GroupLock, m_parent->m_GroupOf != NULL)]]
 // GroupLock is applied when this function is called from inside CUDTGroup::send,
 // which is the only case when the m_parent->m_GroupOf is not NULL.
-int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
+int srt::CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
 {
     bool         bCongestion = false;
 
@@ -6508,13 +6510,13 @@ int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     return size;
 }
 
-int CUDT::recv(char* data, int len)
+int srt::CUDT::recv(char* data, int len)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     return recvmsg2(data, len, (mctrl));
 }
 
-int CUDT::recvmsg(char* data, int len, int64_t& srctime)
+int srt::CUDT::recvmsg(char* data, int len, int64_t& srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     int res = recvmsg2(data, len, (mctrl));
@@ -6525,7 +6527,7 @@ int CUDT::recvmsg(char* data, int len, int64_t& srctime)
 // [[using maybe_locked(CUDTGroup::m_GroupLock, m_parent->m_GroupOf != NULL)]]
 // GroupLock is applied when this function is called from inside CUDTGroup::recv,
 // which is the only case when the m_parent->m_GroupOf is not NULL.
-int CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
+int srt::CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
 {
     // Check if the socket is a member of a receiver group.
     // If so, then reading by receiveMessage is disallowed.
@@ -6557,7 +6559,7 @@ int CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
 // - 0 - by return value
 // - 1 - by exception
 // - 2 - by abort (unused)
-int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_exception)
+int srt::CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_exception)
 {
     // Recvmsg isn't restricted to the congctl type, it's the most
     // basic method of passing the data. You can retrieve data as
@@ -6809,7 +6811,7 @@ int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_excep
     return res;
 }
 
-int64_t CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int block)
+int64_t srt::CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int block)
 {
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -6931,7 +6933,7 @@ int64_t CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int block)
     return size - tosend;
 }
 
-int64_t CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
+int64_t srt::CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -7050,7 +7052,7 @@ int64_t CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
     return size - torecv;
 }
 
-void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
+void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 {
     if (!m_bConnected)
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -7242,7 +7244,7 @@ void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
     }
 }
 
-bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
+bool srt::CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
 {
     // Special things that must be done HERE, not in SrtCongestion,
     // because it involves the input buffer in CUDT. It would be
@@ -7360,7 +7362,7 @@ bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
     return true;
 }
 
-void CUDT::initSynch()
+void srt::CUDT::initSynch()
 {
     setupMutex(m_SendBlockLock, "SendBlock");
     setupCond(m_SendBlockCond, "SendBlock");
@@ -7375,7 +7377,7 @@ void CUDT::initSynch()
     setupCond(m_RcvTsbPdCond, "RcvTsbPd");
 }
 
-void CUDT::destroySynch()
+void srt::CUDT::destroySynch()
 {
     releaseMutex(m_SendBlockLock);
 
@@ -7400,7 +7402,7 @@ void CUDT::destroySynch()
     releaseCond(m_RcvTsbPdCond);
 }
 
-void CUDT::releaseSynch()
+void srt::CUDT::releaseSynch()
 {
     SRT_ASSERT(m_bClosing);
     // wake up user calls
@@ -7430,7 +7432,7 @@ void CUDT::releaseSynch()
 }
 
 // [[using locked(m_RcvBufferLock)]];
-int32_t CUDT::ackDataUpTo(int32_t ack)
+int32_t srt::CUDT::ackDataUpTo(int32_t ack)
 {
     int acksize = CSeqNo::seqoff(m_iRcvLastSkipAck, ack);
 
@@ -7456,6 +7458,7 @@ int32_t CUDT::ackDataUpTo(int32_t ack)
     return ack;
 }
 
+namespace srt {
 #if ENABLE_HEAVY_LOGGING
 static void DebugAck(string hdr, int prev, int ack)
 {
@@ -7487,8 +7490,9 @@ static void DebugAck(string hdr, int prev, int ack)
 #else
 static inline void DebugAck(string, int, int) {}
 #endif
+}
 
-void CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam, int size)
+void srt::CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam, int size)
 {
     CPacket ctrlpkt;
     setPacketTS(ctrlpkt, steady_clock::now());
@@ -7627,7 +7631,7 @@ void CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam,
         m_tsLastSndTime = steady_clock::now();
 }
 
-int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
+int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 {
     SRT_ASSERT(ctrlpkt.getMsgTimeStamp() != 0);
     int32_t ack;
@@ -7877,7 +7881,7 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
     return nbsent;
 }
 
-void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
+void srt::CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
 {
 #if ENABLE_EXPERIMENTAL_BONDING
     // This is for the call of CSndBuffer::getMsgNoAt that returns
@@ -7964,7 +7968,7 @@ void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
     leaveCS(m_StatsLock);
 }
 
-void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point& currtime)
+void srt::CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point& currtime)
 {
     const int32_t* ackdata       = (const int32_t*)ctrlpkt.m_pcData;
     const int32_t  ackdata_seqno = ackdata[ACKD_RCVLASTACK];
@@ -8216,7 +8220,7 @@ void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point
     leaveCS(m_StatsLock);
 }
 
-void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival)
+void srt::CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival)
 {
     int32_t ack = 0;
 
@@ -8307,7 +8311,7 @@ void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival
         m_iRcvLastAckAck = ack;
 }
 
-void CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
+void srt::CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
 {
     const int32_t* losslist = (int32_t*)(ctrlpkt.m_pcData);
     const size_t   losslist_len = ctrlpkt.getLength() / 4;
@@ -8451,7 +8455,7 @@ void CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
     leaveCS(m_StatsLock);
 }
 
-void CUDT::processCtrlHS(const CPacket& ctrlpkt)
+void srt::CUDT::processCtrlHS(const CPacket& ctrlpkt)
 {
     CHandShake req;
     req.load_from(ctrlpkt.m_pcData, ctrlpkt.getLength());
@@ -8562,7 +8566,7 @@ void CUDT::processCtrlHS(const CPacket& ctrlpkt)
     }
 }
 
-void CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
+void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
 {
     {
         const bool using_rexmit_flag = m_bPeerRexmitFlag;
@@ -8601,7 +8605,7 @@ void CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
     }
 }
 
-void CUDT::processCtrlShutdown()
+void srt::CUDT::processCtrlShutdown()
 {
     m_bShutdown = true;
     m_bClosing = true;
@@ -8614,7 +8618,7 @@ void CUDT::processCtrlShutdown()
     completeBrokenConnectionDependencies(SRT_ECONNLOST); // LOCKS!
 }
 
-void CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
+void srt::CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
 {
     HLOGC(inlog.Debug, log << CONID() << "CONTROL EXT MSG RECEIVED:"
         << MessageTypeStr(ctrlpkt.getType(), ctrlpkt.getExtendedType())
@@ -8644,7 +8648,7 @@ void CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
     }
 }
 
-void CUDT::processCtrl(const CPacket &ctrlpkt)
+void srt::CUDT::processCtrl(const CPacket &ctrlpkt)
 {
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
@@ -8714,7 +8718,7 @@ void CUDT::processCtrl(const CPacket &ctrlpkt)
     }
 }
 
-void CUDT::updateSrtRcvSettings()
+void srt::CUDT::updateSrtRcvSettings()
 {
     // CHANGED: we need to apply the tsbpd delay only for socket TSBPD.
     // For Group TSBPD the buffer will have to deliver packets always on request
@@ -8745,7 +8749,7 @@ void CUDT::updateSrtRcvSettings()
     }
 }
 
-void CUDT::updateSrtSndSettings()
+void srt::CUDT::updateSrtSndSettings()
 {
     if (m_bPeerTsbPd)
     {
@@ -8768,7 +8772,7 @@ void CUDT::updateSrtSndSettings()
     }
 }
 
-void CUDT::updateAfterSrtHandshake(int hsv)
+void srt::CUDT::updateAfterSrtHandshake(int hsv)
 {
     HLOGC(cnlog.Debug, log << "updateAfterSrtHandshake: HS version " << hsv);
     // This is blocked from being run in the "app reader" version because here
@@ -8823,7 +8827,7 @@ void CUDT::updateAfterSrtHandshake(int hsv)
     }
 }
 
-int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime)
+int srt::CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime)
 {
     // protect m_iSndLastDataAck from updating by ACK processing
     UniqueLock ackguard(m_RecvAckLock);
@@ -8933,7 +8937,7 @@ int CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origintime
     return 0;
 }
 
-std::pair<int, steady_clock::time_point> CUDT::packData(CPacket& w_packet)
+std::pair<int, steady_clock::time_point> srt::CUDT::packData(CPacket& w_packet)
 {
     int payload = 0;
     bool probe = false;
@@ -9214,7 +9218,7 @@ std::pair<int, steady_clock::time_point> CUDT::packData(CPacket& w_packet)
 }
 
 // This is a close request, but called from the
-void CUDT::processClose()
+void srt::CUDT::processClose()
 {
     sendCtrl(UMSG_SHUTDOWN);
 
@@ -9240,7 +9244,7 @@ void CUDT::processClose()
     CGlobEvent::triggerEvent();
 }
 
-void CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
+void srt::CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
 {
     typedef vector<pair<int32_t, int32_t> > loss_seqs_t;
 
@@ -9272,7 +9276,7 @@ void CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_
 }
 
 
-bool CUDT::overrideSndSeqNo(int32_t seq)
+bool srt::CUDT::overrideSndSeqNo(int32_t seq)
 {
     // This function is intended to be called from the socket
     // group managmenet functions to synchronize the sequnece in
@@ -9323,7 +9327,7 @@ bool CUDT::overrideSndSeqNo(int32_t seq)
     return true;
 }
 
-int CUDT::processData(CUnit* in_unit)
+int srt::CUDT::processData(CUnit* in_unit)
 {
     if (m_bClosing)
         return -1;
@@ -9963,7 +9967,7 @@ int CUDT::processData(CUnit* in_unit)
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-void CUDT::updateIdleLinkFrom(CUDT* source)
+void srt::CUDT::updateIdleLinkFrom(CUDT* source)
 {
     ScopedLock lg (m_RecvLock);
 
@@ -9997,7 +10001,7 @@ void CUDT::updateIdleLinkFrom(CUDT* source)
 // XXX This function is currently unused. It should be fixed and put into use.
 // See the blocked call in CUDT::processData().
 // XXX REVIEW LOCKS WHEN REACTIVATING!
-CUDT::loss_seqs_t CUDT::defaultPacketArrival(void* vself, CPacket& pkt)
+srt::CUDT::loss_seqs_t srt::CUDT::defaultPacketArrival(void* vself, CPacket& pkt)
 {
 // [[using affinity(m_pRcvBuffer->workerThread())]];
     CUDT* self = (CUDT*)vself;
@@ -10072,7 +10076,7 @@ CUDT::loss_seqs_t CUDT::defaultPacketArrival(void* vself, CPacket& pkt)
 /// do not include the lacking packet.
 /// The tolerance is not increased infinitely - it's bordered by iMaxReorderTolerance.
 /// This value can be set in options - SRT_LOSSMAXTTL.
-void CUDT::unlose(const CPacket &packet)
+void srt::CUDT::unlose(const CPacket &packet)
 {
     ScopedLock lg(m_RcvLossLock);
     int32_t sequence = packet.m_iSeqNo;
@@ -10217,7 +10221,7 @@ breakbreak:;
     }
 }
 
-void CUDT::dropFromLossLists(int32_t from, int32_t to)
+void srt::CUDT::dropFromLossLists(int32_t from, int32_t to)
 {
     ScopedLock lg(m_RcvLossLock);
     m_pRcvLossList->remove(from, to);
@@ -10260,7 +10264,7 @@ void CUDT::dropFromLossLists(int32_t from, int32_t to)
 }
 
 // This function, as the name states, should bake a new cookie.
-int32_t CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int correction)
+int32_t srt::CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int correction)
 {
     static unsigned int distractor = 0;
     unsigned int        rollover   = distractor + 10;
@@ -10319,7 +10323,7 @@ int32_t CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int correct
 // and this will be directly passed to the caller.
 
 // [[using locked(m_pRcvQueue->m_LSLock)]];
-int CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
+int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
 {
     // XXX ASSUMPTIONS:
     // [[using assert(packet.m_iID == 0)]]
@@ -10673,7 +10677,7 @@ int CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
     return RejectReasonForURQ(hs.m_iReqType);
 }
 
-void CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
+void srt::CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
 {
     if (lo == hi)
         lr.push_back(lo);
@@ -10684,7 +10688,7 @@ void CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
     }
 }
 
-int CUDT::checkACKTimer(const steady_clock::time_point &currtime)
+int srt::CUDT::checkACKTimer(const steady_clock::time_point &currtime)
 {
     int because_decision = BECAUSE_NO_REASON;
     if (currtime > m_tsNextACKTime  // ACK time has come
@@ -10723,7 +10727,7 @@ int CUDT::checkACKTimer(const steady_clock::time_point &currtime)
     return because_decision;
 }
 
-int CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
+int srt::CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
 {
     // XXX The problem with working NAKREPORT with SRT_ARQ_ONREQ
     // is not that it would be inappropriate, but because it's not
@@ -10762,7 +10766,7 @@ int CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
     return debug_decision;
 }
 
-bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_reason ATR_UNUSED)
+bool srt::CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_reason ATR_UNUSED)
 {
     // VERY HEAVY LOGGING
 #if ENABLE_HEAVY_LOGGING & 1
@@ -10857,7 +10861,7 @@ bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_rea
     return false;
 }
 
-void CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
+void srt::CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
 {
     /* There are two algorithms of blind packet retransmission: LATEREXMIT and FASTREXMIT.
      *
@@ -10931,7 +10935,7 @@ void CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
     m_pSndQueue->m_pSndUList->update(this, CSndUList::DO_RESCHEDULE);
 }
 
-void CUDT::checkTimers()
+void srt::CUDT::checkTimers()
 {
     // update CC parameters
     updateCC(TEV_CHECKTIMER, EventVariant(TEV_CHT_INIT));
@@ -10979,7 +10983,7 @@ void CUDT::checkTimers()
     }
 }
 
-void CUDT::updateBrokenConnection()
+void srt::CUDT::updateBrokenConnection()
 {
     m_bClosing = true;
     releaseSynch();
@@ -10988,7 +10992,7 @@ void CUDT::updateBrokenConnection()
     CGlobEvent::triggerEvent();
 }
 
-void CUDT::completeBrokenConnectionDependencies(int errorcode)
+void srt::CUDT::completeBrokenConnectionDependencies(int errorcode)
 {
     int token = -1;
 
@@ -11047,7 +11051,7 @@ void CUDT::completeBrokenConnectionDependencies(int errorcode)
 #endif
 }
 
-void CUDT::addEPoll(const int eid)
+void srt::CUDT::addEPoll(const int eid)
 {
     enterCS(s_UDTUnited.m_EPoll.m_EPollLock);
     m_sPollID.insert(eid);
@@ -11069,7 +11073,7 @@ void CUDT::addEPoll(const int eid)
     }
 }
 
-void CUDT::removeEPollEvents(const int eid)
+void srt::CUDT::removeEPollEvents(const int eid)
 {
     // clear IO events notifications;
     // since this happens after the epoll ID has been removed, they cannot be set again
@@ -11078,14 +11082,14 @@ void CUDT::removeEPollEvents(const int eid)
     s_UDTUnited.m_EPoll.update_events(m_SocketID, remove, SRT_EPOLL_IN | SRT_EPOLL_OUT, false);
 }
 
-void CUDT::removeEPollID(const int eid)
+void srt::CUDT::removeEPollID(const int eid)
 {
     enterCS(s_UDTUnited.m_EPoll.m_EPollLock);
     m_sPollID.erase(eid);
     leaveCS(s_UDTUnited.m_EPoll.m_EPollLock);
 }
 
-void CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
+void srt::CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
 {
     if (evt >= TEV_E_SIZE)
         return; // sanity check
@@ -11093,7 +11097,7 @@ void CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
     m_Slots[evt].push_back(sl);
 }
 
-void CUDT::DisconnectSignal(ETransmissionEvent evt)
+void srt::CUDT::DisconnectSignal(ETransmissionEvent evt)
 {
     if (evt >= TEV_E_SIZE)
         return; // sanity check
@@ -11101,7 +11105,7 @@ void CUDT::DisconnectSignal(ETransmissionEvent evt)
     m_Slots[evt].clear();
 }
 
-void CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
+void srt::CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
 {
     for (std::vector<EventSlot>::iterator i = m_Slots[tev].begin(); i != m_Slots[tev].end(); ++i)
     {
@@ -11109,7 +11113,7 @@ void CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
     }
 }
 
-int CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
+int srt::CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
 {
     CUDTSocket *s = s_UDTUnited.locateSocket(u);
     if (!s || !s->m_pUDT)
@@ -11132,7 +11136,7 @@ int CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
     return std::abs(timespan);
 }
 
-int CUDT::rejectReason(SRTSOCKET u)
+int srt::CUDT::rejectReason(SRTSOCKET u)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(u);
     if (!s || !s->m_pUDT)
@@ -11141,7 +11145,7 @@ int CUDT::rejectReason(SRTSOCKET u)
     return s->m_pUDT->m_RejectReason;
 }
 
-int CUDT::rejectReason(SRTSOCKET u, int value)
+int srt::CUDT::rejectReason(SRTSOCKET u, int value)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(u);
     if (!s || !s->m_pUDT)
@@ -11154,7 +11158,7 @@ int CUDT::rejectReason(SRTSOCKET u, int value)
     return 0;
 }
 
-int64_t CUDT::socketStartTime(SRTSOCKET u)
+int64_t srt::CUDT::socketStartTime(SRTSOCKET u)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(u);
     if (!s || !s->m_pUDT)
@@ -11163,7 +11167,7 @@ int64_t CUDT::socketStartTime(SRTSOCKET u)
     return count_microseconds(s->m_pUDT->m_stats.tsStartTime.time_since_epoch());
 }
 
-bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)
+bool srt::CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)
 {
     // Prepare the information for the hook.
 
@@ -11264,7 +11268,7 @@ bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs
     return true;
 }
 
-void CUDT::handleKeepalive(const char* /*data*/, size_t /*size*/)
+void srt::CUDT::handleKeepalive(const char* /*data*/, size_t /*size*/)
 {
     // Here can be handled some protocol definition
     // for extra data sent through keepalive.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -137,14 +137,16 @@ enum SeqPairItems
     SEQ_BEGIN = 0, SEQ_END = 1, SEQ_SIZE = 2
 };
 
-#if ENABLE_EXPERIMENTAL_BONDING
-class CUDTGroup;
-#endif
 
 // Extended SRT Congestion control class - only an incomplete definition required
 class CCryptoControl;
+
+namespace srt {
 class CUDTUnited;
 class CUDTSocket;
+#if ENABLE_EXPERIMENTAL_BONDING
+class CUDTGroup;
+#endif
 
 // XXX REFACTOR: The 'CUDT' class is to be merged with 'CUDTSocket'.
 // There's no reason for separating them, there's no case of having them
@@ -167,10 +169,10 @@ class CUDT
     friend class PacketFilter;
     friend class CUDTGroup;
     friend struct FByOldestActive; // this functional will use private fields
-    friend class TestMockCUDT;
+    friend class TestMockCUDT; // unit tests
 
-    typedef srt::sync::steady_clock::time_point time_point;
-    typedef srt::sync::steady_clock::duration duration;
+    typedef sync::steady_clock::time_point time_point;
+    typedef sync::steady_clock::duration duration;
 
 private: // constructor and desctructor
     void construct();
@@ -1111,12 +1113,12 @@ private: // Timers functions
 
 
 private: // for UDP multiplexer
-    CSndQueue* m_pSndQueue;         // packet sending queue
-    CRcvQueue* m_pRcvQueue;         // packet receiving queue
-    sockaddr_any m_PeerAddr;        // peer address
-    uint32_t m_piSelfIP[4];         // local UDP IP address
-    CSNode* m_pSNode;               // node information for UDT list used in snd queue
-    CRNode* m_pRNode;               // node information for UDT list used in rcv queue
+    CSndQueue* m_pSndQueue;    // packet sending queue
+    CRcvQueue* m_pRcvQueue;    // packet receiving queue
+    sockaddr_any m_PeerAddr;   // peer address
+    uint32_t m_piSelfIP[4];    // local UDP IP address
+    CSNode* m_pSNode;          // node information for UDT list used in snd queue
+    CRNode* m_pRNode;          // node information for UDT list used in rcv queue
 
 public: // For SrtCongestion
     const CSndQueue* sndQueue() { return m_pSndQueue; }
@@ -1129,5 +1131,6 @@ private: // for epoll
     void removeEPollID(const int eid);
 };
 
+} // namespace srt
 
 #endif

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -27,6 +27,7 @@ written by
 #include "logging.h"
 #include "core.h"
 
+using namespace srt;
 using namespace srt_logging;
 
 #define SRT_MAX_KMRETRY     10

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -38,6 +38,11 @@ extern Logger cnlog;
 #endif
 }
 
+namespace srt
+{
+    class CUDT;
+}
+
 
 // For KMREQ/KMRSP. Only one field is used.
 const size_t SRT_KMR_KMSTATE = 0;
@@ -49,8 +54,7 @@ enum Whether2RegenKm {DONT_REGEN_KM = 0, REGEN_KM = 1};
 
 class CCryptoControl
 {
-//public:
-    class CUDT* m_parent;
+    srt::CUDT*  m_parent;
     SRTSOCKET   m_SocketID;
 
     size_t      m_iSndKmKeyLen;        //Key length
@@ -192,7 +196,7 @@ public:
         return false;
     }
 
-    CCryptoControl(CUDT* parent, SRTSOCKET id);
+    CCryptoControl(srt::CUDT* parent, SRTSOCKET id);
 
     // DEBUG PURPOSES:
     std::string CONID() const;
@@ -254,14 +258,14 @@ public:
     /// the encryption will fail.
     /// XXX Encryption flags in the PH_MSGNO
     /// field in the header must be correctly set before calling.
-    EncryptionStatus encrypt(CPacket& w_packet);
+    EncryptionStatus encrypt(srt::CPacket& w_packet);
 
     /// Decrypts the packet. If the packet has ENCKEYSPEC part
     /// in PH_MSGNO set to EK_NOENC, it does nothing. It decrypts
     /// only if the encryption correctly configured, otherwise it
     /// fails. After successful decryption, the ENCKEYSPEC part
     // in PH_MSGNO is set to EK_NOENC.
-    EncryptionStatus decrypt(CPacket& w_packet);
+    EncryptionStatus decrypt(srt::CPacket& w_packet);
 
     ~CCryptoControl();
 };

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -348,11 +348,18 @@ std::string DisplayEpollWatch();
    }
 };
 
+namespace srt
+{
+    class CUDT;
+    class CRendezvousQueue;
+    class CUDTGroup;
+}
+
 class CEPoll
 {
-friend class CUDT;
-friend class CUDTGroup;
-friend class CRendezvousQueue;
+friend class srt::CUDT;
+friend class srt::CUDTGroup;
+friend class srt::CRendezvousQueue;
 
 public:
    CEPoll();

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -35,6 +35,7 @@
 using namespace std;
 using namespace srt_logging;
 
+namespace srt {
 
 const char FECFilterBuiltin::defaultConfig [] = "fec,rows:1,layout:staircase,arq:onreq";
 
@@ -1118,11 +1119,11 @@ static void DebugPrintCells(int32_t base, const std::deque<bool>& cells, size_t 
     }
 
     // Ok, we have some empty cells, so just adjust to the start of a row.
-	size_t bstep = i % row_size;
-	if (i < bstep)  // you never know...
-		i = 0;
-	else
-		i -= bstep;
+    size_t bstep = i % row_size;
+    if (i < bstep)  // you never know...
+        i = 0;
+    else
+        i -= bstep;
     
     for ( ; i < cells.size(); i += row_size )
     {
@@ -2557,3 +2558,5 @@ size_t FECFilterBuiltin::ExtendColumns(size_t colgx)
 
     return colgx;
 }
+
+} // namespace srt

--- a/srtcore/fec.h
+++ b/srtcore/fec.h
@@ -19,6 +19,8 @@
 
 #include "packetfilter_api.h"
 
+namespace srt {
+
 class FECFilterBuiltin: public SrtPacketFilterBase
 {
     SrtFilterConfig cfg;
@@ -269,5 +271,7 @@ public:
     static const char defaultConfig [];
     static bool verifyConfig(const SrtFilterConfig& config, std::string& w_errormsg);
 };
+
+} // namespace srt
 
 #endif

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -13,6 +13,8 @@ using namespace srt_logging;
 // The SRT_DEF_VERSION is defined in core.cpp.
 extern const int32_t SRT_DEF_VERSION;
 
+namespace srt {
+
 int32_t CUDTGroup::s_tokenGen = 0;
 
 // [[using locked(this->m_GroupLock)]];
@@ -4587,3 +4589,5 @@ void CUDTGroup::debugGroup()
     }
 }
 #endif
+
+} // namespace srt

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -58,18 +58,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "utilities.h"
 
 using namespace std;
+using namespace srt;
 
 
-CHandShake::CHandShake():
-m_iVersion(0),
-m_iType(0), // Universal: UDT_UNDEFINED or no flags
-m_iISN(0),
-m_iMSS(0),
-m_iFlightFlagSize(0),
-m_iReqType(URQ_WAVEAHAND),
-m_iID(0),
-m_iCookie(0),
-m_extension(false)
+CHandShake::CHandShake()
+    : m_iVersion(0)
+    , m_iType(0) // Universal: UDT_UNDEFINED or no flags
+    , m_iISN(0)
+    , m_iMSS(0)
+    , m_iFlightFlagSize(0)
+    , m_iReqType(URQ_WAVEAHAND)
+    , m_iID(0)
+    , m_iCookie(0)
+    , m_extension(false)
 {
    for (int i = 0; i < 4; ++ i)
       m_piPeerIP[i] = 0;

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -174,14 +174,14 @@ namespace srt_logging
 using namespace srt_logging;
 
 // Set up the aliases in the constructure
-CPacket::CPacket():
-m_extra_pad(),
-m_data_owned(false),
-m_iSeqNo((int32_t&)(m_nHeader[SRT_PH_SEQNO])),
-m_iMsgNo((int32_t&)(m_nHeader[SRT_PH_MSGNO])),
-m_iTimeStamp((int32_t&)(m_nHeader[SRT_PH_TIMESTAMP])),
-m_iID((int32_t&)(m_nHeader[SRT_PH_ID])),
-m_pcData((char*&)(m_PacketVector[PV_DATA].dataRef()))
+srt::CPacket::CPacket():
+    m_extra_pad(),
+    m_data_owned(false),
+    m_iSeqNo((int32_t&)(m_nHeader[SRT_PH_SEQNO])),
+    m_iMsgNo((int32_t&)(m_nHeader[SRT_PH_MSGNO])),
+    m_iTimeStamp((int32_t&)(m_nHeader[SRT_PH_TIMESTAMP])),
+    m_iID((int32_t&)(m_nHeader[SRT_PH_ID])),
+    m_pcData((char*&)(m_PacketVector[PV_DATA].dataRef()))
 {
     m_nHeader.clear();
 
@@ -195,12 +195,12 @@ m_pcData((char*&)(m_PacketVector[PV_DATA].dataRef()))
     m_PacketVector[PV_DATA].set(NULL, 0);
 }
 
-char* CPacket::getData()
+char* srt::CPacket::getData()
 {
     return (char*)m_PacketVector[PV_DATA].dataRef();
 }
 
-void CPacket::allocate(size_t alloc_buffer_size)
+void srt::CPacket::allocate(size_t alloc_buffer_size)
 {
     if (m_data_owned)
     {
@@ -214,14 +214,14 @@ void CPacket::allocate(size_t alloc_buffer_size)
     m_data_owned = true;
 }
 
-void CPacket::deallocate()
+void srt::CPacket::deallocate()
 {
     if (m_data_owned)
         delete [] (char*)m_PacketVector[PV_DATA].data();
     m_PacketVector[PV_DATA].set(NULL, 0);
 }
 
-char* CPacket::release()
+char* srt::CPacket::release()
 {
     // When not owned, release returns NULL.
     char* buffer = NULL;
@@ -235,7 +235,7 @@ char* CPacket::release()
     return buffer;
 }
 
-CPacket::~CPacket()
+srt::CPacket::~CPacket()
 {
     // PV_HEADER is always owned, PV_DATA may use a "borrowed" buffer.
     // Delete the internal buffer only if it was declared as owned.
@@ -244,17 +244,17 @@ CPacket::~CPacket()
 }
 
 
-size_t CPacket::getLength() const
+size_t srt::CPacket::getLength() const
 {
    return m_PacketVector[PV_DATA].size();
 }
 
-void CPacket::setLength(size_t len)
+void srt::CPacket::setLength(size_t len)
 {
    m_PacketVector[PV_DATA].setLength(len);
 }
 
-void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
+void srt::CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
 {
     // Set (bit-0 = 1) and (bit-1~15 = type)
     setControl(pkttype);
@@ -365,7 +365,7 @@ void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, 
    }
 }
 
-void CPacket::toNL()
+void srt::CPacket::toNL()
 {
     // XXX USE HtoNLA!
     if (isControl())
@@ -383,7 +383,7 @@ void CPacket::toNL()
     }
 }
 
-void CPacket::toHL()
+void srt::CPacket::toHL()
 {
     // convert back into local host order
     uint32_t* p = m_nHeader;
@@ -401,22 +401,22 @@ void CPacket::toHL()
 }
 
 
-IOVector* CPacket::getPacketVector()
+IOVector* srt::CPacket::getPacketVector()
 {
    return m_PacketVector;
 }
 
-UDTMessageType CPacket::getType() const
+UDTMessageType srt::CPacket::getType() const
 {
     return UDTMessageType(SEQNO_MSGTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]));
 }
 
-int CPacket::getExtendedType() const
+int srt::CPacket::getExtendedType() const
 {
     return SEQNO_EXTTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]);
 }
 
-int32_t CPacket::getAckSeqNo() const
+int32_t srt::CPacket::getAckSeqNo() const
 {
    // read additional information field
    // This field is used only in UMSG_ACK and UMSG_ACKACK,
@@ -425,7 +425,7 @@ int32_t CPacket::getAckSeqNo() const
    return m_nHeader[SRT_PH_MSGNO];
 }
 
-uint16_t CPacket::getControlFlags() const
+uint16_t srt::CPacket::getControlFlags() const
 {
     // This returns exactly the "extended type" value,
     // which is not used at all in case when the standard
@@ -434,17 +434,17 @@ uint16_t CPacket::getControlFlags() const
     return SEQNO_EXTTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]);
 }
 
-PacketBoundary CPacket::getMsgBoundary() const
+PacketBoundary srt::CPacket::getMsgBoundary() const
 {
     return PacketBoundary(MSGNO_PACKET_BOUNDARY::unwrap(m_nHeader[SRT_PH_MSGNO]));
 }
 
-bool CPacket::getMsgOrderFlag() const
+bool srt::CPacket::getMsgOrderFlag() const
 {
     return 0!=  MSGNO_PACKET_INORDER::unwrap(m_nHeader[SRT_PH_MSGNO]);
 }
 
-int32_t CPacket::getMsgSeq(bool has_rexmit) const
+int32_t srt::CPacket::getMsgSeq(bool has_rexmit) const
 {
     if ( has_rexmit )
     {
@@ -456,13 +456,13 @@ int32_t CPacket::getMsgSeq(bool has_rexmit) const
     }
 }
 
-bool CPacket::getRexmitFlag() const
+bool srt::CPacket::getRexmitFlag() const
 {
     // return false; //
     return 0 !=  MSGNO_REXMIT::unwrap(m_nHeader[SRT_PH_MSGNO]);
 }
 
-EncryptionKeySpec CPacket::getMsgCryptoFlags() const
+EncryptionKeySpec srt::CPacket::getMsgCryptoFlags() const
 {
     return EncryptionKeySpec(MSGNO_ENCKEYSPEC::unwrap(m_nHeader[SRT_PH_MSGNO]));
 }
@@ -470,19 +470,19 @@ EncryptionKeySpec CPacket::getMsgCryptoFlags() const
 // This is required as the encryption/decryption happens in place.
 // This is required to clear off the flags after decryption or set
 // crypto flags after encrypting a packet.
-void CPacket::setMsgCryptoFlags(EncryptionKeySpec spec)
+void srt::CPacket::setMsgCryptoFlags(EncryptionKeySpec spec)
 {
     int32_t clr_msgno = m_nHeader[SRT_PH_MSGNO] & ~MSGNO_ENCKEYSPEC::mask;
     m_nHeader[SRT_PH_MSGNO] = clr_msgno | EncryptionKeyBits(spec);
 }
 
-uint32_t CPacket::getMsgTimeStamp() const
+uint32_t srt::CPacket::getMsgTimeStamp() const
 {
    // SRT_DEBUG_TSBPD_WRAP may enable smaller timestamp for faster wraparoud handling tests
    return (uint32_t)m_nHeader[SRT_PH_TIMESTAMP] & TIMESTAMP_MASK;
 }
 
-CPacket* CPacket::clone() const
+srt::CPacket* srt::CPacket::clone() const
 {
    CPacket* pkt = new CPacket;
    memcpy((pkt->m_nHeader), m_nHeader, HDR_SIZE);
@@ -492,6 +492,8 @@ CPacket* CPacket::clone() const
 
    return pkt;
 }
+
+namespace srt {
 
 // Useful for debugging
 std::string PacketMessageFlagStr(uint32_t msgno_field)
@@ -521,8 +523,10 @@ inline void SprintSpecialWord(std::ostream& os, int32_t val)
         os << val;
 }
 
+} // namespace srt
+
 #if ENABLE_LOGGING
-std::string CPacket::Info()
+std::string srt::CPacket::Info()
 {
     std::ostringstream os;
     os << "TARGET=@" << m_iID << " ";

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -214,9 +214,9 @@ inline EncryptionKeySpec GetEncryptionKeySpec(int32_t msgno)
 
 const int32_t PUMASK_SEQNO_PROBE = 0xF;
 
-std::string PacketMessageFlagStr(uint32_t msgno_field);
 
-class CChannel;
+namespace srt {
+std::string PacketMessageFlagStr(uint32_t msgno_field);
 
 class CPacket
 {
@@ -284,7 +284,7 @@ public:
 
    void setControl(UDTMessageType type)
    {
-       m_nHeader[SRT_PH_SEQNO] = SEQNO_CONTROL::mask | SEQNO_MSGTYPE::wrap(type);
+       m_nHeader[srt::SRT_PH_SEQNO] = SEQNO_CONTROL::mask | SEQNO_MSGTYPE::wrap(type);
    }
 
       /// Read the extended packet type.
@@ -429,5 +429,7 @@ public:
    std::string Info() { return std::string(); }
 #endif
 };
+
+} // namespace srt
 
 #endif

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using namespace srt_logging;
 using namespace srt::sync;
 
-bool ParseFilterConfig(std::string s, SrtFilterConfig& w_config, PacketFilter::Factory** ppf)
+bool srt::ParseFilterConfig(string s, SrtFilterConfig& w_config, PacketFilter::Factory** ppf)
 {
     if (!SrtParseConfig(s, (w_config)))
         return false;
@@ -43,13 +43,13 @@ bool ParseFilterConfig(std::string s, SrtFilterConfig& w_config, PacketFilter::F
     return true;
 }
 
-bool ParseFilterConfig(std::string s, SrtFilterConfig& w_config)
+bool srt::ParseFilterConfig(string s, SrtFilterConfig& w_config)
 {
     return ParseFilterConfig(s, (w_config), NULL);
 }
 
 // Parameters are passed by value because they need to be potentially modicied inside.
-bool CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer)
+bool srt::CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer)
 {
     PacketFilter::Factory* fac = PacketFilter::find(w_agent.type);
     if (!fac)
@@ -109,18 +109,20 @@ bool CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer)
     return true;
 }
 
-struct SortBySequence
-{
-    bool operator()(const CUnit* u1, const CUnit* u2)
+namespace srt {
+    struct SortBySequence
     {
-        int32_t s1 = u1->m_Packet.getSeqNo();
-        int32_t s2 = u2->m_Packet.getSeqNo();
+        bool operator()(const CUnit* u1, const CUnit* u2)
+        {
+            int32_t s1 = u1->m_Packet.getSeqNo();
+            int32_t s2 = u2->m_Packet.getSeqNo();
 
-        return CSeqNo::seqcmp(s1, s2) < 0;
-    }
-};
+            return CSeqNo::seqcmp(s1, s2) < 0;
+        }
+    };
+} // namespace srt
 
-void PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_seqs_t& w_loss_seqs)
+void srt::PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_seqs_t& w_loss_seqs)
 {
     const CPacket& rpkt = unit->m_Packet;
 
@@ -206,7 +208,7 @@ void PacketFilter::receive(CUnit* unit, std::vector<CUnit*>& w_incoming, loss_se
 
 }
 
-bool PacketFilter::packControlPacket(int32_t seq, int kflg, CPacket& w_packet)
+bool srt::PacketFilter::packControlPacket(int32_t seq, int kflg, CPacket& w_packet)
 {
     bool have = m_filter->packControlPacket(m_sndctlpkt, seq);
     if (!have)
@@ -238,7 +240,7 @@ bool PacketFilter::packControlPacket(int32_t seq, int kflg, CPacket& w_packet)
 }
 
 
-void PacketFilter::InsertRebuilt(vector<CUnit*>& incoming, CUnitQueue* uq)
+void srt::PacketFilter::InsertRebuilt(vector<CUnit*>& incoming, CUnitQueue* uq)
 {
     if (m_provided.empty())
         return;
@@ -273,19 +275,21 @@ void PacketFilter::InsertRebuilt(vector<CUnit*>& incoming, CUnitQueue* uq)
     m_provided.clear();
 }
 
-bool PacketFilter::IsBuiltin(const string& s)
+bool srt::PacketFilter::IsBuiltin(const string& s)
 {
     return builtin_filters.count(s);
 }
 
+namespace srt {
 std::set<std::string> PacketFilter::builtin_filters;
 PacketFilter::filters_map_t PacketFilter::filters;
+}
 
-PacketFilter::Factory::~Factory()
+srt::PacketFilter::Factory::~Factory()
 {
 }
 
-void PacketFilter::globalInit()
+void srt::PacketFilter::globalInit()
 {
     // Add here builtin packet filters and mark them
     // as builtin. This will disallow users to register
@@ -295,7 +299,7 @@ void PacketFilter::globalInit()
     builtin_filters.insert("fec");
 }
 
-bool PacketFilter::configure(CUDT* parent, CUnitQueue* uq, const std::string& confstr)
+bool srt::PacketFilter::configure(CUDT* parent, CUnitQueue* uq, const std::string& confstr)
 {
     m_parent = parent;
 
@@ -329,7 +333,7 @@ bool PacketFilter::configure(CUDT* parent, CUnitQueue* uq, const std::string& co
     return true;
 }
 
-bool PacketFilter::correctConfig(const SrtFilterConfig& conf)
+bool srt::PacketFilter::correctConfig(const SrtFilterConfig& conf)
 {
     const string* pname = map_getp(conf.parameters, "type");
 
@@ -346,7 +350,7 @@ bool PacketFilter::correctConfig(const SrtFilterConfig& conf)
     return true;
 }
 
-PacketFilter::~PacketFilter()
+srt::PacketFilter::~PacketFilter()
 {
     delete m_filter;
 }

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -19,6 +19,8 @@
 #include "utilities.h"
 #include "packetfilter_api.h"
 
+namespace srt {
+
 class CUnitQueue;
 struct CUnit;
 class CUDT;
@@ -211,5 +213,7 @@ inline void PacketFilter::feedSource(CPacket& w_packet) { SRT_ASSERT(m_filter); 
 inline SRT_ARQLevel PacketFilter::arqLevel() { SRT_ASSERT(m_filter); return m_filter->arqLevel(); }
 
 bool ParseFilterConfig(std::string s, SrtFilterConfig& out, PacketFilter::Factory** ppf);
+
+} // namespace srt
 
 #endif

--- a/srtcore/packetfilter_api.h
+++ b/srtcore/packetfilter_api.h
@@ -19,6 +19,8 @@
 #include <vector>
 #include <utility>
 
+namespace srt {
+
 class CPacket;
 
 enum SrtPktHeaderFields
@@ -151,6 +153,6 @@ protected:
     }
 };
 
-
+} // namespace srt
 
 #endif

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -78,14 +78,14 @@ CUnitQueue::CUnitQueue()
 
 CUnitQueue::~CUnitQueue()
 {
-    CQEntry *p = m_pQEntry;
+    CQEntry* p = m_pQEntry;
 
     while (p != NULL)
     {
         delete[] p->m_pUnit;
         delete[] p->m_pBuffer;
 
-        CQEntry *q = p;
+        CQEntry* q = p;
         if (p == m_pLastQueue)
             p = NULL;
         else
@@ -96,9 +96,9 @@ CUnitQueue::~CUnitQueue()
 
 int CUnitQueue::init(int size, int mss, int version)
 {
-    CQEntry *tempq = NULL;
-    CUnit *  tempu = NULL;
-    char *   tempb = NULL;
+    CQEntry* tempq = NULL;
+    CUnit*   tempu = NULL;
+    char*    tempb = NULL;
 
     try
     {
@@ -142,11 +142,11 @@ int CUnitQueue::increase()
 {
     // adjust/correct m_iCount
     int      real_count = 0;
-    CQEntry *p          = m_pQEntry;
+    CQEntry* p          = m_pQEntry;
     while (p != NULL)
     {
-        CUnit *u = p->m_pUnit;
-        for (CUnit *end = u + p->m_iSize; u != end; ++u)
+        CUnit* u = p->m_pUnit;
+        for (CUnit* end = u + p->m_iSize; u != end; ++u)
             if (u->m_iFlag != CUnit::FREE)
                 ++real_count;
 
@@ -159,9 +159,9 @@ int CUnitQueue::increase()
     if (double(m_iCount) / m_iSize < 0.9)
         return -1;
 
-    CQEntry *tempq = NULL;
-    CUnit *  tempu = NULL;
-    char *   tempb = NULL;
+    CQEntry* tempq = NULL;
+    CUnit*   tempu = NULL;
+    char*    tempb = NULL;
 
     // all queues have the same size
     const int size = m_pQEntry->m_iSize;
@@ -179,8 +179,8 @@ int CUnitQueue::increase()
         delete[] tempb;
 
         LOGC(rslog.Error,
-            log << "CUnitQueue:increase: failed to allocate " << size << " new units."
-                << " Current size=" << m_iSize);
+             log << "CUnitQueue:increase: failed to allocate " << size << " new units."
+                 << " Current size=" << m_iSize);
         return -1;
     }
 
@@ -208,7 +208,7 @@ int CUnitQueue::shrink()
     return -1;
 }
 
-CUnit *CUnitQueue::getNextAvailUnit()
+CUnit* CUnitQueue::getNextAvailUnit()
 {
     if (m_iCount * 10 > m_iSize * 9)
         increase();
@@ -219,7 +219,7 @@ CUnit *CUnitQueue::getNextAvailUnit()
     int units_checked = 0;
     do
     {
-        const CUnit *end = m_pCurrQueue->m_pUnit + m_pCurrQueue->m_iSize;
+        const CUnit* end = m_pCurrQueue->m_pUnit + m_pCurrQueue->m_iSize;
         for (; m_pAvailUnit != end; ++m_pAvailUnit, ++units_checked)
         {
             if (m_pAvailUnit->m_iFlag == CUnit::FREE)
@@ -237,7 +237,7 @@ CUnit *CUnitQueue::getNextAvailUnit()
     return NULL;
 }
 
-void CUnitQueue::makeUnitFree(CUnit *unit)
+void CUnitQueue::makeUnitFree(CUnit* unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_iFlag != CUnit::FREE);
@@ -245,7 +245,7 @@ void CUnitQueue::makeUnitFree(CUnit *unit)
     --m_iCount;
 }
 
-void CUnitQueue::makeUnitGood(CUnit *unit)
+void CUnitQueue::makeUnitGood(CUnit* unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_iFlag == CUnit::FREE);
@@ -262,7 +262,7 @@ CSndUList::CSndUList()
     , m_pWindowCond(NULL)
     , m_pTimer(NULL)
 {
-    m_pHeap = new CSNode *[m_iArrayLength];
+    m_pHeap = new CSNode*[m_iArrayLength];
 }
 
 CSndUList::~CSndUList()
@@ -307,7 +307,7 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     if (m_pHeap[0]->m_tsTimeStamp > steady_clock::now())
         return -1;
 
-    CUDT *u = m_pHeap[0]->m_pUDT;
+    CUDT* u = m_pHeap[0]->m_pUDT;
     remove_(u);
 
 #define UST(field) ((u->m_b##field) ? "+" : "-") << #field << " "
@@ -337,7 +337,7 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     return 1;
 }
 
-void CSndUList::remove(const CUDT *u)
+void CSndUList::remove(const CUDT* u)
 {
     ScopedLock listguard(m_ListLock);
 
@@ -356,18 +356,18 @@ steady_clock::time_point CSndUList::getNextProcTime()
 
 void CSndUList::realloc_()
 {
-    CSNode **temp = NULL;
+    CSNode** temp = NULL;
 
     try
     {
-        temp = new CSNode *[2 * m_iArrayLength];
+        temp = new CSNode*[2 * m_iArrayLength];
     }
     catch (...)
     {
         throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
     }
 
-    memcpy((temp), m_pHeap, sizeof(CSNode *) * m_iArrayLength);
+    memcpy((temp), m_pHeap, sizeof(CSNode*) * m_iArrayLength);
     m_iArrayLength *= 2;
     delete[] m_pHeap;
     m_pHeap = temp;
@@ -384,7 +384,7 @@ void CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
 
 void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT* u)
 {
-    CSNode *n = u->m_pSNode;
+    CSNode* n = u->m_pSNode;
 
     // do not insert repeated node
     if (n->m_iHeapLoc >= 0)
@@ -394,7 +394,7 @@ void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT
 
     m_iLastEntry++;
     m_pHeap[m_iLastEntry] = n;
-    n->m_tsTimeStamp = ts;
+    n->m_tsTimeStamp      = ts;
 
     int q = m_iLastEntry;
     int p = q;
@@ -424,7 +424,7 @@ void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT
 
 void CSndUList::remove_(const CUDT* u)
 {
-    CSNode *n = u->m_pSNode;
+    CSNode* n = u->m_pSNode;
 
     if (n->m_iHeapLoc >= 0)
     {
@@ -493,14 +493,20 @@ CSndQueue::~CSndQueue()
     delete m_pSndUList;
 }
 
-int CSndQueue::ioctlQuery(int type) const { return m_pChannel->ioctlQuery(type); }
-int CSndQueue::sockoptQuery(int level, int type) const { return m_pChannel->sockoptQuery(level, type); }
+int CSndQueue::ioctlQuery(int type) const
+{
+    return m_pChannel->ioctlQuery(type);
+}
+int CSndQueue::sockoptQuery(int level, int type) const
+{
+    return m_pChannel->sockoptQuery(level, type);
+}
 
 #if ENABLE_LOGGING
-    int CSndQueue::m_counter = 0;
+int CSndQueue::m_counter = 0;
 #endif
 
-void CSndQueue::init(CChannel *c, CTimer *t)
+void CSndQueue::init(CChannel* c, CTimer* t)
 {
     m_pChannel                 = c;
     m_pTimer                   = t;
@@ -512,7 +518,7 @@ void CSndQueue::init(CChannel *c, CTimer *t)
 #if ENABLE_LOGGING
     ++m_counter;
     const std::string thrname = "SRT:SndQ:w" + Sprint(m_counter);
-    const char* thname = thrname.c_str();
+    const char*       thname  = thrname.c_str();
 #else
     const char* thname = "SRT:SndQ";
 #endif
@@ -520,17 +526,26 @@ void CSndQueue::init(CChannel *c, CTimer *t)
         throw CUDTException(MJ_SYSTEMRES, MN_THREAD);
 }
 
-int CSndQueue::getIpTTL() const { return m_pChannel ? m_pChannel->getIpTTL() : -1; }
+int CSndQueue::getIpTTL() const
+{
+    return m_pChannel ? m_pChannel->getIpTTL() : -1;
+}
 
-int CSndQueue::getIpToS() const { return m_pChannel ? m_pChannel->getIpToS() : -1; }
+int CSndQueue::getIpToS() const
+{
+    return m_pChannel ? m_pChannel->getIpToS() : -1;
+}
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-bool CSndQueue::getBind(char* dst, size_t len) const { return m_pChannel ? m_pChannel->getBind(dst, len) : false; }
+bool CSndQueue::getBind(char* dst, size_t len) const
+{
+    return m_pChannel ? m_pChannel->getBind(dst, len) : false;
+}
 #endif
 
-void *CSndQueue::worker(void *param)
+void* CSndQueue::worker(void* param)
 {
-    CSndQueue *self = (CSndQueue *)param;
+    CSndQueue* self = (CSndQueue*)param;
 
 #if ENABLE_LOGGING
     THREAD_STATE_INIT(("SRT:SndQ:w" + Sprint(m_counter)).c_str());
@@ -558,8 +573,8 @@ void *CSndQueue::worker(void *param)
             self->m_WorkerStats.lNotReadyTs++;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
-            UniqueLock windlock (self->m_WindowLock);
-            CSync windsync  (self->m_WindowCond, windlock);
+            UniqueLock windlock(self->m_WindowLock);
+            CSync      windsync(self->m_WindowCond, windlock);
 
             // wait here if there is no sockets with data to be sent
             THREAD_PAUSED();
@@ -646,9 +661,9 @@ CRcvUList::CRcvUList()
 
 CRcvUList::~CRcvUList() {}
 
-void CRcvUList::insert(const CUDT *u)
+void CRcvUList::insert(const CUDT* u)
 {
-    CRNode *n      = u->m_pRNode;
+    CRNode* n        = u->m_pRNode;
     n->m_tsTimeStamp = steady_clock::now();
 
     if (NULL == m_pUList)
@@ -667,9 +682,9 @@ void CRcvUList::insert(const CUDT *u)
     m_pLast          = n;
 }
 
-void CRcvUList::remove(const CUDT *u)
+void CRcvUList::remove(const CUDT* u)
 {
-    CRNode *n = u->m_pRNode;
+    CRNode* n = u->m_pRNode;
 
     if (!n->m_bOnList)
         return;
@@ -698,9 +713,9 @@ void CRcvUList::remove(const CUDT *u)
     n->m_pNext = n->m_pPrev = NULL;
 }
 
-void CRcvUList::update(const CUDT *u)
+void CRcvUList::update(const CUDT* u)
 {
-    CRNode *n = u->m_pRNode;
+    CRNode* n = u->m_pRNode;
 
     if (!n->m_bOnList)
         return;
@@ -739,10 +754,10 @@ CHash::~CHash()
 {
     for (int i = 0; i < m_iHashSize; ++i)
     {
-        CBucket *b = m_pBucket[i];
+        CBucket* b = m_pBucket[i];
         while (NULL != b)
         {
-            CBucket *n = b->m_pNext;
+            CBucket* n = b->m_pNext;
             delete b;
             b = n;
         }
@@ -753,7 +768,7 @@ CHash::~CHash()
 
 void CHash::init(int size)
 {
-    m_pBucket = new CBucket *[size];
+    m_pBucket = new CBucket*[size];
 
     for (int i = 0; i < size; ++i)
         m_pBucket[i] = NULL;
@@ -761,10 +776,10 @@ void CHash::init(int size)
     m_iHashSize = size;
 }
 
-CUDT *CHash::lookup(int32_t id)
+CUDT* CHash::lookup(int32_t id)
 {
     // simple hash function (% hash table size); suitable for socket descriptors
-    CBucket *b = m_pBucket[id % m_iHashSize];
+    CBucket* b = m_pBucket[id % m_iHashSize];
 
     while (NULL != b)
     {
@@ -776,11 +791,11 @@ CUDT *CHash::lookup(int32_t id)
     return NULL;
 }
 
-void CHash::insert(int32_t id, CUDT *u)
+void CHash::insert(int32_t id, CUDT* u)
 {
-    CBucket *b = m_pBucket[id % m_iHashSize];
+    CBucket* b = m_pBucket[id % m_iHashSize];
 
-    CBucket *n = new CBucket;
+    CBucket* n = new CBucket;
     n->m_iID   = id;
     n->m_pUDT  = u;
     n->m_pNext = b;
@@ -790,8 +805,8 @@ void CHash::insert(int32_t id, CUDT *u)
 
 void CHash::remove(int32_t id)
 {
-    CBucket *b = m_pBucket[id % m_iHashSize];
-    CBucket *p = NULL;
+    CBucket* b = m_pBucket[id % m_iHashSize];
+    CBucket* p = NULL;
 
     while (NULL != b)
     {
@@ -824,26 +839,28 @@ CRendezvousQueue::~CRendezvousQueue()
     m_lRendezvousID.clear();
 }
 
-void CRendezvousQueue::insert(
-    const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const steady_clock::time_point& ttl)
+void CRendezvousQueue::insert(const SRTSOCKET&                id,
+                              CUDT*                           u,
+                              const sockaddr_any&             addr,
+                              const steady_clock::time_point& ttl)
 {
     ScopedLock vg(m_RIDListLock);
 
     CRL r;
-    r.m_iID        = id;
-    r.m_pUDT       = u;
+    r.m_iID      = id;
+    r.m_pUDT     = u;
     r.m_PeerAddr = addr;
-    r.m_tsTTL = ttl;
+    r.m_tsTTL    = ttl;
 
     m_lRendezvousID.push_back(r);
-    HLOGC(cnlog.Debug, log << "RID: adding socket @" << id << " for address: " << addr.str()
-            << " expires: " << FormatTime(ttl)
-            << " (total connectors: " << m_lRendezvousID.size() << ")");
+    HLOGC(cnlog.Debug,
+          log << "RID: adding socket @" << id << " for address: " << addr.str() << " expires: " << FormatTime(ttl)
+              << " (total connectors: " << m_lRendezvousID.size() << ")");
 }
 
-void CRendezvousQueue::remove(const SRTSOCKET &id)
+void CRendezvousQueue::remove(const SRTSOCKET& id)
 {
-    ScopedLock lkv (m_RIDListLock);
+    ScopedLock lkv(m_RIDListLock);
 
     for (list<CRL>::iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
     {
@@ -857,35 +874,36 @@ void CRendezvousQueue::remove(const SRTSOCKET &id)
 
 CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id) const
 {
-    ScopedLock     vg(m_RIDListLock);
+    ScopedLock vg(m_RIDListLock);
 
     // TODO: optimize search
     for (list<CRL>::const_iterator i = m_lRendezvousID.begin(); i != m_lRendezvousID.end(); ++i)
     {
         if (i->m_PeerAddr == addr && ((w_id == 0) || (w_id == i->m_iID)))
         {
-            HLOGC(cnlog.Debug, log << "RID: found id @" << i->m_iID << " while looking for "
-                    << (w_id ? "THIS ID FROM " : "A NEW CONNECTION FROM ")
-                    << i->m_PeerAddr.str());
+            HLOGC(cnlog.Debug,
+                  log << "RID: found id @" << i->m_iID << " while looking for "
+                      << (w_id ? "THIS ID FROM " : "A NEW CONNECTION FROM ") << i->m_PeerAddr.str());
             w_id = i->m_iID;
             return i->m_pUDT;
         }
     }
 
 #if ENABLE_HEAVY_LOGGING
-   std::ostringstream spec;
-   if (w_id == 0)
-       spec << "A NEW CONNECTION REQUEST";
-   else
-       spec << " AGENT @" << w_id;
-   HLOGC(cnlog.Debug, log << "RID: NO CONNECTOR FOR ADR:" << addr.str()
-           << " while looking for " << spec.str() << " (" << m_lRendezvousID.size() << " connectors total)");
+    std::ostringstream spec;
+    if (w_id == 0)
+        spec << "A NEW CONNECTION REQUEST";
+    else
+        spec << " AGENT @" << w_id;
+    HLOGC(cnlog.Debug,
+          log << "RID: NO CONNECTOR FOR ADR:" << addr.str() << " while looking for " << spec.str() << " ("
+              << m_lRendezvousID.size() << " connectors total)");
 #endif
 
     return NULL;
 }
 
-void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket &pktIn)
+void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket& pktIn)
 {
     vector<LinkStatusInfo> toRemove, toProcess;
 
@@ -896,8 +914,9 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
 
     // [[using locked()]];
 
-    HLOGC(cnlog.Debug, log << "updateConnStatus: collected " << toProcess.size() << " for processing, "
-            << toRemove.size() << " to close");
+    HLOGC(cnlog.Debug,
+          log << "updateConnStatus: collected " << toProcess.size() << " for processing, " << toRemove.size()
+              << " to close");
 
     // Repeat (resend) connection request.
     for (vector<LinkStatusInfo>::iterator i = toProcess.begin(); i != toProcess.end(); ++i)
@@ -925,18 +944,18 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
             conn_st = CONN_AGAIN;
         }
 
-        HLOGC(cnlog.Debug, log << "updateConnStatus: processing async conn for @" << i->id << " FROM " << i->peeraddr.str());
+        HLOGC(cnlog.Debug,
+              log << "updateConnStatus: processing async conn for @" << i->id << " FROM " << i->peeraddr.str());
 
         if (!i->u->processAsyncConnectRequest(read_st, conn_st, pktIn, i->peeraddr))
         {
             // cst == CONN_REJECT can only be result of worker_ProcessAddressedPacket and
             // its already set in this case.
             LinkStatusInfo fi = *i;
-            fi.errorcode = SRT_ECONNREJ;
+            fi.errorcode      = SRT_ECONNREJ;
             toRemove.push_back(fi);
             i->u->sendCtrl(UMSG_SHUTDOWN);
         }
-
     }
 
     // NOTE: it is "believed" here that all CUDT objects will not be
@@ -962,7 +981,8 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
         // be normally closed by the application, after it is done with them.
 
         // app can call any UDT API to learn the connection_broken error
-        CUDT::s_UDTUnited.m_EPoll.update_events(i->u->m_SocketID, i->u->m_sPollID, SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR, true);
+        CUDT::s_UDTUnited.m_EPoll.update_events(
+            i->u->m_SocketID, i->u->m_sPollID, SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR, true);
 
         i->u->completeBrokenConnectionDependencies(i->errorcode);
     }
@@ -975,15 +995,21 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
         {
             if (find_if(toRemove.begin(), toRemove.end(), LinkStatusInfo::HasID(i->m_iID)) != toRemove.end())
             {
-                LOGC(cnlog.Error, log << "updateConnStatus: processAsyncConnectRequest FAILED on @" << i->m_iID << ". Setting TTL as EXPIRED.");
-                i->m_tsTTL = steady_clock::time_point(); // Make it expire right now, will be picked up at the next iteration
+                LOGC(cnlog.Error,
+                     log << "updateConnStatus: processAsyncConnectRequest FAILED on @" << i->m_iID
+                         << ". Setting TTL as EXPIRED.");
+                i->m_tsTTL =
+                    steady_clock::time_point(); // Make it expire right now, will be picked up at the next iteration
             }
         }
     }
 }
 
-bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_ATR_UNUSED,
-    int iDstSockID, vector<LinkStatusInfo>& toRemove, vector<LinkStatusInfo>& toProcess)
+bool CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
+                                       EConnectStatus cst      SRT_ATR_UNUSED,
+                                       int                     iDstSockID,
+                                       vector<LinkStatusInfo>& toRemove,
+                                       vector<LinkStatusInfo>& toProcess)
 {
     ScopedLock vg(m_RIDListLock);
 
@@ -991,8 +1017,8 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_A
         return false; // nothing to process.
 
     HLOGC(cnlog.Debug,
-        log << "updateConnStatus: updating after getting pkt with DST socket ID @" << iDstSockID
-        << " status: " << ConnectStatusStr(cst));
+          log << "updateConnStatus: updating after getting pkt with DST socket ID @" << iDstSockID
+              << " status: " << ConnectStatusStr(cst));
 
     for (list<CRL>::iterator i = m_lRendezvousID.begin(), i_next = i; i != m_lRendezvousID.end(); i = i_next)
     {
@@ -1003,11 +1029,11 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_A
 
         if (tsNow >= i->m_tsTTL)
         {
-            HLOGC(cnlog.Debug, log << "RID: socket @" << i->m_iID
-                << " removed - EXPIRED ("
-                // The "enforced on FAILURE" is below when processAsyncConnectRequest failed.
-                << (is_zero(i->m_tsTTL) ? "enforced on FAILURE" : "passed TTL")
-                << "). WILL REMOVE from queue.");
+            HLOGC(cnlog.Debug,
+                  log << "RID: socket @" << i->m_iID
+                      << " removed - EXPIRED ("
+                      // The "enforced on FAILURE" is below when processAsyncConnectRequest failed.
+                      << (is_zero(i->m_tsTTL) ? "enforced on FAILURE" : "passed TTL") << "). WILL REMOVE from queue.");
 
             // Set appropriate error information, but do not update yet.
             // Exit the lock first. Collect objects to update them later.
@@ -1018,7 +1044,7 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_A
                 {
                     // Timer expired, set TIMEOUT forcefully
                     i->m_pUDT->m_RejectReason = SRT_REJ_TIMEOUT;
-                    ccerror = SRT_ENOSERVER;
+                    ccerror                   = SRT_ENOSERVER;
                 }
                 else
                 {
@@ -1031,7 +1057,7 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_A
             // The call to completeBrokenConnectionDependencies() cannot happen here
             // under the lock of m_RIDListLock as it risks a deadlock.
             // Collect in 'toRemove' to update later.
-            LinkStatusInfo fi = { i->m_pUDT, i->m_iID, ccerror, i->m_PeerAddr, -1 };
+            LinkStatusInfo fi = {i->m_pUDT, i->m_iID, ccerror, i->m_PeerAddr, -1};
             toRemove.push_back(fi);
 
             // i_next was preincremented, but this is guaranteed to point to
@@ -1041,12 +1067,14 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_A
         }
         else
         {
-            HLOGC(cnlog.Debug, log << "RID: socket @" << i->m_iID << " still active (remaining "
-                << std::fixed << (count_microseconds(i->m_tsTTL - tsNow) / 1000000.0) << "s of TTL)...");
+            HLOGC(cnlog.Debug,
+                  log << "RID: socket @" << i->m_iID << " still active (remaining " << std::fixed
+                      << (count_microseconds(i->m_tsTTL - tsNow) / 1000000.0) << "s of TTL)...");
         }
 
         const steady_clock::time_point tsLastReq = i->m_pUDT->m_tsLastReqTime;
-        const steady_clock::time_point tsRepeat  = tsLastReq + milliseconds_from(250); // Repeat connection request (send HS).
+        const steady_clock::time_point tsRepeat =
+            tsLastReq + milliseconds_from(250); // Repeat connection request (send HS).
 
         // A connection request is repeated every 250 ms if there was no response from the peer:
         // - RST_AGAIN means no packet was received over UDP.
@@ -1054,20 +1082,21 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus rst, EConnectStatus cst SRT_A
         if ((rst == RST_AGAIN || i->m_iID != iDstSockID) && tsNow <= tsRepeat)
         {
             HLOGC(cnlog.Debug,
-                log << "RID:@" << i->m_iID << std::fixed << count_microseconds(tsNow - tsLastReq) / 1000.0
-                    << " ms passed since last connection request.");
+                  log << "RID:@" << i->m_iID << std::fixed << count_microseconds(tsNow - tsLastReq) / 1000.0
+                      << " ms passed since last connection request.");
 
             continue;
         }
 
-        HLOGC(cnlog.Debug, log << "RID:@" << i->m_iID << " cst=" << ConnectStatusStr(cst) << " -- repeating connection request.");
+        HLOGC(cnlog.Debug,
+              log << "RID:@" << i->m_iID << " cst=" << ConnectStatusStr(cst) << " -- repeating connection request.");
 
         // This queue is used only in case of Async mode (rendezvous or caller-listener).
         // Synchronous connection requests are handled in startConnect() completely.
         if (!i->m_pUDT->m_config.bSynRecving)
         {
             // Collect them so that they can be updated out of m_RIDListLock.
-            LinkStatusInfo fi = { i->m_pUDT, i->m_iID, SRT_SUCCESS, i->m_PeerAddr, -1 };
+            LinkStatusInfo fi = {i->m_pUDT, i->m_iID, SRT_SUCCESS, i->m_PeerAddr, -1};
             toProcess.push_back(fi);
         }
         else
@@ -1116,11 +1145,11 @@ CRcvQueue::~CRcvQueue()
     delete m_pRendezvousQueue;
 
     // remove all queued messages
-    for (map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.begin(); i != m_mBuffer.end(); ++i)
+    for (map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.begin(); i != m_mBuffer.end(); ++i)
     {
         while (!i->second.empty())
         {
-            CPacket *pkt = i->second.front();
+            CPacket* pkt = i->second.front();
             delete[] pkt->m_pcData;
             delete pkt;
             i->second.pop();
@@ -1129,15 +1158,14 @@ CRcvQueue::~CRcvQueue()
 }
 
 #if ENABLE_LOGGING
-    int CRcvQueue::m_counter = 0;
+int CRcvQueue::m_counter = 0;
 #endif
 
-
-void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel *cc, CTimer *t)
+void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel* cc, CTimer* t)
 {
     m_szPayloadSize = payload;
 
-    m_UnitQueue.init(qsize, (int) payload, version);
+    m_UnitQueue.init(qsize, (int)payload, version);
 
     m_pHash = new CHash;
     m_pHash->init(hsize);
@@ -1161,9 +1189,9 @@ void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel
     }
 }
 
-void *CRcvQueue::worker(void *param)
+void* CRcvQueue::worker(void* param)
 {
-    CRcvQueue *  self = (CRcvQueue *)param;
+    CRcvQueue*   self = (CRcvQueue*)param;
     sockaddr_any sa(self->m_UnitQueue.getIPversion());
     int32_t      id = 0;
 
@@ -1173,7 +1201,7 @@ void *CRcvQueue::worker(void *param)
     THREAD_STATE_INIT("SRT:RcvQ:worker");
 #endif
 
-    CUnit *        unit = 0;
+    CUnit*         unit = 0;
     EConnectStatus cst  = CONN_AGAIN;
     while (!self->m_bClosing)
     {
@@ -1243,12 +1271,13 @@ void *CRcvQueue::worker(void *param)
         // OTHERWISE: this is an "AGAIN" situation. No data was read, but the process should continue.
 
         // take care of the timing event for all UDT sockets
-        const steady_clock::time_point curtime_minus_syn = steady_clock::now() - microseconds_from(CUDT::COMM_SYN_INTERVAL_US);
+        const steady_clock::time_point curtime_minus_syn =
+            steady_clock::now() - microseconds_from(CUDT::COMM_SYN_INTERVAL_US);
 
-        CRNode *ul = self->m_pRcvUList->m_pUList;
+        CRNode* ul = self->m_pRcvUList->m_pUList;
         while ((NULL != ul) && (ul->m_tsTimeStamp < curtime_minus_syn))
         {
-            CUDT *u = ul->m_pUDT;
+            CUDT* u = ul->m_pUDT;
 
             if (u->m_bConnected && !u->m_bBroken && !u->m_bClosing)
             {
@@ -1304,7 +1333,7 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
     // check waiting list, if new socket, insert it to the list
     while (ifNewEntry())
     {
-        CUDT *ne = getNewEntry();
+        CUDT* ne = getNewEntry();
         if (ne)
         {
             HLOGC(qrlog.Debug,
@@ -1344,9 +1373,9 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
     if (rst == RST_OK)
     {
         w_id = w_unit->m_Packet.m_iID;
-        HLOGC(qrlog.Debug, log << "INCOMING PACKET: FROM=" << w_addr.str()
-                << " BOUND=" << m_pChannel->bindAddressAny().str()
-                << " " << w_unit->m_Packet.Info());
+        HLOGC(qrlog.Debug,
+              log << "INCOMING PACKET: FROM=" << w_addr.str() << " BOUND=" << m_pChannel->bindAddressAny().str() << " "
+                  << w_unit->m_Packet.Info());
     }
     return rst;
 }
@@ -1354,20 +1383,18 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
 EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
 {
     HLOGC(cnlog.Debug,
-          log << "Got sockID=0 from " << addr.str()
-              << " - trying to resolve it as a connection request...");
+          log << "Got sockID=0 from " << addr.str() << " - trying to resolve it as a connection request...");
     // Introduced protection because it may potentially happen
     // that another thread could have closed the socket at
     // the same time and inject a bug between checking the
     // pointer for NULL and using it.
-    int listener_ret  = SRT_REJ_UNKNOWN;
-    bool              have_listener = false;
+    int  listener_ret  = SRT_REJ_UNKNOWN;
+    bool have_listener = false;
     {
         ScopedLock cg(m_LSLock);
         if (m_pListener)
         {
-            LOGC(cnlog.Note,
-                 log << "PASSING request from: " << addr.str() << " to agent:" << m_pListener->socketID());
+            LOGC(cnlog.Note, log << "PASSING request from: " << addr.str() << " to agent:" << m_pListener->socketID());
             listener_ret = m_pListener->processConnectRequest(addr, unit->m_Packet);
 
             // This function does return a code, but it's hard to say as to whether
@@ -1398,7 +1425,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
 
 EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& addr)
 {
-    CUDT *u = m_pHash->lookup(id);
+    CUDT* u = m_pHash->lookup(id);
     if (!u)
     {
         // Pass this to either async rendezvous connection,
@@ -1412,8 +1439,8 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
     if (addr != u->m_PeerAddr)
     {
         HLOGC(cnlog.Debug,
-              log << CONID() << "Packet for SID=" << id << " asoc with " << u->m_PeerAddr.str()
-                  << " received from " << addr.str() << " (CONSIDERED ATTACK ATTEMPT)");
+              log << CONID() << "Packet for SID=" << id << " asoc with " << u->m_PeerAddr.str() << " received from "
+                  << addr.str() << " (CONSIDERED ATTACK ATTEMPT)");
         // This came not from the address that is the peer associated
         // with the socket. Ignore it.
         return CONN_AGAIN;
@@ -1454,7 +1481,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
     // stored in the rendezvous queue (see CRcvQueue::registerConnector)
     // or simply 0, but then at least the address must match one of these.
     // If the id was 0, it will be set to the actual socket ID of the returned CUDT.
-    CUDT *u = m_pRendezvousQueue->retrieve(addr, (id));
+    CUDT* u = m_pRendezvousQueue->retrieve(addr, (id));
     if (!u)
     {
         // this socket is then completely unknown to the system.
@@ -1525,7 +1552,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
             // that we KNOW (by the cst == CONN_ACCEPT result) that the socket should be inserted
             // into the pending anteroom.
 
-            CUDT *ne = getNewEntry(); // This function actuall removes the entry and returns it.
+            CUDT* ne = getNewEntry(); // This function actuall removes the entry and returns it.
             // This **should** now always return a non-null value, but check it first
             // because if this accidentally isn't true, the call to worker_ProcessAddressedPacket will
             // result in redirecting it to here and so on until the call stack overflow. In case of
@@ -1597,10 +1624,10 @@ void CRcvQueue::stopWorker()
 
 int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
 {
-    UniqueLock bufferlock (m_BufferLock);
-    CSync buffercond    (m_BufferCond, bufferlock);
+    UniqueLock bufferlock(m_BufferLock);
+    CSync      buffercond(m_BufferCond, bufferlock);
 
-    map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
+    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 
     if (i == m_mBuffer.end())
     {
@@ -1617,7 +1644,7 @@ int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
     }
 
     // retrieve the earliest packet
-    CPacket *newpkt = i->second.front();
+    CPacket* newpkt = i->second.front();
 
     if (w_packet.getLength() < newpkt->getLength())
     {
@@ -1649,7 +1676,7 @@ int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
     return (int)w_packet.getLength();
 }
 
-int CRcvQueue::setListener(CUDT *u)
+int CRcvQueue::setListener(CUDT* u)
 {
     ScopedLock lslock(m_LSLock);
 
@@ -1660,7 +1687,7 @@ int CRcvQueue::setListener(CUDT *u)
     return 0;
 }
 
-void CRcvQueue::removeListener(const CUDT *u)
+void CRcvQueue::removeListener(const CUDT* u)
 {
     ScopedLock lslock(m_LSLock);
 
@@ -1668,21 +1695,24 @@ void CRcvQueue::removeListener(const CUDT *u)
         m_pListener = NULL;
 }
 
-void CRcvQueue::registerConnector(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const steady_clock::time_point& ttl)
+void CRcvQueue::registerConnector(const SRTSOCKET&                id,
+                                  CUDT*                           u,
+                                  const sockaddr_any&             addr,
+                                  const steady_clock::time_point& ttl)
 {
     HLOGC(cnlog.Debug,
           log << "registerConnector: adding @" << id << " addr=" << addr.str() << " TTL=" << FormatTime(ttl));
     m_pRendezvousQueue->insert(id, u, addr, ttl);
 }
 
-void CRcvQueue::removeConnector(const SRTSOCKET &id)
+void CRcvQueue::removeConnector(const SRTSOCKET& id)
 {
     HLOGC(cnlog.Debug, log << "removeConnector: removing @" << id);
     m_pRendezvousQueue->remove(id);
 
     ScopedLock bufferlock(m_BufferLock);
 
-    map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
+    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
     if (i != m_mBuffer.end())
     {
         HLOGC(cnlog.Debug,
@@ -1697,34 +1727,37 @@ void CRcvQueue::removeConnector(const SRTSOCKET &id)
     }
 }
 
-void CRcvQueue::setNewEntry(CUDT *u)
+void CRcvQueue::setNewEntry(CUDT* u)
 {
     HLOGC(cnlog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
     ScopedLock listguard(m_IDLock);
     m_vNewEntry.push_back(u);
 }
 
-bool CRcvQueue::ifNewEntry() { return !(m_vNewEntry.empty()); }
+bool CRcvQueue::ifNewEntry()
+{
+    return !(m_vNewEntry.empty());
+}
 
-CUDT *CRcvQueue::getNewEntry()
+CUDT* CRcvQueue::getNewEntry()
 {
     ScopedLock listguard(m_IDLock);
 
     if (m_vNewEntry.empty())
         return NULL;
 
-    CUDT *u = (CUDT *)*(m_vNewEntry.begin());
+    CUDT* u = (CUDT*)*(m_vNewEntry.begin());
     m_vNewEntry.erase(m_vNewEntry.begin());
 
     return u;
 }
 
-void CRcvQueue::storePkt(int32_t id, CPacket *pkt)
+void CRcvQueue::storePkt(int32_t id, CPacket* pkt)
 {
-    UniqueLock bufferlock (m_BufferLock);
-    CSync passcond    (m_BufferCond, bufferlock);
+    UniqueLock bufferlock(m_BufferLock);
+    CSync      passcond(m_BufferCond, bufferlock);
 
-    map<int32_t, std::queue<CPacket *> >::iterator i = m_mBuffer.find(id);
+    map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 
     if (i == m_mBuffer.end())
     {
@@ -1741,10 +1774,9 @@ void CRcvQueue::storePkt(int32_t id, CPacket *pkt)
     }
 }
 
-
 void CMultiplexer::destroy()
 {
-    // Reverse order of the assigned 
+    // Reverse order of the assigned
     delete m_pRcvQueue;
     delete m_pSndQueue;
     delete m_pTimer;

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -65,7 +65,7 @@ using namespace std;
 using namespace srt::sync;
 using namespace srt_logging;
 
-CUnitQueue::CUnitQueue()
+srt::CUnitQueue::CUnitQueue()
     : m_pQEntry(NULL)
     , m_pCurrQueue(NULL)
     , m_pLastQueue(NULL)
@@ -76,7 +76,7 @@ CUnitQueue::CUnitQueue()
 {
 }
 
-CUnitQueue::~CUnitQueue()
+srt::CUnitQueue::~CUnitQueue()
 {
     CQEntry* p = m_pQEntry;
 
@@ -94,7 +94,7 @@ CUnitQueue::~CUnitQueue()
     }
 }
 
-int CUnitQueue::init(int size, int mss, int version)
+int srt::CUnitQueue::init(int size, int mss, int version)
 {
     CQEntry* tempq = NULL;
     CUnit*   tempu = NULL;
@@ -138,7 +138,7 @@ int CUnitQueue::init(int size, int mss, int version)
 
 // XXX Lots of common code with CUnitQueue:init.
 // Consider merging.
-int CUnitQueue::increase()
+int srt::CUnitQueue::increase()
 {
     // adjust/correct m_iCount
     int      real_count = 0;
@@ -202,13 +202,13 @@ int CUnitQueue::increase()
     return 0;
 }
 
-int CUnitQueue::shrink()
+int srt::CUnitQueue::shrink()
 {
     // currently queue cannot be shrunk.
     return -1;
 }
 
-CUnit* CUnitQueue::getNextAvailUnit()
+srt::CUnit* srt::CUnitQueue::getNextAvailUnit()
 {
     if (m_iCount * 10 > m_iSize * 9)
         increase();
@@ -237,7 +237,7 @@ CUnit* CUnitQueue::getNextAvailUnit()
     return NULL;
 }
 
-void CUnitQueue::makeUnitFree(CUnit* unit)
+void srt::CUnitQueue::makeUnitFree(CUnit* unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_iFlag != CUnit::FREE);
@@ -245,7 +245,7 @@ void CUnitQueue::makeUnitFree(CUnit* unit)
     --m_iCount;
 }
 
-void CUnitQueue::makeUnitGood(CUnit* unit)
+void srt::CUnitQueue::makeUnitGood(CUnit* unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_iFlag == CUnit::FREE);
@@ -253,7 +253,7 @@ void CUnitQueue::makeUnitGood(CUnit* unit)
     ++m_iCount;
 }
 
-CSndUList::CSndUList()
+srt::CSndUList::CSndUList()
     : m_pHeap(NULL)
     , m_iArrayLength(512)
     , m_iLastEntry(-1)
@@ -265,12 +265,12 @@ CSndUList::CSndUList()
     m_pHeap = new CSNode*[m_iArrayLength];
 }
 
-CSndUList::~CSndUList()
+srt::CSndUList::~CSndUList()
 {
     delete[] m_pHeap;
 }
 
-void CSndUList::update(const CUDT* u, EReschedule reschedule)
+void srt::CSndUList::update(const CUDT* u, EReschedule reschedule)
 {
     ScopedLock listguard(m_ListLock);
 
@@ -296,7 +296,7 @@ void CSndUList::update(const CUDT* u, EReschedule reschedule)
     insert_(steady_clock::now(), u);
 }
 
-int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
+int srt::CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
 {
     ScopedLock listguard(m_ListLock);
 
@@ -337,14 +337,14 @@ int CSndUList::pop(sockaddr_any& w_addr, CPacket& w_pkt)
     return 1;
 }
 
-void CSndUList::remove(const CUDT* u)
+void srt::CSndUList::remove(const CUDT* u)
 {
     ScopedLock listguard(m_ListLock);
 
     remove_(u);
 }
 
-steady_clock::time_point CSndUList::getNextProcTime()
+steady_clock::time_point srt::CSndUList::getNextProcTime()
 {
     ScopedLock listguard(m_ListLock);
 
@@ -354,7 +354,7 @@ steady_clock::time_point CSndUList::getNextProcTime()
     return m_pHeap[0]->m_tsTimeStamp;
 }
 
-void CSndUList::realloc_()
+void srt::CSndUList::realloc_()
 {
     CSNode** temp = NULL;
 
@@ -373,7 +373,7 @@ void CSndUList::realloc_()
     m_pHeap = temp;
 }
 
-void CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
+void srt::CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
 {
     // increase the heap array size if necessary
     if (m_iLastEntry == m_iArrayLength - 1)
@@ -382,7 +382,7 @@ void CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
     insert_norealloc_(ts, u);
 }
 
-void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT* u)
+void srt::CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT* u)
 {
     CSNode* n = u->m_pSNode;
 
@@ -422,7 +422,7 @@ void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT
     }
 }
 
-void CSndUList::remove_(const CUDT* u)
+void srt::CSndUList::remove_(const CUDT* u)
 {
     CSNode* n = u->m_pSNode;
 
@@ -462,7 +462,7 @@ void CSndUList::remove_(const CUDT* u)
 }
 
 //
-CSndQueue::CSndQueue()
+srt::CSndQueue::CSndQueue()
     : m_pSndUList(NULL)
     , m_pChannel(NULL)
     , m_pTimer(NULL)
@@ -472,7 +472,7 @@ CSndQueue::CSndQueue()
     setupCond(m_WindowCond, "Window");
 }
 
-CSndQueue::~CSndQueue()
+srt::CSndQueue::~CSndQueue()
 {
     m_bClosing = true;
 
@@ -493,20 +493,20 @@ CSndQueue::~CSndQueue()
     delete m_pSndUList;
 }
 
-int CSndQueue::ioctlQuery(int type) const
+int srt::CSndQueue::ioctlQuery(int type) const
 {
     return m_pChannel->ioctlQuery(type);
 }
-int CSndQueue::sockoptQuery(int level, int type) const
+int srt::CSndQueue::sockoptQuery(int level, int type) const
 {
     return m_pChannel->sockoptQuery(level, type);
 }
 
 #if ENABLE_LOGGING
-int CSndQueue::m_counter = 0;
+int srt::CSndQueue::m_counter = 0;
 #endif
 
-void CSndQueue::init(CChannel* c, CTimer* t)
+void srt::CSndQueue::init(CChannel* c, CTimer* t)
 {
     m_pChannel                 = c;
     m_pTimer                   = t;
@@ -526,24 +526,24 @@ void CSndQueue::init(CChannel* c, CTimer* t)
         throw CUDTException(MJ_SYSTEMRES, MN_THREAD);
 }
 
-int CSndQueue::getIpTTL() const
+int srt::CSndQueue::getIpTTL() const
 {
     return m_pChannel ? m_pChannel->getIpTTL() : -1;
 }
 
-int CSndQueue::getIpToS() const
+int srt::CSndQueue::getIpToS() const
 {
     return m_pChannel ? m_pChannel->getIpToS() : -1;
 }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-bool CSndQueue::getBind(char* dst, size_t len) const
+bool srt::CSndQueue::getBind(char* dst, size_t len) const
 {
     return m_pChannel ? m_pChannel->getBind(dst, len) : false;
 }
 #endif
 
-void* CSndQueue::worker(void* param)
+void* srt::CSndQueue::worker(void* param)
 {
     CSndQueue* self = (CSndQueue*)param;
 
@@ -645,7 +645,7 @@ void* CSndQueue::worker(void* param)
     return NULL;
 }
 
-int CSndQueue::sendto(const sockaddr_any& w_addr, CPacket& w_packet)
+int srt::CSndQueue::sendto(const sockaddr_any& w_addr, CPacket& w_packet)
 {
     // send out the packet immediately (high priority), this is a control packet
     m_pChannel->sendto(w_addr, w_packet);
@@ -653,15 +653,15 @@ int CSndQueue::sendto(const sockaddr_any& w_addr, CPacket& w_packet)
 }
 
 //
-CRcvUList::CRcvUList()
+srt::CRcvUList::CRcvUList()
     : m_pUList(NULL)
     , m_pLast(NULL)
 {
 }
 
-CRcvUList::~CRcvUList() {}
+srt::CRcvUList::~CRcvUList() {}
 
-void CRcvUList::insert(const CUDT* u)
+void srt::CRcvUList::insert(const CUDT* u)
 {
     CRNode* n        = u->m_pRNode;
     n->m_tsTimeStamp = steady_clock::now();
@@ -682,7 +682,7 @@ void CRcvUList::insert(const CUDT* u)
     m_pLast          = n;
 }
 
-void CRcvUList::remove(const CUDT* u)
+void srt::CRcvUList::remove(const CUDT* u)
 {
     CRNode* n = u->m_pRNode;
 
@@ -713,7 +713,7 @@ void CRcvUList::remove(const CUDT* u)
     n->m_pNext = n->m_pPrev = NULL;
 }
 
-void CRcvUList::update(const CUDT* u)
+void srt::CRcvUList::update(const CUDT* u)
 {
     CRNode* n = u->m_pRNode;
 
@@ -744,13 +744,13 @@ void CRcvUList::update(const CUDT* u)
 }
 
 //
-CHash::CHash()
+srt::CHash::CHash()
     : m_pBucket(NULL)
     , m_iHashSize(0)
 {
 }
 
-CHash::~CHash()
+srt::CHash::~CHash()
 {
     for (int i = 0; i < m_iHashSize; ++i)
     {
@@ -766,7 +766,7 @@ CHash::~CHash()
     delete[] m_pBucket;
 }
 
-void CHash::init(int size)
+void srt::CHash::init(int size)
 {
     m_pBucket = new CBucket*[size];
 
@@ -776,7 +776,7 @@ void CHash::init(int size)
     m_iHashSize = size;
 }
 
-CUDT* CHash::lookup(int32_t id)
+srt::CUDT* srt::CHash::lookup(int32_t id)
 {
     // simple hash function (% hash table size); suitable for socket descriptors
     CBucket* b = m_pBucket[id % m_iHashSize];
@@ -791,7 +791,7 @@ CUDT* CHash::lookup(int32_t id)
     return NULL;
 }
 
-void CHash::insert(int32_t id, CUDT* u)
+void srt::CHash::insert(int32_t id, CUDT* u)
 {
     CBucket* b = m_pBucket[id % m_iHashSize];
 
@@ -803,7 +803,7 @@ void CHash::insert(int32_t id, CUDT* u)
     m_pBucket[id % m_iHashSize] = n;
 }
 
-void CHash::remove(int32_t id)
+void srt::CHash::remove(int32_t id)
 {
     CBucket* b = m_pBucket[id % m_iHashSize];
     CBucket* p = NULL;
@@ -828,18 +828,18 @@ void CHash::remove(int32_t id)
 }
 
 //
-CRendezvousQueue::CRendezvousQueue()
+srt::CRendezvousQueue::CRendezvousQueue()
     : m_lRendezvousID()
     , m_RIDListLock()
 {
 }
 
-CRendezvousQueue::~CRendezvousQueue()
+srt::CRendezvousQueue::~CRendezvousQueue()
 {
     m_lRendezvousID.clear();
 }
 
-void CRendezvousQueue::insert(const SRTSOCKET&                id,
+void srt::CRendezvousQueue::insert(const SRTSOCKET&                id,
                               CUDT*                           u,
                               const sockaddr_any&             addr,
                               const steady_clock::time_point& ttl)
@@ -858,7 +858,7 @@ void CRendezvousQueue::insert(const SRTSOCKET&                id,
               << " (total connectors: " << m_lRendezvousID.size() << ")");
 }
 
-void CRendezvousQueue::remove(const SRTSOCKET& id)
+void srt::CRendezvousQueue::remove(const SRTSOCKET& id)
 {
     ScopedLock lkv(m_RIDListLock);
 
@@ -872,7 +872,7 @@ void CRendezvousQueue::remove(const SRTSOCKET& id)
     }
 }
 
-CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id) const
+srt::CUDT* srt::CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id) const
 {
     ScopedLock vg(m_RIDListLock);
 
@@ -903,7 +903,7 @@ CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id) cons
     return NULL;
 }
 
-void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket& pktIn)
+void srt::CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket& pktIn)
 {
     vector<LinkStatusInfo> toRemove, toProcess;
 
@@ -1005,7 +1005,7 @@ void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, con
     }
 }
 
-bool CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
+bool srt::CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
                                        EConnectStatus cst      SRT_ATR_UNUSED,
                                        int                     iDstSockID,
                                        vector<LinkStatusInfo>& toRemove,
@@ -1109,7 +1109,7 @@ bool CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
 }
 
 //
-CRcvQueue::CRcvQueue()
+srt::CRcvQueue::CRcvQueue()
     : m_WorkerThread()
     , m_UnitQueue()
     , m_pRcvUList(NULL)
@@ -1129,7 +1129,7 @@ CRcvQueue::CRcvQueue()
     setupCond(m_BufferCond, "QueueBuffer");
 }
 
-CRcvQueue::~CRcvQueue()
+srt::CRcvQueue::~CRcvQueue()
 {
     m_bClosing = true;
 
@@ -1158,10 +1158,10 @@ CRcvQueue::~CRcvQueue()
 }
 
 #if ENABLE_LOGGING
-int CRcvQueue::m_counter = 0;
+int srt::CRcvQueue::m_counter = 0;
 #endif
 
-void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel* cc, CTimer* t)
+void srt::CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel* cc, CTimer* t)
 {
     m_szPayloadSize = payload;
 
@@ -1189,7 +1189,7 @@ void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel
     }
 }
 
-void* CRcvQueue::worker(void* param)
+void* srt::CRcvQueue::worker(void* param)
 {
     CRcvQueue*   self = (CRcvQueue*)param;
     sockaddr_any sa(self->m_UnitQueue.getIPversion());
@@ -1322,7 +1322,7 @@ void* CRcvQueue::worker(void* param)
     return NULL;
 }
 
-EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
+EReadStatus srt::CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
 {
 #if !USE_BUSY_WAITING
     // This might be not really necessary, and probably
@@ -1380,7 +1380,7 @@ EReadStatus CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockad
     return rst;
 }
 
-EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
+EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
 {
     HLOGC(cnlog.Debug,
           log << "Got sockID=0 from " << addr.str() << " - trying to resolve it as a connection request...");
@@ -1423,7 +1423,7 @@ EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const soc
     return worker_TryAsyncRend_OrStore(0, unit, addr); // 0 id because the packet came in with that very ID.
 }
 
-EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& addr)
+EConnectStatus srt::CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& addr)
 {
     CUDT* u = m_pHash->lookup(id);
     if (!u)
@@ -1475,7 +1475,7 @@ EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit,
 // This function then tries to manage the packet as a rendezvous connection
 // request in ASYNC mode; when this is not applicable, it stores the packet
 // in the "receiving queue" so that it will be picked up in the "main" thread.
-EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& addr)
+EConnectStatus srt::CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& addr)
 {
     // This 'retrieve' requires that 'id' be either one of those
     // stored in the rendezvous queue (see CRcvQueue::registerConnector)
@@ -1605,7 +1605,7 @@ EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, c
     return CONN_CONTINUE;
 }
 
-void CRcvQueue::stopWorker()
+void srt::CRcvQueue::stopWorker()
 {
     // We use the decent way, so we say to the thread "please exit".
     m_bClosing = true;
@@ -1622,7 +1622,7 @@ void CRcvQueue::stopWorker()
     m_WorkerThread.join();
 }
 
-int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
+int srt::CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
 {
     UniqueLock bufferlock(m_BufferLock);
     CSync      buffercond(m_BufferCond, bufferlock);
@@ -1676,7 +1676,7 @@ int CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
     return (int)w_packet.getLength();
 }
 
-int CRcvQueue::setListener(CUDT* u)
+int srt::CRcvQueue::setListener(CUDT* u)
 {
     ScopedLock lslock(m_LSLock);
 
@@ -1687,7 +1687,7 @@ int CRcvQueue::setListener(CUDT* u)
     return 0;
 }
 
-void CRcvQueue::removeListener(const CUDT* u)
+void srt::CRcvQueue::removeListener(const CUDT* u)
 {
     ScopedLock lslock(m_LSLock);
 
@@ -1695,7 +1695,7 @@ void CRcvQueue::removeListener(const CUDT* u)
         m_pListener = NULL;
 }
 
-void CRcvQueue::registerConnector(const SRTSOCKET&                id,
+void srt::CRcvQueue::registerConnector(const SRTSOCKET&                id,
                                   CUDT*                           u,
                                   const sockaddr_any&             addr,
                                   const steady_clock::time_point& ttl)
@@ -1705,7 +1705,7 @@ void CRcvQueue::registerConnector(const SRTSOCKET&                id,
     m_pRendezvousQueue->insert(id, u, addr, ttl);
 }
 
-void CRcvQueue::removeConnector(const SRTSOCKET& id)
+void srt::CRcvQueue::removeConnector(const SRTSOCKET& id)
 {
     HLOGC(cnlog.Debug, log << "removeConnector: removing @" << id);
     m_pRendezvousQueue->remove(id);
@@ -1727,19 +1727,19 @@ void CRcvQueue::removeConnector(const SRTSOCKET& id)
     }
 }
 
-void CRcvQueue::setNewEntry(CUDT* u)
+void srt::CRcvQueue::setNewEntry(CUDT* u)
 {
     HLOGC(cnlog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
     ScopedLock listguard(m_IDLock);
     m_vNewEntry.push_back(u);
 }
 
-bool CRcvQueue::ifNewEntry()
+bool srt::CRcvQueue::ifNewEntry()
 {
     return !(m_vNewEntry.empty());
 }
 
-CUDT* CRcvQueue::getNewEntry()
+srt::CUDT* srt::CRcvQueue::getNewEntry()
 {
     ScopedLock listguard(m_IDLock);
 
@@ -1752,7 +1752,7 @@ CUDT* CRcvQueue::getNewEntry()
     return u;
 }
 
-void CRcvQueue::storePkt(int32_t id, CPacket* pkt)
+void srt::CRcvQueue::storePkt(int32_t id, CPacket* pkt)
 {
     UniqueLock bufferlock(m_BufferLock);
     CSync      passcond(m_BufferCond, bufferlock);
@@ -1774,7 +1774,7 @@ void CRcvQueue::storePkt(int32_t id, CPacket* pkt)
     }
 }
 
-void CMultiplexer::destroy()
+void srt::CMultiplexer::destroy()
 {
     // Reverse order of the assigned
     delete m_pRcvQueue;

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -63,8 +63,10 @@ modified by
 #include <queue>
 #include <vector>
 
-class CUDT;
+namespace srt
+{
 class CChannel;
+class CUDT;
 
 struct CUnit
 {
@@ -92,7 +94,6 @@ public: // Storage size operations
         /// @param [in] mss maximum segment size
         /// @param [in] version IP version
         /// @return 0: success, -1: failure.
-
     int init(int size, int mss, int version);
 
     /// Increase (double) the unit queue size.
@@ -112,7 +113,6 @@ public:
 public: // Operations on units
         /// find an available unit for incoming packet.
         /// @return Pointer to the available unit, NULL if not found.
-
     CUnit* getNextAvailUnit();
 
     void makeUnitFree(CUnit* unit);
@@ -149,8 +149,8 @@ private:
 
 struct CSNode
 {
-    CUDT*                               m_pUDT; // Pointer to the instance of CUDT socket
-    srt::sync::steady_clock::time_point m_tsTimeStamp;
+    CUDT*                          m_pUDT; // Pointer to the instance of CUDT socket
+    sync::steady_clock::time_point m_tsTimeStamp;
 
     int m_iHeapLoc; // location on the heap, -1 means not on the heap
 };
@@ -193,7 +193,7 @@ public:
     /// Retrieve the next scheduled processing time.
     /// @return Scheduled processing time of the first UDT socket in the list.
 
-    srt::sync::steady_clock::time_point getNextProcTime();
+    sync::steady_clock::time_point getNextProcTime();
 
 private:
     /// Doubles the size of the list.
@@ -204,14 +204,14 @@ private:
     ///
     /// @param [in] ts time stamp: next processing time
     /// @param [in] u pointer to the UDT instance
-    void insert_(const srt::sync::steady_clock::time_point& ts, const CUDT* u);
+    void insert_(const sync::steady_clock::time_point& ts, const CUDT* u);
 
     /// Insert a new UDT instance into the list without realloc.
     /// Should be called if there is a gauranteed space for the element.
     ///
     /// @param [in] ts time stamp: next processing time
     /// @param [in] u pointer to the UDT instance
-    void insert_norealloc_(const srt::sync::steady_clock::time_point& ts, const CUDT* u);
+    void insert_norealloc_(const sync::steady_clock::time_point& ts, const CUDT* u);
 
     void remove_(const CUDT* u);
 
@@ -220,12 +220,12 @@ private:
     int      m_iArrayLength; // physical length of the array
     int      m_iLastEntry;   // position of last entry on the heap array
 
-    srt::sync::Mutex m_ListLock;
+    sync::Mutex m_ListLock;
 
-    srt::sync::Mutex*     m_pWindowLock;
-    srt::sync::Condition* m_pWindowCond;
+    sync::Mutex*     m_pWindowLock;
+    sync::Condition* m_pWindowCond;
 
-    srt::sync::CTimer* m_pTimer;
+    sync::CTimer* m_pTimer;
 
 private:
     CSndUList(const CSndUList&);
@@ -234,8 +234,8 @@ private:
 
 struct CRNode
 {
-    CUDT*                               m_pUDT;        // Pointer to the instance of CUDT socket
-    srt::sync::steady_clock::time_point m_tsTimeStamp; // Time Stamp
+    CUDT*                          m_pUDT;        // Pointer to the instance of CUDT socket
+    sync::steady_clock::time_point m_tsTimeStamp; // Time Stamp
 
     CRNode* m_pPrev; // previous link
     CRNode* m_pNext; // next link
@@ -401,7 +401,7 @@ private:
     };
     std::list<CRL> m_lRendezvousID; // The sockets currently in rendezvous mode
 
-    mutable srt::sync::Mutex m_RIDListLock;
+    mutable sync::Mutex m_RIDListLock;
 };
 
 class CSndQueue
@@ -514,7 +514,7 @@ public:
     /// @param [in] c UDP channel to be associated to the queue
     /// @param [in] t timer
 
-    void init(int size, size_t payload, int version, int hsize, CChannel* c, srt::sync::CTimer* t);
+    void init(int size, size_t payload, int version, int hsize, CChannel* c, sync::CTimer* t);
 
     /// Read a packet for a specific UDT socket id.
     /// @param [in] id Socket ID
@@ -528,8 +528,8 @@ public:
     void setClosing() { m_bClosing = true; }
 
 private:
-    static void*       worker(void* param);
-    srt::sync::CThread m_WorkerThread;
+    static void*  worker(void* param);
+    sync::CThread m_WorkerThread;
     // Subroutines of worker
     EReadStatus    worker_RetrieveUnit(int32_t& id, CUnit*& unit, sockaddr_any& sa);
     EConnectStatus worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& sa);
@@ -537,11 +537,11 @@ private:
     EConnectStatus worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& sa);
 
 private:
-    CUnitQueue         m_UnitQueue; // The received packet queue
-    CRcvUList*         m_pRcvUList; // List of UDT instances that will read packets from the queue
-    CHash*             m_pHash;     // Hash table for UDT socket looking up
-    CChannel*          m_pChannel;  // UDP channel for receving packets
-    srt::sync::CTimer* m_pTimer;    // shared timer with the snd queue
+    CUnitQueue    m_UnitQueue; // The received packet queue
+    CRcvUList*    m_pRcvUList; // List of UDT instances that will read packets from the queue
+    CHash*        m_pHash;     // Hash table for UDT socket looking up
+    CChannel*     m_pChannel;  // UDP channel for receving packets
+    sync::CTimer* m_pTimer;    // shared timer with the snd queue
 
     size_t m_szPayloadSize; // packet payload size
 
@@ -554,10 +554,10 @@ private:
     int  setListener(CUDT* u);
     void removeListener(const CUDT* u);
 
-    void registerConnector(const SRTSOCKET&                           id,
-                           CUDT*                                      u,
-                           const sockaddr_any&                        addr,
-                           const srt::sync::steady_clock::time_point& ttl);
+    void registerConnector(const SRTSOCKET&                      id,
+                           CUDT*                                 u,
+                           const sockaddr_any&                   addr,
+                           const sync::steady_clock::time_point& ttl);
     void removeConnector(const SRTSOCKET& id);
 
     void  setNewEntry(CUDT* u);
@@ -567,16 +567,16 @@ private:
     void storePkt(int32_t id, CPacket* pkt);
 
 private:
-    srt::sync::Mutex  m_LSLock;
+    sync::Mutex       m_LSLock;
     CUDT*             m_pListener;        // pointer to the (unique, if any) listening UDT entity
     CRendezvousQueue* m_pRendezvousQueue; // The list of sockets in rendezvous mode
 
     std::vector<CUDT*> m_vNewEntry; // newly added entries, to be inserted
-    srt::sync::Mutex   m_IDLock;
+    sync::Mutex        m_IDLock;
 
     std::map<int32_t, std::queue<CPacket*> > m_mBuffer; // temporary buffer for rendezvous connection request
-    srt::sync::Mutex                         m_BufferLock;
-    srt::sync::Condition                     m_BufferCond;
+    sync::Mutex                              m_BufferLock;
+    sync::Condition                          m_BufferCond;
 
 private:
     CRcvQueue(const CRcvQueue&);
@@ -585,10 +585,10 @@ private:
 
 struct CMultiplexer
 {
-    CSndQueue*         m_pSndQueue; // The sending queue
-    CRcvQueue*         m_pRcvQueue; // The receiving queue
-    CChannel*          m_pChannel;  // The UDP channel for sending and receiving
-    srt::sync::CTimer* m_pTimer;    // The timer
+    CSndQueue*    m_pSndQueue; // The sending queue
+    CRcvQueue*    m_pRcvQueue; // The receiving queue
+    CChannel*     m_pChannel;  // The UDP channel for sending and receiving
+    sync::CTimer* m_pTimer;    // The timer
 
     int m_iPort;      // The UDP port number of this multiplexer
     int m_iIPversion; // Address family (AF_INET or AF_INET6)
@@ -610,5 +610,7 @@ struct CMultiplexer
 
     void destroy();
 };
+
+} // namespace srt
 
 #endif

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -50,7 +50,6 @@ modified by
    Haivision Systems Inc.
 *****************************************************************************/
 
-
 #ifndef INC_SRT_QUEUE_H
 #define INC_SRT_QUEUE_H
 
@@ -69,255 +68,257 @@ class CChannel;
 
 struct CUnit
 {
-   CPacket m_Packet;		// packet
-   enum Flag { FREE = 0, GOOD = 1, PASSACK = 2, DROPPED = 3 };
-   Flag m_iFlag;			// 0: free, 1: occupied, 2: msg read but not freed (out-of-order), 3: msg dropped
+    CPacket m_Packet; // packet
+    enum Flag
+    {
+        FREE    = 0,
+        GOOD    = 1,
+        PASSACK = 2,
+        DROPPED = 3
+    };
+    Flag m_iFlag; // 0: free, 1: occupied, 2: msg read but not freed (out-of-order), 3: msg dropped
 };
 
 class CUnitQueue
 {
 
 public:
+    CUnitQueue();
+    ~CUnitQueue();
 
-   CUnitQueue();
-   ~CUnitQueue();
+public: // Storage size operations
+        /// Initialize the unit queue.
+        /// @param [in] size queue size
+        /// @param [in] mss maximum segment size
+        /// @param [in] version IP version
+        /// @return 0: success, -1: failure.
 
-public:     // Storage size operations
+    int init(int size, int mss, int version);
 
-      /// Initialize the unit queue.
-      /// @param [in] size queue size
-      /// @param [in] mss maximum segment size
-      /// @param [in] version IP version
-      /// @return 0: success, -1: failure.
+    /// Increase (double) the unit queue size.
+    /// @return 0: success, -1: failure.
 
-   int init(int size, int mss, int version);
+    int increase();
 
-      /// Increase (double) the unit queue size.
-      /// @return 0: success, -1: failure.
+    /// Decrease (halve) the unit queue size.
+    /// @return 0: success, -1: failure.
 
-   int increase();
-
-      /// Decrease (halve) the unit queue size.
-      /// @return 0: success, -1: failure.
-
-   int shrink();
+    int shrink();
 
 public:
-   int size() const     { return m_iSize - m_iCount; }
-   int capacity() const { return m_iSize; }
+    int size() const { return m_iSize - m_iCount; }
+    int capacity() const { return m_iSize; }
 
-public:     // Operations on units
+public: // Operations on units
+        /// find an available unit for incoming packet.
+        /// @return Pointer to the available unit, NULL if not found.
 
-      /// find an available unit for incoming packet.
-      /// @return Pointer to the available unit, NULL if not found.
+    CUnit* getNextAvailUnit();
 
-   CUnit* getNextAvailUnit();
+    void makeUnitFree(CUnit* unit);
 
-   void makeUnitFree(CUnit * unit);
-
-   void makeUnitGood(CUnit * unit);
+    void makeUnitGood(CUnit* unit);
 
 public:
-   inline int getIPversion() const { return m_iIPversion; }
+    inline int getIPversion() const { return m_iIPversion; }
 
 private:
-   struct CQEntry
-   {
-      CUnit* m_pUnit;   // unit queue
-      char* m_pBuffer;  // data buffer
-      int m_iSize;      // size of each queue
+    struct CQEntry
+    {
+        CUnit* m_pUnit;   // unit queue
+        char*  m_pBuffer; // data buffer
+        int    m_iSize;   // size of each queue
 
-      CQEntry* m_pNext;
-   }
-   *m_pQEntry,          // pointer to the first unit queue
-   *m_pCurrQueue,       // pointer to the current available queue
-   *m_pLastQueue;       // pointer to the last unit queue
+        CQEntry* m_pNext;
+    } * m_pQEntry,     // pointer to the first unit queue
+        *m_pCurrQueue, // pointer to the current available queue
+        *m_pLastQueue; // pointer to the last unit queue
 
-   CUnit* m_pAvailUnit; // recent available unit
+    CUnit* m_pAvailUnit; // recent available unit
 
-   int m_iSize;         // total size of the unit queue, in number of packets
-   int m_iCount;        // total number of valid (occupied) packets in the queue
+    int m_iSize;  // total size of the unit queue, in number of packets
+    int m_iCount; // total number of valid (occupied) packets in the queue
 
-   int m_iMSS;          // unit buffer size
-   int m_iIPversion;    // IP version
+    int m_iMSS;       // unit buffer size
+    int m_iIPversion; // IP version
 
 private:
-   CUnitQueue(const CUnitQueue&);
-   CUnitQueue& operator=(const CUnitQueue&);
+    CUnitQueue(const CUnitQueue&);
+    CUnitQueue& operator=(const CUnitQueue&);
 };
 
 struct CSNode
 {
-   CUDT* m_pUDT;		// Pointer to the instance of CUDT socket
-   srt::sync::steady_clock::time_point m_tsTimeStamp;
+    CUDT*                               m_pUDT; // Pointer to the instance of CUDT socket
+    srt::sync::steady_clock::time_point m_tsTimeStamp;
 
-   int m_iHeapLoc;		// location on the heap, -1 means not on the heap
+    int m_iHeapLoc; // location on the heap, -1 means not on the heap
 };
 
 class CSndUList
 {
-friend class CSndQueue;
+    friend class CSndQueue;
 
 public:
-   CSndUList();
-   ~CSndUList();
+    CSndUList();
+    ~CSndUList();
 
 public:
+    enum EReschedule
+    {
+        DONT_RESCHEDULE = 0,
+        DO_RESCHEDULE   = 1
+    };
 
-   enum EReschedule { DONT_RESCHEDULE = 0, DO_RESCHEDULE = 1 };
+    static EReschedule rescheduleIf(bool cond) { return cond ? DO_RESCHEDULE : DONT_RESCHEDULE; }
 
-   static EReschedule rescheduleIf(bool cond) { return cond ? DO_RESCHEDULE : DONT_RESCHEDULE; }
+    /// Update the timestamp of the UDT instance on the list.
+    /// @param [in] u pointer to the UDT instance
+    /// @param [in] reschedule if the timestamp should be rescheduled
 
-      /// Update the timestamp of the UDT instance on the list.
-      /// @param [in] u pointer to the UDT instance
-      /// @param [in] reschedule if the timestamp should be rescheduled
+    void update(const CUDT* u, EReschedule reschedule);
 
-   void update(const CUDT* u, EReschedule reschedule);
+    /// Retrieve the next packet and peer address from the first entry, and reschedule it in the queue.
+    /// @param [out] addr destination address of the next packet
+    /// @param [out] pkt the next packet to be sent
+    /// @return 1 if successfully retrieved, -1 if no packet found.
 
-      /// Retrieve the next packet and peer address from the first entry, and reschedule it in the queue.
-      /// @param [out] addr destination address of the next packet
-      /// @param [out] pkt the next packet to be sent
-      /// @return 1 if successfully retrieved, -1 if no packet found.
+    int pop(sockaddr_any& addr, CPacket& pkt);
 
-   int pop(sockaddr_any& addr, CPacket& pkt);
+    /// Remove UDT instance from the list.
+    /// @param [in] u pointer to the UDT instance
 
-      /// Remove UDT instance from the list.
-      /// @param [in] u pointer to the UDT instance
+    void remove(const CUDT* u);
 
-   void remove(const CUDT* u);
+    /// Retrieve the next scheduled processing time.
+    /// @return Scheduled processing time of the first UDT socket in the list.
 
-      /// Retrieve the next scheduled processing time.
-      /// @return Scheduled processing time of the first UDT socket in the list.
-
-   srt::sync::steady_clock::time_point getNextProcTime();
-
-private:
-
-   /// Doubles the size of the list.
-   ///
-   void realloc_();
-
-   /// Insert a new UDT instance into the list with realloc if required.
-   ///
-   /// @param [in] ts time stamp: next processing time
-   /// @param [in] u pointer to the UDT instance
-   void insert_(const srt::sync::steady_clock::time_point &ts, const CUDT* u);
-
-   /// Insert a new UDT instance into the list without realloc.
-   /// Should be called if there is a gauranteed space for the element.
-   ///
-   /// @param [in] ts time stamp: next processing time
-   /// @param [in] u pointer to the UDT instance
-   void insert_norealloc_(const srt::sync::steady_clock::time_point &ts, const CUDT* u);
-
-   void remove_(const CUDT* u);
+    srt::sync::steady_clock::time_point getNextProcTime();
 
 private:
-   CSNode** m_pHeap;			// The heap array
-   int m_iArrayLength;			// physical length of the array
-   int m_iLastEntry;			// position of last entry on the heap array
+    /// Doubles the size of the list.
+    ///
+    void realloc_();
 
-   srt::sync::Mutex m_ListLock;
+    /// Insert a new UDT instance into the list with realloc if required.
+    ///
+    /// @param [in] ts time stamp: next processing time
+    /// @param [in] u pointer to the UDT instance
+    void insert_(const srt::sync::steady_clock::time_point& ts, const CUDT* u);
 
-   srt::sync::Mutex* m_pWindowLock;
-   srt::sync::Condition* m_pWindowCond;
+    /// Insert a new UDT instance into the list without realloc.
+    /// Should be called if there is a gauranteed space for the element.
+    ///
+    /// @param [in] ts time stamp: next processing time
+    /// @param [in] u pointer to the UDT instance
+    void insert_norealloc_(const srt::sync::steady_clock::time_point& ts, const CUDT* u);
 
-   srt::sync::CTimer* m_pTimer;
+    void remove_(const CUDT* u);
 
 private:
-   CSndUList(const CSndUList&);
-   CSndUList& operator=(const CSndUList&);
+    CSNode** m_pHeap;        // The heap array
+    int      m_iArrayLength; // physical length of the array
+    int      m_iLastEntry;   // position of last entry on the heap array
+
+    srt::sync::Mutex m_ListLock;
+
+    srt::sync::Mutex*     m_pWindowLock;
+    srt::sync::Condition* m_pWindowCond;
+
+    srt::sync::CTimer* m_pTimer;
+
+private:
+    CSndUList(const CSndUList&);
+    CSndUList& operator=(const CSndUList&);
 };
 
 struct CRNode
 {
-   CUDT* m_pUDT;                // Pointer to the instance of CUDT socket
-   srt::sync::steady_clock::time_point m_tsTimeStamp;      // Time Stamp
+    CUDT*                               m_pUDT;        // Pointer to the instance of CUDT socket
+    srt::sync::steady_clock::time_point m_tsTimeStamp; // Time Stamp
 
-   CRNode* m_pPrev;             // previous link
-   CRNode* m_pNext;             // next link
+    CRNode* m_pPrev; // previous link
+    CRNode* m_pNext; // next link
 
-   bool m_bOnList;              // if the node is already on the list
+    bool m_bOnList; // if the node is already on the list
 };
 
 class CRcvUList
 {
 public:
-   CRcvUList();
-   ~CRcvUList();
+    CRcvUList();
+    ~CRcvUList();
 
 public:
+    /// Insert a new UDT instance to the list.
+    /// @param [in] u pointer to the UDT instance
 
-      /// Insert a new UDT instance to the list.
-      /// @param [in] u pointer to the UDT instance
+    void insert(const CUDT* u);
 
-   void insert(const CUDT* u);
+    /// Remove the UDT instance from the list.
+    /// @param [in] u pointer to the UDT instance
 
-      /// Remove the UDT instance from the list.
-      /// @param [in] u pointer to the UDT instance
+    void remove(const CUDT* u);
 
-   void remove(const CUDT* u);
+    /// Move the UDT instance to the end of the list, if it already exists; otherwise, do nothing.
+    /// @param [in] u pointer to the UDT instance
 
-      /// Move the UDT instance to the end of the list, if it already exists; otherwise, do nothing.
-      /// @param [in] u pointer to the UDT instance
-
-   void update(const CUDT* u);
+    void update(const CUDT* u);
 
 public:
-   CRNode* m_pUList;		// the head node
+    CRNode* m_pUList; // the head node
 
 private:
-   CRNode* m_pLast;		// the last node
+    CRNode* m_pLast; // the last node
 
 private:
-   CRcvUList(const CRcvUList&);
-   CRcvUList& operator=(const CRcvUList&);
+    CRcvUList(const CRcvUList&);
+    CRcvUList& operator=(const CRcvUList&);
 };
 
 class CHash
 {
 public:
-   CHash();
-   ~CHash();
+    CHash();
+    ~CHash();
 
 public:
+    /// Initialize the hash table.
+    /// @param [in] size hash table size
 
-      /// Initialize the hash table.
-      /// @param [in] size hash table size
+    void init(int size);
 
-   void init(int size);
+    /// Look for a UDT instance from the hash table.
+    /// @param [in] id socket ID
+    /// @return Pointer to a UDT instance, or NULL if not found.
 
-      /// Look for a UDT instance from the hash table.
-      /// @param [in] id socket ID
-      /// @return Pointer to a UDT instance, or NULL if not found.
+    CUDT* lookup(int32_t id);
 
-   CUDT* lookup(int32_t id);
+    /// Insert an entry to the hash table.
+    /// @param [in] id socket ID
+    /// @param [in] u pointer to the UDT instance
 
-      /// Insert an entry to the hash table.
-      /// @param [in] id socket ID
-      /// @param [in] u pointer to the UDT instance
+    void insert(int32_t id, CUDT* u);
 
-   void insert(int32_t id, CUDT* u);
+    /// Remove an entry from the hash table.
+    /// @param [in] id socket ID
 
-      /// Remove an entry from the hash table.
-      /// @param [in] id socket ID
-
-   void remove(int32_t id);
-
-private:
-   struct CBucket
-   {
-      int32_t m_iID;		// Socket ID
-      CUDT* m_pUDT;		// Socket instance
-
-      CBucket* m_pNext;		// next bucket
-   } **m_pBucket;		// list of buckets (the hash table)
-
-   int m_iHashSize;		// size of hash table
+    void remove(int32_t id);
 
 private:
-   CHash(const CHash&);
-   CHash& operator=(const CHash&);
+    struct CBucket
+    {
+        int32_t m_iID;  // Socket ID
+        CUDT*   m_pUDT; // Socket instance
+
+        CBucket* m_pNext; // next bucket
+    } * *m_pBucket;       // list of buckets (the hash table)
+
+    int m_iHashSize; // size of hash table
+
+private:
+    CHash(const CHash&);
+    CHash& operator=(const CHash&);
 };
 
 /// @brief A queue of sockets pending for connection.
@@ -336,8 +337,7 @@ public:
     /// @param u pointer to a corresponding CUDT instance.
     /// @param addr remote address to connect to.
     /// @param ttl timepoint for connection attempt to expire.
-    void insert(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr,
-                const srt::sync::steady_clock::time_point &ttl);
+    void insert(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const srt::sync::steady_clock::time_point& ttl);
 
     /// @brief Remove a socket from the connection pending list.
     /// @param id socket ID.
@@ -359,257 +359,256 @@ public:
 private:
     struct LinkStatusInfo
     {
-        CUDT* u;
-        SRTSOCKET id;
-        int errorcode;
+        CUDT*        u;
+        SRTSOCKET    id;
+        int          errorcode;
         sockaddr_any peeraddr;
-        int token;
+        int          token;
 
         struct HasID
         {
             SRTSOCKET id;
-            HasID(SRTSOCKET p) : id(p) {}
-            bool operator()(const LinkStatusInfo& i)
+            HasID(SRTSOCKET p)
+                : id(p)
             {
-                return i.id == id;
             }
+            bool operator()(const LinkStatusInfo& i) { return i.id == id; }
         };
     };
 
     /// @brief Qualify pending connections:
     /// - Sockets with expired TTL go to the 'to_remove' list and removed from the queue straight away.
     /// - If HS request is to be resent (resend 250 ms if no response from the peer) go to the 'to_process' list.
-    /// 
+    ///
     /// @param rst result of reading from a UDP socket: received packet / nothin read / read error.
     /// @param cst target status for pending connection: reject or proceed.
     /// @param iDstSockID destination socket ID of the received packet.
     /// @param[in,out] toRemove stores sockets with expired TTL.
     /// @param[in,out] toProcess stores sockets which should repeat (resend) HS connection request.
-    bool qualifyToHandle(EReadStatus rst, EConnectStatus cst, int iDstSockID,
-        std::vector<LinkStatusInfo>& toRemove, std::vector<LinkStatusInfo>& toProcess);
+    bool qualifyToHandle(EReadStatus                  rst,
+                         EConnectStatus               cst,
+                         int                          iDstSockID,
+                         std::vector<LinkStatusInfo>& toRemove,
+                         std::vector<LinkStatusInfo>& toProcess);
 
 private:
-   struct CRL
-   {
-      SRTSOCKET m_iID;        // SRT socket ID (self)
-      CUDT* m_pUDT;           // CUDT instance
-      sockaddr_any m_PeerAddr;// SRT sonnection peer address
-      srt::sync::steady_clock::time_point m_tsTTL;    // the time that this request expires
-   };
-   std::list<CRL> m_lRendezvousID;    // The sockets currently in rendezvous mode
+    struct CRL
+    {
+        SRTSOCKET                           m_iID;      // SRT socket ID (self)
+        CUDT*                               m_pUDT;     // CUDT instance
+        sockaddr_any                        m_PeerAddr; // SRT sonnection peer address
+        srt::sync::steady_clock::time_point m_tsTTL;    // the time that this request expires
+    };
+    std::list<CRL> m_lRendezvousID; // The sockets currently in rendezvous mode
 
-   mutable srt::sync::Mutex m_RIDListLock;
+    mutable srt::sync::Mutex m_RIDListLock;
 };
 
 class CSndQueue
 {
-friend class CUDT;
-friend class CUDTUnited;
+    friend class CUDT;
+    friend class CUDTUnited;
 
 public:
-   CSndQueue();
-   ~CSndQueue();
+    CSndQueue();
+    ~CSndQueue();
 
 public:
+    // XXX There's currently no way to access the socket ID set for
+    // whatever the queue is currently working for. Required to find
+    // some way to do this, possibly by having a "reverse pointer".
+    // Currently just "unimplemented".
+    std::string CONID() const { return ""; }
 
-   // XXX There's currently no way to access the socket ID set for
-   // whatever the queue is currently working for. Required to find
-   // some way to do this, possibly by having a "reverse pointer".
-   // Currently just "unimplemented".
-   std::string CONID() const { return ""; }
+    /// Initialize the sending queue.
+    /// @param [in] c UDP channel to be associated to the queue
+    /// @param [in] t Timer
 
-      /// Initialize the sending queue.
-      /// @param [in] c UDP channel to be associated to the queue
-      /// @param [in] t Timer
+    void init(CChannel* c, srt::sync::CTimer* t);
 
-   void init(CChannel* c, srt::sync::CTimer* t);
+    /// Send out a packet to a given address.
+    /// @param [in] addr destination address
+    /// @param [in] packet packet to be sent out
+    /// @return Size of data sent out.
 
-      /// Send out a packet to a given address.
-      /// @param [in] addr destination address
-      /// @param [in] packet packet to be sent out
-      /// @return Size of data sent out.
+    int sendto(const sockaddr_any& addr, CPacket& packet);
 
-   int sendto(const sockaddr_any& addr, CPacket& packet);
+    /// Get the IP TTL.
+    /// @param [in] ttl IP Time To Live.
+    /// @return TTL.
 
-      /// Get the IP TTL.
-      /// @param [in] ttl IP Time To Live.
-      /// @return TTL.
+    int getIpTTL() const;
 
-   int getIpTTL() const;
+    /// Get the IP Type of Service.
+    /// @return ToS.
 
-      /// Get the IP Type of Service.
-      /// @return ToS.
-
-   int getIpToS() const;
+    int getIpToS() const;
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-   bool getBind(char* dst, size_t len) const;
+    bool getBind(char* dst, size_t len) const;
 #endif
 
-   int ioctlQuery(int type) const;
-   int sockoptQuery(int level, int type) const;
+    int ioctlQuery(int type) const;
+    int sockoptQuery(int level, int type) const;
 
-   void setClosing()
-   {
-       m_bClosing = true;
-   }
+    void setClosing() { m_bClosing = true; }
 
 private:
-   static void* worker(void* param);
-   srt::sync::CThread m_WorkerThread;
+    static void*       worker(void* param);
+    srt::sync::CThread m_WorkerThread;
 
 private:
-   CSndUList* m_pSndUList;              // List of UDT instances for data sending
-   CChannel* m_pChannel;                // The UDP channel for data sending
-   srt::sync::CTimer* m_pTimer;         // Timing facility
+    CSndUList*         m_pSndUList; // List of UDT instances for data sending
+    CChannel*          m_pChannel;  // The UDP channel for data sending
+    srt::sync::CTimer* m_pTimer;    // Timing facility
 
-   srt::sync::Mutex m_WindowLock;
-   srt::sync::Condition m_WindowCond;
+    srt::sync::Mutex     m_WindowLock;
+    srt::sync::Condition m_WindowCond;
 
-   volatile bool m_bClosing;            // closing the worker
+    volatile bool m_bClosing; // closing the worker
 
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)//>>debug high freq worker
-   uint64_t m_ullDbgPeriod;
-   uint64_t m_ullDbgTime;
-   struct {
+#if defined(SRT_DEBUG_SNDQ_HIGHRATE) //>>debug high freq worker
+    uint64_t m_ullDbgPeriod;
+    uint64_t m_ullDbgTime;
+    struct
+    {
         unsigned long lIteration;   //
-        unsigned long lSleepTo;     //SleepTo
-        unsigned long lNotReadyPop; //Continue
+        unsigned long lSleepTo;     // SleepTo
+        unsigned long lNotReadyPop; // Continue
         unsigned long lSendTo;
-        unsigned long lNotReadyTs;  
-        unsigned long lCondWait;    //block on m_WindowCond
-   } m_WorkerStats;
+        unsigned long lNotReadyTs;
+        unsigned long lCondWait; // block on m_WindowCond
+    } m_WorkerStats;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
 #if ENABLE_LOGGING
-   static int m_counter;
+    static int m_counter;
 #endif
 
 private:
-   CSndQueue(const CSndQueue&);
-   CSndQueue& operator=(const CSndQueue&);
+    CSndQueue(const CSndQueue&);
+    CSndQueue& operator=(const CSndQueue&);
 };
 
 class CRcvQueue
 {
-friend class CUDT;
-friend class CUDTUnited;
+    friend class CUDT;
+    friend class CUDTUnited;
 
 public:
-   CRcvQueue();
-   ~CRcvQueue();
+    CRcvQueue();
+    ~CRcvQueue();
 
 public:
+    // XXX There's currently no way to access the socket ID set for
+    // whatever the queue is currently working. Required to find
+    // some way to do this, possibly by having a "reverse pointer".
+    // Currently just "unimplemented".
+    std::string CONID() const { return ""; }
 
-   // XXX There's currently no way to access the socket ID set for
-   // whatever the queue is currently working. Required to find
-   // some way to do this, possibly by having a "reverse pointer".
-   // Currently just "unimplemented".
-   std::string CONID() const { return ""; }
+    /// Initialize the receiving queue.
+    /// @param [in] size queue size
+    /// @param [in] mss maximum packet size
+    /// @param [in] version IP version
+    /// @param [in] hsize hash table size
+    /// @param [in] c UDP channel to be associated to the queue
+    /// @param [in] t timer
 
-      /// Initialize the receiving queue.
-      /// @param [in] size queue size
-      /// @param [in] mss maximum packet size
-      /// @param [in] version IP version
-      /// @param [in] hsize hash table size
-      /// @param [in] c UDP channel to be associated to the queue
-      /// @param [in] t timer
+    void init(int size, size_t payload, int version, int hsize, CChannel* c, srt::sync::CTimer* t);
 
-   void init(int size, size_t payload, int version, int hsize, CChannel* c, srt::sync::CTimer* t);
+    /// Read a packet for a specific UDT socket id.
+    /// @param [in] id Socket ID
+    /// @param [out] packet received packet
+    /// @return Data size of the packet
 
-      /// Read a packet for a specific UDT socket id.
-      /// @param [in] id Socket ID
-      /// @param [out] packet received packet
-      /// @return Data size of the packet
+    int recvfrom(int32_t id, CPacket& to_packet);
 
-   int recvfrom(int32_t id, CPacket& to_packet);
+    void stopWorker();
 
-   void stopWorker();
-
-   void setClosing()
-   {
-       m_bClosing = true;
-   }
+    void setClosing() { m_bClosing = true; }
 
 private:
-   static void* worker(void* param);
-   srt::sync::CThread m_WorkerThread;
-   // Subroutines of worker
-   EReadStatus worker_RetrieveUnit(int32_t& id, CUnit*& unit, sockaddr_any& sa);
-   EConnectStatus worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& sa);
-   EConnectStatus worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& sa);
-   EConnectStatus worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& sa);
+    static void*       worker(void* param);
+    srt::sync::CThread m_WorkerThread;
+    // Subroutines of worker
+    EReadStatus    worker_RetrieveUnit(int32_t& id, CUnit*& unit, sockaddr_any& sa);
+    EConnectStatus worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& sa);
+    EConnectStatus worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& sa);
+    EConnectStatus worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& sa);
 
 private:
-   CUnitQueue m_UnitQueue;      // The received packet queue
-   CRcvUList* m_pRcvUList;      // List of UDT instances that will read packets from the queue
-   CHash* m_pHash;              // Hash table for UDT socket looking up
-   CChannel* m_pChannel;        // UDP channel for receving packets
-   srt::sync::CTimer* m_pTimer; // shared timer with the snd queue
+    CUnitQueue         m_UnitQueue; // The received packet queue
+    CRcvUList*         m_pRcvUList; // List of UDT instances that will read packets from the queue
+    CHash*             m_pHash;     // Hash table for UDT socket looking up
+    CChannel*          m_pChannel;  // UDP channel for receving packets
+    srt::sync::CTimer* m_pTimer;    // shared timer with the snd queue
 
-   size_t m_szPayloadSize;      // packet payload size
+    size_t m_szPayloadSize; // packet payload size
 
-   volatile bool m_bClosing;    // closing the worker
+    volatile bool m_bClosing; // closing the worker
 #if ENABLE_LOGGING
-   static int m_counter;
+    static int m_counter;
 #endif
 
 private:
-   int setListener(CUDT* u);
-   void removeListener(const CUDT* u);
+    int  setListener(CUDT* u);
+    void removeListener(const CUDT* u);
 
-   void registerConnector(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const srt::sync::steady_clock::time_point& ttl);
-   void removeConnector(const SRTSOCKET& id);
+    void registerConnector(const SRTSOCKET&                           id,
+                           CUDT*                                      u,
+                           const sockaddr_any&                        addr,
+                           const srt::sync::steady_clock::time_point& ttl);
+    void removeConnector(const SRTSOCKET& id);
 
-   void setNewEntry(CUDT* u);
-   bool ifNewEntry();
-   CUDT* getNewEntry();
+    void  setNewEntry(CUDT* u);
+    bool  ifNewEntry();
+    CUDT* getNewEntry();
 
-   void storePkt(int32_t id, CPacket* pkt);
-
-private:
-   srt::sync::Mutex m_LSLock;
-   CUDT* m_pListener;                                   // pointer to the (unique, if any) listening UDT entity
-   CRendezvousQueue* m_pRendezvousQueue;                // The list of sockets in rendezvous mode
-
-   std::vector<CUDT*> m_vNewEntry;                      // newly added entries, to be inserted
-   srt::sync::Mutex m_IDLock;
-
-   std::map<int32_t, std::queue<CPacket*> > m_mBuffer;	// temporary buffer for rendezvous connection request
-   srt::sync::Mutex m_BufferLock;
-   srt::sync::Condition m_BufferCond;
+    void storePkt(int32_t id, CPacket* pkt);
 
 private:
-   CRcvQueue(const CRcvQueue&);
-   CRcvQueue& operator=(const CRcvQueue&);
+    srt::sync::Mutex  m_LSLock;
+    CUDT*             m_pListener;        // pointer to the (unique, if any) listening UDT entity
+    CRendezvousQueue* m_pRendezvousQueue; // The list of sockets in rendezvous mode
+
+    std::vector<CUDT*> m_vNewEntry; // newly added entries, to be inserted
+    srt::sync::Mutex   m_IDLock;
+
+    std::map<int32_t, std::queue<CPacket*> > m_mBuffer; // temporary buffer for rendezvous connection request
+    srt::sync::Mutex                         m_BufferLock;
+    srt::sync::Condition                     m_BufferCond;
+
+private:
+    CRcvQueue(const CRcvQueue&);
+    CRcvQueue& operator=(const CRcvQueue&);
 };
 
 struct CMultiplexer
 {
-   CSndQueue* m_pSndQueue;  // The sending queue
-   CRcvQueue* m_pRcvQueue;  // The receiving queue
-   CChannel* m_pChannel;    // The UDP channel for sending and receiving
-   srt::sync::CTimer* m_pTimer;  // The timer
+    CSndQueue*         m_pSndQueue; // The sending queue
+    CRcvQueue*         m_pRcvQueue; // The receiving queue
+    CChannel*          m_pChannel;  // The UDP channel for sending and receiving
+    srt::sync::CTimer* m_pTimer;    // The timer
 
-   int m_iPort;         // The UDP port number of this multiplexer
-   int m_iIPversion;    // Address family (AF_INET or AF_INET6)
-   int m_iRefCount;     // number of UDT instances that are associated with this multiplexer
+    int m_iPort;      // The UDP port number of this multiplexer
+    int m_iIPversion; // Address family (AF_INET or AF_INET6)
+    int m_iRefCount;  // number of UDT instances that are associated with this multiplexer
 
-   CSrtMuxerConfig m_mcfg;
+    CSrtMuxerConfig m_mcfg;
 
-   int m_iID;           // multiplexer ID
+    int m_iID; // multiplexer ID
 
-   // Constructor should reset all pointers to NULL
-   // to prevent dangling pointer when checking for memory alloc fails
-   CMultiplexer()
-       : m_pSndQueue(NULL)
-       , m_pRcvQueue(NULL)
-       , m_pChannel(NULL)
-       , m_pTimer(NULL)
+    // Constructor should reset all pointers to NULL
+    // to prevent dangling pointer when checking for memory alloc fails
+    CMultiplexer()
+        : m_pSndQueue(NULL)
+        , m_pRcvQueue(NULL)
+        , m_pChannel(NULL)
+        , m_pTimer(NULL)
     {
     }
 
-   void destroy();
+    void destroy();
 };
 
 #endif

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -396,7 +396,7 @@ struct CSrtConfigSetter<SRTO_MSS>
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
         int ival = cast_optval<int>(optval, optlen);
-        if (ival < int(CPacket::UDP_HDR_SIZE + CHandShake::m_iContentSize))
+        if (ival < int(srt::CPacket::UDP_HDR_SIZE + CHandShake::m_iContentSize))
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         co.iMSS = ival;
@@ -435,7 +435,7 @@ struct CSrtConfigSetter<SRTO_SNDBUF>
         if (bs <= 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        co.iSndBufSize = bs / (co.iMSS - CPacket::UDP_HDR_SIZE);
+        co.iSndBufSize = bs / (co.iMSS - srt::CPacket::UDP_HDR_SIZE);
     }
 };
 
@@ -449,7 +449,7 @@ struct CSrtConfigSetter<SRTO_RCVBUF>
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
         // Mimimum recv buffer size is 32 packets
-        const int mssin_size = co.iMSS - CPacket::UDP_HDR_SIZE;
+        const int mssin_size = co.iMSS - srt::CPacket::UDP_HDR_SIZE;
 
         if (val > mssin_size * co.DEF_MIN_FLIGHT_PKT)
             co.iRcvBufSize = val / mssin_size;
@@ -937,8 +937,8 @@ struct CSrtConfigSetter<SRTO_PAYLOADSIZE>
             // This means that the filter might have been installed before,
             // and the fix to the maximum payload size was already applied.
             // This needs to be checked now.
-            SrtFilterConfig fc;
-            if (!ParseFilterConfig(co.sPacketFilterConfig.str(), fc))
+            srt::SrtFilterConfig fc;
+            if (!srt::ParseFilterConfig(co.sPacketFilterConfig.str(), fc))
             {
                 // Break silently. This should not happen
                 LOGC(aclog.Error, log << "SRTO_PAYLOADSIZE: IPE: failing filter configuration installed");
@@ -1128,9 +1128,9 @@ struct CSrtConfigSetter<SRTO_PACKETFILTER>
         using namespace srt_logging;
         std::string arg((const char*)optval, optlen);
         // Parse the configuration string prematurely
-        SrtFilterConfig fc;
-        PacketFilter::Factory* fax = 0;
-        if (!ParseFilterConfig(arg, (fc), (&fax)))
+        srt::SrtFilterConfig fc;
+        srt::PacketFilter::Factory* fax = 0;
+        if (!srt::ParseFilterConfig(arg, (fc), (&fax)))
         {
             LOGC(aclog.Error,
                     log << "SRTO_PACKETFILTER: Incorrect syntax. Use: FILTERTYPE[,KEY:VALUE...]. "

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -24,6 +24,7 @@ written by
 #include "utilities.h"
 
 using namespace std;
+using namespace srt;
 
 
 extern "C" {

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -249,7 +249,7 @@ namespace logging {
     using namespace srt_logging;
 }
 
-}
+} // namespace srt
 
 // Planned deprecated removal: rel1.6.0
 // There's also no portable way possible to enforce a deprecation

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -151,7 +151,7 @@ void CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeW
       r_probeWindow[k] = 1000;    //1 msec -> 1000 pkts/sec
 
    for (size_t i = 0; i < asize; ++ i)
-      r_bytesWindow[i] = CPacket::SRT_MAX_PAYLOAD_SIZE; //based on 1 pkt/sec set in r_pktWindow[i]
+      r_bytesWindow[i] = srt::CPacket::SRT_MAX_PAYLOAD_SIZE; //based on 1 pkt/sec set in r_pktWindow[i]
 }
 
 
@@ -188,7 +188,7 @@ int CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, cons
    // claculate speed, or return 0 if not enough valid value
    if (count > (asize >> 1))
    {
-      bytes += (CPacket::SRT_DATA_HDR_SIZE * count); //Add protocol headers to bytes received
+      bytes += (srt::CPacket::SRT_DATA_HDR_SIZE * count); //Add protocol headers to bytes received
       bytesps = (unsigned long)ceil(1000000.0 / (double(sum) / double(bytes)));
       return (int)ceil(1000000.0 / (sum / count));
    }

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -231,7 +231,7 @@ public:
    }
 
    /// Shortcut to test a packet for possible probe 1 or 2
-   void probeArrival(const CPacket& pkt, bool unordered)
+   void probeArrival(const srt::CPacket& pkt, bool unordered)
    {
        const int inorder16 = pkt.m_iSeqNo & PUMASK_SEQNO_PROBE;
 
@@ -252,7 +252,7 @@ public:
    }
 
    /// Record the arrival time of the first probing packet.
-   void probe1Arrival(const CPacket& pkt, bool unordered)
+   void probe1Arrival(const srt::CPacket& pkt, bool unordered)
    {
        if (unordered && pkt.m_iSeqNo == m_Probe1Sequence)
        {
@@ -269,7 +269,7 @@ public:
 
    /// Record the arrival time of the second probing packet and the interval between packet pairs.
 
-   void probe2Arrival(const CPacket& pkt)
+   void probe2Arrival(const srt::CPacket& pkt)
    {
        // Reject probes that don't refer to the very next packet
        // towards the one that was lately notified by probe1Arrival.
@@ -299,7 +299,7 @@ public:
        // record the probing packets interval
        // Adjust the time for what a complete packet would have take
        const int64_t timediff = srt::sync::count_microseconds(m_tsCurrArrTime - m_tsProbeTime);
-       const int64_t timediff_times_pl_size = timediff * CPacket::SRT_MAX_PAYLOAD_SIZE;
+       const int64_t timediff_times_pl_size = timediff * srt::CPacket::SRT_MAX_PAYLOAD_SIZE;
 
        // Let's take it simpler than it is coded here:
        // (stating that a packet has never zero size)

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -2,6 +2,8 @@
 #include "gtest/gtest.h"
 #include "buffer.h"
 
+using namespace srt;
+
 
 TEST(CRcvBuffer, Create)
 {

--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -13,6 +13,7 @@
 #include "api.h"
 
 using namespace std;
+using namespace srt;
 
 class TestFECRebuilding: public testing::Test
 {
@@ -91,16 +92,18 @@ protected:
     }
 };
 
-class TestMockCUDT
-{
-public:
-    CUDT* core;
-
-    bool checkApplyFilterConfig(const string& s)
+namespace srt {
+    class TestMockCUDT
     {
-        return core->checkApplyFilterConfig(s);
-    }
-};
+    public:
+        CUDT* core;
+
+        bool checkApplyFilterConfig(const string& s)
+        {
+            return core->checkApplyFilterConfig(s);
+        }
+    };
+}
 
 // The expected whole procedure of connection using FEC is
 // expected to:

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -2,6 +2,8 @@
 #include "common.h"
 #include "core.h"
 
+using namespace srt;
+
 
 const int32_t CSeqNo::m_iSeqNoTH;
 const int32_t CSeqNo::m_iMaxSeqNo;

--- a/test/test_unitqueue.cpp
+++ b/test/test_unitqueue.cpp
@@ -3,9 +3,8 @@
 #include "gtest/gtest.h"
 #include "queue.h"
 
-
 using namespace std;
-
+using namespace srt;
 
 /// Create CUnitQueue with queue size of 4 units.
 /// The size of 4 is chosen on purpose, because 

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -2903,7 +2903,7 @@ public:
         struct timeval tv;
         tv.tv_sec = 1;
         tv.tv_usec = 0;
-        if (::setsockopt(m_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0)
+        if (::setsockopt(m_sock, SOL_SOCKET, SO_RCVTIMEO, (const char*) &tv, sizeof(tv)) < 0)
             Error(SysError(), "Setting timeout for UDP");
     }
 


### PR DESCRIPTION
No behavior changes, only refactoring.
- Placed some classes in `srt` namespace: `CUDT`, `CUDTGroup`, `CUDTUnited`, `CUDTSocket`, `CChannel`, `CSndQueue`, `CRcvQueue`, etc. Addresses #1924.
- Applied clang-format on channel.h and cpp, queue.h and cpp as some related further work is expected.