### PR TITLE
[tests] Test FileUpload: find unused UDP port

### DIFF
--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -59,7 +59,6 @@ TEST(Transmission, FileUpload)
         }
 
         ASSERT_TRUE(bind_res == SRT_EINVOP) << "Bind failed not due to an occupied port. Result " << bind_res;
-
     }
 
     ASSERT_GE(bind_res, 0);


### PR DESCRIPTION
The FileTransfer unit test tends to fail because it tries to bind to a port that is already in use.
This PR adds a search for an available UDP port.