### PR TITLE
[core] Fixed setting the peer rexmit flag on the RCV buffer

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -70,7 +70,7 @@ namespace {
  *    m_iMaxPosInc:     none? (modified on add and ack
  */
 
-CRcvBufferNew::CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, bool peerRexmit, bool bMessageAPI)
+CRcvBufferNew::CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, bool bMessageAPI)
     : m_entries(size)
     , m_szSize(size) // TODO: maybe just use m_entries.size()
     , m_pUnitQueue(unitqueue)
@@ -81,7 +81,7 @@ CRcvBufferNew::CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, 
     , m_iNotch(0)
     , m_numOutOfOrderPackets(0)
     , m_iFirstReadableOutOfOrder(-1)
-    , m_bPeerRexmitFlag(peerRexmit)
+    , m_bPeerRexmitFlag(true)
     , m_bMessageAPI(bMessageAPI)
     , m_iBytesCount(0)
     , m_iPktsCount(0)

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -51,7 +51,7 @@ class CRcvBufferNew
     typedef sync::steady_clock::duration   duration;
 
 public:
-    CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, bool peerRexmit, bool bMessageAPI);
+    CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, bool bMessageAPI);
 
     ~CRcvBufferNew();
 
@@ -308,7 +308,7 @@ private:
     size_t m_numOutOfOrderPackets;  // The number of stored packets with "inorder" flag set to false
     int m_iFirstReadableOutOfOrder; // In case of out ouf order packet, points to a position of the first such packet to
                                     // read
-    const bool m_bPeerRexmitFlag;   // Needed to read message number correctly
+    bool m_bPeerRexmitFlag;         // Needed to read message number correctly
     const bool m_bMessageAPI;       // Operation mode flag: message or stream.
 
 public: // TSBPD public functions
@@ -319,6 +319,8 @@ public: // TSBPD public functions
     ///
     /// @return 0
     void setTsbPdMode(const time_point& timebase, bool wrap, duration delay);
+
+    void setPeerRexmitFlag(bool flag) { m_bPeerRexmitFlag = flag; } 
 
     void applyGroupTime(const time_point& timebase, bool wrp, uint32_t delay, const duration& udrift);
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -489,6 +489,7 @@ private:
     SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
     EConnectStatus processRendezvous(const CPacket* response, const sockaddr_any& serv_addr, EReadStatus, CPacket& reqpkt);
 
+    /// Create the CryptoControl object based on the HS packet. Allocates sender and receiver buffers and loss lists.
     SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
     bool prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout);
 

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -34,7 +34,8 @@ protected:
 #if ENABLE_NEW_RCVBUFFER
         const bool enable_msg_api = m_use_message_api;
         const bool enable_peer_rexmit = true;
-        m_rcv_buffer = unique_ptr<CRcvBufferNew>(new CRcvBufferNew(m_init_seqno, m_buff_size_pkts, m_unit_queue.get(), enable_peer_rexmit, enable_msg_api));
+        m_rcv_buffer = unique_ptr<CRcvBufferNew>(new CRcvBufferNew(m_init_seqno, m_buff_size_pkts, m_unit_queue.get(), enable_msg_api));
+        m_rcv_buffer->setPeerRexmitFlag(enable_peer_rexmit);
 #else
         m_rcv_buffer = unique_ptr<CRcvBuffer>(new CRcvBuffer(m_unit_queue.get(), m_buff_size_pkts));
 #endif


### PR DESCRIPTION
Set the peer rexmit flag on the receiver buffer in `srt::CUDT::updateSrtRcvSettings()` instead of passing it on the construction time, as the value is not yet retrieved from the handshake. Fixes #2227. Affected SRT v1.4.5-dev.

There is already the TSBPD flag set in `srt::CUDT::updateSrtRcvSettings()`, ruining the RAII approach.
It would be better to pass both the "peer rexmit flag" and the TSBPD flag in the receiver buffer constructor and make them constant. However, it would touch too much code around the handshake flow with a high risk to introduce more bugs.