### PR TITLE
[core] Update group read state using ack instead of first unread seqno

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8101,7 +8101,7 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
                     // The current "APP reader" needs to simply decide as to whether
                     // the next CUDTGroup::recv() call should return with no blocking or not.
                     // When the group is read-ready, it should update its pollers as it sees fit.
-                    m_parent->m_GroupOf->updateReadState(m_SocketID, first_seq);
+                    m_parent->m_GroupOf->updateReadState(m_SocketID, ack);
                 }
             }
 #endif


### PR DESCRIPTION
I used srt backup mode in 2 links, one 4G, another Wifi, and push live stream on it.
My option is live mode, but tspbd: off, tlpktdrop: off.

When I disconnect the Wifi(main) connection, the group socket will never be readable.
And I check the code, I found the problem.

For example, the buffer state below
![image](https://user-images.githubusercontent.com/8449258/142350079-36af18b5-3381-45d7-a3d6-5ed5c5837fe7.png)

After the Wifi disconnected, when recv packet from 4G, the function below will be called.
```c
updateReadState(socket_id_of_4g, 4/*first seq unread*/)
```
but It always false, because 4 is less than 5(CUDTGroup::m_RcvBaseSeqNo), and the group socket can not read anymore.

This PR show we should check the group readable using ack seqno instead of first unread seqno in recv buffer.
And it works well in my case.