### PR TITLE
[apps] Fixed loop over OptionScheme

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -251,7 +251,7 @@ options_t ProcessOptions(char* const* argv, int argc, std::vector<OptionScheme> 
             }
 
             // Find the key in the scheme. If not found, treat it as ARG_NONE.
-            for (auto s: scheme)
+            for (const auto& s: scheme)
             {
                 if (s.names().count(current_key))
                 {

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -220,7 +220,7 @@ struct OptionScheme
 
     OptionScheme(const OptionName& id, Args tp);
 
-	const std::set<std::string>& names();
+	const std::set<std::string>& names() const;
 };
 
 struct OptionName
@@ -234,6 +234,8 @@ struct OptionName
         : helptext(ht), main_name(first),
           names {first, rest...}
     {
+        int x = 0;
+        x+=1;
     }
 
     template <class... Args>
@@ -265,7 +267,7 @@ private:
 };
 
 inline OptionScheme::OptionScheme(const OptionName& id, Args tp): pid(&id), type(tp) {}
-inline const std::set<std::string>& OptionScheme::names() { return pid->names; }
+inline const std::set<std::string>& OptionScheme::names() const { return pid->names; }
 
 template <class OutType, class OutValue> inline
 typename OutType::type Option(const options_t&, OutValue deflt=OutValue()) { return deflt; }

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -220,7 +220,7 @@ struct OptionScheme
 
     OptionScheme(const OptionName& id, Args tp);
 
-	const std::set<std::string>& names() const;
+    const std::set<std::string>& names() const;
 };
 
 struct OptionName
@@ -234,8 +234,6 @@ struct OptionName
         : helptext(ht), main_name(first),
           names {first, rest...}
     {
-        int x = 0;
-        x+=1;
     }
 
     template <class... Args>


### PR DESCRIPTION
The loop `for (auto s: scheme)` was crashing in `srt_test_multiplex` on MacOS likely due to a bad copy constructor. `s->names()` is an empty set. `s->names().count("i")` crashes.