### PR TITLE
[core] fix `CRcvBufferNew::m_iStartSeqNo` was not sync in group

### DIFF
--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -325,6 +325,8 @@ public: // TSBPD public functions
 
     void setPeerRexmitFlag(bool flag) { m_bPeerRexmitFlag = flag; } 
 
+    void applyGroupISN(int rcv_isn) { m_iStartSeqNo = rcv_isn; }
+
     void applyGroupTime(const time_point& timebase, bool wrp, uint32_t delay, const duration& udrift);
 
     void applyGroupDrift(const time_point& timebase, bool wrp, const duration& udrift);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3330,6 +3330,11 @@ void srt::CUDT::synchronizeWithGroup(CUDTGroup* gp)
                     << " (shift by " << CSeqNo::seqcmp(snd_isn, m_iSndLastAck) << ")");
             setInitialRcvSeq(rcv_isn);
             setInitialSndSeq(snd_isn);
+#if ENABLE_NEW_RCVBUFFER
+            enterCS(m_RecvLock);
+            m_pRcvBuffer->applyGroupISN(rcv_isn);
+            leaveCS(m_RecvLock);
+#endif
         }
         else
         {


### PR DESCRIPTION
Use `m_RecvLock` instead of `m_RcvBufferLock` since the above `m_pRcvBuffer->applyGroupTime()` is protected by `m_RecvLock`, maybe we should change to `m_RcvBufferLock` consistently?