### PR TITLE
[core] Fixed skip non-empty data

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1169,10 +1169,11 @@ bool CRcvBuffer::getRcvFirstMsg(steady_clock::time_point& w_tsbpdtime,
      * No acked packets ready but caller want to know next packet to wait for
      * Check the not yet acked packets that may be stuck by missing packet(s).
      */
-    bool                     haslost   = false;
-    steady_clock::time_point tsbpdtime = steady_clock::time_point();
-    w_tsbpdtime                        = steady_clock::time_point();
-    w_passack                          = true;
+    bool                     haslost        = false;
+    int                      last_ready_pos = -1;
+    steady_clock::time_point tsbpdtime      = steady_clock::time_point();
+    w_tsbpdtime                             = steady_clock::time_point();
+    w_passack                               = true;
 
     // XXX SUSPECTED ISSUE with this algorithm:
     // The above call to getRcvReadyMsg() should report as to whether:
@@ -1222,12 +1223,13 @@ bool CRcvBuffer::getRcvFirstMsg(steady_clock::time_point& w_tsbpdtime,
                 if (!is_zero(w_tsbpdtime)) {
                     HLOGC(brlog.Debug,
                           log << "getRcvFirstMsg: found next ready packet, free last %"
-                              << w_curpktseq);
+                              << w_curpktseq << " POS=" << last_ready_pos);
                     SRT_ASSERT(w_curpktseq != SRT_SEQNO_NONE);
-                    freeUnitAt(w_curpktseq);
+                    freeUnitAt(last_ready_pos);
                 }
-                w_tsbpdtime = tsbpdtime;
-                w_curpktseq = m_pUnit[i]->m_Packet.m_iSeqNo;
+                w_tsbpdtime    = tsbpdtime;
+                w_curpktseq    = m_pUnit[i]->m_Packet.m_iSeqNo;
+                last_ready_pos = i;
                 if (haslost)
                     w_skipseqno = w_curpktseq;
 

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1215,9 +1215,17 @@ bool CRcvBuffer::getRcvFirstMsg(steady_clock::time_point& w_tsbpdtime,
         else
         {
             tsbpdtime = getPktTsbPdTime(m_pUnit[i]->m_Packet.getMsgTimeStamp());
+            /* Packet ready to play */
             if (tsbpdtime <= steady_clock::now())
             {
-                /* Packet ready to play */
+                // If the last ready-to-play packet exists, free it.
+                if (!is_zero(w_tsbpdtime)) {
+                    HLOGC(brlog.Debug,
+                          log << "getRcvFirstMsg: found next ready packet, free last %"
+                              << w_curpktseq);
+                    SRT_ASSERT(w_curpktseq != SRT_SEQNO_NONE);
+                    freeUnitAt(w_curpktseq);
+                }
                 w_tsbpdtime = tsbpdtime;
                 w_curpktseq = m_pUnit[i]->m_Packet.m_iSeqNo;
                 if (haslost)


### PR DESCRIPTION
Fixed a issue introduced by #2026 
The `skipData()` after `getRcvFirstMsg()` can only skip empty data,
while #2026 may skip multiple non-empty ready-to-play packets that smaller than group recv base.