### PR TITLE
Develop/small refax

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1870,8 +1870,6 @@ int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, i
      */
     try
     {
-        // record peer address
-        s->m_PeerAddr = target_addr;
         s->core().startConnect(target_addr, forced_isn);
     }
     catch (CUDTException& e) // Interceptor, just to change the state.

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -123,7 +123,8 @@ public:
 
    void construct();
 
-   srt::sync::atomic<SRT_SOCKSTATUS> m_Status;                  //< current socket state
+   SRT_ATTR_GUARDED_BY(m_ControlLock)
+   sync::atomic<SRT_SOCKSTATUS> m_Status;                  //< current socket state
 
    /// Time when the socket is closed.
    /// When the socket is closed, it is not removed immediately from the list
@@ -441,7 +442,12 @@ private:
    // Utility functions for updateMux
    void configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int af);
    uint16_t installMuxer(CUDTSocket* w_s, CMultiplexer& sm);
-   bool channelSettingsMatch(const CMultiplexer& m, const CUDTSocket* s);
+
+   /// @brief Checks if channel configuration matches the socket configuration.
+   /// @param cfgMuxer multiplexer configuration.
+   /// @param cfgSocket socket configuration.
+   /// @return tru if configurations match, false otherwise.
+   static bool channelSettingsMatch(const CSrtMuxerConfig& cfgMuxer, const CSrtConfig& cfgSocket);
 
 private:
    std::map<int, CMultiplexer> m_mMultiplexer;		// UDP multiplexer

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -499,14 +499,17 @@ private:
     SRT_ATR_NODISCARD size_t fillSrtHandshake_HSRSP(uint32_t* srtdata, size_t srtlen, int hs_version);
     SRT_ATR_NODISCARD size_t fillSrtHandshake(uint32_t* srtdata, size_t srtlen, int msgtype, int hs_version);
 
-    SRT_ATR_NODISCARD bool createSrtHandshake(int srths_cmd, int srtkm_cmd, const uint32_t* data, size_t datalen,
+    SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
+    bool createSrtHandshake(int srths_cmd, int srtkm_cmd, const uint32_t* data, size_t datalen,
             CPacket& w_reqpkt, CHandShake& w_hs);
 
     SRT_ATR_NODISCARD size_t fillHsExtConfigString(uint32_t *pcmdspec, int cmd, const std::string &str);
 #if ENABLE_EXPERIMENTAL_BONDING
     SRT_ATR_NODISCARD size_t fillHsExtGroup(uint32_t *pcmdspec);
 #endif
-    SRT_ATR_NODISCARD size_t fillHsExtKMREQ(uint32_t *pcmdspec, size_t ki);
+    SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
+    size_t fillHsExtKMREQ(uint32_t *pcmdspec, size_t ki);
+
     SRT_ATR_NODISCARD size_t fillHsExtKMRSP(uint32_t *pcmdspec, const uint32_t *kmdata, size_t kmdata_wordsize);
 
     SRT_ATR_NODISCARD size_t prepareSrtHsMsg(int cmd, uint32_t* srtdata, size_t size);


### PR DESCRIPTION
- [core] Small refax of `CUDTUnited::channelSettingsMatch(..)`: pass only what is required (socket and muxer configs).
- [core] Do not set `peerAddress` in `connectIn(..)`. `CUDT::startConnect(..)` sets it by itself. This is a preparational change to define the scrope of member variables. `m_peerAddress` is guarded by `CUDT::m_ConnectionLock`.