### PR TITLE
Revised SND DROP and SND pacing logic

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -455,6 +455,15 @@ int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime,
     return readlen;
 }
 
+CSndBuffer::time_point CSndBuffer::peekNextOriginal() const
+{
+    ScopedLock bufferguard(m_BufLock);
+    if (m_pCurrBlock == m_pLastBlock)
+        return time_point();
+
+    return m_pCurrBlock->m_tsOriginTime;
+}
+
 int32_t CSndBuffer::getMsgNoAt(const int offset)
 {
     ScopedLock bufferguard(m_BufLock);

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -152,6 +152,11 @@ public:
     SRT_ATTR_EXCLUDES(m_BufLock)
     int readData(CPacket& w_packet, time_point& w_origintime, int kflgs, int& w_seqnoinc);
 
+    /// Peek an information on the next original data packet to send.
+    /// @return origin time stamp of the next packet; epoch start time otherwise.
+    SRT_ATTR_EXCLUDES(m_BufLock)
+    time_point peekNextOriginal() const;
+
     /// Find data position to pack a DATA packet for a retransmission.
     /// @param [in] offset offset from the last ACK point (backward sequence number difference)
     /// @param [out] packet the packet to read.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -548,6 +548,12 @@ private:
     SRT_ATTR_REQUIRES(m_RecvAckLock, m_StatsLock)
     int sndDropTooLate();
 
+    /// @bried Allow packet retransmission.
+    /// Depending on the configuration mode (live / file), retransmission
+    /// can be blocked if e.g. there are original packets pending to be sent.
+    /// @return true if retransmission is allowed; false otherwise.
+    bool isRetransmissionAllowed(const time_point& tnow);
+
     /// Connect to a UDT entity as per hs request. This will update
     /// required data in the entity, then update them also in the hs structure,
     /// and then send the response back to the caller.


### PR DESCRIPTION
### Sending Priority

In the live streaming configuration with TL Packet Drop enabled original packet must have priority over packet retransmission because:
- The earlier the latest original packet reaches the receiver, the better the end-to-end latency constraint is kept as the receiver can detect too late packets earlier.
- If original packets are accumulating in the sender buffer, there is a network congestion, and likely most of the packet retransmissions won't reach the receiver. Therefore it is better to prioritize a more up-to-date payload, preserve the end-to-end latency and keep the jitter low. Once congestion is over, the streaming can be restored quicker.
- In-order but belated packets have a negative impact on jitter and end-to-end latency.

Proposed sending priority (for Live Configuration Only):
1. Retransmit a lost packet only if there is no original packet available for sending (which happens when the current sending rate < MaxBW).
2. Otherwise check if FEC packet can be sent.
3. Otherwise send the next original packet (first time sending).

## Extracted Changes

### Prefer Using Source Time if Provided Everywhere (Moved to #2185)

If a source time is provided, it must be considered as the origin time of a message. Meaning that buffer timespan calculation and the TL packet drop logic must rely on this time instead.
Thus there is no need to save two timestamps (`m_tsOriginTime` and `m_llSourceTime_us`). Just use `m_tsOriginTime` everywhere.

### Refactored `CUDT::packData()` (Moved to #2229)

The logic which extracts an original (not ever sent yet_ packet from the sender buffer has been moved to a dedicated function `CUDT::packUniqueData(..)`. The encryption order has been changed.

- [x] Verify sending an encrypted does not have issues.

### Fix SND Drop Logic (Moved to #2230)

Sender dropping logic is applied if the sender buffer timespan exceeds `drop_threshold_ms`.
Instead, the delay of the oldest packet in the buffer should be used (`Tnow - OldestPacketTS`).
This also correlates with the usage of the source time if provided to calculate the timestamp, which was not the case previously.

As before, only packets older than `Tnow - drop_threshold_ms ` are dropped by the sender.

See issue #898, #1910.

### Don't Suppress SND Pacing (Moved to #2232)

Don't allow to force sending if `checkNeedDrop` signals congestion.
Addresses #713.