### PR TITLE
srt-live-transmit.md: add ffplay, ffprobe examples

### DIFF
--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -62,6 +62,16 @@ You should see the stream connect in `srt-live-transmit`.
 Now you can test in VLC (make sure you're using the latest version!) - just go to file -> open network stream and enter
 `srt://127.0.0.1:4201` and you should see bars and tone right away.
 
+Or you can test using ffplay or ffprobe to inspect the stream:
+
+```shell
+ffplay srt://127.0.0.1:4201
+```
+-or-
+```shell
+ffprobe srt://127.0.0.1:4201
+```
+
 If you're having trouble, make sure this works, then add complexity one step at a time (multicast, push vs listen, etc.).
 
 ## URI Syntax


### PR DESCRIPTION
Add usage examples for these tools, which are part of the ffmpeg distribution, because not everyone will have access to a version of VLC (yet) which supports SRT, the reason being that VLC build configuration only accepts older versions of SRT, see https://github.com/videolan/vlc/blob/3.0.16/configure.ac#L4019.