### PR TITLE
Renamed congestion control event-realated functions

### DIFF
--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -34,9 +34,10 @@
 #include "logging.h"
 
 using namespace std;
-using namespace srt;
 using namespace srt::sync;
 using namespace srt_logging;
+
+namespace srt {
 
 SrtCongestionControlBase::SrtCongestionControlBase(CUDT* parent)
 {
@@ -399,7 +400,7 @@ private:
             else
             {
                 double inc = 0;
-                const int loss_bw = 2 * (1000000 / m_dLastDecPeriod); // 2 times last loss point
+                const int loss_bw = static_cast<int>(2 * (1000000 / m_dLastDecPeriod)); // 2 times last loss point
                 const int bw_pktps = min(loss_bw, m_parent->bandwidth());
 
                 int64_t B = (int64_t)(bw_pktps - 1000000.0 / m_dPktSndPeriod);
@@ -500,7 +501,7 @@ private:
         m_bLoss = true;
 
         // TODO: const int pktsInFlight = CSeqNo::seqoff(m_iLastAck, m_parent->sndSeqNo());
-        const int pktsInFlight = m_parent->SRTT() / m_dPktSndPeriod;
+        const int pktsInFlight = static_cast<int>(m_parent->SRTT() / m_dPktSndPeriod);
         const int numPktsLost = m_parent->sndLossLength();
         const int lost_pcent_x10 = pktsInFlight > 0 ? (numPktsLost * 1000) / pktsInFlight : 0;
 
@@ -656,3 +657,5 @@ SrtCongestion::~SrtCongestion()
 {
     dispose();
 }
+
+} // namespace srt

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -17,10 +17,9 @@
 #include <utility>
 
 namespace srt {
-    class CUDT;
-}
-class SrtCongestionControlBase;
 
+class CUDT;
+class SrtCongestionControlBase;
 typedef SrtCongestionControlBase* srtcc_create_t(srt::CUDT* parent);
 
 class SrtCongestion
@@ -131,9 +130,7 @@ public:
     };
 };
 
-namespace srt {
-    class CPacket;
-}
+class CPacket;
 
 class SrtCongestionControlBase
 {
@@ -224,6 +221,6 @@ public:
 };
 
 
-
+} // namespace srt
 
 #endif

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -570,7 +570,7 @@ struct CSrtConfigSetter<SRTO_CONGESTION>
         if (val == "vod")
             val = "file";
 
-        bool res = SrtCongestion::exists(val);
+        bool res = srt::SrtCongestion::exists(val);
         if (!res)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 


### PR DESCRIPTION
Renamed LiveCC and FileCC event-related functions:
- `updateSndPeriod` -> `onACK`
- `slowdownSndPeriod` -> `onLossReport`
- `speedupToWindowSize` -> `onRTO`
- `updatePktSndPeriod_onTimer` -> `onRTO`

Moved congestion control code into the `srt` namespace (partially addresses #1924).

Fixes #1526.
A couple of warnings fixed for #1646.