### PR TITLE
[core] CRcvBufferNew::dropUpTo() able to drop non-empty units

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -178,20 +178,7 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
     const int iDropCnt = len;
     while (len > 0)
     {
-        if (m_entries[m_iStartPos].pUnit != NULL)
-        {
-            if (m_tsbpd.isEnabled())
-            {
-                updateTsbPdTimeBase(m_entries[m_iStartPos].pUnit->m_Packet.getMsgTimeStamp());
-            }
-            else if (m_bMessageAPI && !m_entries[m_iStartPos].pUnit->m_Packet.getMsgOrderFlag())
-            {
-                --m_numOutOfOrderPackets;
-                if (m_iStartPos == m_iFirstReadableOutOfOrder)
-                    m_iFirstReadableOutOfOrder = -1;
-            }
-            releaseUnitInPos(m_iStartPos);
-        }
+        dropUnit(m_iStartPos);
         m_entries[m_iStartPos].status = EntryState_Empty;
         SRT_ASSERT(m_entries[m_iStartPos].pUnit == NULL && m_entries[m_iStartPos].status == EntryState_Empty);
         m_iStartPos = incPos(m_iStartPos);

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -181,8 +181,10 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
         if (m_entries[m_iStartPos].pUnit != NULL)
         {
             if (m_tsbpd.isEnabled())
+            {
                 updateTsbPdTimeBase(m_entries[m_iStartPos].pUnit->m_Packet.getMsgTimeStamp());
-            if (!m_tsbpd.isEnabled() && m_bMessageAPI && !m_entries[m_iStartPos].pUnit->m_Packet.getMsgOrderFlag())
+            }
+            else if (m_bMessageAPI && !m_entries[m_iStartPos].pUnit->m_Packet.getMsgOrderFlag())
             {
                 --m_numOutOfOrderPackets;
                 if (m_iStartPos == m_iFirstReadableOutOfOrder)

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -161,15 +161,10 @@ int CRcvBufferNew::insert(CUnit* unit)
 
 int CRcvBufferNew::dropUpTo(int32_t seqno)
 {
-    // Can drop only when nothing to read, and 
-    // first unacknowledged packet is missing.
-    SRT_ASSERT(m_iStartPos == m_iFirstNonreadPos);
-
     IF_RCVBUF_DEBUG(ScopedLog scoped_log);
     IF_RCVBUF_DEBUG(scoped_log.ss << "CRcvBufferNew::dropUpTo: seqno " << seqno << " m_iStartSeqNo " << m_iStartSeqNo);
 
     int len = CSeqNo::seqoff(m_iStartSeqNo, seqno);
-    SRT_ASSERT(len > 0);
     if (len <= 0)
     {
         IF_RCVBUF_DEBUG(scoped_log.ss << ". Nothing to drop.");
@@ -180,21 +175,20 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
     if (m_iMaxPosInc < 0)
         m_iMaxPosInc = 0;
 
-    // Check that all packets being dropped are missing.
     const int iDropCnt = len;
     while (len > 0)
     {
         if (m_entries[m_iStartPos].pUnit != NULL)
         {
+            if (!m_tsbpd.isEnabled() && m_bMessageAPI && !m_entries[m_iStartPos].pUnit->m_Packet.getMsgOrderFlag())
+            {
+                --m_numOutOfOrderPackets;
+                if (m_iStartPos == m_iFirstReadableOutOfOrder)
+                    m_iFirstReadableOutOfOrder = -1;
+            }
             releaseUnitInPos(m_iStartPos);
         }
-
-        if (m_entries[m_iStartPos].status != EntryState_Empty)
-        {
-            SRT_ASSERT(m_entries[m_iStartPos].status == EntryState_Drop || m_entries[m_iStartPos].status == EntryState_Read);
-            m_entries[m_iStartPos].status = EntryState_Empty;
-        }
-
+        m_entries[m_iStartPos].status = EntryState_Empty;
         SRT_ASSERT(m_entries[m_iStartPos].pUnit == NULL && m_entries[m_iStartPos].status == EntryState_Empty);
         m_iStartPos = incPos(m_iStartPos);
         --len;
@@ -202,12 +196,14 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
 
     // Update positions
     m_iStartSeqNo = seqno;
-    // Move forward if there are "read" entries.
+    // Move forward if there are "read/drop" entries.
     releaseNextFillerEntries();
     // Set nonread position to the starting position before updating,
     // because start position was increased, and preceeding packets are invalid. 
     m_iFirstNonreadPos = m_iStartPos;
     updateNonreadPos();
+    if (!m_tsbpd.isEnabled() && m_bMessageAPI)
+        updateFirstReadableOutOfOrder();
     return iDropCnt;
 }
 

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -180,6 +180,8 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
     {
         if (m_entries[m_iStartPos].pUnit != NULL)
         {
+            if (m_tsbpd.isEnabled())
+                updateTsbPdTimeBase(m_entries[m_iStartPos].pUnit->m_Packet.getMsgTimeStamp());
             if (!m_tsbpd.isEnabled() && m_bMessageAPI && !m_entries[m_iStartPos].pUnit->m_Packet.getMsgOrderFlag())
             {
                 --m_numOutOfOrderPackets;

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -178,7 +178,7 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
     const int iDropCnt = len;
     while (len > 0)
     {
-        dropUnit(m_iStartPos);
+        dropUnitInPos(m_iStartPos);
         m_entries[m_iStartPos].status = EntryState_Empty;
         SRT_ASSERT(m_entries[m_iStartPos].pUnit == NULL && m_entries[m_iStartPos].status == EntryState_Empty);
         m_iStartPos = incPos(m_iStartPos);


### PR DESCRIPTION
Extracted from #2207.