### PR TITLE
[core] Changed the default SRTO_RETRANSMITALGO to 1

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -239,7 +239,7 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_RCVSYN`](#SRTO_RCVSYN)                          |       | post     | `bool`    |         | true              |          | RW  | GSI   |
 | [`SRTO_RCVTIMEO`](#SRTO_RCVTIMEO)                      |       | post     | `int32_t` | ms      | -1                | -1, 0..  | RW  | GSI   |
 | [`SRTO_RENDEZVOUS`](#SRTO_RENDEZVOUS)                  |       | pre      | `bool`    |         | false             |          | RW  | S     |
-| [`SRTO_RETRANSMITALGO`](#SRTO_RETRANSMITALGO)          | 1.4.2 | pre      | `int32_t` |         | 0                 | [0, 1]   | RW  | GSD   |
+| [`SRTO_RETRANSMITALGO`](#SRTO_RETRANSMITALGO)          | 1.4.2 | pre      | `int32_t` |         | 1                 | [0, 1]   | RW  | GSD   |
 | [`SRTO_REUSEADDR`](#SRTO_REUSEADDR)                    |       | pre-bind | `bool`    |         | true              |          | RW  | GSD   |
 | [`SRTO_SENDER`](#SRTO_SENDER)                          | 1.0.4 | pre      | `bool`    |         | false             |          | W   | S     |
 | [`SRTO_SNDBUF`](#SRTO_SNDBUF)                          |       | pre-bind | `int32_t` | bytes   | 8192 payloads     | \*       | RW  | GSD+  |
@@ -1275,12 +1275,12 @@ procedure of `srt_bind` and then `srt_connect` (or `srt_rendezvous`) to one anot
 
 | OptName               | Since | Restrict | Type      | Units  | Default | Range  | Dir | Entity |
 | --------------------- | ----- | -------- | --------- | ------ | ------- | ------ | --- | ------ |
-| `SRTO_RETRANSMITALGO` | 1.4.2 | pre      | `int32_t` |        | 0       | [0, 1] | RW  | GSD    |
+| `SRTO_RETRANSMITALGO` | 1.4.2 | pre      | `int32_t` |        | 1       | [0, 1] | RW  | GSD    |
 
 Retransmission algorithm to use (SENDER option):
 
-- 0 - Default (retransmit on every loss report).
-- 1 - Reduced retransmissions (not more often than once per RTT); reduced
+- 0 - Retransmit on every loss report (higher overhead, but slightly higher chance to recover a lost packet).
+- 1 - Reduced retransmissions (retransmit not more often than once per RTT); reduced
   bandwidth consumption.
 
 This option is effective only on the sending side. It influences the decision

--- a/docs/API/API.md
+++ b/docs/API/API.md
@@ -521,14 +521,15 @@ either `FASTREXMIT` or `LATEREXMIT`. This will be explained below.
 
 Setting `SRTO_TRANSTYPE` to `SRTT_LIVE` sets the following [socket options](API-socket-options.md):
 
-- `SRTO_TSBPDMODE` = true
-- `SRTO_RCVLATENCY` = 120
-- `SRTO_PEERLATENCY` = 0
-- `SRTO_TLPKTDROP` = true
-- `SRTO_MESSAGEAPI` = true
-- `SRTO_NAKREPORT` = true
-- `SRTO_PAYLOADSIZE` = 1316
-- `SRTO_CONGESTION` = "live"
+- [`SRTO_TSBPDMODE`](API-socket-options.md#SRTO_TSBPDMODE) = true
+- [`SRTO_RCVLATENCY`](API-socket-options.md#SRTO_RCVLATENCY) = 120
+- [`SRTO_PEERLATENCY`](API-socket-options.md#SRTO_PEERLATENCY) = 0
+- [`SRTO_TLPKTDROP`](API-socket-options.md#SRTO_TLPKTDROP) = true
+- [`SRTO_MESSAGEAPI`](API-socket-options.md#SRTO_MESSAGEAPI) = true
+- [`SRTO_NAKREPORT`](API-socket-options.md#SRTO_NAKREPORT) = true
+- [`SRTO_RETRANSMITALGO`](API-socket-options.md#SRTO_RETRANSMITALGO) = 1
+- [`SRTO_PAYLOADSIZE`](API-socket-options.md#SRTO_PAYLOADSIZE) = 1316
+- [`SRTO_CONGESTION`](API-socket-options.md#SRTO_CONGESTION) = "live"
 
 In this mode, every call to a sending function is allowed to send only
 so much data, as declared by `SRTO_PAYLOADSIZE`, whose value is still
@@ -580,6 +581,10 @@ loss report itself was lost. Without it, the loss report will be always reported
 just once and never repeated again, and then the lost payload packet will
 be probably dropped by the TLPKTDROP mechanism.
 
+- `SRTO_RETRANSMITALGO`: Given the receiver sends periodic NAK reports,
+the sender can reduce the retransmission overhead by not retransmitting a loss
+more often than once per RTT (value 1).
+
 - `SRTO_PAYLOADSIZE`: Default value is for MPEG TS. If you are going
 to use SRT to send any different kind of payload, such as, for example,
 wrapping a live stream in very small frames, then you can use a bigger
@@ -598,14 +603,15 @@ NAKREPORT method is considered so effective that FASTREXMIT isn't necessary.
 
 Setting `SRTO_TRANSTYPE` to `SRTT_FILE` sets the following [socket options](API-socket-options.md):
 
-- `SRTO_TSBPDMODE` = false
-- `SRTO_RCVLATENCY` = 0
-- `SRTO_PEERLATENCY` = 0
-- `SRTO_TLPKTDROP` = false
-- `SRTO_MESSAGEAPI` = false
-- `SRTO_NAKREPORT` = false
-- `SRTO_PAYLOADSIZE` = 0
-- `SRTO_CONGESTION` = "file"
+- [`SRTO_TSBPDMODE`](API-socket-options.md#SRTO_TSBPDMODE) = false
+- [`SRTO_RCVLATENCY`](API-socket-options.md#SRTO_RCVLATENCY) = 0
+- [`SRTO_PEERLATENCY`](API-socket-options.md#SRTO_PEERLATENCY) = 0
+- [`SRTO_TLPKTDROP`](API-socket-options.md#SRTO_TLPKTDROP) = false
+- [`SRTO_MESSAGEAPI`](API-socket-options.md#SRTO_MESSAGEAPI) = false
+- [`SRTO_NAKREPORT`](API-socket-options.md#SRTO_NAKREPORT) = false
+- [`SRTO_RETRANSMITALGO`](API-socket-options.md#SRTO_RETRANSMITALGO) = 0
+- [`SRTO_PAYLOADSIZE`](API-socket-options.md#SRTO_PAYLOADSIZE) = 0
+- [`SRTO_CONGESTION`](API-socket-options.md#SRTO_CONGESTION) = "file"
 
 In this mode, calling a sending function is allowed to potentially send
 virtually any size of data. The sending function will HANGUP only if the

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -869,7 +869,11 @@ struct CSrtConfigSetter<SRTO_RETRANSMITALGO>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.iRetransmitAlgo = cast_optval<int32_t>(optval, optlen);
+        const int val = cast_optval<int>(optval, optlen);
+        if (val < 0 || val > 1)
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+
+        co.iRetransmitAlgo = val;
     }
 };
 

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -656,6 +656,7 @@ struct CSrtConfigSetter<SRTO_TRANSTYPE>
             co.iSndDropDelay   = 0;
             co.bMessageAPI     = true;
             co.bRcvNakReport   = true;
+            co.iRetransmitAlgo = 1;
             co.zExpPayloadSize = SRT_LIVE_DEF_PLSIZE;
             co.Linger.l_onoff  = 0;
             co.Linger.l_linger = 0;
@@ -676,6 +677,7 @@ struct CSrtConfigSetter<SRTO_TRANSTYPE>
             co.iSndDropDelay   = -1;
             co.bMessageAPI     = false;
             co.bRcvNakReport   = false;
+            co.iRetransmitAlgo = 0;
             co.zExpPayloadSize = 0; // use maximum
             co.Linger.l_onoff  = 1;
             co.Linger.l_linger = CSrtConfig::DEF_LINGER_S;

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -271,7 +271,7 @@ struct CSrtConfig: CSrtMuxerConfig
         , iGroupConnect(0)
         , iPeerIdleTimeout(COMM_RESPONSE_TIMEOUT_MS)
         , uStabilityTimeout(COMM_DEF_STABILITY_TIMEOUT_US)
-        , iRetransmitAlgo(0)
+        , iRetransmitAlgo(1)
         , llInputBW(0)
         , llMinInputBW(0)
         , iOverheadBW(25)

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -209,7 +209,7 @@ const OptionTestEntry g_test_matrix_options[] =
     //SRTO_RCVSYN
     { SRTO_RCVTIMEO,           "SRTO_RCVTIMEO", RestrictionType::POST,    sizeof(int),                -1, INT32_MAX,  -1, 2000, {-2} },
     //SRTO_RENDEZVOUS
-    //SRTO_RETRANSMITALGO
+    { SRTO_RETRANSMITALGO, "SRTO_RETRANSMITALGO", RestrictionType::PRE,   sizeof(int),                 0,         1,   1,    0, {-1, 2} },
     //SRTO_REUSEADDR
     //SRTO_SENDER
     { SRTO_SNDBUF,              "SRTO_SNDBUF",  RestrictionType::PREBIND, sizeof(int), (int)(32 * SRT_PKT_SIZE), 2147483256, (int)(8192 * SRT_PKT_SIZE), 1000000, {-1} },


### PR DESCRIPTION
Tests have confirmed the reduced retransmission algorithm provides better results both under artificial impairments and in real public networks. Making it the default one.