### PR TITLE
[core] Fixed RCV TL drop of packets dropped by SND

### DIFF
--- a/docs/API/statistics.md
+++ b/docs/API/statistics.md
@@ -235,6 +235,8 @@ where `SRTO_PEERLATENCY` is the configured SRT latency, `SRTO_SNDDROPDELAY` adds
 The total number of _dropped_ by the SRT receiver and, as a result, not delivered to the upstream application DATA packets (refer to [TLPKTDROP](https://github.com/Haivision/srt-rfc/blob/master/draft-sharabayko-mops-srt.md#too-late-packet-drop-too-late-packet-drop) mechanism). Available for receiver.
 
 This statistic counts
+
+- not arrived packets including those signalled for dropping by the sender, that were dropped in favor of the subsequent existing packets,
 - arrived too late packets (retransmitted or original packets arrived out of order),
 - arrived in time packets, but decrypted with errors (see also [pktRcvUndecryptTotal](#pktRcvUndecryptTotal) statistic).
 

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -69,8 +69,9 @@ public:
 
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number
+    /// @return  number of dropped packets.
     ///
-    void dropUpTo(int32_t seqno);
+    int dropUpTo(int32_t seqno);
 
     /// @brief Drop the whole message from the buffer.
     /// If message number is 0, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5174,26 +5174,8 @@ void * srt::CUDT::tsbpd(void* param)
             rxready = true;
             if (info.seq_gap)
             {
-                const int seq_gap_len = CSeqNo::seqoff(self->m_iRcvLastSkipAck, info.seqno);
+                const int iDropCnt SRT_ATR_UNUSED = self->dropTooLateUpTo(info.seqno);
 
-                // seq_gap_len can be <= 0 if a packet has been dropped by the sender.
-                if (seq_gap_len > 0)
-                {
-                    // Remove [from,to-inclusive]
-                    self->dropFromLossLists(self->m_iRcvLastSkipAck, CSeqNo::decseq(info.seqno));
-                    self->m_iRcvLastSkipAck = info.seqno;
-                }
-
-                const int iDropCnt = self->m_pRcvBuffer->dropUpTo(info.seqno);
-                if (iDropCnt > 0)
-                {
-                    enterCS(self->m_StatsLock);
-                    // Estimate dropped bytes from average payload size.
-                    const uint64_t avgpayloadsz = self->m_pRcvBuffer->getRcvAvgPayloadSize();
-                    self->m_stats.rcvr.dropped.count(stats::BytesPackets(iDropCnt * avgpayloadsz, (size_t) iDropCnt));
-                    leaveCS(self->m_StatsLock);
-                }
-                
 #if ENABLE_EXPERIMENTAL_BONDING
                 shall_update_group = true;
 #endif
@@ -5538,6 +5520,30 @@ void * srt::CUDT::tsbpd(void *param)
     return NULL;
 }
 #endif // ENABLE_NEW_RCVBUFFER
+
+int srt::CUDT::dropTooLateUpTo(int seqno)
+{
+    const int seq_gap_len = CSeqNo::seqoff(m_iRcvLastSkipAck, seqno);
+
+    // seq_gap_len can be <= 0 if a packet has been dropped by the sender.
+    if (seq_gap_len > 0)
+    {
+        // Remove [from,to-inclusive]
+        dropFromLossLists(m_iRcvLastSkipAck, CSeqNo::decseq(seqno));
+        m_iRcvLastSkipAck = seqno;
+    }
+
+    const int iDropCnt = m_pRcvBuffer->dropUpTo(seqno);
+    if (iDropCnt > 0)
+    {
+        enterCS(m_StatsLock);
+        // Estimate dropped bytes from average payload size.
+        const uint64_t avgpayloadsz = m_pRcvBuffer->getRcvAvgPayloadSize();
+        m_stats.rcvr.dropped.count(stats::BytesPackets(iDropCnt * avgpayloadsz, (size_t) iDropCnt));
+        leaveCS(m_StatsLock);
+    }
+    return iDropCnt;
+}
 
 void srt::CUDT::updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno)
 {

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -705,6 +705,12 @@ private:
     // TSBPD thread main function.
     static void* tsbpd(void* param);
 
+    /// Drop too late packets. Updaet loss lists and ACK positions.
+    /// The @a seqno packet itself is not dropped.
+    /// @param seqno [in] The sequence number of the first packets following those to be dropped.
+    /// @return The number of packets dropped.
+    int dropTooLateUpTo(int seqno);
+
     void updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno);
 
     static loss_seqs_t defaultPacketArrival(void* vself, CPacket& pkt);


### PR DESCRIPTION
The receiver buffer may have packets dropped by sender (marked as `EntryState_Drop`).
In that case, the ACK position is likely ahead of the current reading position. This has to be taken into account in the TSBPD thread.
It can result in the receiver hanging up for a couple of seconds, making the sender break the connection.

1. At some point, the receiver hangs up (for about 12 seconds in total) due to the issue fixed above.
2. Three seconds later the sender detects there is no response from the receiver, and breaks the connection.
3. About ten seconds later receiver wakes up and continues processing incoming packets, that were accumulated in the system buffer of the UDP socket. 
4. Because of that stall it receives heavily delayed ACKACK packets. Based on the ACK - ACKACK pair of packets receiver estimates RTT, in this case, extra 10+ seconds are added to the estimation, significantly raising SRTT and RTTVar values.
5. The overestimated SRTT and RTTVar values then impact the connection expiration timeout of `SRTT + 4 x RTTVar`: it now results in tens of seconds. Therefore, the receiver waits for tens of seconds before concluding the connection with the sender is broken. The SHUTDOWN control packet from the sender is probably lost in that case.

### This PR Changes

- [x] `CRcvBufferNew::dropUpTo(..)` now returns the number of packets actually dropped. This value is used to update the RCV drop statistics.
- [x] The update of `m_iRcvLastSkipAck` happens only if dropping ahead of the current ACK position. Loss lists update as well.
- [x] Move the TL drop logic into a dedicated function `CUDT::dropTooLate(int upTo)`.
- [x] Fix the documentation on the `pktRcvDrop` and `pktRcvDropTotal`.

