### PR TITLE
[build] Improved Windows installer

### DIFF
--- a/scripts/win-installer/README.md
+++ b/scripts/win-installer/README.md
@@ -1,33 +1,123 @@
-## SRT Static Libraries Installer for Windows
+# SRT Static Libraries Installer for Windows
 
 This directory contains scripts to build a binary installer for
 libsrt on Windows systems for Visual Studio applications using SRT.
 
+## SRT developer: Building the libsrt installer
+
+### Prerequisites
+
+These first two steps need to be executed once only.
+
+- Prerequisite 1: Install OpenSSL for Windows, both 64 and 32 bits.
+  This can be done automatically by running the PowerShell script `install-openssl.ps1`.
+
+- Prerequisite 2: Install NSIS, the NullSoft Installation Scripting system.
+  This can be done automatically by running the PowerShell script `install-nsis.ps1`.
+
+### Building the libsrt installer
+
+To build the libsrt installer, simply run the PowerShell script `build-win-installer.ps1`.
+Running it without parameters, for instance launching it from the Windows Explorer, is
+sufficient to build the installer.
+
+Optional parameters:
+
+- `-Version name` :
+  Use the specified string as version number for libsrt. By default, if the
+  current commit has a tag, use that tag (initial "v" removed, for instance
+  `1.4.3`). Otherwise, the defaut version is a detailed version number (most
+  recent version, number of commits since then, short commit SHA, for instance
+  `1.4.3-32-g22cc924`). Use that option if necessary to specify some other
+  non-standard form of version string.
+  
+- `-NoPause` :
+  Do not wait for the user to press `<enter>` at end of execution. By default,
+  execute a `pause` instruction at the end of execution, which is useful
+  when the script was launched from Windows Explorer. Use that option when the
+  script is invoked from another PowerShell script.
+
+The installer is then available in the directory `installers`.
+
+The name of the installer is `libsrt-VERS.exe` where `VERS` is the SRT version number
+(see the `-Version` option).
+
+The installer shall then be published as a release asset in the `srt` repository
+on GitHub, either as `libsrt-VERS.exe` or `libsrt-VERS-win-installer.zip`.
+In the latter case, the archive shall contain `libsrt-VERS.exe`.
+
+## SRT user: Using the libsrt installer
+
+### Installing the SRT libraries
+
+To install the SRT libraries, simply run the `libsrt-VERS.exe` installer which is
+available in the [SRT release area](https://github.com/Haivision/srt/releases).
+
+After installing the libsrt binaries, an environment variable named `LIBSRT` is
+defined with the installation root (typically `C:\Program Files (x86)\libsrt`).
+
+If there is a need for automation, in a CI/CD pipeline for instance, the download
+of the latest `libsrt-VERS.exe` and its installation can be automated using the
+sample PowerShell script `install-libsrt.ps1` which is available in this directory.
+This script may be freely copied in the user's build environment.
+
+When run without parameters (for instance from the Windows explorer), this
+script downloads and installs the latest version of libsrt.
+
+Optional parameters:
+
+- `-Destination path` :
+  Specify a local directory where the libsrt package will be downloaded.
+  By default, use the `tmp` subdirectory from this script's directory.
+
+- `-ForceDownload` :
+  Force a download even if the package is already downloaded in the
+  destination path. Note that the latest version is always checked.
+  If a older package is already present but a newer one is available
+  online, the newer one is always downloaded, even without this option.
+
+- `-GitHubActions` :
+  When used in a GitHub Actions workflow, make sure that the `LIBSRT`
+  environment variable is propagated to subsequent jobs. In your GitHub
+  workflow, in the initial setup phase, use 
+  `script-dir\install-libsrt.ps1 -GitHubActions -NoPause`.
+
+- `-NoInstall` :
+  Do not install the package, only download it. By default, libsrt is installed.
+
+- `-NoPause` :
+  Do not wait for the user to press `<enter>` at end of execution. By default,
+  execute a `pause` instruction at the end of execution, which is useful
+  when the script was launched from Windows Explorer. Use that option when the
+  script is invoked from another PowerShell script.
+
 ### Building Windows applications with libsrt
 
-After installing the libsrt binary, an environment variable named `LIBSRT` is
-defined to the installation root (typically `C:\Program Files (x86)\libsrt`).
-
-In this directory, there is a Visual Studio property file named `libsrt.props`.
-Simply reference this property file in your Visual Studio project to use libsrt.
+In the SRT installation root directory (specified in environment variable `LIBSRT`),
+there is a Visual Studio property file named `libsrt.props`. Simply reference this
+property file in your Visual Studio project to use libsrt.
 
 You can also do that manually by editing the application project file (the XML
 file named with a `.vcxproj` extension). Add the following line just before
 the end of the file:
 
 ~~~
-  <Import Project="$(LIBSRT)\libsrt.props"/>
+<Import Project="$(LIBSRT)\libsrt.props"/>
 ~~~
 
-### Building the installer
+With this setup, just compile your application normally, either using the
+Visual Studio IDE or the MSBuild command line tool.
 
-The first two steps need to be executed once only. Only the last step needs
-to be repeated each time a new version of libsrt is available.
+## Files reference
 
-- Prerequisite 1: Install OpenSSL for Windows, both 64 and 32 bits.
-  This can be done automatically by running the PowerShell script `install-openssl.ps1`.
-- Prerequisite 2: Install NSIS, the NullSoft Installation Scripting system.
-  This can be done automatically by running the PowerShell script `install-nsis.ps1`.
-- Build the libsrt installer by running the PowerShell script `build-win-installer.ps1`.
+This directory contains the following files:
 
-The installer is then available in the directory `installers`.
+| File name               | Usage
+| ----------------------- | -----
+| build-win-installer.ps1 | PowerShell script to build the libsrt installer.
+| install-libsrt.ps1      | Sample PowerShell script to automatically install libsrt (for user's projects).
+| install-openssl.ps1     | PowerShell script to install OpenSSL (prerequisite to build the installer).
+| install-nsis.ps1        | PowerShell script to install NSIS (prerequisite to build the installer).
+| libsrt.nsi              | NSIS installation script (used to build the installer).
+| libsrt.props            | Visual Studio property files to use libsrt (embedded in the installer).
+| README.md               | This text file.

--- a/scripts/win-installer/build-win-installer.ps1
+++ b/scripts/win-installer/build-win-installer.ps1
@@ -200,6 +200,9 @@ if ($Missing -gt 0) {
 # Build the binary installer.
 #-----------------------------------------------------------------------------
 
+$InstallExe = "$OutDir\libsrt-$Version.exe"
+$InstallZip = "$OutDir\libsrt-$Version-win-installer.zip"
+
 Write-Output "Building installer ..."
 & $NSIS /V2 `
     /DVersion="$Version" `
@@ -208,5 +211,17 @@ Write-Output "Building installer ..."
     /DBuildRoot="$TmpDir" `
     /DRepoDir="$RepoDir" `
     "$ScriptDir\libsrt.nsi" 
+
+if (-not (Test-Path $InstallExe)) {
+    Exit-Script "**** Missing $InstallExe"
+}
+
+Write-Output "Building installer archive ..."
+Remove-Item -Force -ErrorAction SilentlyContinue $InstallZip
+Compress-Archive -Path $InstallExe -DestinationPath $InstallZip -CompressionLevel Optimal
+
+if (-not (Test-Path $InstallZip)) {
+    Exit-Script "**** Missing $InstallZip"
+}
 
 Exit-Script

--- a/scripts/win-installer/install-libsrt.ps1
+++ b/scripts/win-installer/install-libsrt.ps1
@@ -1,0 +1,131 @@
+﻿# SRT library download and install for Windows.
+# Copyright (c) 2021, Thierry Lelegard
+# All rights reserved.
+
+<#
+ .SYNOPSIS
+
+  Download and install the libsrt library for Windows. This script is
+  provided to automate the build of Windows applications using libsrt.
+
+ .PARAMETER Destination
+
+  Specify a local directory where the libsrt package will be downloaded.
+  By default, use "tmp" subdirectory from this script.
+
+ .PARAMETER ForceDownload
+
+  Force a download even if the package is already downloaded.
+
+ .PARAMETER GitHubActions
+
+  When used in a GitHub Actions workflow, make sure that the LIBSRT
+  environment variable is propagated to subsequent jobs.
+
+ .PARAMETER NoInstall
+
+  Do not install the package. By default, libsrt is installed.
+
+ .PARAMETER NoPause
+
+  Do not wait for the user to press <enter> at end of execution. By default,
+  execute a "pause" instruction at the end of execution, which is useful
+  when the script was run from Windows Explorer.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+param(
+    [string]$Destination = "",
+    [switch]$ForceDownload = $false,
+    [switch]$GitHubActions = $false,
+    [switch]$NoInstall = $false,
+    [switch]$NoPause = $false
+)
+
+Write-Output "libsrt download and installation procedure"
+
+# Default directory for downloaded products.
+if (-not $Destination) {
+    $Destination = "$PSScriptRoot\tmp"
+}
+
+# A function to exit this script.
+function Exit-Script([string]$Message = "")
+{
+    $Code = 0
+    if ($Message -ne "") {
+        Write-Output "ERROR: $Message"
+        $Code = 1
+    }
+    if (-not $NoPause) {
+        pause
+    }
+    exit $Code
+}
+
+# Without this, Invoke-WebRequest is awfully slow.
+$ProgressPreference = 'SilentlyContinue'
+
+# Get the URL of the latest libsrt installer.
+$URL = (Invoke-RestMethod "https://api.github.com/repos/Haivision/srt/releases?per_page=20" |
+        ForEach-Object { $_.assets } |
+        ForEach-Object { $_.browser_download_url } |
+        Select-String @("/libsrt-.*\.exe$", "/libsrt-.*-win-installer\.zip$") |
+        Select-Object -First 1)
+
+if (-not $URL) {
+    Exit-Script "Could not find a libsrt installer on GitHub"
+}
+if (-not ($URL -match "\.zip$") -and -not ($URL -match "\.exe$")) {
+    Exit-Script "Unexpected URL, not .exe, not .zip: $URL"
+}
+
+# Installer name and path.
+$InstName = (Split-Path -Leaf $URL)
+$InstPath = "$Destination\$InstName"
+
+# Create the directory for downloaded products when necessary.
+[void](New-Item -Path $Destination -ItemType Directory -Force)
+
+# Download installer
+if (-not $ForceDownload -and (Test-Path $InstPath)) {
+    Write-Output "$InstName already downloaded, use -ForceDownload to download again"
+}
+else {
+    Write-Output "Downloading $URL ..."
+    Invoke-WebRequest $URL.ToString() -UseBasicParsing -UserAgent Download -OutFile $InstPath
+    if (-not (Test-Path $InstPath)) {
+        Exit-Script "$URL download failed"
+    }
+}
+
+# If installer is an archive, expect an exe with same name inside.
+if ($InstName -match "\.zip$") {
+
+    # Expected installer name in archive.
+    $ZipName = $InstName
+    $ZipPath = $InstPath
+    $InstName = $ZipName -replace '-win-installer.zip','.exe'
+    $InstPath = "$Destination\$InstName"
+
+    # Extract the installer.
+    Remove-Item -Force $InstPath -ErrorAction SilentlyContinue
+    Write-Output "Expanding $ZipName ..."
+    Expand-Archive $ZipPath -DestinationPath $Destination
+    if (-not (Test-Path $InstPath)) {
+        Exit-Script "$InstName not found in $ZipName"
+    }
+}
+
+# Install libsrt
+if (-not $NoInstall) {
+    Write-Output "Installing $InstName"
+    Start-Process -FilePath $InstPath -ArgumentList @("/S") -Wait
+}
+
+# Propagate LIBSRT in next jobs for GitHub Actions.
+if ($GitHubActions -and (-not -not $env:GITHUB_ENV) -and (Test-Path $env:GITHUB_ENV)) {
+    $libsrt = [System.Environment]::GetEnvironmentVariable("LIBSRT","Machine")
+    Write-Output "LIBSRT=$libsrt" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+}
+
+Exit-Script


### PR DESCRIPTION
- More comprehensive README.

- Added a sample installation script for users to automate the download and
  installation of libsrt. Useful to automate user's CI/CD pipeline.

- Renamed typo in script name ("intaller").

- Updated build script to also produce the .zip archive as published with version 1.4.3.
  But note that binaries don't compress well (only 2% space) and publishing a .zip
  instead of the .exe does not provide much improvement anyway.