### PR TITLE
[core] Fixed build with the old RCV buffer

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -705,11 +705,13 @@ private:
     // TSBPD thread main function.
     static void* tsbpd(void* param);
 
+#if ENABLE_NEW_RCVBUFFER
     /// Drop too late packets. Updaet loss lists and ACK positions.
     /// The @a seqno packet itself is not dropped.
     /// @param seqno [in] The sequence number of the first packets following those to be dropped.
     /// @return The number of packets dropped.
     int dropTooLateUpTo(int seqno);
+#endif
 
     void updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno);
 


### PR DESCRIPTION
The new function `CUDT::dropTooLateUpTo(..)` added in PR #2214 is expected to work only with the new receiver buffer, thus breaking the build if the old receiver buffer is enabled.
This PR enables the function only if the new receiver buffer is used.