### PR TITLE
[core] fix m_iMaxPosInc was not updated in releaseNextFillerEntries()

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -614,6 +614,9 @@ void CRcvBufferNew::releaseNextFillerEntries()
         releaseUnitInPos(pos);
         pos = incPos(pos);
         m_iStartPos = pos;
+        --m_iMaxPosInc;
+        if (m_iMaxPosInc < 0)
+            m_iMaxPosInc = 0;
     }
 }
 


### PR DESCRIPTION
Fixed the crash mentioned in https://github.com/Haivision/srt/pull/2223#issue-1098910115
`m_iMaxPosInc` should be sync with `m_iStartPos`