### PR TITLE
[core] add CRcvBufferNew::dropUnitInPos() to simplify dropUpTo() and dropMessage()

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -159,24 +159,6 @@ int CRcvBufferNew::insert(CUnit* unit)
     return 0;
 }
 
-bool CRcvBufferNew::dropUnit(int pos)
-{
-    if (!m_entries[pos].pUnit)
-        return false;
-    if (m_tsbpd.isEnabled())
-    {
-        updateTsbPdTimeBase(m_entries[pos].pUnit->m_Packet.getMsgTimeStamp());
-    }
-    else if (m_bMessageAPI && !m_entries[pos].pUnit->m_Packet.getMsgOrderFlag())
-    {
-        --m_numOutOfOrderPackets;
-        if (pos == m_iFirstReadableOutOfOrder)
-            m_iFirstReadableOutOfOrder = -1;
-    }
-    releaseUnitInPos(pos);
-    return true;
-}
-
 int CRcvBufferNew::dropUpTo(int32_t seqno)
 {
     // Can drop only when nothing to read, and 
@@ -621,6 +603,24 @@ void CRcvBufferNew::releaseUnitInPos(int pos)
     m_entries[pos] = Entry(); // pUnit = NULL; status = Empty
     if (tmp != NULL)
         m_pUnitQueue->makeUnitFree(tmp);
+}
+
+bool CRcvBufferNew::dropUnitInPos(int pos)
+{
+    if (!m_entries[pos].pUnit)
+        return false;
+    if (m_tsbpd.isEnabled())
+    {
+        updateTsbPdTimeBase(m_entries[pos].pUnit->m_Packet.getMsgTimeStamp());
+    }
+    else if (m_bMessageAPI && !m_entries[pos].pUnit->m_Packet.getMsgOrderFlag())
+    {
+        --m_numOutOfOrderPackets;
+        if (pos == m_iFirstReadableOutOfOrder)
+            m_iFirstReadableOutOfOrder = -1;
+    }
+    releaseUnitInPos(pos);
+    return true;
 }
 
 void CRcvBufferNew::releaseNextFillerEntries()

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -159,6 +159,23 @@ int CRcvBufferNew::insert(CUnit* unit)
     return 0;
 }
 
+bool CRcvBufferNew::dropUnit(int pos) {
+    if (!m_entries[pos].pUnit)
+        return false;
+    if (m_tsbpd.isEnabled())
+    {
+        updateTsbPdTimeBase(m_entries[pos].pUnit->m_Packet.getMsgTimeStamp());
+    }
+    else if (m_bMessageAPI && !m_entries[pos].pUnit->m_Packet.getMsgOrderFlag())
+    {
+        --m_numOutOfOrderPackets;
+        if (pos == m_iFirstReadableOutOfOrder)
+            m_iFirstReadableOutOfOrder = -1;
+    }
+    releaseUnitInPos(pos);
+    return true;
+}
+
 int CRcvBufferNew::dropUpTo(int32_t seqno)
 {
     // Can drop only when nothing to read, and 

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -159,7 +159,8 @@ int CRcvBufferNew::insert(CUnit* unit)
     return 0;
 }
 
-bool CRcvBufferNew::dropUnit(int pos) {
+bool CRcvBufferNew::dropUnit(int pos)
+{
     if (!m_entries[pos].pUnit)
         return false;
     if (m_tsbpd.isEnabled())

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -67,6 +67,11 @@ public:
     // TODO: Previously '-2' also meant 'already acknowledged'. Check usage of this value.
     int insert(CUnit* unit);
 
+    /// @brief Drop a unit from the buffer.
+    /// @param pos position of the unit to drop.
+    /// @return false if nothing to drop, true if the unit was dropped successfully.
+    bool dropUnit(int pos);
+
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number
     /// @return  number of dropped packets.

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -68,7 +68,7 @@ public:
     int insert(CUnit* unit);
 
     /// @brief Drop a unit from the buffer.
-    /// @param pos position of the unit to drop.
+    /// @param pos position in the m_entries of the unit to drop.
     /// @return false if nothing to drop, true if the unit was dropped successfully.
     bool dropUnit(int pos);
 

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -67,11 +67,6 @@ public:
     // TODO: Previously '-2' also meant 'already acknowledged'. Check usage of this value.
     int insert(CUnit* unit);
 
-    /// @brief Drop a unit from the buffer.
-    /// @param pos position in the m_entries of the unit to drop.
-    /// @return false if nothing to drop, true if the unit was dropped successfully.
-    bool dropUnit(int pos);
-
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number
     /// @return  number of dropped packets.
@@ -225,6 +220,11 @@ private:
     void countBytes(int pkts, int bytes);
     void updateNonreadPos();
     void releaseUnitInPos(int pos);
+
+    /// @brief Drop a unit from the buffer.
+    /// @param pos position in the m_entries of the unit to drop.
+    /// @return false if nothing to drop, true if the unit was dropped successfully.
+    bool dropUnitInPos(int pos);
 
     /// Release entries following the current buffer position if they were already
     /// read out of order (EntryState_Read) or dropped (EntryState_Drop).


### PR DESCRIPTION
To simplify #2221 and #2222