### PR TITLE
[core] Moved SND and RCV buffers into the 'srt' namespace

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -59,10 +59,11 @@ modified by
 #include "core.h" // provides some constants
 #include "logging.h"
 
+namespace srt {
+
 using namespace std;
 using namespace srt_logging;
-using namespace srt;
-using namespace srt::sync;
+using namespace sync;
 
 // You can change this value at build config by using "ENFORCE" options.
 #if !defined(SRT_MAVG_SAMPLING_RATE)
@@ -318,7 +319,7 @@ void CSndBuffer::updateInputRate(const steady_clock::time_point& time, int pkts,
     if (early_update || period_us > m_InRatePeriod)
     {
         // Required Byte/sec rate (payload + headers)
-        m_iInRateBytesCount += (m_iInRatePktsCount * srt::CPacket::SRT_DATA_HDR_SIZE);
+        m_iInRateBytesCount += (m_iInRatePktsCount * CPacket::SRT_DATA_HDR_SIZE);
         m_iInRateBps = (int)(((int64_t)m_iInRateBytesCount * 1000000) / period_us);
         HLOGC(bslog.Debug,
               log << "updateInputRate: pkts:" << m_iInRateBytesCount << " bytes:" << m_iInRatePktsCount
@@ -411,7 +412,7 @@ steady_clock::time_point CSndBuffer::getSourceTime(const CSndBuffer::Block& bloc
     return block.m_tsOriginTime;
 }
 
-int CSndBuffer::readData(srt::CPacket& w_packet, steady_clock::time_point& w_srctime, int kflgs)
+int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime, int kflgs)
 {
     // No data to read
     if (m_pCurrBlock == m_pLastBlock)
@@ -512,7 +513,7 @@ int32_t CSndBuffer::getMsgNoAt(const int offset)
     return p->getMsgSeq();
 }
 
-int CSndBuffer::readData(const int offset, srt::CPacket& w_packet, steady_clock::time_point& w_srctime, int& w_msglen)
+int CSndBuffer::readData(const int offset, CPacket& w_packet, steady_clock::time_point& w_srctime, int& w_msglen)
 {
     int32_t& msgno_bitset = w_packet.m_iMsgNo;
 
@@ -605,7 +606,7 @@ int CSndBuffer::readData(const int offset, srt::CPacket& w_packet, steady_clock:
     return readlen;
 }
 
-srt::sync::steady_clock::time_point CSndBuffer::getPacketRexmitTime(const int offset)
+sync::steady_clock::time_point CSndBuffer::getPacketRexmitTime(const int offset)
 {
     ScopedLock bufferguard(m_BufLock);
     const Block* p = m_pFirstBlock;
@@ -935,7 +936,7 @@ int CRcvBuffer::readBuffer(char* data, int len)
             return -1;
         }
 
-        const srt::CPacket& pkt = m_pUnit[p]->m_Packet;
+        const CPacket& pkt = m_pUnit[p]->m_Packet;
 
         if (bTsbPdEnabled)
         {
@@ -1004,7 +1005,7 @@ int CRcvBuffer::readBufferToFile(fstream& ofs, int len)
             continue;
         }
 
-        const srt::CPacket& pkt = m_pUnit[p]->m_Packet;
+        const CPacket& pkt = m_pUnit[p]->m_Packet;
 
 #if ENABLE_LOGGING
         trace_seq = pkt.getSeqNo();
@@ -1476,7 +1477,7 @@ bool CRcvBuffer::isRcvDataReady(steady_clock::time_point& w_tsbpdtime, int32_t& 
 
     if (m_tsbpd.isEnabled())
     {
-        const srt::CPacket* pkt = getRcvReadyPacket(seqdistance);
+        const CPacket* pkt = getRcvReadyPacket(seqdistance);
         if (!pkt)
         {
             HLOGC(brlog.Debug, log << "isRcvDataReady: packet NOT extracted.");
@@ -1613,7 +1614,7 @@ void CRcvBuffer::reportBufferStats() const
     uint64_t lower_time = low_ts;
 
     if (lower_time > upper_time)
-        upper_time += uint64_t(srt::CPacket::MAX_TIMESTAMP) + 1;
+        upper_time += uint64_t(CPacket::MAX_TIMESTAMP) + 1;
 
     int32_t timespan = upper_time - lower_time;
     int     seqspan  = 0;
@@ -2290,3 +2291,5 @@ bool CRcvBuffer::scanMsg(int& w_p, int& w_q, bool& w_passack)
 
     return found;
 }
+
+} // namespace srt

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -71,10 +71,12 @@ modified by
 // a +% b : shift a by b
 // a == b : equality is same as for just numbers
 
+namespace srt {
+
 /// The AvgBufSize class is used to calculate moving average of the buffer (RCV or SND)
 class AvgBufSize
 {
-    typedef srt::sync::steady_clock::time_point time_point;
+    typedef sync::steady_clock::time_point time_point;
 
 public:
     AvgBufSize()
@@ -102,8 +104,8 @@ private:
 
 class CSndBuffer
 {
-    typedef srt::sync::steady_clock::time_point time_point;
-    typedef srt::sync::steady_clock::duration   duration;
+    typedef sync::steady_clock::time_point time_point;
+    typedef sync::steady_clock::duration   duration;
 
 public:
     // XXX There's currently no way to access the socket ID set for
@@ -140,21 +142,19 @@ public:
     int addBufferFromFile(std::fstream& ifs, int len);
 
     /// Find data position to pack a DATA packet from the furthest reading point.
-    /// @param [out] data the pointer to the data position.
-    /// @param [out] msgno message number of the packet.
-    /// @param [out] origintime origin time stamp of the message
-    /// @param [in] kflags Odd|Even crypto key flag
+    /// @param [out] w_packet data packet buffer to fill.
+    /// @param [out] w_origintime origin time stamp of the message.
+    /// @param [in] kflags Odd|Even crypto key flag.
     /// @return Actual length of data read.
-    int readData(srt::CPacket& w_packet, time_point& w_origintime, int kflgs);
+    int readData(CPacket& w_packet, time_point& w_origintime, int kflgs);
 
     /// Find data position to pack a DATA packet for a retransmission.
-    /// @param [out] data the pointer to the data position.
     /// @param [in] offset offset from the last ACK point (backward sequence number difference)
-    /// @param [out] msgno message number of the packet.
-    /// @param [out] origintime origin time stamp of the message
-    /// @param [out] msglen length of the message
+    /// @param [out] w_packet data packet buffer to fill.
+    /// @param [out] w_origintime origin time stamp of the message
+    /// @param [out] w_msglen length of the message
     /// @return Actual length of data read (return 0 if offset too large, -1 if TTL exceeded).
-    int readData(const int offset, srt::CPacket& w_packet, time_point& w_origintime, int& w_msglen);
+    int readData(const int offset, CPacket& w_packet, time_point& w_origintime, int& w_msglen);
 
     /// Get the time of the last retransmission (if any) of the DATA packet.
     /// @param [in] offset offset from the last ACK point (backward sequence number difference)
@@ -207,7 +207,7 @@ private:                                                       // Constants
     static const int      INPUTRATE_INITIAL_BYTESPS = BW_INFINITE;
 
 private:
-    srt::sync::Mutex m_BufLock; // used to synchronize buffer operation
+    sync::Mutex m_BufLock; // used to synchronize buffer operation
 
     struct Block
     {
@@ -274,8 +274,8 @@ private:
 
 class CRcvBuffer
 {
-    typedef srt::sync::steady_clock::time_point time_point;
-    typedef srt::sync::steady_clock::duration   duration;
+    typedef sync::steady_clock::time_point time_point;
+    typedef sync::steady_clock::duration   duration;
 
 public:
     // XXX There's currently no way to access the socket ID set for
@@ -288,7 +288,7 @@ public:
     /// Construct the buffer.
     /// @param [in] queue  CUnitQueue that actually holds the units (packets)
     /// @param [in] bufsize_pkts in units (packets)
-    CRcvBuffer(srt::CUnitQueue* queue, int bufsize_pkts = DEFAULT_SIZE);
+    CRcvBuffer(CUnitQueue* queue, int bufsize_pkts = DEFAULT_SIZE);
     ~CRcvBuffer();
 
 public:
@@ -296,7 +296,7 @@ public:
     /// @param [in] unit pointer to a data unit containing new packet
     /// @param [in] offset offset from last ACK point.
     /// @return 0 is success, -1 if data is repeated.
-    int addData(srt::CUnit* unit, int offset);
+    int addData(CUnit* unit, int offset);
 
     /// Read data into a user buffer.
     /// @param [in] data pointer to user buffer.
@@ -402,7 +402,7 @@ public:
 
     bool     isRcvDataReady();
     bool     isRcvDataAvailable() { return m_iLastAckPos != m_iStartPos; }
-    srt::CPacket* getRcvReadyPacket(int32_t seqdistance);
+    CPacket* getRcvReadyPacket(int32_t seqdistance);
 
     /// Set TimeStamp-Based Packet Delivery Rx Mode
     /// @param [in] timebase localtime base (uSec) of packet time stamps including buffering delay
@@ -468,7 +468,7 @@ private:
     /// data.
     size_t freeUnitAt(size_t p)
     {
-        srt::CUnit* u  = m_pUnit[p];
+        CUnit* u       = m_pUnit[p];
         m_pUnit[p]     = NULL;
         size_t rmbytes = u->m_Packet.getLength();
         m_pUnitQueue->makeUnitFree(u);
@@ -535,9 +535,9 @@ private:
     }
 
 private:
-    srt::CUnit** m_pUnit;      // Array of pointed units collected in the buffer
+    CUnit**     m_pUnit;      // Array of pointed units collected in the buffer
     const int   m_iSize;      // Size of the internal array of CUnit* items
-    srt::CUnitQueue* m_pUnitQueue; // the shared unit queue
+    CUnitQueue* m_pUnitQueue; // the shared unit queue
 
     int m_iStartPos;   // HEAD: first packet available for reading
     int m_iLastAckPos; // the last ACKed position (exclusive), follows the last readable
@@ -550,20 +550,22 @@ private:
                   // up to which data are already retrieved;
                   // in message reading mode it's unused and always 0)
 
-    srt::sync::Mutex m_BytesCountLock;   // used to protect counters operations
-    int              m_iBytesCount;      // Number of payload bytes in the buffer
-    int              m_iAckedPktsCount;  // Number of acknowledged pkts in the buffer
-    int              m_iAckedBytesCount; // Number of acknowledged payload bytes in the buffer
-    unsigned         m_uAvgPayloadSz;    // Average payload size for dropped bytes estimation
+    sync::Mutex m_BytesCountLock;   // used to protect counters operations
+    int         m_iBytesCount;      // Number of payload bytes in the buffer
+    int         m_iAckedPktsCount;  // Number of acknowledged pkts in the buffer
+    int         m_iAckedBytesCount; // Number of acknowledged payload bytes in the buffer
+    unsigned    m_uAvgPayloadSz;    // Average payload size for dropped bytes estimation
 
-    srt::CTsbpdTime  m_tsbpd;
+    CTsbpdTime  m_tsbpd;
 
-    AvgBufSize       m_mavg;
+    AvgBufSize  m_mavg;
 
 private:
     CRcvBuffer();
     CRcvBuffer(const CRcvBuffer&);
     CRcvBuffer& operator=(const CRcvBuffer&);
 };
+
+} // namespace srt
 
 #endif


### PR DESCRIPTION
Moved SND and RCV buffers into the `srt` namespace.
Related to #1924.