### PR TITLE
[build] Default STDCXX_SYNC=ON on Windows, try to use CLOCK_MONOTONIC by default on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,16 @@ if (ENABLE_DEBUG)
 endif()
 
 
+set(ENABLE_STDCXX_SYNC_DEFAULT OFF)
+set(ENABLE_MONOTONIC_CLOCK_DEFAULT OFF)
+set(MONOTONIC_CLOCK_LINKLIB "")
+if (MICROSOFT)
+	set(ENABLE_STDCXX_SYNC_DEFAULT ON)
+elseif (LINUX)
+	test_requires_clock_gettime(ENABLE_MONOTONIC_CLOCK_DEFAULT MONOTONIC_CLOCK_LINKLIB)
+endif()
+
+
 # options
 option(CYGWIN_USE_POSIX "Should the POSIX API be used for cygwin. Ignored if the system isn't cygwin." OFF)
 option(ENABLE_CXX11 "Should the c++11 parts (srt-live-transmit) be enabled" ON)
@@ -129,8 +139,8 @@ option(ENABLE_CXX_DEPS "Extra library dependencies in srt.pc for the CXX librari
 option(USE_STATIC_LIBSTDCXX "Should use static rather than shared libstdc++" OFF)
 option(ENABLE_INET_PTON "Set to OFF to prevent usage of inet_pton when building against modern SDKs while still requiring compatibility with older Windows versions, such as Windows XP, Windows Server 2003 etc." ON)
 option(ENABLE_CODE_COVERAGE "Enable code coverage reporting" OFF)
-option(ENABLE_MONOTONIC_CLOCK "Enforced clock_gettime with monotonic clock on GC CV" OFF)
-option(ENABLE_STDCXX_SYNC "Use C++11 chrono and threads for timing instead of pthreads" OFF)
+option(ENABLE_MONOTONIC_CLOCK "Enforced clock_gettime with monotonic clock on GC CV" ${ENABLE_MONOTONIC_CLOCK_DEFAULT})
+option(ENABLE_STDCXX_SYNC "Use C++11 chrono and threads for timing instead of pthreads" ${ENABLE_STDCXX_SYNC_DEFAULT})
 option(USE_OPENSSL_PC "Use pkg-config to find OpenSSL libraries" ON)
 option(USE_BUSY_WAITING "Enable more accurate sending times at a cost of potentially higher CPU load" OFF)
 option(USE_GNUSTL "Get c++ library/headers from the gnustl.pc" OFF)
@@ -265,6 +275,10 @@ if (DEFINED HAVE_INET_PTON)
 endif()
 
 if (ENABLE_MONOTONIC_CLOCK)
+	if (NOT ENABLE_MONOTONIC_CLOCK_DEFAULT)
+		message(FATAL_ERROR "Your platform does not support CLOCK_MONOTONIC. Build with -DENABLE_MONOTONIC_CLOCK=OFF.")
+	endif()
+	set (WITH_EXTRALIBS "${WITH_EXTRALIBS} ${MONOTONIC_CLOCK_LINKLIB}")
 	add_definitions(-DENABLE_MONOTONIC_CLOCK=1)
 endif()
 
@@ -435,6 +449,7 @@ elseif (ENABLE_STDCXX_SYNC)
 endif()
 
 message(STATUS "STDCXX_SYNC: ${ENABLE_STDCXX_SYNC}")
+message(STATUS "MONOTONIC_CLOCK: ${ENABLE_MONOTONIC_CLOCK}")
 
 if (ENABLE_SOCK_CLOEXEC)
 	add_definitions(-DENABLE_SOCK_CLOEXEC=1)
@@ -524,14 +539,6 @@ if (USE_STATIC_LIBSTDCXX)
 	else()
 		message(FATAL_ERROR "On non-GNU-compat compiler it's not known how to use static C++ standard library.")
 	endif()
-endif()
-
-# We need clock_gettime, but on some systems this is only provided
-# by librt. Check if librt is required.
-if (ENABLE_MONOTONIC_CLOCK AND LINUX)
-	# "requires" - exits on FATAL_ERROR when clock_gettime not available
-	test_requires_clock_gettime(NEED_CLOCK_GETTIME)
-	set (WITH_EXTRALIBS "${WITH_EXTRALIBS} ${NEED_CLOCK_GETTIME}")
 endif()
 
 

--- a/docs/build/build-win.md
+++ b/docs/build/build-win.md
@@ -54,7 +54,7 @@ only unencrypted mode can be used.
 With the enabled SRT encryption,
 one of the following Crypto libraries is required:
 
-- `OpenSSL` (default)
+- `OpenSSL` (**default**)
 - `LibreSSL`
 - `MbedTLS`
 
@@ -62,8 +62,8 @@ one of the following Crypto libraries is required:
 
 SRT as of v1.4.2 supports two threading libraries:
 
-- `pthreads` (default)
-- Standard C++ thread library available in C++11 (recommended for Windows)
+- Standard C++ thread library available in C++11 (**default on Windows**)
+- `pthreads` (not recommended on Windows)
 
 The `pthreads` library is provided out-of-the-box on all POSIX-based systems.
 On Windows it can be provided as a 3rd party library (see below).
@@ -72,6 +72,10 @@ However the C++ standard thread library is recommended to be used on Windows.
 ### 1.3. Package Managers
 
 #### 1.3.1. VCpkg Packet Manager (optional)
+
+Can be used to:
+- build OpenSSL library (dependency of SRT).
+- build pthreads library (dependency of SRT).
 
 [vcpkg](https://github.com/microsoft/vcpkg) is a C++ library manager for Windows, Linux and MacOS.
 Consider its [prerequisites](https://github.com/microsoft/vcpkg/blob/master/README.md#quick-start) before proceeding.
@@ -181,8 +185,8 @@ to specify the directory that will contain the LibreSSL headers and libraries.
 
 SRT can use one of these two threading libraries:
 
-- C++11 threads (SRT v1.4.2 and above) - recommended for Windows
-- `pthreads` (default)
+- C++11 threads (SRT v1.4.2 and above) - recommended, default since SRT v1.4.4;
+- `pthreads` (not recommended on Windows).
 
 #### 2.2.1. Using C++11 Threading
 
@@ -192,6 +196,8 @@ This way there will be also no external dependency on the threading library.
 Otherwise the external PThreads for Windows wrapper library is required.
 
 #### 2.2.2. Building PThreads
+
+It is not recommended to use `pthreads` port on Windows. Consider using [C++11 instead](#221-using-c11-threading),
 
 ##### 2.2.2.1. Using vcpkg
 

--- a/scripts/haiUtil.cmake
+++ b/scripts/haiUtil.cmake
@@ -12,11 +12,11 @@ include(CheckCXXSourceCompiles)
 # Useful for combinging paths
 
 function(adddirname prefix lst out_lst)
-        set(output)
-        foreach(item ${lst})
-                list(APPEND output "${prefix}/${item}")
-        endforeach()
-        set(${out_lst} ${${out_lst}} ${output} PARENT_SCOPE)
+	set(output)
+	foreach(item ${lst})
+		list(APPEND output "${prefix}/${item}")
+	endforeach()
+	set(${out_lst} ${${out_lst}} ${output} PARENT_SCOPE)
 endfunction()
 
 # Splits a version formed as "major.minor.patch" recorded in variable 'prefix'
@@ -32,11 +32,11 @@ ENDMACRO(set_version_variables)
 # Sets given variable to 1, if the condition that follows it is satisfied.
 # Otherwise set it to 0.
 MACRO(set_if varname)
-   IF(${ARGN})
-     SET(${varname} 1)
-   ELSE(${ARGN})
-     SET(${varname} 0)
-   ENDIF(${ARGN})
+	IF(${ARGN})
+		SET(${varname} 1)
+	ELSE(${ARGN})
+		SET(${varname} 0)
+	ENDIF(${ARGN})
 ENDMACRO(set_if)
 
 FUNCTION(join_arguments outvar)
@@ -80,11 +80,11 @@ MACRO(MafReadDir directory maffile)
 	configure_file(${directory}/${maffile} dummy_${maffile}.cmake.out)
 	file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/dummy_${maffile}.cmake.out)
 
-    #message("DEBUG: MAF FILE CONTENTS: ${MAFREAD_CONTENTS}")
-    #message("DEBUG: PASSED VARIABLES:")
-    #foreach(DEBUG_VAR ${MAFREAD_TAGS})
-    #	message("DEBUG: ${DEBUG_VAR}=${MAFREAD_VAR_${DEBUG_VAR}}")
-    #endforeach()
+	#message("DEBUG: MAF FILE CONTENTS: ${MAFREAD_CONTENTS}")
+	#message("DEBUG: PASSED VARIABLES:")
+	#foreach(DEBUG_VAR ${MAFREAD_TAGS})
+	#	message("DEBUG: ${DEBUG_VAR}=${MAFREAD_VAR_${DEBUG_VAR}}")
+	#endforeach()
 
 	# The unnamed section becomes SOURCES
 	set (MAFREAD_VARIABLE ${MAFREAD_VAR_SOURCES})
@@ -186,15 +186,15 @@ MACRO(MafReadDir directory maffile)
 	ENDFOREACH()
 	
 	# Final debug report
-    #set (ALL_VARS "")
-    #message("DEBUG: extracted variables:")
-    #foreach(DEBUG_VAR ${MAFREAD_TAGS})
-    #	list(APPEND ALL_VARS ${MAFREAD_VAR_${DEBUG_VAR}})
-    #endforeach()
-    #list(REMOVE_DUPLICATES ALL_VARS)
-    #foreach(DEBUG_VAR ${ALL_VARS})
-    #	message("DEBUG: --> ${DEBUG_VAR} = ${${DEBUG_VAR}}")
-    #endforeach()
+	#set (ALL_VARS "")
+	#message("DEBUG: extracted variables:")
+	#foreach(DEBUG_VAR ${MAFREAD_TAGS})
+	#	list(APPEND ALL_VARS ${MAFREAD_VAR_${DEBUG_VAR}})
+	#endforeach()
+	#list(REMOVE_DUPLICATES ALL_VARS)
+	#foreach(DEBUG_VAR ${ALL_VARS})
+	#	message("DEBUG: --> ${DEBUG_VAR} = ${${DEBUG_VAR}}")
+	#endforeach()
 ENDMACRO(MafReadDir)
 
 # NOTE: This is historical only. Not in use.
@@ -214,9 +214,9 @@ MACRO(GetMafHeaders directory outvar)
 ENDMACRO(GetMafHeaders)
 
 function (getVarsWith _prefix _varResult)
-    get_cmake_property(_vars VARIABLES)
-    string (REGEX MATCHALL "(^|;)${_prefix}[A-Za-z0-9_]*" _matchedVars "${_vars}")
-    set (${_varResult} ${_matchedVars} PARENT_SCOPE)
+	get_cmake_property(_vars VARIABLES)
+	string (REGEX MATCHALL "(^|;)${_prefix}[A-Za-z0-9_]*" _matchedVars "${_vars}")
+	set (${_varResult} ${_matchedVars} PARENT_SCOPE)
 endfunction()
 
 function (check_testcode_compiles testcode libraries _successful)
@@ -228,15 +228,18 @@ function (check_testcode_compiles testcode libraries _successful)
 	set (CMAKE_REQUIRED_LIBRARIES ${save_required_libraries})
 endfunction()
 
-function (test_requires_clock_gettime _result)
+function (test_requires_clock_gettime _enable _linklib)
 	# This function tests if clock_gettime can be used
 	# - at all
 	# - with or without librt
 
 	# Result will be:
-	# rt (if librt required)
-	# "" (if no extra libraries required)
-	# -- killed by FATAL_ERROR if clock_gettime is not available
+	# - CLOCK_MONOTONIC is available, link with librt:
+	#   _enable = ON; _linklib = "-lrt".
+	# - CLOCK_MONOTONIC is available, link without librt:
+	#   _enable = ON; _linklib = "".
+	# - CLOCK_MONOTONIC is not available:
+	#   _enable = OFF; _linklib = "-".
 
 	set (code "
 		#include <time.h>
@@ -249,19 +252,23 @@ function (test_requires_clock_gettime _result)
 
 	check_testcode_compiles(${code} "" HAVE_CLOCK_GETTIME_IN)
 	if (HAVE_CLOCK_GETTIME_IN)
-		message(STATUS "Checked clock_gettime(): no extra libs needed")
-		set (${_result} "" PARENT_SCOPE)
+		message(STATUS "CLOCK_MONOTONIC: availabe, no extra libs needed")
+		set (${_enable}  ON PARENT_SCOPE)
+		set (${_linklib} "" PARENT_SCOPE)
 		return()
 	endif()
 
 	check_testcode_compiles(${code} "rt" HAVE_CLOCK_GETTIME_LIBRT)
 	if (HAVE_CLOCK_GETTIME_LIBRT)
-		message(STATUS "Checked clock_gettime(): requires -lrt")
-		set (${_result} "-lrt" PARENT_SCOPE)
+		message(STATUS "CLOCK_MONOTONIC: available, requires -lrt")
+		set (${_enable}  ON PARENT_SCOPE)
+		set (${_linklib} "-lrt" PARENT_SCOPE)
 		return()
 	endif()
 
-	message(FATAL_ERROR "clock_gettime() is not available on this system")
+	set (${_enable}  OFF PARENT_SCOPE)
+	set (${_linklib} "-" PARENT_SCOPE)
+	message(STATUS "CLOCK_MONOTONIC: not available on this system")
 endfunction()
 
 function (parse_compiler_type wct _type _suffix)


### PR DESCRIPTION
Fixes #2044.

### TODO

- [x] AppVeyor explicitly defines `ENABLE_STDCXX_SYNC` for all build configurations. It is disabled only for VS2013 Release build.
- [x] Update the `build-win.md` doc.