### PR TITLE
[core] Check Win QPC frequency is non-zero

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -325,8 +325,6 @@ public:
    CEPoll& epoll_ref() { return m_EPoll; }
 
 private:
-//   void init();
-
    /// Generates a new socket ID. This function starts from a randomly
    /// generated value (at initialization time) and goes backward with
    /// with next calls. The possible values come from the range without

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -86,6 +86,12 @@ static int64_t get_cpu_frequency()
     if (QueryPerformanceFrequency(&ccf))
     {
         frequency = ccf.QuadPart / 1000000; // counts per microsecond
+        if (frequency == 0)
+        {
+            LOGC(inlog.Warn, log << "Win QPC frequency of " << ccf.QuadPart
+                << " counts/s is below the required 1 us accuracy. Please consider using C++11 timing (-DENABLE_STDCXX_SYNC=ON) instead.");
+            frequency = 1; // set back to 1 to avoid division by zero.
+        }
     }
     else
     {


### PR DESCRIPTION
As reported in #1974, Win QPC frequency may be below 1 microsecond, which would result in a zero frequency value, eventually leading to a division by zero.
This PR sets the frequency to 1 and shows an error message instructing to consider using C++11 timing instead.

The reported mobile CPU Intel Core(TM) M-5Y10c CPU @ 0.80GHz 1.00GHz was released in Q1 2015.

Fixes #1974 as no further improvements are expected yet. Going to a floating-point frequency may influence SRT performance for general users. Will wait for further feedback with the error message shown to all affected users.