### PR TITLE
[core] Both readData() consider msgttl

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -1703,8 +1703,8 @@ called function should work.
 - `msgttl`: [IN]. In **message** and **live mode** only, specifies the TTL for 
 sending messages (in `[ms]`). Not used for receiving messages. If this value
 is not negative, it defines the maximum time up to which this message should
-stay scheduled for sending. If the message is not successfully sent before TTL
-expires, further retransmission is given up and the message is discarded.
+stay scheduled for sending. If TTL has expired, the message sending and further retransmissions are discarded, even
+if it has never been sent so far.
 
 - `inorder`: [IN]. In **message mode** only, specifies that sent messages should 
 be extracted by the receiver in the order of sending. This can be meaningful if 

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -1703,11 +1703,8 @@ called function should work.
 - `msgttl`: [IN]. In **message** and **live mode** only, specifies the TTL for 
 sending messages (in `[ms]`). Not used for receiving messages. If this value
 is not negative, it defines the maximum time up to which this message should
-stay scheduled for sending for the sake of later retransmission. A message
-is always sent for the first time, but the UDP packet carrying it may be
-(also partially) lost, and if so, lacking packets will be retransmitted. If
-the message is not successfully resent before TTL expires, further retransmission
-is given up and the message is discarded.
+stay scheduled for sending. If the message is not successfully sent before TTL
+expires, further retransmission is given up and the message is discarded.
 
 - `inorder`: [IN]. In **message mode** only, specifies that sent messages should 
 be extracted by the receiver in the order of sending. This can be meaningful if 

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -142,17 +142,18 @@ public:
     int addBufferFromFile(std::fstream& ifs, int len);
 
     /// Find data position to pack a DATA packet from the furthest reading point.
-    /// @param [out] w_packet data packet buffer to fill.
-    /// @param [out] w_origintime origin time stamp of the message.
-    /// @param [in] kflags Odd|Even crypto key flag.
+    /// @param [out] packet the packet to read.
+    /// @param [out] origintime origin time stamp of the message
+    /// @param [in] kflags Odd|Even crypto key flag
+    /// @param [out] seqnoinc the number of packets skipped due to TTL, so that seqno should be incremented.
     /// @return Actual length of data read.
-    int readData(CPacket& w_packet, time_point& w_origintime, int kflgs);
+    int readData(CPacket& w_packet, time_point& w_origintime, int kflgs, int& w_seqnoinc);
 
     /// Find data position to pack a DATA packet for a retransmission.
     /// @param [in] offset offset from the last ACK point (backward sequence number difference)
-    /// @param [out] w_packet data packet buffer to fill.
-    /// @param [out] w_origintime origin time stamp of the message
-    /// @param [out] w_msglen length of the message
+    /// @param [out] packet the packet to read.
+    /// @param [out] origintime origin time stamp of the message
+    /// @param [out] msglen length of the message
     /// @return Actual length of data read (return 0 if offset too large, -1 if TTL exceeded).
     int readData(const int offset, CPacket& w_packet, time_point& w_origintime, int& w_msglen);
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8963,17 +8963,15 @@ int srt::CUDT::packLostData(CPacket& w_packet, steady_clock::time_point& w_origi
             SRT_ASSERT(msglen >= 1);
             seqpair[1] = CSeqNo::incseq(seqpair[0], msglen - 1);
 
-            HLOGC(qrlog.Debug, log << "IPE: loss-reported packets not found in SndBuf - requesting DROP: "
-                    << "msg=" << MSGNO_SEQ::unwrap(w_packet.m_iMsgNo) << " msglen=" << msglen << " SEQ:"
-                    << seqpair[0] << " - " << seqpair[1] << "(" << (-offset) << " packets)");
+            HLOGC(qrlog.Debug,
+                  log << "loss-reported packets expired in SndBuf - requesting DROP: "
+                      << "msgno=" << MSGNO_SEQ::unwrap(w_packet.m_iMsgNo) << " msglen=" << msglen
+                      << " SEQ:" << seqpair[0] << " - " << seqpair[1]);
             sendCtrl(UMSG_DROPREQ, &w_packet.m_iMsgNo, seqpair, sizeof(seqpair));
 
-            // only one msg drop request is necessary
-            m_pSndLossList->removeUpTo(seqpair[1]);
-
             // skip all dropped packets
+            m_pSndLossList->removeUpTo(seqpair[1]);
             m_iSndCurrSeqNo = CSeqNo::maxseq(m_iSndCurrSeqNo, seqpair[1]);
-
             continue;
         }
         else if (payload == 0)
@@ -9071,7 +9069,14 @@ std::pair<int, steady_clock::time_point> srt::CUDT::packData(CPacket& w_packet)
             // It would be nice to research as to whether CSndBuffer::Block::m_iMsgNoBitset field
             // isn't a useless redundant state copy. If it is, then taking the flags here can be removed.
             kflg    = m_pCryptoControl->getSndCryptoFlags();
-            payload = m_pSndBuffer->readData((w_packet), (origintime), kflg);
+            int pktskipseqno = 0;
+            payload = m_pSndBuffer->readData((w_packet), (origintime), kflg, (pktskipseqno));
+            if (pktskipseqno)
+            {
+                // Some packets were skipped due to TTL expiry.
+                m_iSndCurrSeqNo = CSeqNo::incseq(m_iSndCurrSeqNo, pktskipseqno);
+            }
+
             if (payload)
             {
                 // A CHANGE. The sequence number is currently added to the packet


### PR DESCRIPTION
I found that in message mode, messages are often sent after TTL due to congestion control.