### PR TITLE
[apps] Output json stats values as numbers

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -484,7 +484,6 @@ public:
     string WriteStats(int sid, const CBytePerfMon& mon) override
     {
         std::ostringstream output;
-        static const string qt = R"(")";
 
         string pretty_cr, pretty_tab;
         if (Option("pretty"))
@@ -540,9 +539,7 @@ public:
 
             // Print the current field
             output << quotekey(i->name);
-            output << qt;
             i->PrintValue(output, mon);
-            output << qt;
         }
 
         // Close the previous subcategory


### PR DESCRIPTION
After PR #1743 json stats from `srt-live-transmit` has quotation marks around numerical values. Those quotes can be omitted.
TODO:
- [x] Check if it is safe to omit quotation marks around the timepoint `"timepoint":2021-04-29T16:22:41.827006-0300`.