### PR TITLE
[core] fix group recv in message mode

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -834,6 +834,7 @@ CRcvBuffer::CRcvBuffer(CUnitQueue* queue, int bufsize_pkts)
     , m_iAckedPktsCount(0)
     , m_iAckedBytesCount(0)
     , m_uAvgPayloadSz(7 * 188)
+    , m_iLargestReadyMsgNo(SRT_SEQNO_NONE)
 {
     m_pUnit = new CUnit*[m_iSize];
     for (int i = 0; i < m_iSize; ++i)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -556,13 +556,11 @@ private:
 
     AvgBufSize       m_mavg;
 
-#if ENABLE_EXPERIMENTAL_BONDING
     std::map<int32_t, int32_t> m_MsgNoToFirstPktSeq;
     std::map<int32_t, int32_t> m_MsgNoToLastPktSeq;
     std::map<int32_t, int32_t> m_MsgNoToTotalPktNum;
     std::map<int32_t, int32_t> m_MsgNoToReceivedPktNum;
-    int32_t                    m_iLargestReadyMsgNo = SRT_SEQNO_NONE;
-#endif
+    int32_t                    m_iLargestReadyMsgNo;
 
 private:
     CRcvBuffer();

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -466,14 +466,7 @@ private:
     /// This gives up unit at index p. The unit is given back to the
     /// free unit storage for further assignment for the new incoming
     /// data.
-    size_t freeUnitAt(size_t p)
-    {
-        srt::CUnit* u  = m_pUnit[p];
-        m_pUnit[p]     = NULL;
-        size_t rmbytes = u->m_Packet.getLength();
-        m_pUnitQueue->makeUnitFree(u);
-        return rmbytes;
-    }
+    size_t freeUnitAt(size_t p);
 
     /// Adjust receive queue to 1st ready to play message (tsbpdtime < now).
     /// Parameters (of the 1st packet queue, ready to play or not):
@@ -483,6 +476,9 @@ private:
     /// @retval true 1st packet ready to play without discontinuity (no hole)
     /// @retval false tsbpdtime = 0: no packet ready to play
     bool getRcvReadyMsg(time_point& w_tsbpdtime, int32_t& w_curpktseq, int upto, int base_seq = SRT_SEQNO_NONE);
+
+public:
+    int32_t getReadyMsgInMessageMode();
 
 public:
     /// @brief Get clock drift in microseconds.
@@ -559,6 +555,14 @@ private:
     srt::CTsbpdTime  m_tsbpd;
 
     AvgBufSize       m_mavg;
+
+#if ENABLE_EXPERIMENTAL_BONDING
+    std::map<int32_t, int32_t>  m_MsgNoToFirstPktSeq;
+    std::map<int32_t, int32_t>  m_MsgNoToLastPktSeq;
+    std::map<int32_t, uint32_t> m_MsgNoToTotalPktNum;
+    std::map<int32_t, uint32_t> m_MsgNoToReceivedPktNum;
+    int32_t                     m_iLargestReadyMsgNo = SRT_SEQNO_NONE;
+#endif
 
 private:
     CRcvBuffer();

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -557,11 +557,11 @@ private:
     AvgBufSize       m_mavg;
 
 #if ENABLE_EXPERIMENTAL_BONDING
-    std::map<int32_t, int32_t>  m_MsgNoToFirstPktSeq;
-    std::map<int32_t, int32_t>  m_MsgNoToLastPktSeq;
-    std::map<int32_t, uint32_t> m_MsgNoToTotalPktNum;
-    std::map<int32_t, uint32_t> m_MsgNoToReceivedPktNum;
-    int32_t                     m_iLargestReadyMsgNo = SRT_SEQNO_NONE;
+    std::map<int32_t, int32_t> m_MsgNoToFirstPktSeq;
+    std::map<int32_t, int32_t> m_MsgNoToLastPktSeq;
+    std::map<int32_t, int32_t> m_MsgNoToTotalPktNum;
+    std::map<int32_t, int32_t> m_MsgNoToReceivedPktNum;
+    int32_t                    m_iLargestReadyMsgNo = SRT_SEQNO_NONE;
 #endif
 
 private:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6108,7 +6108,9 @@ int srt::CUDT::receiveBuffer(char *data, int len)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
     }
 
+    enterCS(m_RcvBufferLock);
     const int res = m_pRcvBuffer->readBuffer(data, len);
+    leaveCS(m_RcvBufferLock);
 
     /* Kick TsbPd thread to schedule next wakeup (if running) */
     if (m_bTsbPd)

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2353,7 +2353,11 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 // by "more correct data" if found more appropriate later. But we have to
                 // copy these data anyway anywhere, even if they need to fall on the floor later.
                 int stat;
+#if HAVE_CXX11
                 thread_local std::vector<char> extrabuf;
+#else
+                std::vector<char> extrabuf;
+#endif
                 extrabuf.reserve(SRT_LIVE_MAX_PLSIZE);
                 if (!m_bTsbPd)
                     extrabuf.reserve(len);

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2532,7 +2532,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
         {
             if (rp->second.mctrl.pktseq == SRT_SEQNO_NONE)
             {
-                rp = m_Positions.erase(rp);
+                m_Positions.erase(rp++);
             }
             else
             {

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2327,8 +2327,8 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 if (seqdiff > 1)
                 {
                     HLOGC(grlog.Debug,
-                          log << "group/recv: EPOLL: @" << id << " %" << p->mctrl.pktseq << " AHEAD %" << m_RcvBaseSeqNo
-                              << ", not reading.");
+                          log << "group/recv: EPOLL: @" << id << " %" << recv_GetNo(p->mctrl) << " AHEAD %"
+                              << m_RcvBaseSeqNo << ", not reading.");
                     continue;
                 }
             }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2323,7 +2323,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 // x = 0: the socket should be ready to get the exactly next packet
                 // x = 1: the case is already handled by GroupCheckPacketAhead.
                 // x > 1: AHEAD. DO NOT READ.
-                const int seqdiff = CSeqNo::seqcmp(p->mctrl.pktseq, m_RcvBaseSeqNo);
+                const int seqdiff = CSeqNo::seqcmp(recv_GetNo(p->mctrl), m_RcvBaseSeqNo);
                 if (seqdiff > 1)
                 {
                     HLOGC(grlog.Debug,

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -642,15 +642,16 @@ private:
     {
         std::vector<char> packet;
         SRT_MSGCTRL       mctrl;
-        ReadPos(int32_t s)
+        ReadPos()
             : mctrl(srt_msgctrl_default)
         {
-            mctrl.pktseq = s;
         }
     };
     std::map<SRTSOCKET, ReadPos> m_Positions;
 
     ReadPos* checkPacketAhead();
+
+    int32_t recv_GetNo(const SRT_MSGCTRL& mctrl) { return m_bTsbPd ? mctrl.pktseq : mctrl.msgno; }
 
     void recv_CollectAliveAndBroken(std::vector<srt::CUDTSocket*>& w_alive, std::set<srt::CUDTSocket*>& w_broken);
 
@@ -767,10 +768,12 @@ public:
         m_RcvBaseSeqNo = SRT_SEQNO_NONE;
     }
 
-    bool applyGroupTime(time_point& w_start_time, time_point& w_peer_start_time)
+    bool applyGroupTime(time_point& w_start_time, time_point& w_peer_start_time, bool tsbpd)
     {
         using srt::sync::is_zero;
         using srt_logging::gmlog;
+
+        m_bTsbPd = tsbpd;
 
         if (is_zero(m_tsStartTime))
         {

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -665,7 +665,9 @@ private:
     std::vector<srt::CUDTSocket*> recv_WaitForReadReady(const std::vector<srt::CUDTSocket*>& aliveMembers, std::set<srt::CUDTSocket*>& w_broken);
 
     // This is the sequence number of a packet that has been previously
-    // delivered. Initially it should be set to SRT_SEQNO_NONE so that the sequence read
+    // delivered if tsbpd is enabled, else it's the message number of
+    // previously delivered message.
+    // Initially it should be set to SRT_SEQNO_NONE so that the sequence read
     // from the first delivering socket will be taken as a good deal.
     volatile int32_t m_RcvBaseSeqNo;
 


### PR DESCRIPTION
Fix https://github.com/Haivision/srt/issues/2004 and https://github.com/Haivision/srt/issues/1504

* update group read state with ready message
* change the base unit of `Group::recv()` from packet to message if tsbpd is disabled
* clear group read state before `throw` if `nready` is `0`