### PR TITLE
Fixed the new RCV buffer in STREAM mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ endforeach()
 
 # SRT_ENABLE_ECN 1                /* Early Congestion Notification (for source bitrate control) */
 # SRT_DEBUG_TSBPD_OUTJITTER 1     /* Packet Delivery histogram */
-# SRT_DEBUG_TSBPD_DRIFT 1         /* Debug Encoder-Decoder Drift) */
+# SRT_DEBUG_TRACE_DRIFT 1         /* Create a trace log for Encoder-Decoder Clock Drift */
 # SRT_DEBUG_TSBPD_WRAP 1          /* Debug packet timestamp wraparound */
 # SRT_DEBUG_TLPKTDROP_DROPSEQ 1
 # SRT_DEBUG_SNDQ_HIGHRATE 1

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -816,14 +816,6 @@ void CSndBuffer::increase()
  *    m_iMaxPos:     none? (modified on add and ack
  */
 
-// XXX Init values moved to in-class.
-// const uint32_t CRcvBuffer::TSBPD_WRAP_PERIOD = (30*1000000);    //30 seconds (in usec)
-// const int CRcvBuffer::TSBPD_DRIFT_MAX_VALUE   = 5000;  // usec
-// const int CRcvBuffer::TSBPD_DRIFT_MAX_SAMPLES = 1000;  // ACK-ACK packets
-#ifdef SRT_DEBUG_TSBPD_DRIFT
-// const int CRcvBuffer::TSBPD_DRIFT_PRT_SAMPLES = 200;   // ACK-ACK packets
-#endif
-
 CRcvBuffer::CRcvBuffer(CUnitQueue* queue, int bufsize_pkts)
     : m_pUnit(NULL)
     , m_iSize(bufsize_pkts)
@@ -841,11 +833,6 @@ CRcvBuffer::CRcvBuffer(CUnitQueue* queue, int bufsize_pkts)
     m_pUnit = new CUnit*[m_iSize];
     for (int i = 0; i < m_iSize; ++i)
         m_pUnit[i] = NULL;
-
-#ifdef SRT_DEBUG_TSBPD_DRIFT
-    memset(m_TsbPdDriftHisto100us, 0, sizeof(m_TsbPdDriftHisto100us));
-    memset(m_TsbPdDriftHisto1ms, 0, sizeof(m_TsbPdDriftHisto1ms));
-#endif
 
     setupMutex(m_BytesCountLock, "BytesCount");
 }

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -233,7 +233,7 @@ private:
     int  scanNotInOrderMessageRight(int startPos, int msgNo) const;
     int  scanNotInOrderMessageLeft(int startPos, int msgNo) const;
 
-    typedef bool copy_to_dst_f(char* data, int len, void* arg);
+    typedef bool copy_to_dst_f(char* data, int len, int dst_offset, void* arg);
 
     /// Read acknowledged data directly into file.
     /// @param [in] ofs C++ file stream.


### PR DESCRIPTION
- Fixed partial reading of packets from the RCV buffer in stream mode.
- Added unit tests for stream mode.
- Removed unused `SRT_DEBUG_TSBPD_DRIFT`.

Some fixes for read-readiness state tracking regardless of the packet border flag (FIRST, LAST).
Related to #2179 (maybe fixes, but to be further verified).
The new receiver buffer was introduced in PR #1964.