### PR TITLE
fix cookie syn issues

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3178,7 +3178,7 @@ void* srt::CUDTUnited::garbageCollect(void* p)
        for (sockets_t::iterator j = self->m_ClosedSockets.begin();
                j != self->m_ClosedSockets.end(); ++ j)
        {
-           j->second->m_tsClosureTimeStamp = steady_clock::now();
+           j->second->m_tsClosureTimeStamp = steady_clock::time_point();
        }
    }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10610,7 +10610,7 @@ int32_t srt::CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int co
                     clientport,
                     sizeof(clientport),
                     NI_NUMERICHOST | NI_NUMERICSERV);
-        int64_t timestamp = (count_microseconds(steady_clock::now() - m_stats.tsStartTime) / 60000000) + distractor -
+        int64_t timestamp = (count_microseconds(steady_clock::now() - m_stats.tsStartTime) / 60000000) + distractor +
                             correction; // secret changes every one minute
         stringstream cookiestr;
         cookiestr << clienthost << ":" << clientport << ":" << timestamp;
@@ -10785,7 +10785,7 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
           log << "processConnectRequest: received type=" << RequestTypeStr(hs.m_iReqType) << " - checking cookie...");
     if (hs.m_iCookie != cookie_val)
     {
-        cookie_val = bake(addr, cookie_val, 1); // SHOULD generate an earlier, distracted cookie
+        cookie_val = bake(addr, cookie_val, -1); // SHOULD generate an earlier, distracted cookie
 
         if (hs.m_iCookie != cookie_val)
         {


### PR DESCRIPTION
SRT listener-caller handshake uses the cookie the following way:
```
  Caller          Listener

HS Ind Req ---> 
               
           <--- HS Ind Rsp (Create Cookie
		                    from current time)
		   
HS Conc Req
(Listener's --->
Cookie)

                 Validate Connection Request
				 - Generate a cookie from current time.
				 - Check cookie matches with the one in
				 HS Conc Req.
				 - If it does not match, generate a cookie
				   for a time a minute ago and check as well.
```


If the time on the listener side has increased since the previous HS induction response that much, that it results in a different cookie value, a caller may have sent an old cookie in the HS Conclusion Request.
In that case listener's new cookie and the cookie from HS Conclusion Request will mismatch.
To resolve this situation, listener must also check a cookie generated with the time from the past (1 minute ago) to chack if the previous cookie matches the one sent by the caller. 

Hence the correction value `-1` in the code.
However, the `bake` function actually subtracts the correction, which means one minute was wrongfully added instead.

```c++
cookie_val = bake(addr, cookie_val, -1); // SHOULD generate an earlier, distracted cookie
```
