### PR TITLE
[apps] Fixed testing apps building with GCC 4.8

### DIFF
--- a/testing/srt-test-multiplex.cpp
+++ b/testing/srt-test-multiplex.cpp
@@ -464,11 +464,15 @@ int main( int argc, char** argv )
         }
     } cleanupobj;
 
-    // Check options
+    const OptionName
+        o_loglevel = { "ll", "loglevel" },
+        o_input    = { "i" },
+        o_output   = { "o" };
+
     vector<OptionScheme> optargs = {
-        { {"ll", "loglevel"}, OptionScheme::ARG_ONE },
-        { {"i"}, OptionScheme::ARG_VAR },
-        { {"o"}, OptionScheme::ARG_VAR }
+        { o_loglevel, OptionScheme::ARG_ONE },
+        { o_input,    OptionScheme::ARG_VAR },
+        { o_output,   OptionScheme::ARG_VAR }
     };
 
     map<string, vector<string>> params = ProcessOptions(argv, argc, optargs);

--- a/testing/testactivemedia.hpp
+++ b/testing/testactivemedia.hpp
@@ -29,7 +29,7 @@ struct Medium
     std::mutex buffer_lock;
     std::thread thr;
     std::condition_variable ready;
-    std::atomic<bool> running {false};
+    std::atomic<bool> running = {false};
     std::exception_ptr xp; // To catch exception thrown by a thread
 
     virtual void Runner() = 0;

--- a/testing/testmediabase.hpp
+++ b/testing/testmediabase.hpp
@@ -11,6 +11,7 @@
 #ifndef INC_SRT_COMMON_TRANMITBASE_HPP
 #define INC_SRT_COMMON_TRANMITBASE_HPP
 
+#include <atomic>
 #include <string>
 #include <memory>
 #include <vector>


### PR DESCRIPTION
1. `testing/testactivemedia.hpp`:
```shell
 error: ‘atomic’ in namespace ‘std’ does not name a type
```

2. `testing/testmediabase.hpp`:
```shell
error: use of deleted function ‘std::atomic<bool>::atomic(const std::atomic<bool>&)’
```
3. Workaround of the bad move semantics.

```c++
vector<OptionScheme> optargs = {
        { {"ll", "loglevel"}, OptionScheme::ARG_ONE },
        { {"i"}, OptionScheme::ARG_VAR },
        { {"o"}, OptionScheme::ARG_VAR }
    };
```

`OptionScheme`'s `const OptionName* pid` does not own the `pid` object, so move constructor only copies the pointer. In the example above the pointer points to a temporal object `{ "ll", "loglevel" }`. GCC 4.5 removes this r-value object, and CLI parsing is performed incorrectly.