### PR TITLE
fix low prob crash while srt_cleanup called

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3178,7 +3178,7 @@ void* srt::CUDTUnited::garbageCollect(void* p)
        for (sockets_t::iterator j = self->m_ClosedSockets.begin();
                j != self->m_ClosedSockets.end(); ++ j)
        {
-           j->second->m_tsClosureTimeStamp = steady_clock::now();
+           j->second->m_tsClosureTimeStamp = steady_clock::time_point();
        }
    }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10610,7 +10610,7 @@ int32_t srt::CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int co
                     clientport,
                     sizeof(clientport),
                     NI_NUMERICHOST | NI_NUMERICSERV);
-        int64_t timestamp = (count_microseconds(steady_clock::now() - m_stats.tsStartTime) / 60000000) + distractor -
+        int64_t timestamp = (count_microseconds(steady_clock::now() - m_stats.tsStartTime) / 60000000) + distractor +
                             correction; // secret changes every one minute
         stringstream cookiestr;
         cookiestr << clienthost << ":" << clientport << ":" << timestamp;
@@ -10785,7 +10785,7 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
           log << "processConnectRequest: received type=" << RequestTypeStr(hs.m_iReqType) << " - checking cookie...");
     if (hs.m_iCookie != cookie_val)
     {
-        cookie_val = bake(addr, cookie_val, 1); // SHOULD generate an earlier, distracted cookie
+        cookie_val = bake(addr, cookie_val, -1); // SHOULD generate an earlier, distracted cookie
 
         if (hs.m_iCookie != cookie_val)
         {


### PR DESCRIPTION
1. while srt_cleanup called, the garbage collector will close all sockets and exit
2. but Rcv worker or sender worker my access CUDT pointers
3. I think this is a bug of coding mistake, so fix it