### PR TITLE
Cross-compile android from macOS host

### DIFF
--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -343,8 +343,19 @@ proc postprocess {} {
 		# Otherwise don't set PKG_CONFIG_PATH and we'll see.
 	}
 
-	if { $::HAVE_DARWIN && !$toolchain_changed} {
-
+	set use_brew 0
+	if { $::HAVE_DARWIN && !$toolchain_changed } {
+		set use_brew 1
+	}
+	if { $use_brew } {
+		foreach item $::cmakeopt {
+			if { [string first "Android" $item] != -1 } {
+				set use_brew 0
+				break
+			}
+		}
+	}
+	if { $use_brew } {
 		if { $have_gnutls } {
 			# Use gnutls explicitly, as found in brew
 			set er [catch {exec brew info gnutls} res]

--- a/scripts/build-android/build-android
+++ b/scripts/build-android/build-android
@@ -92,7 +92,6 @@ else
  echo "Unknown encryption library. Possible options: openssl mbedtls"
  exit 128
 fi
-[ $? -eq 0 ] || exit 128
 
 if [ ! -d $BASE_DIR/srt ]; then
  git clone https://github.com/Haivision/srt srt
@@ -100,7 +99,6 @@ if [ ! -d $BASE_DIR/srt ]; then
   git -C $BASE_DIR/srt checkout $SRT_VERSION
  fi
 fi
-[ $? -eq 0 ] || exit 128
 
 for build_target in $BUILD_TARGETS; do
  LIB_DIR=$BASE_DIR/$build_target/lib
@@ -110,7 +108,6 @@ for build_target in $BUILD_TARGETS; do
 
  if [ $ENC_LIB = 'mbedtls' ]; then
   $SCRIPT_DIR/mkmbedtls -n $NDK_ROOT -a $API_LEVEL -t $build_target -s $BASE_DIR/mbedtls -i $BASE_DIR/$build_target
-  [ $? -eq 0 ] || exit 128
   cp $LIB_DIR/libmbedcrypto.so $JNI_DIR/libmbedcrypto.so
   cp $LIB_DIR/libmbedtls.so $JNI_DIR/libmbedtls.so
   cp $LIB_DIR/libmbedx509.so $JNI_DIR/libmbedx509.so
@@ -118,6 +115,5 @@ for build_target in $BUILD_TARGETS; do
 
  git -C $BASE_DIR/srt clean -fd
  $SCRIPT_DIR/mksrt -n $NDK_ROOT -a $API_LEVEL -t $build_target -e $ENC_LIB -s $BASE_DIR/srt -i $BASE_DIR/$build_target
- [ $? -eq 0 ] || exit 128
  cp $LIB_DIR/libsrt.so $JNI_DIR/libsrt.so
 done

--- a/scripts/build-android/build-android
+++ b/scripts/build-android/build-android
@@ -52,11 +52,35 @@ else
  fi
 fi
 
-# Determine the path of the executing script
-BASE_DIR=$(readlink -f $0 | xargs dirname)
+SCRIPT_DIR=$(pwd)
+HOST_TAG='unknown'
+unamestr=$(uname -s)
+if [ "$unamestr" = 'Linux' ]; then
+ SCRIPT_DIR=$(readlink -f $0 | xargs dirname)
+ HOST_TAG='linux-x86_64'
+elif [ "$unamestr" = 'Darwin' ]; then
+ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+ if [ $(uname -p) = 'arm' ]; then
+  echo "NDK does not currently support ARM64"
+  exit 128
+ else
+  HOST_TAG='darwin-x86_64'
+ fi
+fi
+
+# Write files relative to current location
+BASE_DIR=$(pwd)
+case "${BASE_DIR}" in
+  *\ * )
+    echo "Your path contains whitespaces, which is not supported by 'make install'."
+    exit 128
+  ;;
+esac
+cd "${BASE_DIR}"
 
 if [ $ENC_LIB = 'openssl' ]; then
- $BASE_DIR/mkssl -n $NDK_ROOT -a $API_LEVEL -t "$BUILD_TARGETS" -o $OPENSSL_VERSION
+ echo "Building OpenSSL $OPENSSL_VERSION"
+ $SCRIPT_DIR/mkssl -n $NDK_ROOT -a $API_LEVEL -t "$BUILD_TARGETS" -o $OPENSSL_VERSION -d $BASE_DIR -h $HOST_TAG
 elif [ $ENC_LIB = 'mbedtls' ]; then
  if [ ! -d $BASE_DIR/mbedtls ]; then
   git clone https://github.com/ARMmbed/mbedtls mbedtls
@@ -68,6 +92,7 @@ else
  echo "Unknown encryption library. Possible options: openssl mbedtls"
  exit 128
 fi
+[ $? -eq 0 ] || exit 128
 
 if [ ! -d $BASE_DIR/srt ]; then
  git clone https://github.com/Haivision/srt srt
@@ -75,6 +100,7 @@ if [ ! -d $BASE_DIR/srt ]; then
   git -C $BASE_DIR/srt checkout $SRT_VERSION
  fi
 fi
+[ $? -eq 0 ] || exit 128
 
 for build_target in $BUILD_TARGETS; do
  LIB_DIR=$BASE_DIR/$build_target/lib
@@ -83,13 +109,15 @@ for build_target in $BUILD_TARGETS; do
  mkdir -p $JNI_DIR
 
  if [ $ENC_LIB = 'mbedtls' ]; then
-  $BASE_DIR/mkmbedtls -n $NDK_ROOT -a $API_LEVEL -t $build_target -s $BASE_DIR/mbedtls -i $BASE_DIR/$build_target
+  $SCRIPT_DIR/mkmbedtls -n $NDK_ROOT -a $API_LEVEL -t $build_target -s $BASE_DIR/mbedtls -i $BASE_DIR/$build_target
+  [ $? -eq 0 ] || exit 128
   cp $LIB_DIR/libmbedcrypto.so $JNI_DIR/libmbedcrypto.so
   cp $LIB_DIR/libmbedtls.so $JNI_DIR/libmbedtls.so
   cp $LIB_DIR/libmbedx509.so $JNI_DIR/libmbedx509.so
  fi
 
  git -C $BASE_DIR/srt clean -fd
- $BASE_DIR/mksrt -n $NDK_ROOT -a $API_LEVEL -t $build_target -e $ENC_LIB -s $BASE_DIR/srt -i $BASE_DIR/$build_target
+ $SCRIPT_DIR/mksrt -n $NDK_ROOT -a $API_LEVEL -t $build_target -e $ENC_LIB -s $BASE_DIR/srt -i $BASE_DIR/$build_target
+ [ $? -eq 0 ] || exit 128
  cp $LIB_DIR/libsrt.so $JNI_DIR/libsrt.so
 done

--- a/scripts/build-android/mkssl
+++ b/scripts/build-android/mkssl
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-while getopts n:o:a:t: option
+while getopts n:o:a:t:d:h: option
 do
  case "${option}"
  in
@@ -8,13 +8,14 @@ do
  o) OPENSSL_VERSION=${OPTARG};;
  a) API_LEVEL=${OPTARG};;
  t) BUILD_TARGETS=${OPTARG};;
+ d) OUT_DIR=${OPTARG};;
+ h) HOST_TAG=${OPTARG};;
  *) twentytwo=${OPTARG};;
  esac
 done
 
 
 BUILD_DIR=/tmp/openssl_android_build
-OUT_DIR=$(pwd)
 
 if [ ! -d openssl-${OPENSSL_VERSION} ]
 then
@@ -29,7 +30,7 @@ cd openssl-${OPENSSL_VERSION} || exit 128
 
 
 ##### Prepare Files #####
-sed -i 's/.*-mandroid.*//' Configurations/15-android.conf
+sed -i.bak 's/.*-mandroid.*//' Configurations/15-android.conf
 patch -p1 -N <<EOP
 --- old/Configurations/unix-Makefile.tmpl   2018-09-11 14:48:19.000000000 +0200
 +++ new/Configurations/unix-Makefile.tmpl   2018-10-18 09:06:27.282007245 +0200
@@ -64,7 +65,7 @@ export ANDROID_NDK
 
 ##### build-function #####
 build_the_thing() {
-    TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
+    TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/$HOST_TAG
     export PATH=$TOOLCHAIN/$TRIBLE/bin:$TOOLCHAIN/bin:"$PATH"
 echo $PATH
     make clean


### PR DESCRIPTION
- Select correct toolchain for OpenSSL (linux-x86_64 vs darwin-x86_64);
- Cross-build should get OpenSSL include dirs from command line, not host ones from brew;
- Minor tweaks to support zsh.