### PR TITLE
[core] fix `CUDTGroup::m_iLastSchedSeqNo` was not updated correctly

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9933,9 +9933,9 @@ int srt::CUDT::processData(CUnit* in_unit)
         {
             if (gi->rcvstate < SRT_GST_RUNNING) // PENDING or IDLE, tho PENDING is unlikely
             {
-                HLOGC(qrlog.Debug, log << "processData: IN-GROUP rcv state transition "
-                        << srt_log_grp_state[gi->rcvstate]
-                        << " -> RUNNING. NOT checking for loss");
+                HLOGC(qrlog.Debug,
+                      log << "processData: IN-GROUP rcv state transition " << srt_log_grp_state[gi->rcvstate]
+                          << " -> RUNNING.");
                 gi->rcvstate = SRT_GST_RUNNING;
             }
             else


### PR DESCRIPTION
As
```
volatile int32_t     m_iLastSchedSeqNo; // represetnts the value of CUDT::m_iSndNextSeqNo for each running socket
```
said, `m_iLastSchedSeqNo` should be "the first seq of next message to send" instead of "the first seq of last message that has been sent",
as `m_iLastSchedSeqNo` will be used as ISN when a new link is connected.
```
            if (m_iLastSchedSeqNo != -1)
            {
                w_snd_isn = m_iLastSchedSeqNo;
                IF_HEAVY_LOGGING(update_reason = "GROUPWISE snd-seq");
            }
```
Btw, we should use `atomic` instead of  `volatile`?