### PR TITLE
Fixed handling SND drop request

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -217,6 +217,7 @@ int CRcvBufferNew::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno)
             if (!m_entries[i].pUnit)
                 continue;
 
+            // TODO: Break the loop if a massege has been found. No need to search further.
             const int32_t msgseq = m_entries[i].pUnit->m_Packet.getMsgSeq(m_bPeerRexmitFlag);
             if (msgseq == msgno)
             {
@@ -261,6 +262,11 @@ int CRcvBufferNew::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno)
     int iDropCnt = 0;
     for (int i = incPos(m_iStartPos, start_off); i != end_pos && i != last_pos; i = incPos(i))
     {
+        // Don't drop messages, if all its packets are already in the buffer.
+        // TODO: Don't drop a several-packet message if all packets are in the buffer.
+        if (m_entries[i].pUnit && m_entries[i].pUnit->m_Packet.getMsgBoundary() == PB_SOLO)
+            continue;
+
         dropUnitInPos(i);
         ++iDropCnt;
         m_entries[i].status = EntryState_Drop;

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -79,7 +79,8 @@ public:
     /// @param seqnolo sequence number of the first packet in the dropping range.
     /// @param seqnohi sequence number of the last packet in the dropping range.
     /// @param msgno message number to drop (0 if unknown)
-    void dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno);
+    /// @return the number of packets actually dropped.
+    int dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno);
 
     /// Read the whole message from one or several packets.
     ///


### PR DESCRIPTION
PR #1964 has changed the handling of [the message drop request](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-01#section-3.2.9) from the sender.
In particular, previously sender's requests to drop packets in the provided range from the receiver buffer were ignored expecting them to be anyway dropped as too late. Corresponding records are removed from the receiver's loss lists anyway to stop retransmission requests of those packets.
PR #1964 implemented the logic of handling sequence-number-based drop requests from the sender. However, this leads to dropping packets that are present in the receiver buffer and actually can be properly delivered to an upstream application.
In fact, only packets referring to a several-packets-long message have to be dropped, and only if at least one packet of the message is missing and is present in the requested range of the MSG DROP REQ.

**This PR:**
- [x] Fixes pktRcvDrop statistics, counting those packets actually dropped by the receiver on the SND message drop request.
- [x] Don't drop existing single-packet messages ("SOLO" packets). But still, drop missing packets.
- [x] In the live streaming configuration (TSBPD and TLPktDrop enabled) sender drop requests are better to be ignored just in case a packet manages to arrive a bit later.
- [x] Extended RCV buffer trace logging.

**Affected SRT version:** v.1.4.5-dev.