### PR TITLE
[apps] Print SRT version and clock type

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -684,3 +684,36 @@ SrtStatsPrintFormat ParsePrintFormat(string pf, string& w_extras)
 
     return SRTSTATS_PROFMAT_INVALID;
 }
+
+const char* SRTClockTypeStr()
+{
+	const int clock_type = srt_clock_type();
+
+	switch (clock_type)
+	{
+	case SRT_SYNC_CLOCK_STDCXX_STEADY:
+		return "CXX11_STEADY";
+	case SRT_SYNC_CLOCK_GETTIME_MONOTONIC:
+		return "GETTIME_MONOTONIC";
+	case SRT_SYNC_CLOCK_WINQPC:
+		return "WIN_QPC";
+	case SRT_SYNC_CLOCK_MACH_ABSTIME:
+		return "MACH_ABSTIME";
+	case SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY:
+		return "POSIX_GETTIMEOFDAY";
+	default:
+		break;
+	}
+	
+	return "UNKNOWN VALUE";
+}
+
+void PrintLibVersion()
+{
+    cerr << "Built with SRT Library version: " << SRT_VERSION  << endl;
+    const uint32_t srtver = srt_getversion();
+    const int major = srtver / 0x10000;
+    const int minor = (srtver / 0x100) % 0x100;
+    const int patch = srtver % 0x100;
+    cerr << "SRT Library version: " << major << "." << minor << "." << patch << ", clock type: " << SRTClockTypeStr() << endl;
+}

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -419,5 +419,8 @@ extern std::vector<std::unique_ptr<SrtStatData>> g_SrtStatsTable;
 
 std::shared_ptr<SrtStatsWriter> SrtStatsWriterFactory(SrtStatsPrintFormat printformat);
 
+const char* SRTClockTypeStr();
+void PrintLibVersion();
+
 
 #endif // INC_SRT_APPCOMMON_H

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -52,7 +52,6 @@ void OnINT_ForceExit(int)
     interrupt = true;
 }
 
-
 struct FileTransmitConfig
 {
     unsigned long chunk_size;
@@ -144,12 +143,7 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
     if (print_help)
     {
         cout << "SRT sample application to transmit files.\n";
-        cerr << "Built with SRT Library version: " << SRT_VERSION << endl;
-        const uint32_t srtver = srt_getversion();
-        const int major = srtver / 0x10000;
-        const int minor = (srtver / 0x100) % 0x100;
-        const int patch = srtver % 0x100;
-        cerr << "SRT Library version: " << major << "." << minor << "." << patch << endl;
+        PrintLibVersion();
         cerr << "Usage: srt-file-transmit [options] <input-uri> <output-uri>\n";
         cerr << "\n";
 
@@ -182,7 +176,7 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
 
     if (Option<OutBool>(params, false, o_version))
     {
-        cerr << "SRT Library version: " << SRT_VERSION << endl;
+        PrintLibVersion();
         return 2;
     }
 

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -164,7 +164,6 @@ void PrintOptionHelp(const OptionName& opt_names, const string &value, const str
     cerr << "\t- " << desc << "\n";
 }
 
-
 int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
 {
     const OptionName
@@ -269,12 +268,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
         }
 
         cout << "SRT sample application to transmit live streaming.\n";
-        cerr << "Built with SRT Library version: " << SRT_VERSION << endl;
-        const uint32_t srtver = srt_getversion();
-        const int major = srtver / 0x10000;
-        const int minor = (srtver / 0x100) % 0x100;
-        const int patch = srtver % 0x100;
-        cerr << "SRT Library version: " << major << "." << minor << "." << patch << endl;
+        PrintLibVersion();
         cerr << "Usage: srt-live-transmit [options] <input-uri> <output-uri>\n";
         cerr << "\n";
 #ifndef _WIN32
@@ -313,7 +307,7 @@ int parse_args(LiveTransmitConfig &cfg, int argc, char** argv)
 
     if (print_version)
     {
-        cerr << "SRT Library version: " <<  SRT_VERSION << endl;
+        PrintLibVersion();
         return 2;
     }
 


### PR DESCRIPTION
- Moved SRT version printing to a separate function.
- Added printing clock type in `srt-live-transmit` and `srt-file-transmit` on `-version` and `-help` flags.

Example output:
```shell
./srt-live-transmit -version
Built with SRT Library version: 1.4.4
SRT Library version: 1.4.4, clock type: MACH_ABSTIME
```