### PR TITLE
[core] Protect RCV buffer access from socket stats

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7443,7 +7443,8 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 
         if (m_pRcvBuffer)
         {
-            perf->byteAvailRcvBuf = getAvailRcvBufferSizeLock() * m_config.iMSS;
+            ScopedLock lck(m_RcvBufferLock);
+            perf->byteAvailRcvBuf = getAvailRcvBufferSizeNoLock() * m_config.iMSS;
             if (instantaneous) // no need for historical API for Rcv side
             {
                 perf->pktRcvBuf = m_pRcvBuffer->getRcvDataSize(perf->byteRcvBuf, perf->msRcvBuf);


### PR DESCRIPTION
Lock `m_RcvBufferLock` while retrieving receiver buffer status from SRT socket stats.

Fixes #2133.