### PR TITLE
[core] Refactoring: added packUniqueData(..) function

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -410,30 +410,19 @@ int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime,
         w_packet.setLength(readlen);
         w_packet.m_iSeqNo = m_pCurrBlock->m_iSeqNo;
 
-        // XXX This is probably done because the encryption should happen
-        // just once, and so this sets the encryption flags to both msgno bitset
-        // IN THE PACKET and IN THE BLOCK. This is probably to make the encryption
-        // happen at the time when scheduling a new packet to send, but the packet
-        // must remain in the send buffer until it's ACKed. For the case of rexmit
-        // the packet will be taken "as is" (that is, already encrypted).
-        //
-        // The problem is in the order of things:
-        // 0. When the application stores the data, some of the flags for PH_MSGNO are set.
-        // 1. The readData() is called to get the original data sent by the application.
-        // 2. The data are original and must be encrypted. They WILL BE encrypted, later.
-        // 3. So far we are in readData() so the encryption flags must be updated NOW because
-        //    later we won't have access to the block's data.
-        // 4. After exiting from readData(), the packet is being encrypted. It's immediately
-        //    sent, however the data must remain in the sending buffer until they are ACKed.
-        // 5. In case when rexmission is needed, the second overloaded version of readData
-        //    is being called, and the buffer + PH_MSGNO value is extracted. All interesting
-        //    flags must be present and correct at that time.
-        //
-        // The only sensible way to fix this problem is to encrypt the packet not after
-        // extracting from here, but when the packet is stored into CSndBuffer. The appropriate
-        // flags for PH_MSGNO will be applied directly there. Then here the value for setting
-        // PH_MSGNO will be set as is.
-
+        // 1. On submission (addBuffer), the KK flag is set to EK_NOENC (0).
+        // 2. The readData() is called to get the original (unique) payload not ever sent yet.
+        //    The payload must be encrypted for the first time if the encryption
+        //    is enabled (arg kflgs != EK_NOENC). The KK encryption flag of the data packet
+        //    header must be set and remembered accordingly (see EncryptionKeySpec).
+        // 3. The next time this packet is read (only for retransmission), the payload is already
+        //    encrypted, and the proper flag value is already stored.
+        
+        // TODO: Alternatively, encryption could happen before the packet is submitted to the buffer
+        // (before the addBuffer() call), and corresponding flags could be set accordingly.
+        // This may also put an encryption burden on the application thread, rather than the sending thread,
+        // which could be more efficient. Note that packet sequence number must be properly set in that case,
+        // as it is used as a counter for the AES encryption.
         if (kflgs == -1)
         {
             HLOGC(bslog.Debug, log << CONID() << " CSndBuffer: ERROR: encryption required and not possible. NOT SENDING.");

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1030,15 +1030,23 @@ private: // Generation and processing of packets
     /// @return payload size on success, <=0 on failure
     int packLostData(CPacket &packet, time_point &origintime);
 
+    /// Pack a unique data packet (never sent so far) in CPacket for sending.
+    ///
+    /// @param packet [in, out] a CPacket structure to fill.
+    /// @param origintime [in, out] origin timestamp of the packet.
+    ///
+    /// @return true if a packet has been packets; false otherwise.
+    bool packUniqueData(CPacket& packet, time_point& origintime);
+
     /// Pack in CPacket the next data to be send.
     ///
     /// @param packet [in, out] a CPacket structure to fill
     ///
-    /// @return A pair of values is returned (payload, timestamp).
-    ///         The payload tells the size of the payload, packed in CPacket.
+    /// @return A pair of values is returned (is_payload_valid, timestamp).
+    ///         If is_payload_valid is false, there was nothing packed for sending,
+    ///         and the timestamp value should be ignored.
     ///         The timestamp is the full source/origin timestamp of the data.
-    ///         If payload is <= 0, consider the timestamp value invalid.
-    std::pair<int, time_point> packData(CPacket& packet);
+    std::pair<bool, time_point> packData(CPacket& packet);
 
     int processData(CUnit* unit);
     void processClose();

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -635,10 +635,10 @@ void* srt::CSndQueue::worker(void* param)
 
         // pack a packet from the socket
         CPacket pkt;
-        const std::pair<int, steady_clock::time_point> res_time = u->packData((pkt));
+        const std::pair<bool, steady_clock::time_point> res_time = u->packData((pkt));
 
         // Check if payload size is invalid.
-        if (res_time.first <= 0)
+        if (res_time.first == false)
         {
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
             self->m_WorkerStats.lNotReadyPop++;

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -465,7 +465,7 @@ TEST_F(CRcvBufferReadMsg, SmallReadBuffer)
 }
 
 // BUG!!!
-// Checks signalling of read-readiness of a half-acknowledged message.
+// Checks signaling of read-readiness of a half-acknowledged message.
 // The RCV buffer implementation has an issue here: when only half of the message is
 // acknowledged, the RCV buffer signals read-readiness, even though
 // the message can't be read, and reading returns 0.


### PR DESCRIPTION
The code related to forming an original data packet for sending has been moved to a separate function `packUniqueData(..)`.
The encryption of the payload has been moved inside that function as well, as it is only needed to encrypt the original payload. Once encrypted, it is stored so in the sender buffer, thus the second encryption call is needed when the packet is being retransmitted.
Moving the encryption inside the `packUniqueData(..)` also means that packet timestamp and destination socket ID are not yet set in the header of the packet. However, only the packet sequence number is used as the counter for the AES encryption, therefore this change is safe.

Changes extracted from PR #2180.

### Tests

Checked encryption and decryption including KM refresh using `srt-xtransmit`:

```shell
(receiver)
./srt-xtransmit receive "srt://:4200?passphrase=abcdefghij" --enable-metrics -v

(sender)
./srt-xtransmit generate "srt://127.0.0.1:4200?passphrase=abcdefghij&kmrefreshrate=1000&kmpreannounce=200" \
                         --enable-metrics --sendrate 10Mbps --duration 60s -v
```