### PR TITLE
[core] Removed ThreadName(const char*).

### DIFF
--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -240,8 +240,8 @@ public:
     void Start()
     {
         Verb() << "START: " << media[DIR_IN]->uri() << " --> " << media[DIR_OUT]->uri();
-        std::string thrn = media[DIR_IN]->id() + ">" + media[DIR_OUT]->id();
-        srt::ThreadName tn(thrn.c_str());
+        const std::string thrn = media[DIR_IN]->id() + ">" + media[DIR_OUT]->id();
+        srt::ThreadName tn(thrn);
 
         thr = thread([this]() { Worker(); });
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9395,10 +9395,10 @@ int srt::CUDT::processData(CUnit* in_unit)
 
         const string& tn = tns2.str();
 
-        ThreadName tnkeep(tn.c_str());
-        const char* thname = tn.c_str();
+        ThreadName tnkeep(tn);
+        const string& thname = tn;
 #else
-        const char* thname = "SRT:TsbPd";
+        const string thname = "SRT:TsbPd";
 #endif
         if (!StartThread(m_RcvTsbPdThread, CUDT::tsbpd, this, thname))
             return -1;

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -79,9 +79,9 @@ std::string FormatTimeSys(const steady_clock::time_point& timestamp)
 
 
 #ifdef ENABLE_STDCXX_SYNC
-bool StartThread(CThread& th, ThreadFunc&& f, void* args, const char* name)
+bool StartThread(CThread& th, ThreadFunc&& f, void* args, const string& name)
 #else
-bool StartThread(CThread& th, void* (*f) (void*), void* args, const char* name)
+bool StartThread(CThread& th, void* (*f) (void*), void* args, const string& name)
 #endif
 {
     ThreadName tn(name);

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -905,9 +905,9 @@ namespace this_thread
 ///
 #ifdef ENABLE_STDCXX_SYNC
 typedef void* (&ThreadFunc) (void*);
-bool StartThread(CThread& th, ThreadFunc&& f, void* args, const char* name);
+bool StartThread(CThread& th, ThreadFunc&& f, void* args, const std::string& name);
 #else
-bool StartThread(CThread& th, void* (*f) (void*), void* args, const char* name);
+bool StartThread(CThread& th, void* (*f) (void*), void* args, const std::string& name);
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/srtcore/threadname.h
+++ b/srtcore/threadname.h
@@ -202,21 +202,16 @@ public:
         return ret;
     }
 
-    // note: set can fail if name is too long. The upper limit is platform
-    // dependent. strlen(name) <= 15 should work on most of the platform.
-    static bool set(const char* name) { return ThreadNameImpl::set(name); }
-
     static bool set(const std::string& name) { return set(name.c_str()); }
 
-    ThreadName(const char* name)
-        : impl(name)
-    {
-    }
-
-    ThreadName(const std::string& name)
+    explicit ThreadName(const std::string& name)
         : impl(name.c_str())
     {
     }
+
+private:
+    ThreadName(const ThreadName&);
+    ThreadName(const char*);
 };
 
 } // namespace srt

--- a/test/test_threadname.cpp
+++ b/test/test_threadname.cpp
@@ -28,12 +28,12 @@ TEST(ThreadName, GetSet)
 
 TEST(ThreadName, AutoReset)
 {
-    std::string old_name("old");
+    const std::string old_name("old");
     std::string new_name("new-name");
     if (ThreadName::DUMMY_IMPL)
     {
         // just make sure the API is correct
-        ThreadName t("test");
+        ThreadName t(std::string("test"));
         return;
     }
 

--- a/testing/srt-test-multiplex.cpp
+++ b/testing/srt-test-multiplex.cpp
@@ -196,7 +196,7 @@ public:
         med.name = name;
 
         // Ok, got this, so we can start transmission.
-        srt::ThreadName tn(thread_name.c_str());
+        srt::ThreadName tn(thread_name);
 
         med.runner = thread( [&med]() { med.TransmissionLoop(); });
         return med;

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -438,7 +438,7 @@ void SrtMainLoop::run()
 
         std::ostringstream tns;
         tns << "Input:" << this;
-        srt::ThreadName tn(tns.str().c_str());
+        srt::ThreadName tn(tns.str());
         m_input_thr = thread([this] {
                 try {
                     InputRunner();

--- a/testing/testactivemedia.hpp
+++ b/testing/testactivemedia.hpp
@@ -58,7 +58,7 @@ struct Medium
         running = true;
         std::ostringstream tns;
         tns << typeid(*this).name() << ":" << this;
-        srt::ThreadName tn(tns.str().c_str());
+        srt::ThreadName tn(tns.str());
         thr = thread( [this] { RunnerBase(); } );
     }
 


### PR DESCRIPTION
To avoid passing a `NULL` pointer to `ThreadName` constructor or `ThreadName::set(const char*)` function now only `string&` argument is expected.