### PR TITLE
Fix build for Linux GLIBC-2.8 and earlier.

### DIFF
--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -142,11 +142,6 @@ EMFILE: The per-user limit on the number of epoll instances imposed by /proc/sys
 ENFILE: The system limit on the total number of open files has been reached.
 ENOMEM: There was insufficient memory to create the kernel object.
        */
-   // NOTE: The standard says epoll_create1() returns -1 on error. So
-   //    theoretically -2 or some other negative fd value would be a valid
-   //    descriptor and indicate success. I imagine that allowing valid negative
-   //    descriptors through, would break other parts of the code that are also
-   //    checking for <0 as a failure. So ignoring this for now.
    if (localid < 0)
       throw CUDTException(MJ_SETUP, MN_NONE, errno);
    #elif defined(BSD) || TARGET_OS_MAC


### PR DESCRIPTION
`epoll_create1()` and `EPOLL_CLOEXEC` were introduced in `GLIBC-2.9`.

This patch fixes the build for `GLIBC-2.8` and earlier targets.

Tested on CentOS5.