### PR TITLE
Fixed checking the packet seqno validity when reading from a group member

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -638,7 +638,7 @@ public:
    /// Prior to calling this function the caller must be certain that
    /// @a seq2 is a sequence coming from a later time than @a seq1,
    /// and that the distance does not exceed m_iMaxSeqNo.
-   inline static int32_t seqlen(int32_t seq1, int32_t seq2)
+   inline static int seqlen(int32_t seq1, int32_t seq2)
    {
        SRT_ASSERT(seq1 >= 0 && seq1 <= m_iMaxSeqNo);
        SRT_ASSERT(seq2 >= 0 && seq2 <= m_iMaxSeqNo);

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -634,12 +634,16 @@ public:
    /// WITH A PRECONDITION that certainly @a seq1 is earlier than @a seq2.
    /// This can also include an enormously large distance between them,
    /// that is, exceeding the m_iSeqNoTH value (can be also used to test
-   /// if this distance is larger). Prior to calling this function the
-   /// caller must be certain that @a seq2 is a sequence coming from a
-   /// later time than @a seq1, and still, of course, this distance didn't
-   /// exceed m_iMaxSeqNo.
-   inline static int seqlen(int32_t seq1, int32_t seq2)
-   {return (seq1 <= seq2) ? (seq2 - seq1 + 1) : (seq2 - seq1 + m_iMaxSeqNo + 2);}
+   /// if this distance is larger).
+   /// Prior to calling this function the caller must be certain that
+   /// @a seq2 is a sequence coming from a later time than @a seq1,
+   /// and that the distance does not exceed m_iMaxSeqNo.
+   inline static uint32_t seqlen(int32_t seq1, int32_t seq2)
+   {
+       SRT_ASSERT(seq1 >= 0 && seq1 <= m_iMaxSeqNo);
+       SRT_ASSERT(seq2 >= 0 && seq2 <= m_iMaxSeqNo);
+       return (seq1 <= seq2) ? (seq2 - seq1 + 1) : (m_iMaxSeqNo - seq1 + seq2 + 2);
+   }
 
    /// This behaves like seq2 - seq1, with the precondition that the true
    /// distance between two sequence numbers never exceeds m_iSeqNoTH.

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -638,11 +638,11 @@ public:
    /// Prior to calling this function the caller must be certain that
    /// @a seq2 is a sequence coming from a later time than @a seq1,
    /// and that the distance does not exceed m_iMaxSeqNo.
-   inline static uint32_t seqlen(int32_t seq1, int32_t seq2)
+   inline static int32_t seqlen(int32_t seq1, int32_t seq2)
    {
        SRT_ASSERT(seq1 >= 0 && seq1 <= m_iMaxSeqNo);
        SRT_ASSERT(seq2 >= 0 && seq2 <= m_iMaxSeqNo);
-       return (seq1 <= seq2) ? (seq2 - seq1 + 1) : (m_iMaxSeqNo - seq1 + seq2 + 2);
+       return (seq1 <= seq2) ? (seq2 - seq1 + 1) : (seq2 - seq1 + m_iMaxSeqNo + 2);
    }
 
    /// This behaves like seq2 - seq1, with the precondition that the true

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2149,6 +2149,18 @@ void CUDTGroup::updateWriteState()
 }
 
 /// Validate iPktSeqno is in range [iBaseSeqno - m_iSeqNoTH/2; iBaseSeqno + m_iSeqNoTH].
+///
+/// EXPECT_EQ(isValidSeqno(125, 124), true); // behind
+/// EXPECT_EQ(isValidSeqno(125, 125), true); // behind
+/// EXPECT_EQ(isValidSeqno(125, 126), true); // the next in order
+/// EXPECT_EQ(isValidSeqno(0x7FFFFFFF, 0), true); // the next in order
+/// EXPECT_EQ(isValidSeqno(0x7FFFFFFF, 1), true); // ahead by 1 seqno
+/// EXPECT_EQ(isValidSeqno(0, 0x7FFFFFFF), true); // behind by 1 seqno
+///
+/// EXPECT_EQ(isValidSeqno(0, 0x3FFFFFFF + 10), false); // too far ahead
+/// EXPECT_EQ(isValidSeqno(0x3FFFFFFF - 10, 0x7FFFFFFF), false); // too far (ahead?)
+/// EXPECT_EQ(isValidSeqno(0x3FFFFFFF + 10, 0x7FFFFFFF), false); // too far (behind?)
+///
 /// @return false if @a iPktSeqno is not inside the valid range; otherwise true.
 static bool isValidSeqno(int32_t iBaseSeqno, int32_t iPktSeqno)
 {

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -117,9 +117,8 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
         return 0;
     }
 
-    // TODO: inserted_range now can't be negative
     const int inserted_range = CSeqNo::seqlen(seqno1, seqno2);
-    if (inserted_range == 0 || inserted_range >= m_iSize) {
+    if (inserted_range <= 0 || inserted_range >= m_iSize) {
         LOGC(qslog.Error, log << "IPE: Tried to insert too big range of seqno: " << inserted_range <<  ". Ignoring. "
                 << "seqno " << seqno1 << ":" << seqno2);
         return 0;

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -117,8 +117,9 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
         return 0;
     }
 
+    // TODO: inserted_range now can't be negative
     const int inserted_range = CSeqNo::seqlen(seqno1, seqno2);
-    if (inserted_range <= 0 || inserted_range >= m_iSize) {
+    if (inserted_range == 0 || inserted_range >= m_iSize) {
         LOGC(qslog.Error, log << "IPE: Tried to insert too big range of seqno: " << inserted_range <<  ". Ignoring. "
                 << "seqno " << seqno1 << ":" << seqno2);
         return 0;

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -16,7 +16,6 @@ TEST(CSeqNo, constants)
     EXPECT_EQ(CSeqNo::m_iSeqNoTH,  0x3FFFFFFF);
 }
 
-
 TEST(CSeqNo, seqcmp)
 {
     // Compare two seq#, considering the wraping.
@@ -30,7 +29,6 @@ TEST(CSeqNo, seqcmp)
     EXPECT_EQ(CSeqNo::seqcmp(0x7FFFFFFF, 1), int(0x80000002));   // -2147483646
     EXPECT_EQ(CSeqNo::seqcmp(1, 0x7FFFFFFF), 0x7FFFFFFE);   //  2147483646
 }
-
 
 TEST(CSeqNo, seqoff)
 {
@@ -50,151 +48,7 @@ TEST(CSeqNo, seqlen)
     EXPECT_EQ(CSeqNo::seqlen(125, 126), 2);
 
     EXPECT_EQ(CSeqNo::seqlen(2147483647, 0), 2);
-    EXPECT_EQ(CSeqNo::seqlen(0, 2147483647), 2147483648);
-
-    // seq2 %> seq1, but the distance exceeds m_iSeqNoTH = 0x3FFFFFFF.
-    //EXPECT_TRUE(CSeqNo::seqlen(0, 0x3FFFFFFF + 10) > 0x3FFFFFFF);
-    //EXPECT_TRUE(CSeqNo::seqlen(0x7FFFFFFF, 0x3FFFFFFF + 10) > 0x3FFFFFFF);
-
-    // seq2 <% seq1, but the distance exceeds m_iSeqNoTH = 0x3FFFFFFF.
-    //EXPECT_EQ(CSeqNo::seqlen(0x3FFFFFFF + 10, 0), 2);
-    //EXPECT_EQ(CSeqNo::seqlen(0x7FFFFFFF, 0x3FFFFFFF + 10), 2);
-}
-
-enum class pkt_validity
-{
-    descrepancy = -1,
-    ok = 0,
-    behind = 1,
-    ahead = 2
-};
-
-const char* to_cstr(pkt_validity val)
-{
-    switch (val)
-    {
-    case pkt_validity::descrepancy:
-        return "DESCREPANCY";
-    case pkt_validity::ok:
-        return "OK";
-    case pkt_validity::behind:
-        return "BEHIND";
-    case pkt_validity::ahead:
-        return "AHEAD";
-    default:
-        break;
-    }
-
-    return "INVAL";
-}
-
-
-pkt_validity ValidateSeqno(int base_seqno, int pkt_seqno)
-{
-    const uint32_t seqlen_ahead  = CSeqNo::seqlen(base_seqno, pkt_seqno);
-    std::cout << "SeqLen ahead: " << seqlen_ahead << std::endl;
-    if (seqlen_ahead == 2)
-        return pkt_validity::ok;
-
-    if (seqlen_ahead <= 1)
-        return pkt_validity::behind;
-
-    if (seqlen_ahead < CSeqNo::m_iSeqNoTH) {
-        return pkt_validity::ahead;
-    }
-
-    const uint32_t seqlen_behind = CSeqNo::seqlen(pkt_seqno, base_seqno);
-    std::cout << "SeqLen behind: " << seqlen_behind << std::endl;
-
-    if (seqlen_behind < CSeqNo::m_iSeqNoTH / 2)
-        return pkt_validity::behind;
-
-    return pkt_validity::descrepancy;
-}
-
-TEST(CSeqNo, Descrepancy)
-{
-    EXPECT_EQ(ValidateSeqno(       125,  124), pkt_validity::behind);
-    EXPECT_EQ(ValidateSeqno(       125,  125), pkt_validity::behind);
-    EXPECT_EQ(ValidateSeqno(       125,  126), pkt_validity::ok);
-    EXPECT_EQ(ValidateSeqno(0x7FFFFFFF,    0), pkt_validity::ok);
-    EXPECT_EQ(ValidateSeqno(0x7FFFFFFF,    1), pkt_validity::ahead);
-    EXPECT_EQ(ValidateSeqno(         0, 0x7FFFFFFF), pkt_validity::behind);
-
-    // pkt_seqno is ahead and descrepancy
-    EXPECT_EQ(ValidateSeqno(0, 0x3FFFFFFF + 10), pkt_validity::descrepancy);
-    EXPECT_EQ(ValidateSeqno(0x3FFFFFFF - 10, 0x7FFFFFFF), pkt_validity::descrepancy);   
-}
-
-
-///
-/// @return false if @a iPktSeqno is not inside the valid range; otherwise true.
-static bool isValidSeqno(int32_t iBaseSeqno, int32_t iPktSeqno)
-{
-    using std::hex;
-    using std::setw;
-    using std::setfill;
-
-    std::ios init_fmt(NULL);
-    init_fmt.copyfmt(std::cout);
-    std::cout << "iBaseSeqno = 0x" << hex << setw(8) << setfill('0') << iBaseSeqno
-              << " iPktSeqno = 0x" << /*hex << setw(8) << setfill('0') <<*/ iPktSeqno << std::endl;
-    std::cout.copyfmt(init_fmt);
-    const int32_t iLenAhead = CSeqNo::seqlen(iBaseSeqno, iPktSeqno);
-    std::cout << "SeqLen ahead: " << iLenAhead << std::endl;
-    if (iLenAhead >= 0 && iLenAhead < CSeqNo::m_iSeqNoTH)
-        return true;
-
-    const int32_t iLenBehind = CSeqNo::seqlen(iPktSeqno, iBaseSeqno);
-    std::cout << "SeqLen behind: " << iLenBehind << std::endl;
-    if (iLenBehind >= 0 && iLenBehind < CSeqNo::m_iSeqNoTH / 2)
-        return true;
-
-    return false;
-}
-
-// m_iSeqNoTH = 0x3FFFFFFF  = 1073741823
-// 0x3FFFFFFF / 2 = 536870911
-// The valid offset range is ( -536870911; 1073741823 )
-// or ( -(m_iSeqNoTH / 2) ; + m_iSeqNoTH)
-TEST(CSeqNo, isValid)
-{
-    EXPECT_EQ(isValidSeqno(125, 124), true); // behind
-    EXPECT_EQ(isValidSeqno(125, 125), true); // behind (the same packet, not the next one)
-    EXPECT_EQ(isValidSeqno(125, 126), true); // the next in order
-    EXPECT_EQ(isValidSeqno(0x7FFFFFFF, 0), true); // the next in order
-    EXPECT_EQ(isValidSeqno(0x7FFFFFFF, 1), true); // ahead by 1 seqno
-    EXPECT_EQ(isValidSeqno(0, 0x7FFFFFFF), true); // behind by 1 seqno
-
-    EXPECT_EQ(isValidSeqno(0, 0x3FFFFFFF - 2), true);  // ahead, but ok
-    EXPECT_EQ(isValidSeqno(0, 0x3FFFFFFF - 1), false); // too far ahead
-
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF + 0, 0x7FFFFFFF), false); // too far (ahead?)
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF + 1, 0x7FFFFFFF), false); // too far (ahead?)
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF + 2, 0x7FFFFFFF), false); // too far ahead.
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF + 3, 0x7FFFFFFF), true); // ahead, but ok.
-
-    // 0x3FFFFFFF / 2 = 0x1FFFFFFF
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF, 0x1FFFFFFF), false); // too far (behind)
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF, 0x1FFFFFFF + 1), false); // too far (behind)
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF, 0x1FFFFFFF + 2), false); // too far (behind)
-    EXPECT_EQ(isValidSeqno(0x3FFFFFFF, 0x1FFFFFFF + 3), true); // behind by 536870910, but ok
-
-    // 0x3FFFFFFF / 4 = 0x0FFFFFFF
-    // 0x7FFFFFFF - 0x0FFFFFFF = 0x70000000
-    EXPECT_EQ(isValidSeqno(0x70000000, 0x7FFFFFFF), true);
-    EXPECT_EQ(isValidSeqno(0x70000000, 0x0FFFFFFF), true);
-    EXPECT_EQ(isValidSeqno(0x70000000, 0x30000000), false);
-    EXPECT_EQ(isValidSeqno(0x70000000, 0x30000000 - 1), false);
-    EXPECT_EQ(isValidSeqno(0x70000000, 0x30000000 - 2), false);
-    EXPECT_EQ(isValidSeqno(0x70000000, 0x30000000 - 3), true); // ahead by 1073741822
-
-    EXPECT_EQ(isValidSeqno(0x0FFFFFFF, 0), true);
-    EXPECT_EQ(isValidSeqno(0x0FFFFFFF, 0x7FFFFFFF), true);
-    EXPECT_EQ(isValidSeqno(0x0FFFFFFF, 0x70000000), false);
-    EXPECT_EQ(isValidSeqno(0x0FFFFFFF, 0x70000001), false);
-    EXPECT_EQ(isValidSeqno(0x0FFFFFFF, 0x70000002), true);  // behind by 536870910
-    EXPECT_EQ(isValidSeqno(0x0FFFFFFF, 0x70000003), true);
+    EXPECT_EQ(CSeqNo::seqlen(0, 2147483647), -2147483648);
 }
 
 TEST(CUDT, getFlightSpan)
@@ -221,7 +75,6 @@ TEST(CSeqNo, incseq)
     EXPECT_EQ(CSeqNo::incseq(0x3FFFFFFF), 0x40000000);
 }
 
-
 TEST(CSeqNo, decseq)
 {
     // decseq: decrease the seq# by 1
@@ -230,7 +83,6 @@ TEST(CSeqNo, decseq)
     EXPECT_EQ(CSeqNo::decseq(0),          0x7FFFFFFF);
     EXPECT_EQ(CSeqNo::decseq(0x40000000), 0x3FFFFFFF);
 }
-
 
 TEST(CSeqNo, incseqint)
 {
@@ -245,7 +97,6 @@ TEST(CSeqNo, incseqint)
     EXPECT_EQ(CSeqNo::incseq(0x3FFFFFFF, 0x40000001), 0x00000000);
 }
 
-
 TEST(CSeqNo, decseqint)
 {
     // decseq: decrease the seq# by 1
@@ -254,4 +105,3 @@ TEST(CSeqNo, decseqint)
     EXPECT_EQ(CSeqNo::decseq(0, 1),          0x7FFFFFFF);
     EXPECT_EQ(CSeqNo::decseq(0x40000000, 1), 0x3FFFFFFF);
 }
-

--- a/test/test_seqno.cpp
+++ b/test/test_seqno.cpp
@@ -48,6 +48,46 @@ TEST(CSeqNo, seqlen)
 {
     EXPECT_EQ(CSeqNo::seqlen(125, 125), 1);
     EXPECT_EQ(CSeqNo::seqlen(125, 126), 2);
+
+    EXPECT_EQ(CSeqNo::seqlen(2147483647, 0), 2);
+    EXPECT_EQ(CSeqNo::seqlen(0, 2147483647), 2147483648);
+
+    // seq2 %> seq1, but the distance exceeds m_iSeqNoTH = 0x3FFFFFFF.
+    //EXPECT_TRUE(CSeqNo::seqlen(0, 0x3FFFFFFF + 10) > 0x3FFFFFFF);
+    //EXPECT_TRUE(CSeqNo::seqlen(0x7FFFFFFF, 0x3FFFFFFF + 10) > 0x3FFFFFFF);
+
+    // seq2 <% seq1, but the distance exceeds m_iSeqNoTH = 0x3FFFFFFF.
+    //EXPECT_EQ(CSeqNo::seqlen(0x3FFFFFFF + 10, 0), 2);
+    //EXPECT_EQ(CSeqNo::seqlen(0x7FFFFFFF, 0x3FFFFFFF + 10), 2);
+}
+
+enum class pkt_validity
+{
+    descrepancy = -1,
+    ok = 0,
+    behind = 1,
+    ahead = 2
+};
+
+
+pkt_validity ValidateSeqno(int base_seqno, int pkt_seqno)
+{
+    return 0;
+}
+
+TEST(CSeqNo, Descrepancy)
+{
+    EXPECT_EQ(ValidateSeqno(       125,  124), pkt_validity::behind);
+    EXPECT_EQ(ValidateSeqno(       125,  125), pkt_validity::behind);
+    EXPECT_EQ(ValidateSeqno(       125,  126), pkt_validity::ok);
+    EXPECT_EQ(ValidateSeqno(0x7FFFFFFF,    0), pkt_validity::ok);
+    EXPECT_EQ(ValidateSeqno(0x7FFFFFFF,    1), pkt_validity::ahead);
+    EXPECT_EQ(ValidateSeqno(         0, 0x7FFFFFFF), pkt_validity::behind);
+
+    // pkt_seqno is ahead and descrepancy
+    EXPECT_EQ(ValidateSeqno(0, 0x3FFFFFFF + 10), pkt_validity::descrepancy);
+    EXPECT_EQ(ValidateSeqno(0x3FFFFFFF - 10, 0x7FFFFFFF), pkt_validity::descrepancy);
+    
 }
 
 TEST(CUDT, getFlightSpan)


### PR DESCRIPTION
### The Problem

There is an issue with the discrepancy check of packet sequence number performed by a group reader.
The issue was originally described in #2138 (issue no. 1 of 2).

A group reads packet with sequence number `0x7FFFFFFF` (maximum seqno value).
The base seqno `m_RcvBaseSeqNo` of a group reader is set to `0x7FFFFFFF`.
The next expected packet number is 0. However, once a packet with seqno 0 (`mctrl.pktseq = 0`) is read from one of group members, the following check evaluates into `true`, and a sequence discrepancy is wrongfully detected. 
```c++
abs(m_RcvBaseSeqNo - mctrl.pktseq) > CSeqNo::m_iSeqNoTH)
```
The member socket is then identified as broken and is to be closing. Closing this socket results in the issue no.2 described in #2138. Issue no. 2 is not addressed in this PR.

### The Proposed Fix

Check the packet seqno read from a group member is in range `(iBaseSeqno - m_iSeqNoTH/2; iBaseSeqno + m_iSeqNoTH).`

<img width="243" alt="image" src="https://user-images.githubusercontent.com/12700120/135480382-281383f8-e4ec-41f9-a65e-f53424cb69a2.png">



### TODO

- [x] Decided not to return an unsigned integer from `seqlen(..)` to avoid possible side effects to the rest of the code right before the v1.4.4 release.
- [x] Remove redundant unit test function.
- [x] Adjust and check the valid range. Currently the range is likely `(iBaseSeqno - m_iSeqNoTH/2 - 2; iBaseSeqno + m_iSeqNoTH).`