### PR TITLE
[core] make sure data to be inserted into CRcvLossList are monotonic

### DIFF
--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -511,6 +511,9 @@ void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
     {
         if (CSeqNo::seqcmp(seqno2, m_iLargestSeq) > 0)
         {
+            LOGC(qrlog.Warn,
+                 log << "RCV-LOSS/insert: seqno1=" << seqno1 << " too small, adjust to "
+                     << CSeqNo::incseq(m_iLargestSeq));
             seqno1 = CSeqNo::incseq(m_iLargestSeq);
         }
         else

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -518,9 +518,9 @@ void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
         }
         else
         {
-            LOGC(qrlog.Error,
-                 log << "RCV-LOSS/insert: IPE: (" << seqno1 << "," << seqno2
-                     << ") to be inserted too small: m_iLargestSeq=" << m_iLargestSeq << ", m_iLength=" << m_iLength
+            LOGC(qrlog.Warn,
+                 log << "RCV-LOSS/insert: (" << seqno1 << "," << seqno2
+                     << ") to be inserted is too small: m_iLargestSeq=" << m_iLargestSeq << ", m_iLength=" << m_iLength
                      << ", m_iHead=" << m_iHead << ", m_iTail=" << m_iTail << " -- REJECTING");
             return;
         }

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -509,11 +509,18 @@ void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
     // Data to be inserted must be larger than all those in the list
     if (m_iLargestSeq != SRT_SEQNO_NONE && CSeqNo::seqcmp(seqno1, m_iLargestSeq) <= 0)
     {
-        LOGC(qrlog.Error,
-             log << "RCV-LOSS/insert: IPE: (" << seqno1 << "," << seqno2
-                 << ") to be inserted too small: m_iLargestSeq=" << m_iLargestSeq << ", m_iLength=" << m_iLength
-                 << ", m_iHead=" << m_iHead << ", m_iTail=" << m_iTail << " -- REJECTING");
-        return;
+        if (CSeqNo::seqcmp(seqno2, m_iLargestSeq) > 0)
+        {
+            seqno1 = CSeqNo::incseq(m_iLargestSeq);
+        }
+        else
+        {
+            LOGC(qrlog.Error,
+                 log << "RCV-LOSS/insert: IPE: (" << seqno1 << "," << seqno2
+                     << ") to be inserted too small: m_iLargestSeq=" << m_iLargestSeq << ", m_iLength=" << m_iLength
+                     << ", m_iHead=" << m_iHead << ", m_iTail=" << m_iTail << " -- REJECTING");
+            return;
+        }
     }
     m_iLargestSeq = seqno2;
 

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -487,6 +487,7 @@ CRcvLossList::CRcvLossList(int size)
     , m_iTail(-1)
     , m_iLength(0)
     , m_iSize(size)
+    , m_iLargestSeq(SRT_SEQNO_NONE)
 {
     m_caSeq = new Seq[m_iSize];
 
@@ -506,7 +507,15 @@ CRcvLossList::~CRcvLossList()
 void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
 {
     // Data to be inserted must be larger than all those in the list
-    // guaranteed by the UDT receiver
+    if (m_iLargestSeq != SRT_SEQNO_NONE && CSeqNo::seqcmp(seqno1, m_iLargestSeq) <= 0)
+    {
+        LOGC(qrlog.Error,
+             log << "RCV-LOSS/insert: IPE: (" << seqno1 << "," << seqno2
+                 << ") to be inserted too small: m_iLargestSeq=" << m_iLargestSeq << ", m_iLength=" << m_iLength
+                 << ", m_iHead=" << m_iHead << ", m_iTail=" << m_iTail << " -- REJECTING");
+        return;
+    }
+    m_iLargestSeq = seqno2;
 
     if (0 == m_iLength)
     {
@@ -561,6 +570,9 @@ void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
 
 bool CRcvLossList::remove(int32_t seqno)
 {
+    if (m_iLargestSeq == SRT_SEQNO_NONE || CSeqNo::seqcmp(seqno, m_iLargestSeq) > 0)
+        m_iLargestSeq = seqno;
+
     if (0 == m_iLength)
         return false;
 

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -185,6 +185,7 @@ private:
     int m_iTail;   // last node in the list;
     int m_iLength; // loss length
     int m_iSize;   // size of the static array
+    int m_iLargestSeq; // largest seq ever seen
 
 private:
     CRcvLossList(const CRcvLossList&);


### PR DESCRIPTION
fix https://github.com/Haivision/srt/issues/2192#issuecomment-983376741
Previously, these is a comment saying that `Data to be inserted must be larger than all those in the list, guaranteed by the UDT receive`, let's guarantee this by the internal check.