### PR TITLE
[tests] Fixed possible TestIPv6 hangups if connection fails

### DIFF
--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -48,11 +48,14 @@ public:
     {
         sockaddr_any sa (family);
         sa.hport(m_listen_port);
-        ASSERT_EQ(inet_pton(family, address.c_str(), sa.get_addr()), 1);
+        EXPECT_EQ(inet_pton(family, address.c_str(), sa.get_addr()), 1);
 
         std::cout << "Calling: " << address << "(" << fam[family] << ")\n";
 
-        ASSERT_NE(srt_connect(m_caller_sock, (sockaddr*)&sa, sizeof sa), SRT_ERROR);
+        const int connect_res = srt_connect(m_caller_sock, (sockaddr*)&sa, sizeof sa);
+        EXPECT_NE(connect_res, SRT_ERROR) << "srt_connect() failed with: " << srt_getlasterror_str();
+        if (connect_res == SRT_ERROR)
+            srt_close(m_listener_sock);
 
         PrintAddresses(m_caller_sock, "CALLER");
     }
@@ -61,7 +64,7 @@ public:
 
     void ShowAddress(std::string src, const sockaddr_any& w)
     {
-        ASSERT_NE(fam.count(w.family()), 0U) << "INVALID FAMILY";
+        EXPECT_NE(fam.count(w.family()), 0U) << "INVALID FAMILY";
         std::cout << src << ": " << w.str() << " (" << fam[w.family()] << ")" << std::endl;
     }
 
@@ -70,16 +73,23 @@ public:
         sockaddr_any sc1;
 
         SRTSOCKET accepted_sock = srt_accept(m_listener_sock, sc1.get(), &sc1.len);
-        EXPECT_NE(accepted_sock, SRT_INVALID_SOCK);
+        EXPECT_NE(accepted_sock, SRT_INVALID_SOCK) << "accept() failed with: " << srt_getlasterror_str();
+        if (accepted_sock == SRT_INVALID_SOCK) {
+            return sockaddr_any();
+        }
 
         PrintAddresses(accepted_sock, "ACCEPTED");
 
         sockaddr_any sn;
         EXPECT_NE(srt_getsockname(accepted_sock, sn.get(), &sn.len), SRT_ERROR);
+        EXPECT_NE(sn.get_addr(), nullptr);
 
-        int32_t ipv6_zero [] = {0, 0, 0, 0};
-        EXPECT_NE(memcmp(ipv6_zero, sn.get_addr(), sizeof ipv6_zero), 0)
-            << "EMPTY address in srt_getsockname";
+        if (sn.get_addr() != nullptr)
+        {
+            const int32_t ipv6_zero[] = { 0, 0, 0, 0 };
+            EXPECT_NE(memcmp(ipv6_zero, sn.get_addr(), sizeof ipv6_zero), 0)
+                << "EMPTY address in srt_getsockname";
+        }
 
         srt_close(accepted_sock);
         return sn;


### PR DESCRIPTION
On systems with IPv6 support disabled the connection fails, but the blocking `DoAccept()` still waits for incoming connections (hanging forever).
Instead, if the caller fails to connect, it now closes the listening socket to break waiting for `srt_accept()`.