### PR TITLE
[build-android] Support NDK r23, OpenSSL v3

### DIFF
--- a/scripts/build-android/build-android
+++ b/scripts/build-android/build-android
@@ -3,16 +3,16 @@
 echo_help()
 {
   echo "Usage: $0 [options...]"
-  echo "    -n    Specify NDK root path for the build."
-  echo "    -a    Select target API level."
-  echo "    -t    Select target architectures."
-  echo "          Android supports the following architectures: armeabi-v7a arm64-v8a x86 x86_64."
+  echo "    -n    NDK root path for the build"
+  echo "    -a    Target API level"
+  echo "    -t    Space-separated list of target architectures"
+  echo "          Android supports the following architectures: armeabi-v7a arm64-v8a x86 x86_64"
   echo "    -e    Encryption library to be used. Possible options: openssl (default) mbedtls"
-  echo "    -o    Select OpenSSL (1.1.1 series) version. E.g. 1.1.1h"
-  echo "    -m    Select Mbed TLS version. E.g. v2.26.0"
-  echo "    -s    Select SRT version. E.g. v1.4.3"
+  echo "    -o    OpenSSL version. E.g. 1.1.1l"
+  echo "    -m    Mbed TLS version. E.g. v2.26.0"
+  echo "    -s    SRT version. E.g. v1.4.4"
   echo
-  echo "Example: ./build-android -n /home/username/Android/Sdk/ndk/21.4.7075529 -a 28 -t \"armeabi-v7a arm64-v8a x86 x86_64\" -o 1.1.1h -s v1.4.3"
+  echo "Example: ./build-android -n /home/username/Android/Sdk/ndk/23.0.7599858 -a 28 -t \"arm64-v8a x86_64\""
   echo
 }
 
@@ -20,7 +20,7 @@ echo_help()
 NDK_ROOT=""
 API_LEVEL=28
 BUILD_TARGETS="armeabi-v7a arm64-v8a x86 x86_64"
-OPENSSL_VERSION=1.1.1h
+OPENSSL_VERSION=1.1.1l
 SRT_VERSION=""
 ENC_LIB=openssl
 MBEDTLS_VERSION=v2.26.0

--- a/scripts/build-android/mkssl
+++ b/scripts/build-android/mkssl
@@ -29,48 +29,22 @@ fi
 cd openssl-${OPENSSL_VERSION} || exit 128
 
 
-##### Prepare Files #####
-sed -i.bak 's/.*-mandroid.*//' Configurations/15-android.conf
-patch -p1 -N <<EOP
---- old/Configurations/unix-Makefile.tmpl   2018-09-11 14:48:19.000000000 +0200
-+++ new/Configurations/unix-Makefile.tmpl   2018-10-18 09:06:27.282007245 +0200
-@@ -43,12 +43,17 @@
-      # will return the name from shlib(\$libname) with any SO version number
-      # removed.  On some systems, they may therefore return the exact same
-      # string.
--     sub shlib {
-+     sub shlib_simple {
-          my \$lib = shift;
-          return () if \$disabled{shared} || \$lib =~ /\\.a$/;
--         return \$unified_info{sharednames}->{\$lib}. \$shlibvariant. '\$(SHLIB_EXT)';
-+
-+         if (windowsdll()) {
-+             return \$lib . '\$(SHLIB_EXT_IMPORT)';
-+         }
-+         return \$lib .  '\$(SHLIB_EXT_SIMPLE)';
-      }
--     sub shlib_simple {
-+     
-+   sub shlib {
-          my \$lib = shift;
-          return () if \$disabled{shared} || \$lib =~ /\\.a$/;
-
-EOP
-
-##### remove output-directory #####
-#rm -rf $OUT_DIR
-
 ##### export ndk directory. Required by openssl-build-scripts #####
-export ANDROID_NDK
+case ${OPENSSL_VERSION} in
+    1.1.1*)
+        export ANDROID_NDK_HOME=$ANDROID_NDK
+    ;;
+    *)
+        export ANDROID_NDK_ROOT=$ANDROID_NDK
+    ;;
+esac
+
+export PATH=$ANDROID_NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin:$PATH
 
 ##### build-function #####
 build_the_thing() {
-    TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/$HOST_TAG
-    export PATH=$TOOLCHAIN/$TRIBLE/bin:$TOOLCHAIN/bin:"$PATH"
-echo $PATH
     make clean
-    #./Configure $SSL_TARGET $OPTIONS -fuse-ld="$TOOLCHAIN/$TRIBLE/bin/ld" "-gcc-toolchain $TOOLCHAIN" && \
-    ./Configure $SSL_TARGET $OPTIONS -fuse-ld="$TOOLCHAIN/$TRIBLE/bin/ld" && \
+    ./Configure $SSL_TARGET -D__ANDROID_API__=$API_LEVEL && \
     make && \
     make install DESTDIR=$DESTDIR || exit 128
 }
@@ -79,39 +53,19 @@ echo $PATH
 for build_target in $BUILD_TARGETS
 do
     case $build_target in
-    armeabi)
-        TRIBLE="arm-linux-androideabi"
-        TC_NAME="arm-linux-androideabi-4.9"
-        #OPTIONS="--target=armv5te-linux-androideabi -mthumb -fPIC -latomic -D__ANDROID_API__=$API_LEVEL"
-        OPTIONS="--target=armv5te-linux-androideabi -mthumb -fPIC -latomic -D__ANDROID_API__=$API_LEVEL"
-        DESTDIR="$BUILD_DIR/armeabi"
-        SSL_TARGET="android-arm"
-    ;;
     armeabi-v7a)
-        TRIBLE="arm-linux-androideabi"
-        TC_NAME="arm-linux-androideabi-4.9"
-        OPTIONS="--target=armv7a-linux-androideabi -Wl,--fix-cortex-a8 -fPIC -D__ANDROID_API__=$API_LEVEL"
         DESTDIR="$BUILD_DIR/armeabi-v7a"
         SSL_TARGET="android-arm"
     ;;
     x86)
-        TRIBLE="i686-linux-android"
-        TC_NAME="x86-4.9"
-        OPTIONS="-fPIC -D__ANDROID_API__=${API_LEVEL}"
         DESTDIR="$BUILD_DIR/x86"
         SSL_TARGET="android-x86"
     ;;
     x86_64)
-        TRIBLE="x86_64-linux-android"
-        TC_NAME="x86_64-4.9"
-        OPTIONS="-fPIC -D__ANDROID_API__=${API_LEVEL}"
         DESTDIR="$BUILD_DIR/x86_64"
         SSL_TARGET="android-x86_64"
     ;;
     arm64-v8a)
-        TRIBLE="aarch64-linux-android"
-        TC_NAME="aarch64-linux-android-4.9"
-        OPTIONS="-fPIC -D__ANDROID_API__=${API_LEVEL}"
         DESTDIR="$BUILD_DIR/arm64-v8a"
         SSL_TARGET="android-arm64"
     ;;


### PR DESCRIPTION
- Update default openssl version to 1.1.1l that fixes NDK r23 build (https://github.com/openssl/openssl/issues/13685);
- Clean mkssl script and use default configuration options;
- Add both v3 and v1.1.1 support to mkssl.