### PR TITLE
Fixed group drift synchronization

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1549,8 +1549,8 @@ CPacket* CRcvBuffer::getRcvReadyPacket(int32_t seqdistance)
         HLOGC(brlog.Debug, log << "getRcvReadyPacket: Sequence offset=" << seqdistance << " IS NOT RECEIVED.");
         return 0;
     }
-    IF_HEAVY_LOGGING(int nskipped = 0);
 
+    IF_HEAVY_LOGGING(int nskipped = 0);
     for (int i = m_iStartPos, n = m_iLastAckPos; i != n; i = shiftFwd(i))
     {
         /*
@@ -1559,8 +1559,8 @@ CPacket* CRcvBuffer::getRcvReadyPacket(int32_t seqdistance)
         if (m_pUnit[i] && m_pUnit[i]->m_iFlag == CUnit::GOOD)
         {
             HLOGC(brlog.Debug,
-                  log << "getRcvReadyPacket: Found next packet seq=%" << m_pUnit[i]->m_Packet.getSeqNo() << " ("
-                      << nskipped << " empty cells skipped)");
+                log << "getRcvReadyPacket: Found next packet seq=%" << m_pUnit[i]->m_Packet.getSeqNo() << " ("
+                << nskipped << " empty cells skipped)");
             return &m_pUnit[i]->m_Packet;
         }
         IF_HEAVY_LOGGING(++nskipped);
@@ -1881,12 +1881,9 @@ void CRcvBuffer::setRcvTsbPdMode(const steady_clock::time_point& timebase, const
     m_tsbpd.setTsbPdMode(timebase, no_wrap_check, delay);
 }
 
-bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t                  timestamp_us,
-                                        int                       rtt,
-                                        steady_clock::duration&   w_udrift,
-                                        steady_clock::time_point& w_newtimebase)
+bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, int rtt)
 {
-    return m_tsbpd.addDriftSample(timestamp_us, rtt, w_udrift, w_newtimebase);
+    return m_tsbpd.addDriftSample(timestamp_us, rtt);
 }
 
 int CRcvBuffer::readMsg(char* data, int len)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -411,12 +411,8 @@ public:
 
     /// Add packet timestamp for drift caclculation and compensation
     /// @param [in] timestamp packet time stamp
-    /// @param [out] w_udrift current drift value
-    /// @param [out] w_newtimebase current TSBPD base time
-    bool addRcvTsbPdDriftSample(uint32_t          timestamp,
-                                int               rtt,
-                                duration&         w_udrift,
-                                time_point&       w_newtimebase);
+    /// @param [in] rtt RTT sample
+    bool addRcvTsbPdDriftSample(uint32_t timestamp, int rtt);
 
 #ifdef SRT_DEBUG_TSBPD_DRIFT
     void printDriftHistogram(int64_t iDrift);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8324,17 +8324,14 @@ void srt::CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsAr
     // srt_recvfile (which doesn't make any sense), you'll have a deadlock.
     if (m_config.bDriftTracer)
     {
-        steady_clock::duration udrift(0);
-        steady_clock::time_point newtimebase;
-        const bool drift_updated SRT_ATR_UNUSED = m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(),
-            rtt, (udrift), (newtimebase));
+        const bool drift_updated SRT_ATR_UNUSED = m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(), rtt);
 #if ENABLE_EXPERIMENTAL_BONDING
         if (drift_updated && m_parent->m_GroupOf)
         {
             ScopedLock glock(s_UDTUnited.m_GlobControlLock);
             if (m_parent->m_GroupOf)
             {
-                m_parent->m_GroupOf->synchronizeDrift(this, udrift, newtimebase);
+                m_parent->m_GroupOf->synchronizeDrift(this);
             }
         }
 #endif

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2741,7 +2741,7 @@ void CUDTGroup::synchronizeDrift(const srt::CUDT* srcMember)
     srcMember->m_pRcvBuffer->getInternalTimeBase((timebase), (wrap_period), (udrift));
 
     HLOGC(grlog.Debug,
-        log << "GROUP: synch uDRIFT=" << FormatDuration(udrift) << " TB=" << FormatTime(newtimebase) << "("
+        log << "GROUP: synch uDRIFT=" << FormatDuration(udrift) << " TB=" << FormatTime(timebase) << "("
         << (wrap_period ? "" : "NO ") << "wrap period)");
 
     // Now that we have the minimum timebase and drift calculated, apply this to every link,

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -798,7 +798,10 @@ public:
     // Live state synchronization
     bool getBufferTimeBase(srt::CUDT* forthesakeof, time_point& w_tb, bool& w_wp, duration& w_dr);
     bool applyGroupSequences(SRTSOCKET, int32_t& w_snd_isn, int32_t& w_rcv_isn);
-    void synchronizeDrift(srt::CUDT* cu, duration udrift, time_point newtimebase);
+
+    /// @brief Synchronize TSBPD base time and clock drift among members using the @a srcMember as a reference.
+    /// @param srcMember a reference for synchronization.
+    void synchronizeDrift(const srt::CUDT* srcMember);
 
     void updateLatestRcv(srt::CUDTSocket*);
 

--- a/srtcore/tsbpd_time.cpp
+++ b/srtcore/tsbpd_time.cpp
@@ -103,10 +103,7 @@ drift_logger g_drift_logger;
 
 #endif // SRT_DEBUG_TRACE_DRIFT
 
-bool CTsbpdTime::addDriftSample(uint32_t                  usPktTimestamp,
-                                int                       usRTTSample,
-                                steady_clock::duration&   w_udrift,
-                                steady_clock::time_point& w_newtimebase)
+bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, int usRTTSample)
 {
     if (!m_bTsbPdMode)
         return false;
@@ -148,9 +145,6 @@ bool CTsbpdTime::addDriftSample(uint32_t                  usPktTimestamp,
         HLOGC(brlog.Debug,
               log << "DRIFT=" << FormatDuration(tdDrift) << " TB REMAINS: " << FormatTime(m_tsTsbPdTimeBase));
     }
-
-    w_udrift      = tdDrift;
-    w_newtimebase = m_tsTsbPdTimeBase;
 
 #if SRT_DEBUG_TRACE_DRIFT
     g_drift_logger.trace(usPktTimestamp,

--- a/srtcore/tsbpd_time.h
+++ b/srtcore/tsbpd_time.h
@@ -67,14 +67,9 @@ public:
     /// 
     /// @param [in] pktTimestamp Timestamp of the arrived ACKACK packet.
     /// @param [in] usRTTSample RTT sample from an ACK-ACKACK pair.
-    /// @param [out] w_udrift Current clock drift value.
-    /// @param [out] w_newtimebase Current TSBPD base time.
     /// 
     /// @return true if TSBPD base time has changed, false otherwise.
-    bool addDriftSample(uint32_t                  pktTimestamp,
-                        int                       usRTTSample,
-                        steady_clock::duration&   w_udrift,
-                        steady_clock::time_point& w_newtimebase);
+    bool addDriftSample(uint32_t pktTimestamp, int usRTTSample);
 
     /// @brief Handle timestamp of data packet when 32-bit integer carryover is about to happen.
     /// When packet timestamp approaches CPacket::MAX_TIMESTAMP, the TSBPD base time should be


### PR DESCRIPTION
When a group member updates its clock drift value and potentially the TSBPD base time, all other members need to be synchronized to use the same value.

Previously, the minimum drift value and the minimum TSBPD base time among all group member was taken as a reference, which resulted in bad behavior.
Having the improved drift tracer logic (PR #1965) now allows to do a proper synchronization of group members,


### Experiment

**Network**: Win 10 <--> 1Gbps switch <--> CentOS 7.
**Network impairments**: RTT 40 ms, 1% packet loss.
**SRT latency**: 120 ms.

Both broadcast group transmission and single path transmission are running in parallel over the same local switch as described below.

#### Broadcast Group Transmission

```shell
(broadcast group sender)
srt-xtransmit generate srt://192.168.0.7:4200 srt://192.168.0.7:5200 --sendrate 10Mbps --enable-metrics

(group receiver)
srt-xtransmit receive srt://:4200 srt://:5200 --enable-metrics --reconnect
```

#### Single Path Transmission

```shell
(single path sender)
srt-xtransmit generate srt://192.168.0.7:1234 --sendrate 10Mbps --enable-metrics

(single path receiver)
srt-xtransmit receive srt://:1234 --enable-metrics
```


#### Results: Broadcast Receiver v1.4.4-rc.1

**Experiment duration:** ~4 hours.

<details><summary>Plots (click to expand/collapse)</summary>
<p>

![image](https://user-images.githubusercontent.com/12700120/135060045-511ac063-c41f-4a90-ba6c-c8adcdcdbaea.png)

</p></details>

##### Broadcast Group State
**End-to-end Latency, us (min/max/avg):** 2112032 / 2123588 / 2116079.
**Jitter**: 2051us.
**Packets received** 11717902
**Reordered:** 0 (dist 0)
**Packets Lost (aka dropped):** 13989 (0.12%) ❗ 

##### Single Socket State
**End-to-end Latency, us (min/max/avg):** 2235667 / 2235974 / 2235747
**Jitter:** 14us.
**Packets received:** 11844550
**Reordered:** 0 (dist 0)
**Packets Lost (aka dropped):** 0.