### PR TITLE
Update Windows installer for alternate platform names

### DIFF
--- a/scripts/win-installer/libsrt.props
+++ b/scripts/win-installer/libsrt.props
@@ -4,6 +4,25 @@
 
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- Normalize platform name to x64 and Win32 (some projects use x86 or Win64) -->
+  <Choose>
+    <When Condition="'$(Platform)' == 'x86'">
+      <PropertyGroup Label="UserMacros">
+        <SrtPlatform>Win32</SrtPlatform>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(Platform)' == 'Win64'">
+      <PropertyGroup Label="UserMacros">
+        <SrtPlatform>x64</SrtPlatform>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup Label="UserMacros">
+        <SrtPlatform>$(Platform)</SrtPlatform>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
   <!-- Compilation and link options -->
   <ItemDefinitionGroup>
     <ClCompile>
@@ -11,7 +30,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>srt.lib;libssl.lib;libcrypto.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>$(LIBSRT)\lib\$(Configuration)-$(Platform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(LIBSRT)\lib\$(Configuration)-$(SrtPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
The libsrt is compiled for platforms Win32 and x64, the traditional
names with Visual Studio. Some applications are built with custom names,
typically x86 or Win64. This commit makes sure that these applications
use the correct libsrt platform.