### PR TITLE
Updates for Android build script

### DIFF
--- a/scripts/build-android/build-android
+++ b/scripts/build-android/build-android
@@ -6,9 +6,11 @@ echo_help()
   echo "    -n    Specify NDK root path for the build."
   echo "    -a    Select target API level."
   echo "    -t    Select target architectures."
-  echo "          Android supports the following architectures: armeabi armeabi-v7a arm64-v8a x86 x86_64."
+  echo "          Android supports the following architectures: armeabi-v7a arm64-v8a x86 x86_64."
+  echo "    -e    Encryption library to be used. Possible options: openssl (default) mbedtls"
   echo "    -o    Select OpenSSL (1.1.1 series) version. E.g. 1.1.1h"
-  echo "    -s    Select a specific SRT tag. E.g. v1.4.3"
+  echo "    -m    Select Mbed TLS version. E.g. v2.26.0"
+  echo "    -s    Select SRT version. E.g. v1.4.3"
   echo
   echo "Example: ./build-android -n /home/username/Android/Sdk/ndk/21.4.7075529 -a 28 -t \"armeabi-v7a arm64-v8a x86 x86_64\" -o 1.1.1h -s v1.4.3"
   echo
@@ -17,11 +19,13 @@ echo_help()
 # Init optional command line vars
 NDK_ROOT=""
 API_LEVEL=28
-BUILD_TARGETS="armeabi armeabi-v7a arm64-v8a x86 x86_64"
+BUILD_TARGETS="armeabi-v7a arm64-v8a x86 x86_64"
 OPENSSL_VERSION=1.1.1h
 SRT_VERSION=""
+ENC_LIB=openssl
+MBEDTLS_VERSION=v2.26.0
 
-while getopts n:a:t:o:s: option
+while getopts n:a:t:o:s:e:m: option
 do
  case "${option}"
  in
@@ -30,6 +34,8 @@ do
  t) BUILD_TARGETS=${OPTARG};;
  o) OPENSSL_VERSION=${OPTARG};;
  s) SRT_VERSION=${OPTARG};;
+ e) ENC_LIB=${OPTARG};;
+ m) MBEDTLS_VERSION=${OPTARG};;
  *) twentytwo=${OPTARG};;
  esac
 done
@@ -49,7 +55,19 @@ fi
 # Determine the path of the executing script
 BASE_DIR=$(readlink -f $0 | xargs dirname)
 
-$BASE_DIR/mkssl -n $NDK_ROOT -a $API_LEVEL -t "$BUILD_TARGETS" -o $OPENSSL_VERSION
+if [ $ENC_LIB = 'openssl' ]; then
+ $BASE_DIR/mkssl -n $NDK_ROOT -a $API_LEVEL -t "$BUILD_TARGETS" -o $OPENSSL_VERSION
+elif [ $ENC_LIB = 'mbedtls' ]; then
+ if [ ! -d $BASE_DIR/mbedtls ]; then
+  git clone https://github.com/ARMmbed/mbedtls mbedtls
+  if [ ! -z "$MBEDTLS_VERSION" ]; then
+   git -C $BASE_DIR/mbedtls checkout $MBEDTLS_VERSION
+  fi
+ fi
+else
+ echo "Unknown encryption library. Possible options: openssl mbedtls"
+ exit 128
+fi
 
 if [ ! -d $BASE_DIR/srt ]; then
  git clone https://github.com/Haivision/srt srt
@@ -58,12 +76,20 @@ if [ ! -d $BASE_DIR/srt ]; then
  fi
 fi
 
-JNI_DIR=$BASE_DIR/prebuilt
-
 for build_target in $BUILD_TARGETS; do
- git -C $BASE_DIR/srt clean -fd
- $BASE_DIR/mksrt -n $NDK_ROOT -a $API_LEVEL -t $build_target -s $BASE_DIR/srt -i $BASE_DIR/$build_target
+ LIB_DIR=$BASE_DIR/$build_target/lib
+ JNI_DIR=$BASE_DIR/prebuilt/$build_target
 
- mkdir -p $JNI_DIR/$build_target
- cp $BASE_DIR/$build_target/lib/libsrt.so $JNI_DIR/$build_target/libsrt.so
+ mkdir -p $JNI_DIR
+
+ if [ $ENC_LIB = 'mbedtls' ]; then
+  $BASE_DIR/mkmbedtls -n $NDK_ROOT -a $API_LEVEL -t $build_target -s $BASE_DIR/mbedtls -i $BASE_DIR/$build_target
+  cp $LIB_DIR/libmbedcrypto.so $JNI_DIR/libmbedcrypto.so
+  cp $LIB_DIR/libmbedtls.so $JNI_DIR/libmbedtls.so
+  cp $LIB_DIR/libmbedx509.so $JNI_DIR/libmbedx509.so
+ fi
+
+ git -C $BASE_DIR/srt clean -fd
+ $BASE_DIR/mksrt -n $NDK_ROOT -a $API_LEVEL -t $build_target -e $ENC_LIB -s $BASE_DIR/srt -i $BASE_DIR/$build_target
+ cp $LIB_DIR/libsrt.so $JNI_DIR/libsrt.so
 done

--- a/scripts/build-android/mkmbedtls
+++ b/scripts/build-android/mkmbedtls
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+while getopts s:i:t:n:a: option
+do
+ case "${option}"
+ in
+ s) SRC_DIR=${OPTARG};;
+ i) INSTALL_DIR=${OPTARG};;
+ t) ARCH_ABI=${OPTARG};;
+ n) NDK_ROOT=${OPTARG};;
+ a) API_LEVEL=${OPTARG};;
+ *) twentytwo=${OPTARG};;
+ esac
+done
+
+
+BUILD_DIR=/tmp/mbedtls_android_build
+rm -rf $BUILD_DIR
+mkdir $BUILD_DIR
+cd $BUILD_DIR
+cmake -DENABLE_TESTING=Off -DUSE_SHARED_MBEDTLS_LIBRARY=On \
+-DCMAKE_PREFIX_PATH=$INSTALL_DIR -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCMAKE_ANDROID_NDK=$NDK_ROOT \
+-DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=$API_LEVEL -DCMAKE_ANDROID_ARCH_ABI=$ARCH_ABI \
+-DCMAKE_C_FLAGS="-fPIC" -DCMAKE_SHARED_LINKER_FLAGS="-Wl,--build-id" \
+-DCMAKE_BUILD_TYPE=RelWithDebInfo $SRC_DIR
+cmake --build .
+cmake --install .

--- a/scripts/build-android/mksrt
+++ b/scripts/build-android/mksrt
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-while getopts s:i:t:n:a: option
+while getopts s:i:t:n:a:e: option
 do
  case "${option}"
  in
@@ -9,13 +9,20 @@ do
  t) ARCH_ABI=${OPTARG};;
  n) NDK_ROOT=${OPTARG};;
  a) API_LEVEL=${OPTARG};;
+ e) ENC_LIB=${OPTARG};;
  *) twentytwo=${OPTARG};;
  esac
 done
 
 
 cd $SRC_DIR
-./configure --use-openssl-pc=OFF --OPENSSL_USE_STATIC_LIBS=true \
+./configure --use-enclib=$ENC_LIB \
+--use-openssl-pc=OFF --OPENSSL_USE_STATIC_LIBS=TRUE \
+--OPENSSL_INCLUDE_DIR=$INSTALL_DIR/include \
+--OPENSSL_CRYPTO_LIBRARY=$INSTALL_DIR/lib/libcrypto.a --OPENSSL_SSL_LIBRARY=$INSTALL_DIR/lib/libssl.a \
+--STATIC_MBEDTLS=FALSE \
+--MBEDTLS_INCLUDE_DIR=$INSTALL_DIR/include --MBEDTLS_INCLUDE_DIRS=$INSTALL_DIR/include \
+--MBEDTLS_LIBRARIES=$INSTALL_DIR/lib/libmbedtls.so \
 --CMAKE_PREFIX_PATH=$INSTALL_DIR --CMAKE_INSTALL_PREFIX=$INSTALL_DIR --CMAKE_ANDROID_NDK=$NDK_ROOT \
 --CMAKE_SYSTEM_NAME=Android --CMAKE_SYSTEM_VERSION=$API_LEVEL --CMAKE_ANDROID_ARCH_ABI=$ARCH_ABI \
 --CMAKE_C_FLAGS="-fPIC" --CMAKE_SHARED_LINKER_FLAGS="-Wl,--build-id" \


### PR DESCRIPTION
Fixes #2022 

The fix: Always set OpenSSL paths explicitly. This works for new CMake 3.20 branch as well as for Ubuntu LTS's CMake 3.16.

Also this PR adds support for Mbed TLS build for Android.