### PR TITLE
[test] Added fixes for FEC test occasional failure

### DIFF
--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -297,7 +297,7 @@ TEST(TestFEC, Connection)
 
     ASSERT_NE(srt_setsockflag(s, SRTO_PACKETFILTER, fec_config1, (sizeof fec_config1)-1), -1);
     ASSERT_NE(srt_setsockflag(l, SRTO_PACKETFILTER, fec_config2, (sizeof fec_config2)-1), -1);
-    
+
     srt_listen(l, 1);
 
     auto connect_res = std::async(std::launch::async, [&s, &sa]() {
@@ -305,19 +305,21 @@ TEST(TestFEC, Connection)
         });
 
     SRTSOCKET la[] = { l };
-    SRTSOCKET a = srt_accept_bond(la, 1, 1000);
-    EXPECT_NE(a, SRT_ERROR);
+    // Given 2s timeout for accepting as it has occasionally happened with Travis
+    // that 1s might not be enough.
+    SRTSOCKET a = srt_accept_bond(la, 1, 2000);
+    ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
 
     // Now that the connection is established, check negotiated config
 
-    char result_config1[200];
+    char result_config1[200] = "";
     int result_config1_size = 200;
-    char result_config2[200];
+    char result_config2[200] = "";
     int result_config2_size = 200;
 
-    srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size);
-    srt_getsockflag(a, SRTO_PACKETFILTER, result_config2, &result_config2_size);
+    EXPECT_NE(srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size), -1);
+    EXPECT_NE(srt_getsockflag(a, SRTO_PACKETFILTER, result_config2, &result_config2_size), -1);
 
     string caller_config = result_config1;
     string accept_config = result_config2;
@@ -358,15 +360,15 @@ TEST(TestFEC, ConnectionReorder)
         });
 
     SRTSOCKET la[] = { l };
-    SRTSOCKET a = srt_accept_bond(la, 1, 1000);
-    EXPECT_NE(a, SRT_ERROR);
+    SRTSOCKET a = srt_accept_bond(la, 1, 2000);
+    ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
 
     // Now that the connection is established, check negotiated config
 
-    char result_config1[200];
+    char result_config1[200] = "";
     int result_config1_size = 200;
-    char result_config2[200];
+    char result_config2[200] = "";
     int result_config2_size = 200;
 
     srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size);
@@ -411,15 +413,15 @@ TEST(TestFEC, ConnectionFull1)
         });
 
     SRTSOCKET la[] = { l };
-    SRTSOCKET a = srt_accept_bond(la, 1, 1000);
-    EXPECT_NE(a, SRT_ERROR);
+    SRTSOCKET a = srt_accept_bond(la, 1, 2000);
+    ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
 
     // Now that the connection is established, check negotiated config
 
-    char result_config1[200];
+    char result_config1[200] = "";
     int result_config1_size = 200;
-    char result_config2[200];
+    char result_config2[200] = "";
     int result_config2_size = 200;
 
     srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size);
@@ -463,15 +465,15 @@ TEST(TestFEC, ConnectionFull2)
         });
 
     SRTSOCKET la[] = { l };
-    SRTSOCKET a = srt_accept_bond(la, 1, 1000);
-    EXPECT_NE(a, SRT_ERROR);
+    SRTSOCKET a = srt_accept_bond(la, 1, 2000);
+    ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
 
     // Now that the connection is established, check negotiated config
 
-    char result_config1[200];
+    char result_config1[200] = "";
     int result_config1_size = 200;
-    char result_config2[200];
+    char result_config2[200] = "";
     int result_config2_size = 200;
 
     srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size);
@@ -516,15 +518,15 @@ TEST(TestFEC, ConnectionMess)
         });
 
     SRTSOCKET la[] = { l };
-    SRTSOCKET a = srt_accept_bond(la, 1, 1000);
-    EXPECT_NE(a, SRT_ERROR);
+    SRTSOCKET a = srt_accept_bond(la, 1, 2000);
+    ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
 
     // Now that the connection is established, check negotiated config
 
-    char result_config1[200];
+    char result_config1[200] = "";
     int result_config1_size = 200;
-    char result_config2[200];
+    char result_config2[200] = "";
     int result_config2_size = 200;
 
     srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size);
@@ -567,15 +569,15 @@ TEST(TestFEC, ConnectionForced)
         });
 
     SRTSOCKET la[] = { l };
-    SRTSOCKET a = srt_accept_bond(la, 1, 1000);
-    EXPECT_NE(a, SRT_ERROR);
+    SRTSOCKET a = srt_accept_bond(la, 1, 2000);
+    ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
 
     // Now that the connection is established, check negotiated config
 
-    char result_config1[200];
+    char result_config1[200] = "";
     int result_config1_size = 200;
-    char result_config2[200];
+    char result_config2[200] = "";
     int result_config2_size = 200;
 
     srt_getsockflag(s, SRTO_PACKETFILTER, result_config1, &result_config1_size);


### PR DESCRIPTION
This adds fixes:

1. Extended timeout for `srt_accept_bond` call to 2 seconds.
2. Preinitialized buffers for extracted FEC configuration (happened to be displayed with garbage contents)
3. Made the accept failure assert instead of expect (failure will only lead to other failures).