### PR TITLE
[core] Check if socket is still open before replying to HS

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3769,6 +3769,8 @@ bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
     bool status = true;
 
     ScopedLock cg(m_ConnectionLock);
+    if (!m_bOpened) // Check the socket has not been closed before already.
+        return false;
 
     if (cst == CONN_RENDEZVOUS)
     {

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -989,11 +989,12 @@ void srt::CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst
     for (vector<LinkStatusInfo>::iterator i = toRemove.begin(); i != toRemove.end(); ++i)
     {
         HLOGC(cnlog.Debug, log << "updateConnStatus: COMPLETING dep objects update on failed @" << i->id);
-        /*
-         * Setting m_bConnecting to false but keeping socket in rendezvous queue is not a good idea.
-         * Next CUDT::close will not remove it from rendezvous queue (because !m_bConnecting)
-         * and may crash on next pass.
-         */
+        //
+        // Setting m_bConnecting to false, and need to remove the socket from the rendezvous queue
+        // because the next CUDT::close will not remove it from the queue when m_bConnecting = false,
+        // and may crash on next pass.
+        //
+        // TODO: maybe lock i->u->m_ConnectionLock?
         i->u->m_bConnecting = false;
         remove(i->u->m_SocketID);
 


### PR DESCRIPTION
As described in #1979 in [this comment](https://github.com/Haivision/srt/issues/1979#issuecomment-896845181), if a socket was closed and already removed from the connection queue (`CRendezvousQueue`), it may still get itself to `vector<LinkStatusInfo> toProcess` in `CRendezvousQueue::updateConnStatus(..)`.
After PR #2075 nothing serious would happen. Still, it might be worth checking this situation earlier, and not even start to fill the response handshake.

The `CUDT::closeInternal` sets `m_bOpened = false` in the end under the `m_ConnectionLock`. So checking `m_bOpened` in the beginning of `CUDT::processAsyncConnectRequest(..)` would allow to return earlier.

Fixes #1979.