### PR TITLE
[core] Fixed std::runtime_error usage (use C++03 version instead of C++11)

### DIFF
--- a/srtcore/strerror_defs.cpp
+++ b/srtcore/strerror_defs.cpp
@@ -140,7 +140,7 @@ const char* strerror_get_message(size_t major, size_t minor)
     }
 
     const char** array = strerror_array_major[major];
-    size_t size = strerror_array_sizes[major];
+    const size_t size = strerror_array_sizes[major];
 
     if (minor >= size)
     {

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -470,9 +470,9 @@ private:
     FixedArray<T>& operator=(const FixedArray<T>&);
 
 private:
-    const std::string m_strIndexErr;
-    size_t    m_size;
-    T* const  m_entries;
+    const char* m_strIndexErr;
+    size_t      m_size;
+    T* const    m_entries;
 };
 
 } // namespace srt

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -44,6 +44,7 @@ written by
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
+#include <stdexcept>
 
 // -------------- UTILITIES ------------------------
 
@@ -418,7 +419,8 @@ class FixedArray
 {
 public:
     FixedArray(size_t size)
-        : m_size(size)
+        : m_strIndexErr("FixedArray: invalid index")
+        , m_size(size)
         , m_entries(new T[size])
     {
     }
@@ -432,7 +434,7 @@ public:
     const T& operator[](size_t index) const
     {
         if (index >= m_size)
-            throw std::runtime_error("Invalid index");
+            throw std::runtime_error(m_strIndexErr);
 
         return m_entries[index];
     }
@@ -440,7 +442,7 @@ public:
     T& operator[](size_t index)
     {
         if (index >= m_size)
-            throw std::runtime_error("Invalid index");
+            throw std::runtime_error(m_strIndexErr);
 
         return m_entries[index];
     }
@@ -448,7 +450,7 @@ public:
     const T& operator[](int index) const
     {
         if (index < 0 || static_cast<size_t>(index) >= m_size)
-            throw std::runtime_error("Invalid index");
+            throw std::runtime_error(m_strIndexErr);
 
         return m_entries[index];
     }
@@ -456,7 +458,7 @@ public:
     T& operator[](int index)
     {
         if (index < 0 || static_cast<size_t>(index) >= m_size)
-            throw std::runtime_error("Invalid index");
+            throw std::runtime_error(m_strIndexErr);
 
         return m_entries[index];
     }
@@ -468,6 +470,7 @@ private:
     FixedArray<T>& operator=(const FixedArray<T>&);
 
 private:
+    const std::string m_strIndexErr;
     size_t    m_size;
     T* const  m_entries;
 };


### PR DESCRIPTION
Added missing include of `<stdexcept>`.

Also there are several versions of the `runtime_error` constructor:
```c++
std::runtime_error( const std::string& what_arg ); // C++03
std::runtime_error( const char* what_arg );  // since C++11
```

The error message argument of the `std::runtime_error` is copied to an internal member of the `runtime_error`, so the initial object does not have to remain valid after an exception is thrown.

If C++03 is used, an implicit conversion from `const char*` to `std::string` should happen.

### To Consider

- `m_strIndexErr` could be defined in `srterror_defs.cpp`.