### PR TITLE
[core] Improved group readiness updating in sendCtrlAck()

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1075,8 +1075,7 @@ private: // Generation and processing of packets
     /// @brief Acknowledge reading position up to the @p seq.
     /// Updates m_iRcvLastAck and m_iRcvLastSkipAck to @p seq.
     /// @param seq first unacknowledged packet sequence number.
-    /// @return 
-    int32_t ackDataUpTo(int32_t seq);
+    void ackDataUpTo(int32_t seq);
 
     void handleKeepalive(const char* data, size_t lenghth);
 


### PR DESCRIPTION
* Decouple `group_read_seq` from `ackDataUpTo()`.
* If new recv buffer enabled, use `getFirstReadablePacketInfo()` instead of `getAvailablePacketsRange()` to support out-of-order messages. This need #2207 to make sure `getFirstReadablePacketInfo()` will not return seq behind `group_read_base`.
* If new recv buffer disabled, use `decseq(ack)` instead of `ack`.
