### PR TITLE
[core] refactor Group::recv() base on new rcv buffer to support message mode

### DIFF
--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -164,6 +164,8 @@ public:
     ///                   IF skipseqno == -1, no missing packet but 1st not ready to play.
     PacketInfo getFirstValidPacketInfo() const;
 
+    PacketInfo getFirstReadablePacketInfo(time_point time_now) const;
+
     /// Get information on packets available to be read.
     /// @returns a pair of sequence numbers (first available; first unavailable).
     /// 


### PR DESCRIPTION
Replace #2046.
Fix #2138 btw.

* The previous `Group::recv()` does not support to read a message that across multiple packets.
* Reduce `Group::recv()` from 500+ lines to 100+ lines.