### PR TITLE
Fixed SHUTDOWN message with a wrong (uninitialized) DST socket ID

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -325,14 +325,21 @@ public:
    CEPoll& epoll_ref() { return m_EPoll; }
 
 private:
-//   void init();
-
    /// Generates a new socket ID. This function starts from a randomly
    /// generated value (at initialization time) and goes backward with
    /// with next calls. The possible values come from the range without
    /// the SRTGROUP_MASK bit, and the group bit is set when the ID is
    /// generated for groups. It is also internally checked if the
    /// newly generated ID isn't already used by an existing socket or group.
+   /// 
+   /// Socket ID value range.
+   /// - [0]: reserved for handshake procedure. If the destination Socket ID is 0
+   ///   (destination Socket ID unknown) the packet will be sent to the listening socket
+   ///   or to a socket that is in the rendezvous connection phase.
+   /// - [1; 2 ^ 30): single socket ID range.
+   /// - (2 ^ 30; 2 ^ 31): group socket ID range. Effectively any positive number
+   ///   from [1; 2 ^ 30) with bit 30 set to 1. Bit 31 is zero.
+   /// The most significant bit 31 (sign bit) is left unused so that checking for a value <= 0 identifies an invalid socket ID.
    ///
    /// @param group The socket id should be for socket group.
    /// @return The new socket ID.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1029,7 +1029,7 @@ private: // Generation and processing of packets
 private: // Trace
     struct CoreStats
     {
-        time_point tsStartTime;                 // timestamp when the UDT entity is started
+        time_point tsStartTime;             // timestamp when the UDT entity is started
         int64_t sentTotal;                  // total number of sent data packets, including retransmissions
         int64_t sentUniqTotal;              // total number of sent data packets, excluding rexmit and filter control
         int64_t recvTotal;                  // total number of received packets

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -349,7 +349,7 @@ bool CheckInvalidValues(const OptionTestEntry& entry, SRTSOCKET sock, const char
     {
         try {
             const ValueType val = linb::any_cast<ValueType>(inval);
-            CheckSetSockOpt<ValueType>(entry, sock, val, SRT_ERROR, "[Caller, invalid val]");
+            CheckSetSockOpt<ValueType>(entry, sock, val, SRT_ERROR, sock_name);
         }
         catch (const linb::bad_any_cast&)
         {
@@ -454,17 +454,18 @@ TEST_F(TestSocketOptions, InvalidVals)
     // Note: Changing SRTO_FC changes SRTO_RCVBUF limitation
     for (const auto& entry : g_test_matrix_options)
     {
+        const char* desc = "[Caller, invalid val]";
         if (entry.dflt_val.type() == typeid(bool))
         {
-            EXPECT_TRUE(CheckInvalidValues<bool>(entry, m_caller_sock, "[Caller, invalid val]"));
+            EXPECT_TRUE(CheckInvalidValues<bool>(entry, m_caller_sock, desc));
         }
         else if (entry.dflt_val.type() == typeid(int))
         {
-            EXPECT_TRUE(CheckInvalidValues<int>(entry, m_caller_sock, "[Caller, invalid val]"));
+            EXPECT_TRUE(CheckInvalidValues<int>(entry, m_caller_sock, desc));
         }
         else if (entry.dflt_val.type() == typeid(int64_t))
         {
-            EXPECT_TRUE(CheckInvalidValues<int64_t>(entry, m_caller_sock, "[Caller, invalid val]"));
+            EXPECT_TRUE(CheckInvalidValues<int64_t>(entry, m_caller_sock, desc));
         }
         else
         {


### PR DESCRIPTION
`CUDT::m_PeerID` is not initialized by the constructor. It has a random (garbage) value until set during HS.

When a caller with a passphrase tries to connect to a listener without a passphrase, the listener sends a rejection conclusion HS.
The caller, receiving the HS, sees the rejection code (in `CUDT::processAsyncConnectRequest(..)`), and returns from the function without initializing `m_PeerID`.
As `processAsyncConnectRequest(..)` returns false, a SHUTDOWN control packet is sent from `CRendezvousQueue::updateConnStatus(..)`.
 But destination SRT socket ID is still not initialized and may contain some garbage value, that could match some existing SRT socket ID on the listener side.
In the worst case, it could lead to a closure of a different valid connection existing on the same port, when SHUTDOWN is sent from the same IP.