### PR TITLE
[core] fix unrecoverable initial packets lose in group message mode

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9887,8 +9887,6 @@ int srt::CUDT::processData(CUnit* in_unit)
         }
     }
 
-    bool need_notify_loss = true;
-
     // [[using locked()]];  // (NOTHING locked)
 
 #if ENABLE_EXPERIMENTAL_BONDING
@@ -9916,10 +9914,6 @@ int srt::CUDT::processData(CUnit* in_unit)
                         << srt_log_grp_state[gi->rcvstate]
                         << " -> RUNNING. NOT checking for loss");
                 gi->rcvstate = SRT_GST_RUNNING;
-
-                // The function unfortunately can't return here.
-                // We just need to skip loss reporting.
-                need_notify_loss = false;
             }
             else
             {
@@ -10112,7 +10106,7 @@ int srt::CUDT::processData(CUnit* in_unit)
                 HLOGC(qrlog.Debug,
                       log << "CONTIGUITY CHECK: sequence distance: " << CSeqNo::seqoff(m_iRcvCurrSeqNo, rpkt.m_iSeqNo));
 
-                if (need_notify_loss && CSeqNo::seqcmp(rpkt.m_iSeqNo, CSeqNo::incseq(m_iRcvCurrSeqNo)) > 0) // Loss detection.
+                if (CSeqNo::seqcmp(rpkt.m_iSeqNo, CSeqNo::incseq(m_iRcvCurrSeqNo)) > 0) // Loss detection.
                 {
                     int32_t seqlo = CSeqNo::incseq(m_iRcvCurrSeqNo);
                     int32_t seqhi = CSeqNo::decseq(rpkt.m_iSeqNo);


### PR DESCRIPTION
Fix #2236:

The `need_notify_loss = false` was introduced by #1448, according to https://github.com/Haivision/srt/pull/1448#issuecomment-1054299732
> This is to prevent checking for loss for a freshly turned-to-running link. If this isn't done then the sequence distance between the last reception - which in this case, as a group member, is artificially updated to be in synch with other links in the group - and the current packet reception would be treated as loss and loss-reported. This actually isn't a loss because the "previous" sequence is not really a received packet sequence. After turning to RUNNING state though since this moment this range should be treated as a loss.

But it also introduces another bug #2236
I have carefully checked  `synchronizeWithGroup()`, `updateIdleLinkFrom()`, `processCtrlAck()`, `processCtrlLossReport()` and `packLostData()`, with this PR, receivers may send ACK/NAK behind `m_iSndLastAck`, but senders will ~~just ignore them~~, so it should be ok to remove `need_notify_loss`.