### PR TITLE
[core] Prefer the endian.h header file from glibc if available

### DIFF
--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -57,7 +57,7 @@ written by
 
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || defined(__GLIBC__)
 
 #	include <endian.h>
 
@@ -115,7 +115,7 @@ written by
 
 #	include <sys/endian.h>
 
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
 
 #	include <sys/endian.h>
 


### PR DESCRIPTION
On the Debian kfreebsd port, both endian.h and sys/endian.h are
available. After discussing with the kfreebsd port maintainer and since
this is userspace related, we should prefer the one from the glibc

See: #2066