### PR TITLE
[core] Use SND buffer delay for TL Packet Drop instead of the timespan

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -686,10 +686,14 @@ int CSndBuffer::getCurrBufSize(int& w_bytes, int& w_timespan)
     return m_iCount;
 }
 
-CSndBuffer::time_point CSndBuffer::getOldestTime() const
+CSndBuffer::duration CSndBuffer::getBufferingDelay(const time_point& tnow) const
 {
+    ScopedLock lck(m_BufLock);
     SRT_ASSERT(m_pFirstBlock);
-    return m_pFirstBlock->m_tsOriginTime;
+    if (m_iCount == 0)
+        return duration(0);
+
+    return tnow - m_pFirstBlock->m_tsOriginTime;
 }
 
 int CSndBuffer::dropLateData(int& w_bytes, int32_t& w_first_msgno, const steady_clock::time_point& too_late_time)

--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -402,6 +402,7 @@ int CSndBuffer::readData(CPacket& w_packet, steady_clock::time_point& w_srctime,
     int readlen = 0;
     w_seqnoinc = 0;
 
+    ScopedLock bufferguard(m_BufLock);
     while (m_pCurrBlock != m_pLastBlock)
     {
         // Make the packet REFLECT the data stored in the buffer.

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -133,12 +133,14 @@ public:
     /// @param [in] data pointer to the user data block.
     /// @param [in] len size of the block.
     /// @param [inout] w_mctrl Message control data
+    SRT_ATTR_EXCLUDES(m_BufLock)
     void addBuffer(const char* data, int len, SRT_MSGCTRL& w_mctrl);
 
     /// Read a block of data from file and insert it into the sending list.
     /// @param [in] ifs input file stream.
     /// @param [in] len size of the block.
     /// @return actual size of data added from the file.
+    SRT_ATTR_EXCLUDES(m_BufLock)
     int addBufferFromFile(std::fstream& ifs, int len);
 
     /// Find data position to pack a DATA packet from the furthest reading point.
@@ -147,6 +149,7 @@ public:
     /// @param [in] kflags Odd|Even crypto key flag
     /// @param [out] seqnoinc the number of packets skipped due to TTL, so that seqno should be incremented.
     /// @return Actual length of data read.
+    SRT_ATTR_EXCLUDES(m_BufLock)
     int readData(CPacket& w_packet, time_point& w_origintime, int kflgs, int& w_seqnoinc);
 
     /// Find data position to pack a DATA packet for a retransmission.
@@ -155,12 +158,14 @@ public:
     /// @param [out] origintime origin time stamp of the message
     /// @param [out] msglen length of the message
     /// @return Actual length of data read (return 0 if offset too large, -1 if TTL exceeded).
+    SRT_ATTR_EXCLUDES(m_BufLock)
     int readData(const int offset, CPacket& w_packet, time_point& w_origintime, int& w_msglen);
 
     /// Get the time of the last retransmission (if any) of the DATA packet.
     /// @param [in] offset offset from the last ACK point (backward sequence number difference)
     ///
     /// @return Last time of the last retransmission event for the corresponding DATA packet.
+    SRT_ATTR_EXCLUDES(m_BufLock)
     time_point getPacketRexmitTime(const int offset);
 
     /// Update the ACK point and may release/unmap/return the user data according to the flag.
@@ -173,6 +178,7 @@ public:
     /// @return Current size of the data in the sending list.
     int getCurrBufSize() const;
 
+    SRT_ATTR_EXCLUDES(m_BufLock)
     int dropLateData(int& bytes, int32_t& w_first_msgno, const time_point& too_late_time);
 
     void updAvgBufSize(const time_point& time);
@@ -181,6 +187,7 @@ public:
 
     /// @brief Get the buffering delay of the oldest message in the buffer.
     /// @return the delay value.
+    SRT_ATTR_EXCLUDES(m_BufLock)
     duration getBufferingDelay(const time_point& tnow) const;
 
     uint64_t getInRatePeriod() const { return m_InRatePeriod; }

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -179,7 +179,9 @@ public:
     int  getAvgBufSize(int& bytes, int& timespan);
     int  getCurrBufSize(int& bytes, int& timespan);
 
-    time_point getOldestTime() const;
+    /// @brief Get the buffering delay of the oldest message in the buffer.
+    /// @return the delay value.
+    duration getBufferingDelay(const time_point& tnow) const;
 
     uint64_t getInRatePeriod() const { return m_InRatePeriod; }
 
@@ -207,7 +209,7 @@ private:                                                       // Constants
     static const int      INPUTRATE_INITIAL_BYTESPS = BW_INFINITE;
 
 private:
-    sync::Mutex m_BufLock; // used to synchronize buffer operation
+    mutable sync::Mutex m_BufLock; // used to synchronize buffer operation
 
     struct Block
     {
@@ -216,7 +218,7 @@ private:
 
         int32_t    m_iMsgNoBitset; // message number
         int32_t    m_iSeqNo;       // sequence number for scheduling
-        time_point m_tsOriginTime; // block origin time (either provided from above or equials the time a message was submitted for sending.
+        time_point m_tsOriginTime; // block origin time (either provided from above or equals the time a message was submitted for sending.
         time_point m_tsRexmitTime; // packet retransmission time
         int        m_iTTL; // time to live (milliseconds)
 


### PR DESCRIPTION
### 1. Use SND buffer delay for TL Packet Drop

Use SND buffer delay for TL Packet Drop instead of the timespan between the first and the last packet in the buffer.

Sender dropping logic is applied if the sender buffer timespan exceeds `drop_threshold_ms`.
Instead, the delay of the oldest packet in the buffer should be used (`Tnow - OldestPacketTS`).
This also correlates with the usage of the source time if provided to calculate the timestamp, which was not the case previously (PR #2185).

As before, only packets older than `Tnow - drop_threshold_ms ` are dropped by the sender.

Fixes #898.

### 2. Added missing mutex lock to CSndBuffer::readData(..) function.

For some reason the lock was missing from the `CSndBuffer::readData(CPacket& w_packet, ..)`.