### PR TITLE
[core] Repurpose SRTO_GROUPMINSTABLETIMEO

### DIFF
--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -254,7 +254,7 @@ const SocketOption srt_options [] {
     { "bindtodevice", 0, SRTO_BINDTODEVICE, SocketOption::PRE, SocketOption::STRING, nullptr},
 #endif
 #if ENABLE_EXPERIMENTAL_BONDING
-    { "groupstabtimeo", 0, SRTO_GROUPSTABTIMEO, SocketOption::POST, SocketOption::INT, nullptr},
+    { "groupminstabletimeo", 0, SRTO_GROUPMINSTABLETIMEO, SocketOption::POST, SocketOption::INT, nullptr},
 #endif
     { "retransmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
 };

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -249,12 +249,10 @@ const SocketOption srt_options [] {
     { "packetfilter", 0, SRTO_PACKETFILTER, SocketOption::PRE, SocketOption::STRING, nullptr },
 #if ENABLE_EXPERIMENTAL_BONDING
     { "groupconnect", 0, SRTO_GROUPCONNECT, SocketOption::PRE, SocketOption::INT, nullptr},
+    { "groupminstabletimeo", 0, SRTO_GROUPMINSTABLETIMEO, SocketOption::PRE, SocketOption::INT, nullptr},
 #endif
 #ifdef SRT_ENABLE_BINDTODEVICE
     { "bindtodevice", 0, SRTO_BINDTODEVICE, SocketOption::PRE, SocketOption::STRING, nullptr},
-#endif
-#if ENABLE_EXPERIMENTAL_BONDING
-    { "groupminstabletimeo", 0, SRTO_GROUPMINSTABLETIMEO, SocketOption::POST, SocketOption::INT, nullptr},
 #endif
     { "retransmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
 };

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -205,7 +205,7 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_EVENT`](#SRTO_EVENT)                            |       |          | `int32_t` | flags   |                   |          | R   | S     |
 | [`SRTO_FC`](#SRTO_FC)                                  |       | pre      | `int32_t` | pkts    | 25600             | 32..     | RW  | GSD   |
 | [`SRTO_GROUPCONNECT`](#SRTO_GROUPCONNECT)              | 1.5.0 | pre      | `int32_t` |         | 0                 | 0...1    | W   | S     |
-| [`SRTO_GROUPSTABTIMEO`](#SRTO_GROUPSTABTIMEO)          | 1.5.0 | pre      | `int32_t` | ms      | 80                | 10-...   | W   | GSD+  |
+| [`SRTO_GROUPMINSTABLETIMEO`](#SRTO_GROUPMINSTABLETIMEO)          | 1.5.0 | pre      | `int32_t` | ms      | 80                | 10-...   | W   | GSD+  |
 | [`SRTO_GROUPTYPE`](#SRTO_GROUPTYPE)                    | 1.5.0 |          | `int32_t` | enum    |                   |          | R   | S     |
 | [`SRTO_INPUTBW`](#SRTO_INPUTBW)                        | 1.0.5 | post     | `int64_t` | B/s     | 0                 | 0..      | RW  | GSD   |
 | [`SRTO_IPTOS`](#SRTO_IPTOS)                            | 1.0.5 | pre-bind | `int32_t` |         | (system)          | 0..255   | RW  | GSD   |
@@ -455,11 +455,11 @@ function will return the group, not this socket ID.
 
 ---
 
-#### SRTO_GROUPSTABTIMEO
+#### SRTO_GROUPMINSTABLETIMEO
 
 | OptName               | Since | Restrict | Type       | Units  | Default  | Range  | Dir | Entity |
 | --------------------- | ----- | -------- | ---------- | ------ | -------- | ------ | --- | ------ |
-| `SRTO_GROUPSTABTIMEO` | 1.5.0 | pre      | `int32_t`  | ms     | 80       | 10-... | W   | GSD+   |
+| `SRTO_GROUPMINSTABLETIMEO` | 1.5.0 | pre      | `int32_t`  | ms     | 80       | 10-... | W   | GSD+   |
 
 **Not in use at the moment. Is to be repurposed in SRT v1.4.3!**
 
@@ -494,7 +494,7 @@ for 100% for a time of one ACK interval).
 Note that the value of this option is not allowed to exceed the value of
 `SRTO_PEERIDLETIMEO`. Usually it is only meaningful if you change the latter
 option, as the default value of it is way above any sensible value of
-`SRTO_GROUPSTABTIMEO`.
+`SRTO_GROUPMINSTABLETIMEO`.
 
 [Return to list](#list-of-options)
 

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -205,7 +205,7 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_EVENT`](#SRTO_EVENT)                            |       |          | `int32_t` | flags   |                   |          | R   | S     |
 | [`SRTO_FC`](#SRTO_FC)                                  |       | pre      | `int32_t` | pkts    | 25600             | 32..     | RW  | GSD   |
 | [`SRTO_GROUPCONNECT`](#SRTO_GROUPCONNECT)              | 1.5.0 | pre      | `int32_t` |         | 0                 | 0...1    | W   | S     |
-| [`SRTO_GROUPMINSTABLETIMEO`](#SRTO_GROUPMINSTABLETIMEO)          | 1.5.0 | pre      | `int32_t` | ms      | 80                | 10-...   | W   | GSD+  |
+| [`SRTO_GROUPMINSTABLETIMEO`](#SRTO_GROUPMINSTABLETIMEO) | 1.4.5 | pre     | `int32_t` | ms      | 60                | 60-...   | W   | GDI+  |
 | [`SRTO_GROUPTYPE`](#SRTO_GROUPTYPE)                    | 1.5.0 |          | `int32_t` | enum    |                   |          | R   | S     |
 | [`SRTO_INPUTBW`](#SRTO_INPUTBW)                        | 1.0.5 | post     | `int64_t` | B/s     | 0                 | 0..      | RW  | GSD   |
 | [`SRTO_IPTOS`](#SRTO_IPTOS)                            | 1.0.5 | pre-bind | `int32_t` |         | (system)          | 0..255   | RW  | GSD   |
@@ -459,44 +459,31 @@ function will return the group, not this socket ID.
 
 | OptName               | Since | Restrict | Type       | Units  | Default  | Range  | Dir | Entity |
 | --------------------- | ----- | -------- | ---------- | ------ | -------- | ------ | --- | ------ |
-| `SRTO_GROUPMINSTABLETIMEO` | 1.5.0 | pre      | `int32_t`  | ms     | 80       | 10-... | W   | GSD+   |
+| `SRTO_GROUPMINSTABLETIMEO` | 1.4.5 | pre | `int32_t`  | ms     | 60       | 60-... | W   | GDI+   |
 
-TODO: Update the escription.
+The option is used for groups of type `SRT_GTYPE_BACKUP`. It defines the **minimum** value of the stability
+timeout for all active member sockets in a group.
+The actual timeout value is determined in runtime based on the RTT estimate of an individual member socket.
+If there is no response from the peer for the calculated timeout,
+the member is considered unstable, triggering activation of an idle backup member.
 
-**Not in use at the moment. Is to be repurposed in SRT v1.4.3!**
+The samller the value is, the earlier a backup member might be activated to prepare transision to that path.
+However, it may also lead to spurious activations of backup paths.
+The higher the value is, the later would a backup link be activated. All unacknowledged payload packets
+have to be retransmitted through the backup path. If they don't reach the receiver in time, they would be dropped.
+Therefore, an appropriate adjustment of the SRT buffering delay
+(`SRTO_PEERLATENCY` on sender, `SRTO_RCVLATENCY` on receiver) should also be considered.
 
-This setting is used for groups of type `SRT_GTYPE_BACKUP`. It defines the stability
-timeout, which is the maximum interval between two consecutive packets retrieved from
-the peer on the currently active link. These two packets can be of any type,
-but this setting usually refers to control packets while the agent is a sender.
-Idle links exchange only keepalive messages once per second, so they do not
-count. Note that this option is meaningless on sockets that are not members of
-the Backup-type group.
+Normally the receiver should send an ACK back to sender every 10 ms. In case of congestion,
+in the live streaming configuration of SRT a loss report is expected to be sent every RTT/2.
+The network jitter and increase of RTT on the public internet causes
+these intervals to be stretched.
+The default minimum value of 60 ms is selected as a general fit for most of the use cases.
 
-This value should be set with a thoroughly selected balance and correspond to
-the maximum stretched response time between two consecutive ACK messages. By default
-ACK messages are sent every 10ms (so this interval is not dependent on the network
-latency), and so should be the interval between two consecutive received ACK
-messages. Note, however, that the network jitter on the public internet causes
-these intervals to be stretched, even to multiples of that interval. Both large
-and small values of this option have consequences:
-
-Large values of this option prevent overreaction on highly stretched response
-times, but introduce a latency penalty - the latency must be greater
-than this value (otherwise switching to another link won't preserve
-smooth signal sending). Large values will also contribute to higher packet
-bursts sent at the moment when an idle link is activated.
-
-Smaller values of this option respect low latency requirements very
-well, but may cause overreaction on even slightly stretched response times. This is
-unwanted, as a link switch should ideally happen only when the currently active
-link is really broken, as every link switch costs extra overhead (it counts
-for 100% for a time of one ACK interval).
+Please refer to the [SRT Connection Bonding: Main/Backup](../features/bonding-main-backup.md) document for more details.
 
 Note that the value of this option is not allowed to exceed the value of
-`SRTO_PEERIDLETIMEO`. Usually it is only meaningful if you change the latter
-option, as the default value of it is way above any sensible value of
-`SRTO_GROUPMINSTABLETIMEO`.
+`SRTO_PEERIDLETIMEO`, which determines the timeout to actually break an idle (irresponsive) connection.
 
 [Return to list](#list-of-options)
 

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -467,14 +467,14 @@ The actual timeout value is determined in runtime based on the RTT estimate of a
 If there is no response from the peer for the calculated timeout,
 the member is considered unstable, triggering activation of an idle backup member.
 
-The samller the value is, the earlier a backup member might be activated to prepare transision to that path.
+The smaller the value is, the earlier a backup member might be activated to prepare transition to that path.
 However, it may also lead to spurious activations of backup paths.
-The higher the value is, the later would a backup link be activated. All unacknowledged payload packets
+The higher the value is, the later the backup link would be activated. All unacknowledged payload packets
 have to be retransmitted through the backup path. If they don't reach the receiver in time, they would be dropped.
 Therefore, an appropriate adjustment of the SRT buffering delay
 (`SRTO_PEERLATENCY` on sender, `SRTO_RCVLATENCY` on receiver) should also be considered.
 
-Normally the receiver should send an ACK back to sender every 10 ms. In case of congestion,
+Normally the receiver should send an ACK back to the sender every 10 ms. In the case of congestion,
 in the live streaming configuration of SRT a loss report is expected to be sent every RTT/2.
 The network jitter and increase of RTT on the public internet causes
 these intervals to be stretched.

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -461,6 +461,8 @@ function will return the group, not this socket ID.
 | --------------------- | ----- | -------- | ---------- | ------ | -------- | ------ | --- | ------ |
 | `SRTO_GROUPMINSTABLETIMEO` | 1.5.0 | pre      | `int32_t`  | ms     | 80       | 10-... | W   | GSD+   |
 
+TODO: Update the escription.
+
 **Not in use at the moment. Is to be repurposed in SRT v1.4.3!**
 
 This setting is used for groups of type `SRT_GTYPE_BACKUP`. It defines the stability

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -340,7 +340,7 @@ following type specification:
 | `enforcedencryption` | `bool`           | `SRTO_ENFORCEDENCRYPTION` | Reject connection if parties set different passphrase. |
 | `fc`                 | `bytes`          | `SRTO_FC`                 | Flow control window size. |
 | `groupconnect`       | {`0`, `1`}       | `SRTO_GROUPCONNECT`       | Accept group connections. |
-| `groupstabtimeo`     | `ms`             | `SRTO_GROUPSTABTIMEO`     | Group stability timeout. |
+| `groupminstabletimeo`| 60.. `ms`        | `SRTO_GROUPMINSTABLETIMEO`| Group minimum stability timeout. |
 | `inputbw`            | `bytes`          | `SRTO_INPUTBW`            | Input bandwidth. |
 | `iptos`              | 0..255           | `SRTO_IPTOS`              | IP socket type of service |
 | `ipttl`              | 1..255           | `SRTO_IPTTL`              | Defines IP socket "time to live" option. |

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9704,7 +9704,7 @@ bool srt::CUDT::overrideSndSeqNo(int32_t seq)
     const int diff = CSeqNo(seq) - CSeqNo(m_iSndCurrSeqNo);
     if (diff < 0 || diff > CSeqNo::m_iSeqNoTH)
     {
-        LOGC(gslog.Error, log << CONID() << "IPE: Overridding with seq %" << seq << " DISCREPANCY against current %"
+        LOGC(gslog.Error, log << CONID() << "IPE: Overriding with seq %" << seq << " DISCREPANCY against current %"
                 << m_iSndCurrSeqNo << " and next sched %" << m_iSndNextSeqNo << " - diff=" << diff);
         return false;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -199,6 +199,7 @@ struct SrtOptionAction
 #endif
 #if ENABLE_EXPERIMENTAL_BONDING
         flags[SRTO_GROUPCONNECT]       = SRTO_R_PRE;
+        flags[SRTO_GROUPMINSTABLETIMEO]= SRTO_R_PRE;
 #endif
         flags[SRTO_PACKETFILTER]       = SRTO_R_PRE;
         flags[SRTO_RETRANSMITALGO]     = SRTO_R_PRE;
@@ -767,8 +768,13 @@ void srt::CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 
 #if ENABLE_EXPERIMENTAL_BONDING
     case SRTO_GROUPCONNECT:
-        optlen         = sizeof (int);
+        optlen        = sizeof (int);
         *(int*)optval = m_config.iGroupConnect;
+        break;
+
+    case SRTO_GROUPMINSTABLETIMEO:
+        optlen = sizeof(int);
+        *(int*)optval = (int)m_config.uMinStabilityTimeout_ms;
         break;
 
     case SRTO_GROUPTYPE:
@@ -788,7 +794,7 @@ void srt::CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_PEERIDLETIMEO:
-        *(int *)optval = m_config.iPeerIdleTimeout;
+        *(int *)optval = m_config.iPeerIdleTimeout_ms;
         optlen         = sizeof(int);
         break;
 
@@ -11191,7 +11197,7 @@ bool srt::CUDT::checkExpTimer(const steady_clock::time_point& currtime, int chec
         return false;
 
     // ms -> us
-    const int PEER_IDLE_TMO_US = m_config.iPeerIdleTimeout * 1000;
+    const int PEER_IDLE_TMO_US = m_config.iPeerIdleTimeout_ms * 1000;
     // Haven't received any information from the peer, is it dead?!
     // timeout: at least 16 expirations and must be greater than 5 seconds
     time_point last_rsp_time = m_tsLastRspTime.load();

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -327,7 +327,7 @@ public: // internal API
     int         MSS()               const { return m_config.iMSS; }
 
     uint32_t        peerLatency_us()        const { return m_iPeerTsbPdDelay_ms * 1000; }
-    int             peerIdleTimeout_ms()    const { return m_config.iPeerIdleTimeout; }
+    int             peerIdleTimeout_ms()    const { return m_config.iPeerIdleTimeout_ms; }
     size_t          maxPayloadSize()        const { return m_iMaxSRTPayloadSize; }
     size_t          OPT_PayloadSize()       const { return m_config.zExpPayloadSize; }
     int             sndLossLength()               { return m_pSndLossList->getLossLength(); }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -390,10 +390,11 @@ void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     case SRTO_GROUPMINSTABLETIMEO:
     {
         const int val_ms = cast_optval<int>(optval, optlen);
-        if (val_ms < (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
+        const int min_timeo_ms = (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS;
+        if (val_ms < min_timeo_ms)
         {
             LOGC(qmlog.Error,
-                log << "group option: SRTO_GROUPMINSTABLETIMEO min allowed value is " << CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS << " ms.");
+                 log << "group option: SRTO_GROUPMINSTABLETIMEO min allowed value is " << min_timeo_ms << " ms.");
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -3338,8 +3338,6 @@ CUDTGroup::BackupMemberState CUDTGroup::sendBackup_QualifyActiveState(const gli_
     const int64_t initial_stabtout_us = max<int64_t>(min_stability_us, latency_us);
     const int64_t probing_period_us = initial_stabtout_us + 5 * CUDT::COMM_SYN_INTERVAL_US;
 
-    LOGC(smlog.Warn, log << "sendBackup_QualifyActiveState min_stability_us " << min_stability_us);
-
     // RTT and RTTVar values are still being refined during the probing period,
     // therefore the dymanic timeout should not be used during the probing period.
     const bool is_activation_phase = !is_zero(u.freshActivationStart())

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -387,6 +387,8 @@ void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         m_iRcvTimeOut = cast_optval<int>(optval, optlen);
         break;
 
+    // The CUDTGroup is included in the build even when bonding is disabled.
+#if ENABLE_EXPERIMENTAL_BONDING
     case SRTO_GROUPMINSTABLETIMEO:
     {
         const int val_ms = cast_optval<int>(optval, optlen);
@@ -417,6 +419,7 @@ void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     }
 
     break;
+#endif
 
         // XXX Currently no socket groups allow any other
         // congestion control mode other than live.

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -258,7 +258,7 @@ CUDTGroup::CUDTGroup(SRT_GROUP_TYPE gtype)
     , m_iBusy()
     , m_iSndOldestMsgNo(SRT_MSGNO_NONE)
     , m_iSndAckedMsgNo(SRT_MSGNO_NONE)
-    , m_uOPT_MinStabilityTimeout(CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_US)
+    , m_uOPT_MinStabilityTimeout_us(1000 * CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
     // -1 = "undefined"; will become defined with first added socket
     , m_iMaxPayloadSize(-1)
     , m_bSynRecving(true)
@@ -389,10 +389,16 @@ void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
 
     case SRTO_GROUPMINSTABLETIMEO:
     {
-        const int val = cast_optval<int>(optval, optlen);
+        const int val_ms = cast_optval<int>(optval, optlen);
+        if (val_ms < (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
+        {
+            LOGC(qmlog.Error,
+                log << "group option: SRTO_GROUPMINSTABLETIMEO min allowed value is " << CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS << " ms.");
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+        }
 
         // Search if you already have SRTO_PEERIDLETIMEO set
-        int                          idletmo = CSrtConfig::COMM_RESPONSE_TIMEOUT_MS;
+        int idletmo = CSrtConfig::COMM_RESPONSE_TIMEOUT_MS;
         vector<ConfigItem>::iterator f =
             find_if(m_config.begin(), m_config.end(), ConfigItem::OfType(SRTO_PEERIDLETIMEO));
         if (f != m_config.end())
@@ -400,14 +406,14 @@ void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
             f->get(idletmo); // worst case, it will leave it unchanged.
         }
 
-        if (val >= idletmo)
+        if (val_ms > idletmo)
         {
             LOGC(qmlog.Error,
-                 log << "group option: SRTO_GROUPMINSTABLETIMEO=" << val << " exceeds SRTO_PEERIDLETIMEO=" << idletmo);
+                 log << "group option: SRTO_GROUPMINSTABLETIMEO=" << val_ms << " exceeds SRTO_PEERIDLETIMEO=" << idletmo);
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        m_uOPT_MinStabilityTimeout = val * 1000;
+        m_uOPT_MinStabilityTimeout_us = 1000 * val_ms;
     }
 
     break;
@@ -563,8 +569,8 @@ void CUDTGroup::deriveSettings(CUDT* u)
     IM(SRTO_MINVERSION, uMinimumPeerSrtVersion);
     IM(SRTO_ENFORCEDENCRYPTION, bEnforcedEnc);
     IM(SRTO_IPV6ONLY, iIpV6Only);
-    IM(SRTO_PEERIDLETIMEO, iPeerIdleTimeout);
-    IM(SRTO_GROUPMINSTABLETIMEO, uMinStabilityTimeoutUS);
+    IM(SRTO_PEERIDLETIMEO, iPeerIdleTimeout_ms);
+    IM(SRTO_GROUPMINSTABLETIMEO, uMinStabilityTimeout_ms * 1000);
 
     importOption(m_config, SRTO_PACKETFILTER, u->m_config.sPacketFilterConfig.str());
 
@@ -760,7 +766,7 @@ static bool getOptDefault(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
     case SRTO_PAYLOADSIZE:
         RD(0);
     case SRTO_GROUPMINSTABLETIMEO:
-        RD(CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_US);
+        RD(CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS);
     }
 
 #undef RD
@@ -3329,7 +3335,8 @@ CUDTGroup::BackupMemberState CUDTGroup::sendBackup_QualifyActiveState(const gli_
     const CUDT& u = d->ps->core();
 
     const uint32_t latency_us = u.peerLatency_us();
-    const int32_t min_stability_us = 60000; // Minimum Link Stability Timeout: 60ms.
+
+    const int32_t min_stability_us = m_uOPT_MinStabilityTimeout_us;
     const int64_t initial_stabtout_us = max<int64_t>(min_stability_us, latency_us);
     const int64_t probing_period_us = initial_stabtout_us + 5 * CUDT::COMM_SYN_INTERVAL_US;
 

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -614,7 +614,7 @@ private:
     senderBuffer_t   m_SenderBuffer;
     int32_t          m_iSndOldestMsgNo; // oldest position in the sender buffer
     volatile int32_t m_iSndAckedMsgNo;
-    uint32_t         m_uOPT_StabilityTimeout;
+    uint32_t         m_uOPT_MinStabilityTimeout;
 
     // THIS function must be called only in a function for a group type
     // that does use sender buffer.

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -614,7 +614,7 @@ private:
     senderBuffer_t   m_SenderBuffer;
     int32_t          m_iSndOldestMsgNo; // oldest position in the sender buffer
     volatile int32_t m_iSndAckedMsgNo;
-    uint32_t         m_uOPT_MinStabilityTimeout;
+    uint32_t         m_uOPT_MinStabilityTimeout_us;
 
     // THIS function must be called only in a function for a group type
     // that does use sender buffer.

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -864,6 +864,7 @@ struct CSrtConfigSetter<SRTO_GROUPMINSTABLETIMEO>
         }
 
         co.uMinStabilityTimeout_ms = val_ms;
+        LOGC(smlog.Error, log << "SRTO_GROUPMINSTABLETIMEO set " << val_ms);
     }
 };
 #endif

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -846,7 +846,7 @@ struct CSrtConfigSetter<SRTO_GROUPMINSTABLETIMEO>
         const int val_ms = cast_optval<int>(optval, optlen);
         const int min_timeo_ms = (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS;
 
-        if (val_ms < (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
+        if (val_ms < min_timeo_ms)
         {
             LOGC(qmlog.Error,
                 log << "group option: SRTO_GROUPMINSTABLETIMEO min allowed value is "

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -209,7 +209,7 @@ struct CSrtConfigSetter<SRTO_RCVSYN>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.bSynRecving = cast_optval<bool>(optval, optlen); 
+        co.bSynRecving = cast_optval<bool>(optval, optlen);
     }
 };
 

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -209,7 +209,7 @@ struct CSrtConfigSetter<SRTO_RCVSYN>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.bSynRecving = cast_optval<bool>(optval, optlen);
+        co.bSynRecving = cast_optval<bool>(optval, optlen); 
     }
 };
 
@@ -263,7 +263,6 @@ struct CSrtConfigSetter<SRTO_BINDTODEVICE>
         using namespace srt_logging;
 #ifdef SRT_ENABLE_BINDTODEVICE
         using namespace std;
-        using namespace srt_logging;
 
         string val;
         if (optlen == -1)
@@ -843,14 +842,15 @@ struct CSrtConfigSetter<SRTO_GROUPMINSTABLETIMEO>
         // This option is meaningless for the socket itself.
         // It's set here just for the sake of setting it on a listener
         // socket so that it is then applied on the group when a
-        // group connection is configuired.
+        // group connection is configured.
         const int val_ms = cast_optval<int>(optval, optlen);
+        const int min_timeo_ms = (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS;
 
         if (val_ms < (int) CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
         {
             LOGC(qmlog.Error,
                 log << "group option: SRTO_GROUPMINSTABLETIMEO min allowed value is "
-                    << CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS << " ms.");
+                    << min_timeo_ms << " ms.");
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -835,7 +835,7 @@ struct CSrtConfigSetter<SRTO_PACKETFILTER>
 
 #if ENABLE_EXPERIMENTAL_BONDING
 template<>
-struct CSrtConfigSetter<SRTO_GROUPSTABTIMEO>
+struct CSrtConfigSetter<SRTO_GROUPMINSTABLETIMEO>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
@@ -845,23 +845,19 @@ struct CSrtConfigSetter<SRTO_GROUPSTABTIMEO>
         // socket so that it is then applied on the group when a
         // group connection is configuired.
         const int val = cast_optval<int>(optval, optlen);
-
-        // Search if you already have SRTO_PEERIDLETIMEO set
-
         const int idletmo = co.iPeerIdleTimeout;
 
-        // Both are in milliseconds.
         // This option is RECORDED in microseconds, while
         // idletmo is recorded in milliseconds, only translated to
         // microseconds directly before use.
         if (val >= idletmo)
         {
-            LOGC(aclog.Error, log << "group option: SRTO_GROUPSTABTIMEO(" << val
+            LOGC(aclog.Error, log << "group option: SRTO_GROUPMINSTABLETIMEO(" << val
                                   << ") exceeds SRTO_PEERIDLETIMEO(" << idletmo << ")");
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
 
-        co.uStabilityTimeout = val * 1000;
+        co.uMinStabilityTimeoutUS = val * 1000;
     }
 };
 #endif
@@ -935,7 +931,7 @@ int dispatchSet(SRT_SOCKOPT optName, CSrtConfig& co, const void* optval, int opt
         DISPATCH(SRTO_IPV6ONLY);
         DISPATCH(SRTO_PACKETFILTER);
 #if ENABLE_EXPERIMENTAL_BONDING
-        DISPATCH(SRTO_GROUPSTABTIMEO);
+        DISPATCH(SRTO_GROUPMINSTABLETIMEO);
 #endif
         DISPATCH(SRTO_RETRANSMITALGO);
 
@@ -964,7 +960,7 @@ bool SRT_SocketOptionObject::add(SRT_SOCKOPT optname, const void* optval, size_t
     case SRTO_CONNTIMEO:
     case SRTO_DRIFTTRACER:
         //SRTO_FC - not allowed to be different among group members
-    case SRTO_GROUPSTABTIMEO:
+    case SRTO_GROUPMINSTABLETIMEO:
         //SRTO_INPUTBW - per transmission setting
     case SRTO_IPTOS:
     case SRTO_IPTTL:

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -174,7 +174,7 @@ struct CSrtConfig: CSrtMuxerConfig
         DEF_CONNTIMEO_S = 3;    // 3 seconds
 
     static const int      COMM_RESPONSE_TIMEOUT_MS      = 5 * 1000; // 5 seconds
-    static const uint32_t COMM_DEF_MIN_STABILITY_TIMEOUT_US = 60 * 1000; // 60 ms
+    static const uint32_t COMM_DEF_MIN_STABILITY_TIMEOUT_MS = 60;   // 60 ms
 
     // Mimimum recv flight flag size is 32 packets
     static const int    DEF_MIN_FLIGHT_PKT = 32;
@@ -218,8 +218,8 @@ struct CSrtConfig: CSrtMuxerConfig
     int      iSndDropDelay; // Extra delay when deciding to snd-drop for TLPKTDROP, -1 to off
     bool     bEnforcedEnc;  // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
     int      iGroupConnect;    // 1 - allow group connections
-    int      iPeerIdleTimeout; // Timeout for hearing anything from the peer.
-    uint32_t uMinStabilityTimeoutUS;
+    int      iPeerIdleTimeout_ms; // Timeout for hearing anything from the peer (ms).
+    uint32_t uMinStabilityTimeout_ms;
     int      iRetransmitAlgo;
 
     int64_t llInputBW;         // Input stream rate (bytes/sec). 0: use internally estimated input bandwidth
@@ -269,8 +269,8 @@ struct CSrtConfig: CSrtMuxerConfig
         , iSndDropDelay(0)
         , bEnforcedEnc(true)
         , iGroupConnect(0)
-        , iPeerIdleTimeout(COMM_RESPONSE_TIMEOUT_MS)
-        , uMinStabilityTimeoutUS(COMM_DEF_MIN_STABILITY_TIMEOUT_US)
+        , iPeerIdleTimeout_ms(COMM_RESPONSE_TIMEOUT_MS)
+        , uMinStabilityTimeout_ms(COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
         , iRetransmitAlgo(1)
         , llInputBW(0)
         , llMinInputBW(0)

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -174,7 +174,7 @@ struct CSrtConfig: CSrtMuxerConfig
         DEF_CONNTIMEO_S = 3;    // 3 seconds
 
     static const int      COMM_RESPONSE_TIMEOUT_MS      = 5 * 1000; // 5 seconds
-    static const uint32_t COMM_DEF_STABILITY_TIMEOUT_US = 80 * 1000;
+    static const uint32_t COMM_DEF_MIN_STABILITY_TIMEOUT_US = 60 * 1000; // 60 ms
 
     // Mimimum recv flight flag size is 32 packets
     static const int    DEF_MIN_FLIGHT_PKT = 32;
@@ -219,7 +219,7 @@ struct CSrtConfig: CSrtMuxerConfig
     bool     bEnforcedEnc;  // Off by default. When on, any connection other than nopw-nopw & pw1-pw1 is rejected.
     int      iGroupConnect;    // 1 - allow group connections
     int      iPeerIdleTimeout; // Timeout for hearing anything from the peer.
-    uint32_t uStabilityTimeout;
+    uint32_t uMinStabilityTimeoutUS;
     int      iRetransmitAlgo;
 
     int64_t llInputBW;         // Input stream rate (bytes/sec). 0: use internally estimated input bandwidth
@@ -270,7 +270,7 @@ struct CSrtConfig: CSrtMuxerConfig
         , bEnforcedEnc(true)
         , iGroupConnect(0)
         , iPeerIdleTimeout(COMM_RESPONSE_TIMEOUT_MS)
-        , uStabilityTimeout(COMM_DEF_STABILITY_TIMEOUT_US)
+        , uMinStabilityTimeoutUS(COMM_DEF_MIN_STABILITY_TIMEOUT_US)
         , iRetransmitAlgo(1)
         , llInputBW(0)
         , llMinInputBW(0)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -239,7 +239,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_BINDTODEVICE,        // Forward the SOL_SOCKET/SO_BINDTODEVICE option on socket (pass packets only from that device)
 #if ENABLE_EXPERIMENTAL_BONDING
    SRTO_GROUPCONNECT,        // Set on a listener to allow group connection
-   SRTO_GROUPMINSTABLETIMEO, // Minimum Link Stability timeout (backup mode) in microseconds
+   SRTO_GROUPMINSTABLETIMEO, // Minimum Link Stability timeout (backup mode) in milliseconds
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake
 #endif
    SRTO_PACKETFILTER = 60,   // Add and configure a packet filter

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -239,7 +239,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_BINDTODEVICE,        // Forward the SOL_SOCKET/SO_BINDTODEVICE option on socket (pass packets only from that device)
 #if ENABLE_EXPERIMENTAL_BONDING
    SRTO_GROUPCONNECT,        // Set on a listener to allow group connection
-   SRTO_GROUPSTABTIMEO,      // Stability timeout (backup groups) in [us]
+   SRTO_GROUPMINSTABLETIMEO, // Minimum Link Stability timeout (backup mode) in microseconds
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake
 #endif
    SRTO_PACKETFILTER = 60,   // Add and configure a packet filter

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -172,7 +172,7 @@ const OptionTestEntry g_test_matrix_options[] =
     //SRTO_EVENT
     { SRTO_FC,                      "SRTO_FC",  RestrictionType::PRE,     sizeof(int),               32,  INT32_MAX,    25600,        10000,   {-1, 31} },
     //SRTO_GROUPCONNECT
-    //SRTO_GROUPSTABTIMEO
+    //SRTO_GROUPMINSTABLETIMEO
     //SRTO_GROUPTYPE
     //SRTO_INPUTBW
     //SRTO_IPTOS

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -172,7 +172,10 @@ const OptionTestEntry g_test_matrix_options[] =
     //SRTO_EVENT
     { SRTO_FC,                      "SRTO_FC",  RestrictionType::PRE,     sizeof(int),               32,  INT32_MAX,    25600,        10000,   {-1, 31} },
     //SRTO_GROUPCONNECT
-    //SRTO_GROUPMINSTABLETIMEO
+#if ENABLE_EXPERIMENTAL_BONDING
+    // Max value can't exceed SRTO_PEERIDLETIMEO
+    { SRTO_GROUPMINSTABLETIMEO, "SRTO_GROUPMINSTABLETIMEO", RestrictionType::PRE, sizeof(int),       60,       5000,       60,           70,     {0, -1, 50, 5001} },
+#endif
     //SRTO_GROUPTYPE
     //SRTO_INPUTBW
     //SRTO_IPTOS


### PR DESCRIPTION
`SRTO_GROUPMINSTABLETIMEO` is a socket option for SRT socket group. It does not do anything when set on an individual socket, but when set on a listener socket - it is used to derive the value for a group. Defines the minimum value of the stability timeout for a member socket to be considered unstable.


### API Changes

- [x] Renamed `SRTO_GROUPSTABTIMEO` to `SRTO_GROUPMINSTABLETIMEO`. Default: 60 ms.
- [x] The `SRTO_GROUPMINSTABLETIMEO` option can be set on an individual socket and on a group socket.

### Logic

- [x] The option value is used in `CUDTGroup::sendBackup_QualifyActiveState(..)` instead of the constant value of 60 ms.

### URI Scheme

- [x] `groupminstabletimeo=<int>`

### Tests

- [x] Several Listeners in a Group, Sender.
- [x] One Listener in a Group, Sender.
- [x] A Group of Callers, Sender

### Docs

- [x] Update the docs

Fixes #1792
Fixes #2254 (a typo).