### PR TITLE
Fixed missing ws2_32 lib in Windows installer

### DIFF
--- a/scripts/win-installer/libsrt.props
+++ b/scripts/win-installer/libsrt.props
@@ -29,7 +29,7 @@
       <AdditionalIncludeDirectories>$(LIBSRT)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>srt.lib;libssl.lib;libcrypto.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>srt.lib;libssl.lib;libcrypto.lib;crypt32.lib;ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(LIBSRT)\lib\$(Configuration)-$(SrtPlatform);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>


### PR DESCRIPTION
The property file libsrt.props did not reference ws2_32.lib. For large
applications which already reference the Windows socket library, there
is no difference. In small test applications which reference libsrt only,
there were undefined symbols.