### PR TITLE
[build]: Fix socket type for MinGW

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -152,11 +152,7 @@ typedef int32_t SRTSOCKET;
 static const int32_t SRTGROUP_MASK = (1 << 30);
 
 #ifdef _WIN32
-   #ifndef __MINGW32__
-      typedef SOCKET SYSSOCKET;
-   #else
-      typedef int SYSSOCKET;
-   #endif
+   typedef SOCKET SYSSOCKET;
 #else
    typedef int SYSSOCKET;
 #endif


### PR DESCRIPTION
Just use SOCKET type for any WIN32 environment including MinGW.
This fixes the warnings like:
```
srt/srtcore/channel.cpp:167:19: warning: comparison of integer expressions of different signedness: 'UDPSOCKET' {aka 'int'} and 'SOCKET' {aka 'long long unsigned int'} [-Wsign-compare]
  167 |     if (m_iSocket == INVALID_SOCKET)
      |                   ^
```
