### PR TITLE
[core] FIX: Added check for NULL unit when passing to updateConnStatus

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3744,7 +3744,7 @@ EConnectStatus srt::CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NO
 
 bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
                                       EConnectStatus      cst,
-                                      const CPacket*      pResponse,
+                                      const CPacket*      pResponse /*[[nullable]]*/,
                                       const sockaddr_any& serv_addr)
 {
     // IMPORTANT!
@@ -3976,7 +3976,7 @@ EConnectStatus srt::CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatas
 }
 
 EConnectStatus srt::CUDT::processRendezvous(
-    const CPacket* pResponse, const sockaddr_any& serv_addr,
+    const CPacket* pResponse /*[[nullable]]*/, const sockaddr_any& serv_addr,
     EReadStatus rst, CPacket& w_reqpkt)
 {
     if (m_RdvState == CHandShake::RDV_CONNECTED)
@@ -4525,6 +4525,8 @@ EConnectStatus srt::CUDT::postConnect(const CPacket* pResponse, bool rendezvous,
             }
             return CONN_REJECT;
         }
+
+        // [[assert (pResponse != NULL)]];
 
         // NOTE: THIS function must be called before calling prepareConnectionObjects.
         // The reason why it's not part of prepareConnectionObjects is that the activities

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -475,12 +475,12 @@ private:
     /// @param response incoming handshake response packet to be interpreted
     /// @param serv_addr incoming packet's address
     /// @param rst Current read status to know if the HS packet was freshly received from the peer, or this is only a periodic update (RST_AGAIN)
-    SRT_ATR_NODISCARD EConnectStatus processRendezvous(const CPacket &response, const sockaddr_any& serv_addr, EReadStatus, CPacket& reqpkt);
+    SRT_ATR_NODISCARD EConnectStatus processRendezvous(const CPacket* response, const sockaddr_any& serv_addr, EReadStatus, CPacket& reqpkt);
     SRT_ATR_NODISCARD bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
-    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket& response, bool rendezvous, CUDTException* eout) ATR_NOEXCEPT;
+    SRT_ATR_NODISCARD EConnectStatus postConnect(const CPacket* response, bool rendezvous, CUDTException* eout) ATR_NOEXCEPT;
     SRT_ATR_NODISCARD bool applyResponseSettings() ATR_NOEXCEPT;
     SRT_ATR_NODISCARD EConnectStatus processAsyncConnectResponse(const CPacket& pkt) ATR_NOEXCEPT;
-    SRT_ATR_NODISCARD bool processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const CPacket& response, const sockaddr_any& serv_addr);
+    SRT_ATR_NODISCARD bool processAsyncConnectRequest(EReadStatus rst, EConnectStatus cst, const CPacket* response, const sockaddr_any& serv_addr);
     SRT_ATR_NODISCARD EConnectStatus craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatasize);
 
     void checkUpdateCryptoKeyLen(const char* loghdr, int32_t typefield);

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -354,7 +354,7 @@ public:
     /// @param rst result of reading from a UDP socket: received packet / nothin read / read error.
     /// @param cst target status for pending connection: reject or proceed.
     /// @param pktIn packet received from the UDP socket.
-    void updateConnStatus(EReadStatus rst, EConnectStatus cst, const CPacket& pktIn);
+    void updateConnStatus(EReadStatus rst, EConnectStatus cst, CUnit* unit);
 
 private:
     struct LinkStatusInfo


### PR DESCRIPTION
Fixes #2027

Fixed a problem: when `getNextAvailableUnit` returns NULL, the packet is read temporarily and dropped, as there's no possible storage where it could land. The problem is, however, that this packet's data were also necessary in some of the subprocedures in `updateConnStatus` and therefore it was being accessed (which was new towards UDT, and it's related to some bugfixes and additional data access necessity in case of HSv5).

The fix: the socket ID is pre-extracted (with fallback to 0 in case of lack of extracted unit) and wherever a packet is required to be accessed, a check for NULL is added, as well as a NULL pointer to a packet is now acceptable (replaced reference).