### PR TITLE
[core] Fixed FileCC random decrease

### DIFF
--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -535,8 +535,7 @@ private:
 
             m_iLastDecSeq = m_parent->sndSeqNo();
 
-            // remove global synchronization using randomization.
-            m_iDecRandom = genRandomInt(1, m_iAvgNAKNum);
+            m_iDecRandom = m_iAvgNAKNum > 1 ? genRandomInt(1, m_iAvgNAKNum) : 1;
             SRT_ASSERT(m_iDecRandom >= 1);
             HLOGC(cclog.Debug, log << "FileCC: LOSS:NEW lseqno=" << lossbegin
                 << ", lastsentseqno=" << m_iLastDecSeq


### PR DESCRIPTION
PR #1997 introduced an issue in FileCC, where `genRandomInt(1, max)` can be called with `max=0`. This results in an invalid call, as it means a request to generate a random value in range [1; 0].