### PR TITLE
[core] fix CRcvLossList::m_iTail not reset to -1

### DIFF
--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -583,6 +583,8 @@ bool CRcvLossList::remove(int32_t seqno)
                 m_iHead = m_caSeq[m_iHead].inext;
                 if (-1 != m_iHead)
                     m_caSeq[m_iHead].iprior = -1;
+                else
+                    m_iTail = -1;
             }
             else
             {


### PR DESCRIPTION
During the debug of https://github.com/Haivision/srt/issues/2192, I found that `m_iTail` would not be reset to `-1`, although it's harmless, let's keep member variables consistent.