### PR TITLE
Fixed 'undef' warning with gcc and clang

### DIFF
--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -45,7 +45,7 @@
    #endif
 #else
 
-#if __APPLE__
+#if defined(__APPLE__) && __APPLE__
 // XXX Check if this condition doesn't require checking of
 // also other macros, like TARGET_OS_IOS etc.
 

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -46,6 +46,14 @@
 #else
 
 #if defined(__APPLE__) && __APPLE__
+// Warning: please keep this test as it is, do not make it
+// "#if __APPLE__" or "#ifdef __APPLE__". In applications with
+// a strict "no warning policy", "#if __APPLE__" triggers an "undef"
+// error. With GCC, an old & never fixed bug prevents muting this
+// warning (see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431).
+// Before this fix, the solution was to "#define __APPLE__ 0" before
+// including srt.h. So, don't use "#ifdef __APPLE__" either.
+
 // XXX Check if this condition doesn't require checking of
 // also other macros, like TARGET_OS_IOS etc.
 


### PR DESCRIPTION
Fix for this warning:
~~~
srt/platform_sys.h:48:5: error: "__APPLE__" is not defined, evaluates to 0 [-Werror=undef]
   48 | #if __APPLE__
      |     ^~~~~~~~~
~~~

With clang, it is possible to use a pragma diagnostics before `#include <srt/srt.h>` to mute the warning.

With gcc, however, the situation is critical. Although the same pragma exists, it does nothing due to a known gcc bug since 2012, never fixed. Apparently, the bug appears too early in the lex analysis phase and #pragma are not yet parsed. It seems a bit difficult to solve and nobody wanted to fix it in 9 years.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53431

The problem is important in applications with a strict "no warning policy" (`-Wall -Wextra -Werror`). If a warning is impossible to mute, the compilation fails.

Note: please note that `#if __APPLE__` was replaced with `#if defined(__APPLE__) && __APPLE__`. Please keep it like this and do not use `#ifdef __APPLE__`. Because of the gcc bug, in order to compile the application, I have found no other solution than this:
~~~
#if defined(__GNUC__) && !defined(__APPLE__)
#define __APPLE__ 0
#define ZERO__APPLE__ 1
#endif

#include <srt/srt.h>

#if defined(ZERO__APPLE__)
#undef __APPLE__
#undef ZERO__APPLE__
#endif
~~~
So, if you use `#ifdef __APPLE__`, it won't work as expected.