### PR TITLE
Rafactoring: CUDTSocket now owns a member CUDT class

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -76,6 +76,8 @@ namespace srt {
 
 class CUDT;
 
+/// @brief Class CUDTSocket is a control layer on top of the CUDT core functionality layer.
+/// CUDTSocket owns CUDT.
 class CUDTSocket
 {
 public:
@@ -89,7 +91,26 @@ public:
        , m_GroupOf()
 #endif
        , m_iISN(0)
-       , m_pUDT(NULL)
+       , m_UDT(this)
+       , m_AcceptCond()
+       , m_AcceptLock()
+       , m_uiBackLog(0)
+       , m_iMuxID(-1)
+   {
+       construct();
+   }
+
+   CUDTSocket(const CUDTSocket& ancestor)
+       : m_Status(SRTS_INIT)
+       , m_SocketID(0)
+       , m_ListenSocket(0)
+       , m_PeerID(0)
+#if ENABLE_EXPERIMENTAL_BONDING
+       , m_GroupMemberData()
+       , m_GroupOf()
+#endif
+       , m_iISN(0)
+       , m_UDT(this, ancestor.m_UDT)
        , m_AcceptCond()
        , m_AcceptLock()
        , m_uiBackLog(0)
@@ -125,8 +146,10 @@ public:
 
    int32_t m_iISN;                           //< initial sequence number, used to tell different connection from same IP:port
 
-   CUDT* m_pUDT;                             //< pointer to the UDT entity
+private:
+   CUDT m_UDT;                               //< internal SRT socket logic
 
+public:
    std::set<SRTSOCKET> m_QueuedSockets;      //< set of connections waiting for accept()
 
    sync::Condition m_AcceptCond;             //< used to block "accept" call
@@ -149,7 +172,8 @@ public:
 
    sync::Mutex m_ControlLock;           //< lock this socket exclusively for control APIs: bind/listen/connect
 
-   CUDT& core() { return *m_pUDT; }
+   CUDT& core() { return m_UDT; }
+   const CUDT& core() const { return m_UDT; }
 
    static int64_t getPeerSpec(SRTSOCKET id, int32_t isn)
    {
@@ -188,7 +212,6 @@ public:
    bool broken() const;
 
 private:
-   CUDTSocket(const CUDTSocket&);
    CUDTSocket& operator=(const CUDTSocket&);
 };
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4670,8 +4670,8 @@ EConnectStatus srt::CUDT::postConnect(const CPacket* pResponse, bool rendezvous,
     // the local port must be correctly assigned BEFORE CUDT::startConnect(),
     // otherwise if startConnect() fails, the multiplexer cannot be located
     // by garbage collection and will cause leak
-    s->m_pUDT->m_pSndQueue->m_pChannel->getSockAddr((s->m_SelfAddr));
-    CIPAddress::pton((s->m_SelfAddr), s->m_pUDT->m_piSelfIP, m_PeerAddr);
+    s->core().m_pSndQueue->m_pChannel->getSockAddr((s->m_SelfAddr));
+    CIPAddress::pton((s->m_SelfAddr), s->core().m_piSelfIP, m_PeerAddr);
 
     //int token = -1;
 #if ENABLE_EXPERIMENTAL_BONDING
@@ -11154,10 +11154,10 @@ void srt::CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
 int srt::CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
 {
     CUDTSocket *s = s_UDTUnited.locateSocket(u);
-    if (!s || !s->m_pUDT)
+    if (!s)
         return -1;
 
-    CSndBuffer *b = s->m_pUDT->m_pSndBuffer;
+    CSndBuffer *b = s->core().m_pSndBuffer;
 
     if (!b)
         return -1;
@@ -11177,32 +11177,32 @@ int srt::CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
 int srt::CUDT::rejectReason(SRTSOCKET u)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(u);
-    if (!s || !s->m_pUDT)
+    if (!s)
         return SRT_REJ_UNKNOWN;
 
-    return s->m_pUDT->m_RejectReason;
+    return s->core().m_RejectReason;
 }
 
 int srt::CUDT::rejectReason(SRTSOCKET u, int value)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(u);
-    if (!s || !s->m_pUDT)
+    if (!s)
         return APIError(MJ_NOTSUP, MN_SIDINVAL);
 
     if (value < SRT_REJC_PREDEFINED)
         return APIError(MJ_NOTSUP, MN_INVAL);
 
-    s->m_pUDT->m_RejectReason = value;
+    s->core().m_RejectReason = value;
     return 0;
 }
 
 int64_t srt::CUDT::socketStartTime(SRTSOCKET u)
 {
     CUDTSocket* s = s_UDTUnited.locateSocket(u);
-    if (!s || !s->m_pUDT)
+    if (!s)
         return APIError(MJ_NOTSUP, MN_SIDINVAL);
 
-    return count_microseconds(s->m_pUDT->m_stats.tsStartTime.time_since_epoch());
+    return count_microseconds(s->core().m_stats.tsStartTime.time_since_epoch());
 }
 
 bool srt::CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)


### PR DESCRIPTION
Previously `CUDTSocket was holding a pointer to the `CUDT` instance and actually owned it, as it was deleting the instance in its destructor. The `CUDT` was allocated and assigned to the pointer separately, which does not protect from someone wrongfully changing the pointer afterwards.
With this PR `CUDTSocket` owns a member CUDT class and constructs it within its own construction.