### PR TITLE
[core] Applied clang-format on api.h and api.cpp.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -70,11 +70,11 @@ modified by
 #include "udt.h"
 
 #ifdef _WIN32
-   #include <win/wintime.h>
+#include <win/wintime.h>
 #endif
 
 #ifdef _MSC_VER
-   #pragma warning(error: 4530)
+#pragma warning(error : 4530)
 #endif
 
 using namespace std;
@@ -82,25 +82,23 @@ using namespace srt_logging;
 using namespace srt::sync;
 extern LogConfig srt_logger_config;
 
-
 void srt::CUDTSocket::construct()
 {
 #if ENABLE_EXPERIMENTAL_BONDING
-   m_GroupOf = NULL;
-   m_GroupMemberData = NULL;
+    m_GroupOf         = NULL;
+    m_GroupMemberData = NULL;
 #endif
-   setupMutex(m_AcceptLock, "Accept");
-   setupCond(m_AcceptCond, "Accept");
-   setupMutex(m_ControlLock, "Control");
+    setupMutex(m_AcceptLock, "Accept");
+    setupCond(m_AcceptCond, "Accept");
+    setupMutex(m_ControlLock, "Control");
 }
 
 srt::CUDTSocket::~CUDTSocket()
 {
-   releaseMutex(m_AcceptLock);
-   releaseCond(m_AcceptCond);
-   releaseMutex(m_ControlLock);
+    releaseMutex(m_AcceptLock);
+    releaseCond(m_AcceptCond);
+    releaseMutex(m_ControlLock);
 }
-
 
 SRT_SOCKSTATUS srt::CUDTSocket::getStatus()
 {
@@ -123,8 +121,8 @@ SRT_SOCKSTATUS srt::CUDTSocket::getStatus()
 void srt::CUDTSocket::breakSocket_LOCKED()
 {
     // This function is intended to be called from GC,
-    // under a lock of m_GlobControlLock. 
-    m_UDT.m_bBroken = true;
+    // under a lock of m_GlobControlLock.
+    m_UDT.m_bBroken        = true;
     m_UDT.m_iBrokenCounter = 0;
     HLOGC(smlog.Debug, log << "@" << m_SocketID << " CLOSING AS SOCKET");
     m_UDT.closeInternal();
@@ -145,7 +143,7 @@ void srt::CUDTSocket::setClosed()
 void srt::CUDTSocket::setBrokenClosed()
 {
     m_UDT.m_iBrokenCounter = 60;
-    m_UDT.m_bBroken = true;
+    m_UDT.m_bBroken        = true;
     setClosed();
 }
 
@@ -163,9 +161,7 @@ bool srt::CUDTSocket::readReady()
 
 bool srt::CUDTSocket::writeReady() const
 {
-    return (m_UDT.m_bConnected
-                && (m_UDT.m_pSndBuffer->getCurrBufSize() < m_UDT.m_config.iSndBufSize))
-        || broken();
+    return (m_UDT.m_bConnected && (m_UDT.m_pSndBuffer->getCurrBufSize() < m_UDT.m_config.iSndBufSize)) || broken();
 }
 
 bool srt::CUDTSocket::broken() const
@@ -175,34 +171,34 @@ bool srt::CUDTSocket::broken() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-srt::CUDTUnited::CUDTUnited():
-    m_Sockets(),
-    m_GlobControlLock(),
-    m_IDLock(),
-    m_mMultiplexer(),
-    m_MultiplexerLock(),
-    m_pCache(NULL),
-    m_bClosing(false),
-    m_GCStopCond(),
-    m_InitLock(),
-    m_iInstanceCount(0),
-    m_bGCStatus(false),
-    m_ClosedSockets()
+srt::CUDTUnited::CUDTUnited()
+    : m_Sockets()
+    , m_GlobControlLock()
+    , m_IDLock()
+    , m_mMultiplexer()
+    , m_MultiplexerLock()
+    , m_pCache(NULL)
+    , m_bClosing(false)
+    , m_GCStopCond()
+    , m_InitLock()
+    , m_iInstanceCount(0)
+    , m_bGCStatus(false)
+    , m_ClosedSockets()
 {
-   // Socket ID MUST start from a random value
-   m_SocketIDGenerator = genRandomInt(1, MAX_SOCKET_VAL);
-   m_SocketIDGenerator_init = m_SocketIDGenerator;
+    // Socket ID MUST start from a random value
+    m_SocketIDGenerator      = genRandomInt(1, MAX_SOCKET_VAL);
+    m_SocketIDGenerator_init = m_SocketIDGenerator;
 
-   // XXX An unlikely exception thrown from the below calls
-   // might destroy the application before `main`. This shouldn't
-   // be a problem in general.
-   setupMutex(m_GCStopLock, "GCStop");
-   setupCond(m_GCStopCond, "GCStop");
-   setupMutex(m_GlobControlLock, "GlobControl");
-   setupMutex(m_IDLock, "ID");
-   setupMutex(m_InitLock, "Init");
+    // XXX An unlikely exception thrown from the below calls
+    // might destroy the application before `main`. This shouldn't
+    // be a problem in general.
+    setupMutex(m_GCStopLock, "GCStop");
+    setupCond(m_GCStopCond, "GCStop");
+    setupMutex(m_GlobControlLock, "GlobControl");
+    setupMutex(m_IDLock, "ID");
+    setupMutex(m_InitLock, "Init");
 
-   m_pCache = new CCache<CInfoBlock>;
+    m_pCache = new CCache<CInfoBlock>;
 }
 
 srt::CUDTUnited::~CUDTUnited()
@@ -234,7 +230,7 @@ srt::CUDTUnited::~CUDTUnited()
 
 string srt::CUDTUnited::CONID(SRTSOCKET sock)
 {
-    if ( sock == 0 )
+    if (sock == 0)
         return "";
 
     std::ostringstream os;
@@ -244,76 +240,76 @@ string srt::CUDTUnited::CONID(SRTSOCKET sock)
 
 int srt::CUDTUnited::startup()
 {
-   ScopedLock gcinit(m_InitLock);
+    ScopedLock gcinit(m_InitLock);
 
-   if (m_iInstanceCount++ > 0)
-       return 1;
+    if (m_iInstanceCount++ > 0)
+        return 1;
 
-   // Global initialization code
+        // Global initialization code
 #ifdef _WIN32
-   WORD wVersionRequested;
-   WSADATA wsaData;
-   wVersionRequested = MAKEWORD(2, 2);
+    WORD    wVersionRequested;
+    WSADATA wsaData;
+    wVersionRequested = MAKEWORD(2, 2);
 
-   if (0 != WSAStartup(wVersionRequested, &wsaData))
-      throw CUDTException(MJ_SETUP, MN_NONE,  WSAGetLastError());
+    if (0 != WSAStartup(wVersionRequested, &wsaData))
+        throw CUDTException(MJ_SETUP, MN_NONE, WSAGetLastError());
 #endif
 
-   PacketFilter::globalInit();
+    PacketFilter::globalInit();
 
-   if (m_bGCStatus)
-      return 1;
+    if (m_bGCStatus)
+        return 1;
 
-   m_bClosing = false;
+    m_bClosing = false;
 
-   if (!StartThread(m_GCThread, garbageCollect, this, "SRT:GC"))
-      return -1;
+    if (!StartThread(m_GCThread, garbageCollect, this, "SRT:GC"))
+        return -1;
 
-   m_bGCStatus = true;
+    m_bGCStatus = true;
 
-   HLOGC(inlog.Debug, log << "SRT Clock Type: " << SRT_SYNC_CLOCK_STR);
+    HLOGC(inlog.Debug, log << "SRT Clock Type: " << SRT_SYNC_CLOCK_STR);
 
-   return 0;
+    return 0;
 }
 
 int srt::CUDTUnited::cleanup()
 {
-   // IMPORTANT!!!
-   // In this function there must be NO LOGGING AT ALL.  This function may
-   // potentially be called from within the global program destructor, and
-   // therefore some of the facilities used by the logging system - including
-   // the default std::cerr object bound to it by default, but also a different
-   // stream that the user's app has bound to it, and which got destroyed
-   // together with already exited main() - may be already deleted when
-   // executing this procedure.
-   ScopedLock gcinit(m_InitLock);
+    // IMPORTANT!!!
+    // In this function there must be NO LOGGING AT ALL.  This function may
+    // potentially be called from within the global program destructor, and
+    // therefore some of the facilities used by the logging system - including
+    // the default std::cerr object bound to it by default, but also a different
+    // stream that the user's app has bound to it, and which got destroyed
+    // together with already exited main() - may be already deleted when
+    // executing this procedure.
+    ScopedLock gcinit(m_InitLock);
 
-   if (--m_iInstanceCount > 0)
-       return 0;
+    if (--m_iInstanceCount > 0)
+        return 0;
 
-   if (!m_bGCStatus)
-       return 0;
+    if (!m_bGCStatus)
+        return 0;
 
-   {
-       UniqueLock gclock(m_GCStopLock);
-       m_bClosing = true;
-   }
-   // NOTE: we can do relaxed signaling here because
-   // waiting on m_GCStopCond has a 1-second timeout,
-   // after which the m_bClosing flag is cheched, which
-   // is set here above. Worst case secenario, this
-   // pthread_join() call will block for 1 second.
-   CSync::signal_relaxed(m_GCStopCond);
-   m_GCThread.join();
+    {
+        UniqueLock gclock(m_GCStopLock);
+        m_bClosing = true;
+    }
+    // NOTE: we can do relaxed signaling here because
+    // waiting on m_GCStopCond has a 1-second timeout,
+    // after which the m_bClosing flag is cheched, which
+    // is set here above. Worst case secenario, this
+    // pthread_join() call will block for 1 second.
+    CSync::signal_relaxed(m_GCStopCond);
+    m_GCThread.join();
 
-   m_bGCStatus = false;
+    m_bGCStatus = false;
 
-   // Global destruction code
+    // Global destruction code
 #ifdef _WIN32
-   WSACleanup();
+    WSACleanup();
 #endif
 
-   return 0;
+    return 0;
 }
 
 SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
@@ -344,7 +340,7 @@ SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
     // and reaches the same value from the opposite side.
     // This is still a valid socket value, but this time
     // we have to check, which sockets have been used already.
-    if ( sockval == m_SocketIDGenerator_init )
+    if (sockval == m_SocketIDGenerator_init)
     {
         // Mark that since this point on the checks for
         // whether the socket ID is in use must be done.
@@ -354,7 +350,7 @@ SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
     // This is when all socket numbers have been already used once.
     // This may happen after many years of running an application
     // constantly when the connection breaks and gets restored often.
-    if ( m_SocketIDGenerator_init == 0 )
+    if (m_SocketIDGenerator_init == 0)
     {
         int startval = sockval;
         for (;;) // Roll until an unused value is found
@@ -386,7 +382,7 @@ SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
                     // never happen". This should make the socket creation functions, from
                     // socket_create and accept, return this error.
 
-                    m_SocketIDGenerator = sockval+1; // so that any next call will cause the same error
+                    m_SocketIDGenerator = sockval + 1; // so that any next call will cause the same error
                     throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
                 }
 
@@ -420,425 +416,422 @@ SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
 
 SRTSOCKET srt::CUDTUnited::newSocket(CUDTSocket** pps)
 {
-   // XXX consider using some replacement of std::unique_ptr
-   // so that exceptions will clean up the object without the
-   // need for a dedicated code.
-   CUDTSocket* ns = NULL;
+    // XXX consider using some replacement of std::unique_ptr
+    // so that exceptions will clean up the object without the
+    // need for a dedicated code.
+    CUDTSocket* ns = NULL;
 
-   try
-   {
-      ns = new CUDTSocket;
-   }
-   catch (...)
-   {
-      delete ns;
-      throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
+    try
+    {
+        ns = new CUDTSocket;
+    }
+    catch (...)
+    {
+        delete ns;
+        throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
 
-   try
-   {
-      ns->m_SocketID = generateSocketID();
-   }
-   catch (...)
-   {
-       delete ns;
-       throw;
-   }
-   ns->m_Status = SRTS_INIT;
-   ns->m_ListenSocket = 0;
-   ns->core().m_SocketID = ns->m_SocketID;
-   ns->core().m_pCache = m_pCache;
+    try
+    {
+        ns->m_SocketID = generateSocketID();
+    }
+    catch (...)
+    {
+        delete ns;
+        throw;
+    }
+    ns->m_Status          = SRTS_INIT;
+    ns->m_ListenSocket    = 0;
+    ns->core().m_SocketID = ns->m_SocketID;
+    ns->core().m_pCache   = m_pCache;
 
-   try
-   {
-      HLOGC(smlog.Debug, log << CONID(ns->m_SocketID)
-         << "newSocket: mapping socket "
-         << ns->m_SocketID);
+    try
+    {
+        HLOGC(smlog.Debug, log << CONID(ns->m_SocketID) << "newSocket: mapping socket " << ns->m_SocketID);
 
-      // protect the m_Sockets structure.
-      ScopedLock cs(m_GlobControlLock);
-      m_Sockets[ns->m_SocketID] = ns;
-   }
-   catch (...)
-   {
-      //failure and rollback
-      delete ns;
-      ns = NULL;
-   }
+        // protect the m_Sockets structure.
+        ScopedLock cs(m_GlobControlLock);
+        m_Sockets[ns->m_SocketID] = ns;
+    }
+    catch (...)
+    {
+        // failure and rollback
+        delete ns;
+        ns = NULL;
+    }
 
-   if (!ns)
-      throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
+    if (!ns)
+        throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
 
     if (pps)
         *pps = ns;
 
-   return ns->m_SocketID;
+    return ns->m_SocketID;
 }
 
-int srt::CUDTUnited::newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
-        CHandShake& w_hs, int& w_error, CUDT*& w_acpu)
+int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
+                                   const sockaddr_any& peer,
+                                   const CPacket&      hspkt,
+                                   CHandShake&         w_hs,
+                                   int&                w_error,
+                                   CUDT*&              w_acpu)
 {
-   CUDTSocket* ns = NULL;
-   w_acpu = NULL;
+    CUDTSocket* ns = NULL;
+    w_acpu         = NULL;
 
-   w_error = SRT_REJ_IPE;
+    w_error = SRT_REJ_IPE;
 
-   // Can't manage this error through an exception because this is
-   // running in the listener loop.
-   CUDTSocket* ls = locateSocket(listen);
-   if (!ls)
-   {
-       LOGC(cnlog.Error, log << "IPE: newConnection by listener socket id=" << listen << " which DOES NOT EXIST.");
-       return -1;
-   }
+    // Can't manage this error through an exception because this is
+    // running in the listener loop.
+    CUDTSocket* ls = locateSocket(listen);
+    if (!ls)
+    {
+        LOGC(cnlog.Error, log << "IPE: newConnection by listener socket id=" << listen << " which DOES NOT EXIST.");
+        return -1;
+    }
 
-   HLOGC(cnlog.Debug, log << "newConnection: creating new socket after listener @"
-         << listen << " contacted with backlog=" << ls->m_uiBackLog);
+    HLOGC(cnlog.Debug,
+          log << "newConnection: creating new socket after listener @" << listen
+              << " contacted with backlog=" << ls->m_uiBackLog);
 
-   // if this connection has already been processed
-   if ((ns = locatePeer(peer, w_hs.m_iID, w_hs.m_iISN)) != NULL)
-   {
-      if (ns->core().m_bBroken)
-      {
-         // last connection from the "peer" address has been broken
-         ns->setClosed();
+    // if this connection has already been processed
+    if ((ns = locatePeer(peer, w_hs.m_iID, w_hs.m_iISN)) != NULL)
+    {
+        if (ns->core().m_bBroken)
+        {
+            // last connection from the "peer" address has been broken
+            ns->setClosed();
 
-         ScopedLock acceptcg(ls->m_AcceptLock);
-         ls->m_QueuedSockets.erase(ns->m_SocketID);
-      }
-      else
-      {
-         // connection already exist, this is a repeated connection request
-         // respond with existing HS information
-         HLOGC(cnlog.Debug, log
-               << "newConnection: located a WORKING peer @"
-               << w_hs.m_iID << " - ADAPTING.");
+            ScopedLock acceptcg(ls->m_AcceptLock);
+            ls->m_QueuedSockets.erase(ns->m_SocketID);
+        }
+        else
+        {
+            // connection already exist, this is a repeated connection request
+            // respond with existing HS information
+            HLOGC(cnlog.Debug, log << "newConnection: located a WORKING peer @" << w_hs.m_iID << " - ADAPTING.");
 
-         w_hs.m_iISN = ns->core().m_iISN;
-         w_hs.m_iMSS = ns->core().MSS();
-         w_hs.m_iFlightFlagSize = ns->core().m_config.iFlightFlagSize;
-         w_hs.m_iReqType = URQ_CONCLUSION;
-         w_hs.m_iID = ns->m_SocketID;
+            w_hs.m_iISN            = ns->core().m_iISN;
+            w_hs.m_iMSS            = ns->core().MSS();
+            w_hs.m_iFlightFlagSize = ns->core().m_config.iFlightFlagSize;
+            w_hs.m_iReqType        = URQ_CONCLUSION;
+            w_hs.m_iID             = ns->m_SocketID;
 
-         // Report the original UDT because it will be
-         // required to complete the HS data for conclusion response.
-         w_acpu = &ns->core();
+            // Report the original UDT because it will be
+            // required to complete the HS data for conclusion response.
+            w_acpu = &ns->core();
 
-         return 0;
+            return 0;
 
-         //except for this situation a new connection should be started
-      }
-   }
-   else
-   {
-       HLOGC(cnlog.Debug, log << "newConnection: NOT located any peer @"
-               << w_hs.m_iID << " - resuming with initial connection.");
-   }
+            // except for this situation a new connection should be started
+        }
+    }
+    else
+    {
+        HLOGC(cnlog.Debug,
+              log << "newConnection: NOT located any peer @" << w_hs.m_iID << " - resuming with initial connection.");
+    }
 
-   // exceeding backlog, refuse the connection request
-   if (ls->m_QueuedSockets.size() >= ls->m_uiBackLog)
-   {
-       w_error = SRT_REJ_BACKLOG;
-       LOGC(cnlog.Note, log << "newConnection: listen backlog=" << ls->m_uiBackLog << " EXCEEDED");
-       return -1;
-   }
+    // exceeding backlog, refuse the connection request
+    if (ls->m_QueuedSockets.size() >= ls->m_uiBackLog)
+    {
+        w_error = SRT_REJ_BACKLOG;
+        LOGC(cnlog.Note, log << "newConnection: listen backlog=" << ls->m_uiBackLog << " EXCEEDED");
+        return -1;
+    }
 
-   try
-   {
-      ns = new CUDTSocket(*ls);
-      // No need to check the peer, this is the address from which the request has come.
-      ns->m_PeerAddr = peer;
-   }
-   catch (...)
-   {
-      w_error = SRT_REJ_RESOURCE;
-      delete ns;
-      LOGC(cnlog.Error, log << "IPE: newConnection: unexpected exception (probably std::bad_alloc)");
-      return -1;
-   }
+    try
+    {
+        ns = new CUDTSocket(*ls);
+        // No need to check the peer, this is the address from which the request has come.
+        ns->m_PeerAddr = peer;
+    }
+    catch (...)
+    {
+        w_error = SRT_REJ_RESOURCE;
+        delete ns;
+        LOGC(cnlog.Error, log << "IPE: newConnection: unexpected exception (probably std::bad_alloc)");
+        return -1;
+    }
 
-   ns->core().m_RejectReason = SRT_REJ_UNKNOWN; // pre-set a universal value
+    ns->core().m_RejectReason = SRT_REJ_UNKNOWN; // pre-set a universal value
 
-   try
-   {
-       ns->m_SocketID = generateSocketID();
-   }
-   catch (const CUDTException&)
-   {
-       LOGF(cnlog.Fatal, "newConnection: IPE: all sockets occupied? Last gen=%d", m_SocketIDGenerator);
-       // generateSocketID throws exception, which can be naturally handled
-       // when the call is derived from the API call, but here it's called
-       // internally in response to receiving a handshake. It must be handled
-       // here and turned into an erroneous return value.
-       delete ns;
-       return -1;
-   }
+    try
+    {
+        ns->m_SocketID = generateSocketID();
+    }
+    catch (const CUDTException&)
+    {
+        LOGF(cnlog.Fatal, "newConnection: IPE: all sockets occupied? Last gen=%d", m_SocketIDGenerator);
+        // generateSocketID throws exception, which can be naturally handled
+        // when the call is derived from the API call, but here it's called
+        // internally in response to receiving a handshake. It must be handled
+        // here and turned into an erroneous return value.
+        delete ns;
+        return -1;
+    }
 
-   ns->m_ListenSocket = listen;
-   ns->core().m_SocketID = ns->m_SocketID;
-   ns->m_PeerID = w_hs.m_iID;
-   ns->m_iISN = w_hs.m_iISN;
+    ns->m_ListenSocket    = listen;
+    ns->core().m_SocketID = ns->m_SocketID;
+    ns->m_PeerID          = w_hs.m_iID;
+    ns->m_iISN            = w_hs.m_iISN;
 
-   HLOGC(cnlog.Debug, log << "newConnection: DATA: lsnid=" << listen
-            << " id=" << ns->core().m_SocketID
-            << " peerid=" << ns->core().m_PeerID
-            << " ISN=" << ns->m_iISN);
+    HLOGC(cnlog.Debug,
+          log << "newConnection: DATA: lsnid=" << listen << " id=" << ns->core().m_SocketID
+              << " peerid=" << ns->core().m_PeerID << " ISN=" << ns->m_iISN);
 
-   int error = 0;
-   bool should_submit_to_accept = true;
+    int  error                   = 0;
+    bool should_submit_to_accept = true;
 
-   // Set the error code for all prospective problems below.
-   // It won't be interpreted when result was successful.
-   w_error = SRT_REJ_RESOURCE;
+    // Set the error code for all prospective problems below.
+    // It won't be interpreted when result was successful.
+    w_error = SRT_REJ_RESOURCE;
 
-   // These can throw exception only when the memory allocation failed.
-   // CUDT::connect() translates exception into CUDTException.
-   // CUDT::open() may only throw original std::bad_alloc from new.
-   // This is only to make the library extra safe (when your machine lacks
-   // memory, it will continue to work, but fail to accept connection).
+    // These can throw exception only when the memory allocation failed.
+    // CUDT::connect() translates exception into CUDTException.
+    // CUDT::open() may only throw original std::bad_alloc from new.
+    // This is only to make the library extra safe (when your machine lacks
+    // memory, it will continue to work, but fail to accept connection).
 
-   try
-   {
-       // This assignment must happen b4 the call to CUDT::connect() because
-       // this call causes sending the SRT Handshake through this socket.
-       // Without this mapping the socket cannot be found and therefore
-       // the SRT Handshake message would fail.
-       HLOGF(cnlog.Debug,
-               "newConnection: incoming %s, mapping socket %d",
-               peer.str().c_str(), ns->m_SocketID);
-       {
-           ScopedLock cg(m_GlobControlLock);
-           m_Sockets[ns->m_SocketID] = ns;
-       }
+    try
+    {
+        // This assignment must happen b4 the call to CUDT::connect() because
+        // this call causes sending the SRT Handshake through this socket.
+        // Without this mapping the socket cannot be found and therefore
+        // the SRT Handshake message would fail.
+        HLOGF(cnlog.Debug, "newConnection: incoming %s, mapping socket %d", peer.str().c_str(), ns->m_SocketID);
+        {
+            ScopedLock cg(m_GlobControlLock);
+            m_Sockets[ns->m_SocketID] = ns;
+        }
 
-       if (ls->core().m_cbAcceptHook)
-       {
-           if (!ls->core().runAcceptHook(&ns->core(), peer.get(), w_hs, hspkt))
-           {
-               w_error = ns->core().m_RejectReason;
+        if (ls->core().m_cbAcceptHook)
+        {
+            if (!ls->core().runAcceptHook(&ns->core(), peer.get(), w_hs, hspkt))
+            {
+                w_error = ns->core().m_RejectReason;
 
-               error = 1;
-               goto ERR_ROLLBACK;
-           }
-       }
+                error = 1;
+                goto ERR_ROLLBACK;
+            }
+        }
 
-       // bind to the same addr of listening socket
-       ns->core().open();
-       updateListenerMux(ns, ls);
+        // bind to the same addr of listening socket
+        ns->core().open();
+        updateListenerMux(ns, ls);
 
-       ns->core().acceptAndRespond(ls->m_SelfAddr, peer, hspkt, (w_hs));
-   }
-   catch (...)
-   {
-       // Extract the error that was set in this new failed entity.
-       w_error = ns->core().m_RejectReason;
-       error = 1;
-       goto ERR_ROLLBACK;
-   }
+        ns->core().acceptAndRespond(ls->m_SelfAddr, peer, hspkt, (w_hs));
+    }
+    catch (...)
+    {
+        // Extract the error that was set in this new failed entity.
+        w_error = ns->core().m_RejectReason;
+        error   = 1;
+        goto ERR_ROLLBACK;
+    }
 
-   ns->m_Status = SRTS_CONNECTED;
+    ns->m_Status = SRTS_CONNECTED;
 
-   // copy address information of local node
-   // Precisely, what happens here is:
-   // - Get the IP address and port from the system database
-   ns->core().m_pSndQueue->m_pChannel->getSockAddr((ns->m_SelfAddr));
-   // - OVERWRITE just the IP address itself by a value taken from piSelfIP
-   // (the family is used exactly as the one taken from what has been returned
-   // by getsockaddr)
-   CIPAddress::pton((ns->m_SelfAddr), ns->core().m_piSelfIP, peer);
+    // copy address information of local node
+    // Precisely, what happens here is:
+    // - Get the IP address and port from the system database
+    ns->core().m_pSndQueue->m_pChannel->getSockAddr((ns->m_SelfAddr));
+    // - OVERWRITE just the IP address itself by a value taken from piSelfIP
+    // (the family is used exactly as the one taken from what has been returned
+    // by getsockaddr)
+    CIPAddress::pton((ns->m_SelfAddr), ns->core().m_piSelfIP, peer);
 
-   {
-       // protect the m_PeerRec structure (and group existence)
-       ScopedLock glock (m_GlobControlLock);
-       try
-       {
-           HLOGF(cnlog.Debug,
-                   "newConnection: mapping peer %d to that socket (%d)\n",
-                   ns->m_PeerID, ns->m_SocketID);
-           m_PeerRec[ns->getPeerSpec()].insert(ns->m_SocketID);
-       }
-       catch (...)
-       {
-           LOGC(cnlog.Error, log << "newConnection: error when mapping peer!");
-           error = 2;
-       }
+    {
+        // protect the m_PeerRec structure (and group existence)
+        ScopedLock glock(m_GlobControlLock);
+        try
+        {
+            HLOGF(cnlog.Debug, "newConnection: mapping peer %d to that socket (%d)\n", ns->m_PeerID, ns->m_SocketID);
+            m_PeerRec[ns->getPeerSpec()].insert(ns->m_SocketID);
+        }
+        catch (...)
+        {
+            LOGC(cnlog.Error, log << "newConnection: error when mapping peer!");
+            error = 2;
+        }
 
-       // The access to m_GroupOf should be also protected, as the group
-       // could be requested deletion in the meantime. This will hold any possible
-       // removal from group and resetting m_GroupOf field.
+        // The access to m_GroupOf should be also protected, as the group
+        // could be requested deletion in the meantime. This will hold any possible
+        // removal from group and resetting m_GroupOf field.
 
 #if ENABLE_EXPERIMENTAL_BONDING
-       if (ns->m_GroupOf)
-       {
-           // XXX this might require another check of group type.
-           // For redundancy group, at least, update the status in the group
-           CUDTGroup* g = ns->m_GroupOf;
-           ScopedLock glock (g->m_GroupLock);
-           if (g->m_bClosing)
-           {
-               error = 1; // "INTERNAL REJECTION"
-               goto ERR_ROLLBACK;
-           }
+        if (ns->m_GroupOf)
+        {
+            // XXX this might require another check of group type.
+            // For redundancy group, at least, update the status in the group
+            CUDTGroup* g = ns->m_GroupOf;
+            ScopedLock glock(g->m_GroupLock);
+            if (g->m_bClosing)
+            {
+                error = 1; // "INTERNAL REJECTION"
+                goto ERR_ROLLBACK;
+            }
 
-           // Check if this is the first socket in the group.
-           // If so, give it up to accept, otherwise just do nothing
-           // The client will be informed about the newly added connection at the
-           // first moment when attempting to get the group status.
-           for (CUDTGroup::gli_t gi = g->m_Group.begin(); gi != g->m_Group.end(); ++gi)
-           {
-               if (gi->laststatus == SRTS_CONNECTED)
-               {
-                   HLOGC(cnlog.Debug, log << "Found another connected socket in the group: $"
-                           << gi->id << " - socket will be NOT given up for accepting");
-                   should_submit_to_accept = false;
-                   break;
-               }
-           }
+            // Check if this is the first socket in the group.
+            // If so, give it up to accept, otherwise just do nothing
+            // The client will be informed about the newly added connection at the
+            // first moment when attempting to get the group status.
+            for (CUDTGroup::gli_t gi = g->m_Group.begin(); gi != g->m_Group.end(); ++gi)
+            {
+                if (gi->laststatus == SRTS_CONNECTED)
+                {
+                    HLOGC(cnlog.Debug,
+                          log << "Found another connected socket in the group: $" << gi->id
+                              << " - socket will be NOT given up for accepting");
+                    should_submit_to_accept = false;
+                    break;
+                }
+            }
 
-           // Update the status in the group so that the next
-           // operation can include the socket in the group operation.
-           CUDTGroup::SocketData* gm = ns->m_GroupMemberData;
+            // Update the status in the group so that the next
+            // operation can include the socket in the group operation.
+            CUDTGroup::SocketData* gm = ns->m_GroupMemberData;
 
-           HLOGC(cnlog.Debug, log << "newConnection(GROUP): Socket @" << ns->m_SocketID << " BELONGS TO $" << g->id()
-                   << " - will " << (should_submit_to_accept? "" : "NOT ") << "report in accept");
-           gm->sndstate = SRT_GST_IDLE;
-           gm->rcvstate = SRT_GST_IDLE;
-           gm->laststatus = SRTS_CONNECTED;
+            HLOGC(cnlog.Debug,
+                  log << "newConnection(GROUP): Socket @" << ns->m_SocketID << " BELONGS TO $" << g->id() << " - will "
+                      << (should_submit_to_accept ? "" : "NOT ") << "report in accept");
+            gm->sndstate   = SRT_GST_IDLE;
+            gm->rcvstate   = SRT_GST_IDLE;
+            gm->laststatus = SRTS_CONNECTED;
 
-           if (!g->m_bConnected)
-           {
-               HLOGC(cnlog.Debug, log << "newConnection(GROUP): First socket connected, SETTING GROUP CONNECTED");
-               g->m_bConnected = true;
-           }
+            if (!g->m_bConnected)
+            {
+                HLOGC(cnlog.Debug, log << "newConnection(GROUP): First socket connected, SETTING GROUP CONNECTED");
+                g->m_bConnected = true;
+            }
 
-           // XXX PROLBEM!!! These events are subscribed here so that this is done once, lazily,
-           // but groupwise connections could be accepted from multiple listeners for the same group!
-           // m_listener MUST BE A CONTAINER, NOT POINTER!!!
-           // ALSO: Maybe checking "the same listener" is not necessary as subscruption may be done
-           // multiple times anyway?
-           if (!g->m_listener)
-           {
-               // Newly created group from the listener, which hasn't yet
-               // the listener set.
-               g->m_listener = ls;
+            // XXX PROLBEM!!! These events are subscribed here so that this is done once, lazily,
+            // but groupwise connections could be accepted from multiple listeners for the same group!
+            // m_listener MUST BE A CONTAINER, NOT POINTER!!!
+            // ALSO: Maybe checking "the same listener" is not necessary as subscruption may be done
+            // multiple times anyway?
+            if (!g->m_listener)
+            {
+                // Newly created group from the listener, which hasn't yet
+                // the listener set.
+                g->m_listener = ls;
 
-               // Listen on both first connected socket and continued sockets.
-               // This might help with jump-over situations, and in regular continued
-               // sockets the IN event won't be reported anyway.
-               int listener_modes = SRT_EPOLL_ACCEPT | SRT_EPOLL_UPDATE;
-               epoll_add_usock_INTERNAL(g->m_RcvEID, ls, &listener_modes);
+                // Listen on both first connected socket and continued sockets.
+                // This might help with jump-over situations, and in regular continued
+                // sockets the IN event won't be reported anyway.
+                int listener_modes = SRT_EPOLL_ACCEPT | SRT_EPOLL_UPDATE;
+                epoll_add_usock_INTERNAL(g->m_RcvEID, ls, &listener_modes);
 
-               // This listening should be done always when a first connected socket
-               // appears as accepted off the listener. This is for the sake of swait() calls
-               // inside the group receiving and sending functions so that they get
-               // interrupted when a new socket is connected.
-           }
+                // This listening should be done always when a first connected socket
+                // appears as accepted off the listener. This is for the sake of swait() calls
+                // inside the group receiving and sending functions so that they get
+                // interrupted when a new socket is connected.
+            }
 
-           // Add also per-direction subscription for the about-to-be-accepted socket.
-           // Both first accepted socket that makes the group-accept and every next
-           // socket that adds a new link.
-           int read_modes = SRT_EPOLL_IN | SRT_EPOLL_ERR;
-           int write_modes = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
-           epoll_add_usock_INTERNAL(g->m_RcvEID, ns, &read_modes);
-           epoll_add_usock_INTERNAL(g->m_SndEID, ns, &write_modes);
+            // Add also per-direction subscription for the about-to-be-accepted socket.
+            // Both first accepted socket that makes the group-accept and every next
+            // socket that adds a new link.
+            int read_modes  = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+            int write_modes = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
+            epoll_add_usock_INTERNAL(g->m_RcvEID, ns, &read_modes);
+            epoll_add_usock_INTERNAL(g->m_SndEID, ns, &write_modes);
 
-           // With app reader, do not set groupPacketArrival (block the
-           // provider array feature completely for now).
+            // With app reader, do not set groupPacketArrival (block the
+            // provider array feature completely for now).
 
-
-           /* SETUP HERE IF NEEDED
-              ns->core().m_cbPacketArrival.set(ns->m_pUDT, &CUDT::groupPacketArrival);
-            */
-       }
-       else
-       {
-           HLOGC(cnlog.Debug, log << "newConnection: Socket @" << ns->m_SocketID << " is not in a group");
-       }
+            /* SETUP HERE IF NEEDED
+               ns->core().m_cbPacketArrival.set(ns->m_pUDT, &CUDT::groupPacketArrival);
+             */
+        }
+        else
+        {
+            HLOGC(cnlog.Debug, log << "newConnection: Socket @" << ns->m_SocketID << " is not in a group");
+        }
 #endif
-   }
+    }
 
-   if (should_submit_to_accept)
-   {
-      enterCS(ls->m_AcceptLock);
-      try
-      {
-         ls->m_QueuedSockets.insert(ns->m_SocketID);
-      }
-      catch (...)
-      {
-         LOGC(cnlog.Error, log << "newConnection: error when queuing socket!");
-         error = 3;
-      }
-      leaveCS(ls->m_AcceptLock);
+    if (should_submit_to_accept)
+    {
+        enterCS(ls->m_AcceptLock);
+        try
+        {
+            ls->m_QueuedSockets.insert(ns->m_SocketID);
+        }
+        catch (...)
+        {
+            LOGC(cnlog.Error, log << "newConnection: error when queuing socket!");
+            error = 3;
+        }
+        leaveCS(ls->m_AcceptLock);
 
-      HLOGC(cnlog.Debug, log << "ACCEPT: new socket @" << ns->m_SocketID << " submitted for acceptance");
-      // acknowledge users waiting for new connections on the listening socket
-      m_EPoll.update_events(listen, ls->core().m_sPollID, SRT_EPOLL_ACCEPT, true);
+        HLOGC(cnlog.Debug, log << "ACCEPT: new socket @" << ns->m_SocketID << " submitted for acceptance");
+        // acknowledge users waiting for new connections on the listening socket
+        m_EPoll.update_events(listen, ls->core().m_sPollID, SRT_EPOLL_ACCEPT, true);
 
-      CGlobEvent::triggerEvent();
+        CGlobEvent::triggerEvent();
 
-      // XXX the exact value of 'error' is ignored
-      if (error > 0)
-      {
-         goto ERR_ROLLBACK;
-      }
+        // XXX the exact value of 'error' is ignored
+        if (error > 0)
+        {
+            goto ERR_ROLLBACK;
+        }
 
-      // wake up a waiting accept() call
-      CSync::lock_signal(ls->m_AcceptCond, ls->m_AcceptLock);
-   }
-   else
-   {
-      HLOGC(cnlog.Debug, log << "ACCEPT: new socket @" << ns->m_SocketID
-            << " NOT submitted to acceptance, another socket in the group is already connected");
+        // wake up a waiting accept() call
+        CSync::lock_signal(ls->m_AcceptCond, ls->m_AcceptLock);
+    }
+    else
+    {
+        HLOGC(cnlog.Debug,
+              log << "ACCEPT: new socket @" << ns->m_SocketID
+                  << " NOT submitted to acceptance, another socket in the group is already connected");
 
-      // acknowledge INTERNAL users waiting for new connections on the listening socket
-      // that are reported when a new socket is connected within an already connected group.
-      m_EPoll.update_events(listen, ls->core().m_sPollID, SRT_EPOLL_UPDATE, true);
-      CGlobEvent::triggerEvent();
-   }
+        // acknowledge INTERNAL users waiting for new connections on the listening socket
+        // that are reported when a new socket is connected within an already connected group.
+        m_EPoll.update_events(listen, ls->core().m_sPollID, SRT_EPOLL_UPDATE, true);
+        CGlobEvent::triggerEvent();
+    }
 
 ERR_ROLLBACK:
-   // XXX the exact value of 'error' is ignored
-   if (error > 0)
-   {
+    // XXX the exact value of 'error' is ignored
+    if (error > 0)
+    {
 #if ENABLE_LOGGING
-       static const char* why [] = {
-           "UNKNOWN ERROR",
-           "INTERNAL REJECTION",
-           "IPE when mapping a socket",
-           "IPE when inserting a socket"
-       };
-       LOGC(cnlog.Warn, log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: "
-               << why[error] << " - " << RequestTypeStr(URQFailure(w_error)));
+        static const char* why[] = {
+            "UNKNOWN ERROR", "INTERNAL REJECTION", "IPE when mapping a socket", "IPE when inserting a socket"};
+        LOGC(cnlog.Warn,
+             log << CONID(ns->m_SocketID) << "newConnection: connection rejected due to: " << why[error] << " - "
+                 << RequestTypeStr(URQFailure(w_error)));
 #endif
 
-      SRTSOCKET id = ns->m_SocketID;
-      ns->core().closeInternal();
-      ns->setClosed();
+        SRTSOCKET id = ns->m_SocketID;
+        ns->core().closeInternal();
+        ns->setClosed();
 
-      // The mapped socket should be now unmapped to preserve the situation that
-      // was in the original UDT code.
-      // In SRT additionally the acceptAndRespond() function (it was called probably
-      // connect() in UDT code) may fail, in which case this socket should not be
-      // further processed and should be removed.
-      {
-          ScopedLock cg(m_GlobControlLock);
+        // The mapped socket should be now unmapped to preserve the situation that
+        // was in the original UDT code.
+        // In SRT additionally the acceptAndRespond() function (it was called probably
+        // connect() in UDT code) may fail, in which case this socket should not be
+        // further processed and should be removed.
+        {
+            ScopedLock cg(m_GlobControlLock);
 
 #if ENABLE_EXPERIMENTAL_BONDING
-          if (ns->m_GroupOf)
-          {
-              HLOGC(smlog.Debug, log << "@" << ns->m_SocketID << " IS MEMBER OF $" << ns->m_GroupOf->id() << " - REMOVING FROM GROUP");
-              ns->removeFromGroup(true);
-          }
+            if (ns->m_GroupOf)
+            {
+                HLOGC(smlog.Debug,
+                      log << "@" << ns->m_SocketID << " IS MEMBER OF $" << ns->m_GroupOf->id()
+                          << " - REMOVING FROM GROUP");
+                ns->removeFromGroup(true);
+            }
 #endif
-          m_Sockets.erase(id);
-          m_ClosedSockets[id] = ns;
-      }
+            m_Sockets.erase(id);
+            m_ClosedSockets[id] = ns;
+        }
 
-      return -1;
-   }
+        return -1;
+    }
 
-   return 1;
+    return 1;
 }
 
 // static forwarder
@@ -875,7 +868,7 @@ int srt::CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_callback_
 #if ENABLE_EXPERIMENTAL_BONDING
         if (u & SRTGROUP_MASK)
         {
-            GroupKeeper k (*this, u, ERH_THROW);
+            GroupKeeper k(*this, u, ERH_THROW);
             k.group->installConnectHook(hook, opaq);
             return 0;
         }
@@ -911,113 +904,114 @@ SRT_SOCKSTATUS srt::CUDTUnited::getStatus(const SRTSOCKET u)
 
 int srt::CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
 {
-   ScopedLock cg(s->m_ControlLock);
+    ScopedLock cg(s->m_ControlLock);
 
-   // cannot bind a socket more than once
-   if (s->m_Status != SRTS_INIT)
-      throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
+    // cannot bind a socket more than once
+    if (s->m_Status != SRTS_INIT)
+        throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
 
-   s->core().open();
-   updateMux(s, name);
-   s->m_Status = SRTS_OPENED;
+    s->core().open();
+    updateMux(s, name);
+    s->m_Status = SRTS_OPENED;
 
-   // copy address information of local node
-   s->core().m_pSndQueue->m_pChannel->getSockAddr((s->m_SelfAddr));
+    // copy address information of local node
+    s->core().m_pSndQueue->m_pChannel->getSockAddr((s->m_SelfAddr));
 
-   return 0;
+    return 0;
 }
 
 int srt::CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
 {
-   ScopedLock cg(s->m_ControlLock);
+    ScopedLock cg(s->m_ControlLock);
 
-   // cannot bind a socket more than once
-   if (s->m_Status != SRTS_INIT)
-      throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
+    // cannot bind a socket more than once
+    if (s->m_Status != SRTS_INIT)
+        throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
 
-   sockaddr_any name;
-   socklen_t namelen = sizeof name; // max of inet and inet6
+    sockaddr_any name;
+    socklen_t    namelen = sizeof name; // max of inet and inet6
 
-   // This will preset the sa_family as well; the namelen is given simply large
-   // enough for any family here.
-   if (::getsockname(udpsock, &name.sa, &namelen) == -1)
-      throw CUDTException(MJ_NOTSUP, MN_INVAL);
+    // This will preset the sa_family as well; the namelen is given simply large
+    // enough for any family here.
+    if (::getsockname(udpsock, &name.sa, &namelen) == -1)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL);
 
-   // Successfully extracted, so update the size
-   name.len = namelen;
+    // Successfully extracted, so update the size
+    name.len = namelen;
 
-   s->core().open();
-   updateMux(s, name, &udpsock);
-   s->m_Status = SRTS_OPENED;
+    s->core().open();
+    updateMux(s, name, &udpsock);
+    s->m_Status = SRTS_OPENED;
 
-   // copy address information of local node
-   s->core().m_pSndQueue->m_pChannel->getSockAddr(s->m_SelfAddr);
+    // copy address information of local node
+    s->core().m_pSndQueue->m_pChannel->getSockAddr(s->m_SelfAddr);
 
-   return 0;
+    return 0;
 }
 
 int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
 {
-   if (backlog <= 0)
-      throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    if (backlog <= 0)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   // Don't search for the socket if it's already -1;
-   // this never is a valid socket.
-   if (u == UDT::INVALID_SOCK)
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+    // Don't search for the socket if it's already -1;
+    // this never is a valid socket.
+    if (u == UDT::INVALID_SOCK)
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
-   CUDTSocket* s = locateSocket(u);
-   if (!s)
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+    CUDTSocket* s = locateSocket(u);
+    if (!s)
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
-   ScopedLock cg(s->m_ControlLock);
+    ScopedLock cg(s->m_ControlLock);
 
-   // NOTE: since now the socket is protected against simultaneous access.
-   // In the meantime the socket might have been closed, which means that
-   // it could have changed the state. It could be also set listen in another
-   // thread, so check it out.
+    // NOTE: since now the socket is protected against simultaneous access.
+    // In the meantime the socket might have been closed, which means that
+    // it could have changed the state. It could be also set listen in another
+    // thread, so check it out.
 
-   // do nothing if the socket is already listening
-   if (s->m_Status == SRTS_LISTENING)
-      return 0;
+    // do nothing if the socket is already listening
+    if (s->m_Status == SRTS_LISTENING)
+        return 0;
 
-   // a socket can listen only if is in OPENED status
-   if (s->m_Status != SRTS_OPENED)
-      throw CUDTException(MJ_NOTSUP, MN_ISUNBOUND, 0);
+    // a socket can listen only if is in OPENED status
+    if (s->m_Status != SRTS_OPENED)
+        throw CUDTException(MJ_NOTSUP, MN_ISUNBOUND, 0);
 
-   // [[using assert(s->m_Status == OPENED)]];
+    // [[using assert(s->m_Status == OPENED)]];
 
-   // listen is not supported in rendezvous connection setup
-   if (s->core().m_config.bRendezvous)
-      throw CUDTException(MJ_NOTSUP, MN_ISRENDEZVOUS, 0);
+    // listen is not supported in rendezvous connection setup
+    if (s->core().m_config.bRendezvous)
+        throw CUDTException(MJ_NOTSUP, MN_ISRENDEZVOUS, 0);
 
-   s->m_uiBackLog = backlog;
+    s->m_uiBackLog = backlog;
 
-   // [[using assert(s->m_Status == OPENED)]]; // (still, unchanged)
+    // [[using assert(s->m_Status == OPENED)]]; // (still, unchanged)
 
-   s->core().setListenState();  // propagates CUDTException,
-                                 // if thrown, remains in OPENED state if so.
-   s->m_Status = SRTS_LISTENING;
+    s->core().setListenState(); // propagates CUDTException,
+                                // if thrown, remains in OPENED state if so.
+    s->m_Status = SRTS_LISTENING;
 
-   return 0;
+    return 0;
 }
 
-SRTSOCKET srt::CUDTUnited::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut)
+SRTSOCKET srt::CUDTUnited::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut)
 {
-    CEPollDesc* ed = 0;
-    int eid = m_EPoll.create(&ed);
+    CEPollDesc* ed  = 0;
+    int         eid = m_EPoll.create(&ed);
 
     // Destroy it at return - this function can be interrupted
     // by an exception.
     struct AtReturn
     {
-        int eid;
+        int         eid;
         CUDTUnited* that;
-        AtReturn(CUDTUnited* t, int e): eid(e), that(t) {}
-        ~AtReturn()
+        AtReturn(CUDTUnited* t, int e)
+            : eid(e)
+            , that(t)
         {
-            that->m_EPoll.release(eid);
         }
+        ~AtReturn() { that->m_EPoll.release(eid); }
     } l_ar(this, eid);
 
     // Subscribe all of listeners for accept
@@ -1040,153 +1034,155 @@ SRTSOCKET srt::CUDTUnited::accept_bond(const SRTSOCKET listeners [], int lsize, 
     // Theoretically we can have a situation that more than one
     // listener is ready for accept. In this case simply get
     // only the first found.
-    int lsn = st.begin()->first;
+    int              lsn = st.begin()->first;
     sockaddr_storage dummy;
-    int outlen = sizeof dummy;
+    int              outlen = sizeof dummy;
     return accept(lsn, ((sockaddr*)&dummy), (&outlen));
 }
 
 SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_addrlen)
 {
-   if (pw_addr && !pw_addrlen)
-   {
-      LOGC(cnlog.Error, log << "srt_accept: provided address, but address length parameter is missing");
-      throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
-   }
+    if (pw_addr && !pw_addrlen)
+    {
+        LOGC(cnlog.Error, log << "srt_accept: provided address, but address length parameter is missing");
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    }
 
-   CUDTSocket* ls = locateSocket(listen);
+    CUDTSocket* ls = locateSocket(listen);
 
-   if (ls == NULL)
-   {
-      LOGC(cnlog.Error, log << "srt_accept: invalid listener socket ID value: " << listen);
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
-   }
+    if (ls == NULL)
+    {
+        LOGC(cnlog.Error, log << "srt_accept: invalid listener socket ID value: " << listen);
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+    }
 
-   // the "listen" socket must be in LISTENING status
-   if (ls->m_Status != SRTS_LISTENING)
-   {
-      LOGC(cnlog.Error, log << "srt_accept: socket @" << listen << " is not in listening state (forgot srt_listen?)");
-      throw CUDTException(MJ_NOTSUP, MN_NOLISTEN, 0);
-   }
+    // the "listen" socket must be in LISTENING status
+    if (ls->m_Status != SRTS_LISTENING)
+    {
+        LOGC(cnlog.Error, log << "srt_accept: socket @" << listen << " is not in listening state (forgot srt_listen?)");
+        throw CUDTException(MJ_NOTSUP, MN_NOLISTEN, 0);
+    }
 
-   // no "accept" in rendezvous connection setup
-   if (ls->core().m_config.bRendezvous)
-   {
-       LOGC(cnlog.Fatal, log << "CUDTUnited::accept: RENDEZVOUS flag passed through check in srt_listen when it set listen state");
-       // This problem should never happen because `srt_listen` function should have
-       // checked this situation before and not set listen state in result.
-       // Inform the user about the invalid state in the universal way.
-       throw CUDTException(MJ_NOTSUP, MN_NOLISTEN, 0);
-   }
+    // no "accept" in rendezvous connection setup
+    if (ls->core().m_config.bRendezvous)
+    {
+        LOGC(cnlog.Fatal,
+             log << "CUDTUnited::accept: RENDEZVOUS flag passed through check in srt_listen when it set listen state");
+        // This problem should never happen because `srt_listen` function should have
+        // checked this situation before and not set listen state in result.
+        // Inform the user about the invalid state in the universal way.
+        throw CUDTException(MJ_NOTSUP, MN_NOLISTEN, 0);
+    }
 
-   SRTSOCKET u = CUDT::INVALID_SOCK;
-   bool accepted = false;
+    SRTSOCKET u        = CUDT::INVALID_SOCK;
+    bool      accepted = false;
 
-   // !!only one conection can be set up each time!!
-   while (!accepted)
-   {
-       UniqueLock accept_lock(ls->m_AcceptLock);
-       CSync accept_sync(ls->m_AcceptCond, accept_lock);
+    // !!only one conection can be set up each time!!
+    while (!accepted)
+    {
+        UniqueLock accept_lock(ls->m_AcceptLock);
+        CSync      accept_sync(ls->m_AcceptCond, accept_lock);
 
-       if ((ls->m_Status != SRTS_LISTENING) || ls->core().m_bBroken)
-       {
-           // This socket has been closed.
-           accepted = true;
-       }
-       else if (ls->m_QueuedSockets.size() > 0)
-       {
-           set<SRTSOCKET>::iterator b = ls->m_QueuedSockets.begin();
-           u = *b;
-           ls->m_QueuedSockets.erase(b);
-           accepted = true;
-       }
-       else if (!ls->core().m_config.bSynRecving)
-       {
-           accepted = true;
-       }
+        if ((ls->m_Status != SRTS_LISTENING) || ls->core().m_bBroken)
+        {
+            // This socket has been closed.
+            accepted = true;
+        }
+        else if (ls->m_QueuedSockets.size() > 0)
+        {
+            set<SRTSOCKET>::iterator b = ls->m_QueuedSockets.begin();
+            u                          = *b;
+            ls->m_QueuedSockets.erase(b);
+            accepted = true;
+        }
+        else if (!ls->core().m_config.bSynRecving)
+        {
+            accepted = true;
+        }
 
-       if (!accepted && (ls->m_Status == SRTS_LISTENING))
-           accept_sync.wait();
+        if (!accepted && (ls->m_Status == SRTS_LISTENING))
+            accept_sync.wait();
 
-       if (ls->m_QueuedSockets.empty())
-           m_EPoll.update_events(listen, ls->core().m_sPollID, SRT_EPOLL_ACCEPT, false);
-   }
+        if (ls->m_QueuedSockets.empty())
+            m_EPoll.update_events(listen, ls->core().m_sPollID, SRT_EPOLL_ACCEPT, false);
+    }
 
-   if (u == CUDT::INVALID_SOCK)
-   {
-      // non-blocking receiving, no connection available
-      if (!ls->core().m_config.bSynRecving)
-      {
-         LOGC(cnlog.Error, log << "srt_accept: no pending connection available at the moment");
-         throw CUDTException(MJ_AGAIN, MN_RDAVAIL, 0);
-      }
+    if (u == CUDT::INVALID_SOCK)
+    {
+        // non-blocking receiving, no connection available
+        if (!ls->core().m_config.bSynRecving)
+        {
+            LOGC(cnlog.Error, log << "srt_accept: no pending connection available at the moment");
+            throw CUDTException(MJ_AGAIN, MN_RDAVAIL, 0);
+        }
 
-      LOGC(cnlog.Error, log << "srt_accept: listener socket @" << listen << " is already closed");
-      // listening socket is closed
-      throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
-   }
+        LOGC(cnlog.Error, log << "srt_accept: listener socket @" << listen << " is already closed");
+        // listening socket is closed
+        throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
+    }
 
-   CUDTSocket* s = locateSocket(u);
-   if (s == NULL)
-   {
-      LOGC(cnlog.Error, log << "srt_accept: pending connection has unexpectedly closed");
-      throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
-   }
+    CUDTSocket* s = locateSocket(u);
+    if (s == NULL)
+    {
+        LOGC(cnlog.Error, log << "srt_accept: pending connection has unexpectedly closed");
+        throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
+    }
 
-   // Set properly the SRTO_GROUPCONNECT flag
-   s->core().m_config.iGroupConnect = 0;
+    // Set properly the SRTO_GROUPCONNECT flag
+    s->core().m_config.iGroupConnect = 0;
 
-   // Check if LISTENER has the SRTO_GROUPCONNECT flag set,
-   // and the already accepted socket has successfully joined
-   // the mirror group. If so, RETURN THE GROUP ID, not the socket ID.
+    // Check if LISTENER has the SRTO_GROUPCONNECT flag set,
+    // and the already accepted socket has successfully joined
+    // the mirror group. If so, RETURN THE GROUP ID, not the socket ID.
 #if ENABLE_EXPERIMENTAL_BONDING
-   if (ls->core().m_config.iGroupConnect == 1 && s->m_GroupOf)
-   {
-       // Put a lock to protect the group against accidental deletion
-       // in the meantime.
-       ScopedLock glock (m_GlobControlLock);
-       // Check again; it's unlikely to happen, but
-       // it's a theoretically possible scenario
-       if (s->m_GroupOf)
-       {
-           u = s->m_GroupOf->m_GroupID;
-           s->core().m_config.iGroupConnect = 1; // should be derived from ls, but make sure
+    if (ls->core().m_config.iGroupConnect == 1 && s->m_GroupOf)
+    {
+        // Put a lock to protect the group against accidental deletion
+        // in the meantime.
+        ScopedLock glock(m_GlobControlLock);
+        // Check again; it's unlikely to happen, but
+        // it's a theoretically possible scenario
+        if (s->m_GroupOf)
+        {
+            u                                = s->m_GroupOf->m_GroupID;
+            s->core().m_config.iGroupConnect = 1; // should be derived from ls, but make sure
 
-           // Mark the beginning of the connection at the moment
-           // when the group ID is returned to the app caller
+            // Mark the beginning of the connection at the moment
+            // when the group ID is returned to the app caller
             s->m_GroupOf->m_stats.tsLastSampleTime = steady_clock::now();
-       }
-       else
-       {
-           LOGC(smlog.Error, log << "accept: IPE: socket's group deleted in the meantime of accept process???");
-       }
-   }
+        }
+        else
+        {
+            LOGC(smlog.Error, log << "accept: IPE: socket's group deleted in the meantime of accept process???");
+        }
+    }
 #endif
 
-   ScopedLock cg(s->m_ControlLock);
+    ScopedLock cg(s->m_ControlLock);
 
-   if (pw_addr != NULL && pw_addrlen != NULL)
-   {
-      // Check if the length of the buffer to fill the name in
-      // was large enough.
-      const int len = s->m_PeerAddr.size();
-      if (*pw_addrlen < len)
-          throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    if (pw_addr != NULL && pw_addrlen != NULL)
+    {
+        // Check if the length of the buffer to fill the name in
+        // was large enough.
+        const int len = s->m_PeerAddr.size();
+        if (*pw_addrlen < len)
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-      memcpy((pw_addr), &s->m_PeerAddr, len);
-      *pw_addrlen = len;
-   }
+        memcpy((pw_addr), &s->m_PeerAddr, len);
+        *pw_addrlen = len;
+    }
 
-   return u;
+    return u;
 }
 
 int srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int namelen)
 {
     // Here both srcname and tarname must be specified
-    if (!srcname || !tarname || size_t(namelen) < sizeof (sockaddr_in))
+    if (!srcname || !tarname || size_t(namelen) < sizeof(sockaddr_in))
     {
-        LOGC(aclog.Error, log << "connect(with source): invalid call: srcname="
-                << srcname << " tarname=" << tarname << " namelen=" << namelen);
+        LOGC(aclog.Error,
+             log << "connect(with source): invalid call: srcname=" << srcname << " tarname=" << tarname
+                 << " namelen=" << namelen);
         throw CUDTException(MJ_NOTSUP, MN_INVAL);
     }
 
@@ -1203,12 +1199,12 @@ int srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockadd
     // the group.
     if (u & SRTGROUP_MASK)
     {
-        GroupKeeper k (*this, u, ERH_THROW);
+        GroupKeeper k(*this, u, ERH_THROW);
         // Note: forced_isn is ignored when connecting a group.
         // The group manages the ISN by itself ALWAYS, that is,
         // it's generated anew for the very first socket, and then
         // derived by all sockets in the group.
-        SRT_SOCKGROUPCONFIG gd[1] = { srt_prepare_endpoint(srcname, tarname, namelen) };
+        SRT_SOCKGROUPCONFIG gd[1] = {srt_prepare_endpoint(srcname, tarname, namelen)};
 
         // When connecting to exactly one target, only this very target
         // can be returned as a socket, so rewritten back array can be ignored.
@@ -1237,13 +1233,13 @@ int srt::CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namele
     // the group.
     if (u & SRTGROUP_MASK)
     {
-        GroupKeeper k (*this, u, ERH_THROW);
+        GroupKeeper k(*this, u, ERH_THROW);
 
         // Note: forced_isn is ignored when connecting a group.
         // The group manages the ISN by itself ALWAYS, that is,
         // it's generated anew for the very first socket, and then
         // derived by all sockets in the group.
-        SRT_SOCKGROUPCONFIG gd[1] = { srt_prepare_endpoint(NULL, name, namelen) };
+        SRT_SOCKGROUPCONFIG gd[1] = {srt_prepare_endpoint(NULL, name, namelen)};
         return singleMemberConnect(k.group, gd);
     }
 #endif
@@ -1311,14 +1307,16 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
     // group is already OPENED returns immediately, regardless if the
     // connection is going to later succeed or fail (this will be
     // known in the group state information).
-    bool block_new_opened = !g.m_bOpened && g.m_bSynRecving;
-    const bool was_empty = g.groupEmpty();
+    bool       block_new_opened = !g.m_bOpened && g.m_bSynRecving;
+    const bool was_empty        = g.groupEmpty();
 
     // In case the group was retried connection, clear first all epoll readiness.
     const int ncleared = m_EPoll.update_events(g.id(), g.m_sPollID, SRT_EPOLL_ERR, false);
     if (was_empty || ncleared)
     {
-        HLOGC(aclog.Debug, log << "srt_connect/group: clearing IN/OUT because was_empty=" << was_empty << " || ncleared=" << ncleared);
+        HLOGC(aclog.Debug,
+              log << "srt_connect/group: clearing IN/OUT because was_empty=" << was_empty
+                  << " || ncleared=" << ncleared);
         // IN/OUT only in case when the group is empty, otherwise it would
         // clear out correct readiness resulting from earlier calls.
         // This also should happen if ERR flag was set, as IN and OUT could be set, too.
@@ -1326,7 +1324,7 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
     }
     SRTSOCKET retval = -1;
 
-    int eid = -1;
+    int eid           = -1;
     int connect_modes = SRT_EPOLL_CONNECT | SRT_EPOLL_ERR;
     if (block_new_opened)
     {
@@ -1339,16 +1337,17 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
     // overall map.
     map<SRTSOCKET, CUDTSocket*> spawned;
 
-    HLOGC(aclog.Debug, log << "groupConnect: will connect " << arraysize << " links and "
-            << (block_new_opened ? "BLOCK until any is ready" : "leave the process in background"));
+    HLOGC(aclog.Debug,
+          log << "groupConnect: will connect " << arraysize << " links and "
+              << (block_new_opened ? "BLOCK until any is ready" : "leave the process in background"));
 
     for (int tii = 0; tii < arraysize; ++tii)
     {
         sockaddr_any target_addr(targets[tii].peeraddr);
         sockaddr_any source_addr(targets[tii].srcaddr);
-        SRTSOCKET& sid_rloc = targets[tii].id;
-        int& erc_rloc = targets[tii].errorcode;
-        erc_rloc = SRT_SUCCESS; // preinitialized
+        SRTSOCKET&   sid_rloc = targets[tii].id;
+        int&         erc_rloc = targets[tii].errorcode;
+        erc_rloc              = SRT_SUCCESS; // preinitialized
         HLOGC(aclog.Debug, log << "groupConnect: taking on " << sockaddr_any(targets[tii].peeraddr).str());
 
         CUDTSocket* ns = 0;
@@ -1381,7 +1380,7 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             {
                 HLOGC(aclog.Debug, log << "groupConnect: OPTION @" << sid << " #" << g.m_config[i].so);
                 error_reason = "setting group-derived option: #" + Sprint(g.m_config[i].so);
-                ns->core().setOpt(g.m_config[i].so, &g.m_config[i].value[0], (int) g.m_config[i].value.size());
+                ns->core().setOpt(g.m_config[i].so, &g.m_config[i].value[0], (int)g.m_config[i].value.size());
             }
 
             // Do not try to set a user option if failed already.
@@ -1395,7 +1394,6 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             // We got it. Bind the socket, if the source address was set
             if (!source_addr.empty())
                 bind(ns, source_addr);
-
         }
         catch (CUDTException& e)
         {
@@ -1424,7 +1422,7 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
         else
         {
             // Otherwise generate and write back the token
-            data.token = CUDTGroup::genToken();
+            data.token         = CUDTGroup::genToken();
             targets[tii].token = data.token;
         }
 
@@ -1449,22 +1447,24 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
 
             if (targets[tii].errorcode != SRT_SUCCESS)
             {
-                HLOGC(aclog.Debug, log << "srt_connect_group: not processing @" << sid << " due to error in setting options");
+                HLOGC(aclog.Debug,
+                      log << "srt_connect_group: not processing @" << sid << " due to error in setting options");
                 proceed = false;
             }
 
             if (g.m_bClosing)
             {
-                HLOGC(aclog.Debug, log << "srt_connect_group: not processing @" << sid << " due to CLOSED GROUP $" << g.m_GroupID);
+                HLOGC(aclog.Debug,
+                      log << "srt_connect_group: not processing @" << sid << " due to CLOSED GROUP $" << g.m_GroupID);
                 proceed = false;
             }
 
             if (proceed)
             {
                 CUDTGroup::SocketData* f = g.add(data);
-                ns->m_GroupMemberData = f;
-                ns->m_GroupOf = &g;
-                f->weight = targets[tii].weight;
+                ns->m_GroupMemberData    = f;
+                ns->m_GroupOf            = &g;
+                f->weight                = targets[tii].weight;
                 LOGC(aclog.Note, log << "srt_connect_group: socket @" << sid << " added to group $" << g.m_GroupID);
             }
             else
@@ -1478,7 +1478,6 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
                 continue;
             }
         }
-
 
         // XXX This should be reenabled later, this should
         // be probably still in use to exchange information about
@@ -1533,15 +1532,16 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
         }
         catch (const CUDTException& e)
         {
-            LOGC(aclog.Error, log << "groupConnect: socket @" << sid << " in group " << pg->id() << " failed to connect");
+            LOGC(aclog.Error,
+                 log << "groupConnect: socket @" << sid << " in group " << pg->id() << " failed to connect");
             // We know it does belong to a group.
             // Remove it first because this involves a mutex, and we want
             // to avoid locking more than one mutex at a time.
-            erc_rloc = e.getErrorCode();
+            erc_rloc               = e.getErrorCode();
             targets[tii].errorcode = e.getErrorCode();
-            targets[tii].id = CUDT::INVALID_SOCK;
+            targets[tii].id        = CUDT::INVALID_SOCK;
 
-            ScopedLock cl (m_GlobControlLock);
+            ScopedLock cl(m_GlobControlLock);
             ns->removeFromGroup(false);
             m_Sockets.erase(ns->m_SocketID);
             // Intercept to delete the socket on failure.
@@ -1552,8 +1552,8 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
         {
             LOGC(aclog.Fatal, log << "groupConnect: IPE: UNKNOWN EXCEPTION from connectIn");
             targets[tii].errorcode = SRT_ESYSOBJ;
-            targets[tii].id = CUDT::INVALID_SOCK;
-            ScopedLock cl (m_GlobControlLock);
+            targets[tii].id        = CUDT::INVALID_SOCK;
+            ScopedLock cl(m_GlobControlLock);
             ns->removeFromGroup(false);
             m_Sockets.erase(ns->m_SocketID);
             // Intercept to delete the socket on failure.
@@ -1565,14 +1565,14 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
 
         SRT_SOCKSTATUS st;
         {
-            ScopedLock grd (ns->m_ControlLock);
+            ScopedLock grd(ns->m_ControlLock);
             st = ns->getStatus();
         }
 
         {
             // NOTE: Not applying m_GlobControlLock because the group is now
             // set busy, so it won't be deleted, even if it was requested to be closed.
-            ScopedLock grd (g.m_GroupLock);
+            ScopedLock grd(g.m_GroupLock);
 
             if (!ns->m_GroupOf)
             {
@@ -1601,13 +1601,14 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
                 // set BROKEN or PENDING.
                 f->sndstate = SRT_GST_PENDING;
                 f->rcvstate = SRT_GST_PENDING;
-                retval = -1;
+                retval      = -1;
                 break;
             }
 
-            HLOGC(aclog.Debug, log << "groupConnect: @" << sid << " connection successful, setting group OPEN (was "
-                    << (g.m_bOpened ? "ALREADY" : "NOT") << "), will " << (block_new_opened ? "" : "NOT ")
-                    << "block the connect call, status:" << SockStatusStr(st));
+            HLOGC(aclog.Debug,
+                  log << "groupConnect: @" << sid << " connection successful, setting group OPEN (was "
+                      << (g.m_bOpened ? "ALREADY" : "NOT") << "), will " << (block_new_opened ? "" : "NOT ")
+                      << "block the connect call, status:" << SockStatusStr(st));
 
             // XXX OPEN OR CONNECTED?
             // BLOCK IF NOT OPEN OR BLOCK IF NOT CONNECTED?
@@ -1626,7 +1627,7 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             // Turn the group state of the socket to IDLE only if
             // connection is established or in progress
             f->agent = source_addr;
-            f->peer = target_addr;
+            f->peer  = target_addr;
 
             if (st >= SRTS_BROKEN)
             {
@@ -1637,13 +1638,13 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             }
             else
             {
-                f->sndstate = SRT_GST_PENDING;
-                f->rcvstate = SRT_GST_PENDING;
+                f->sndstate  = SRT_GST_PENDING;
+                f->rcvstate  = SRT_GST_PENDING;
                 spawned[sid] = ns;
 
                 sid_rloc = sid;
                 erc_rloc = 0;
-                retval = sid;
+                retval   = sid;
             }
         }
     }
@@ -1665,15 +1666,18 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             break;
         }
         HLOGC(aclog.Debug, log << "groupConnect: first connection, applying EPOLL WAITING.");
-        int len = (int) spawned.size();
+        int               len = (int)spawned.size();
         vector<SRTSOCKET> ready(spawned.size());
-        const int estat = srt_epoll_wait(eid,
-                    NULL, NULL,  // IN/ACCEPT
-                    &ready[0], &len, // OUT/CONNECT
-                    -1, // indefinitely (FIXME Check if it needs to REGARD CONNECTION TIMEOUT!)
-                    NULL, NULL,
-                    NULL, NULL
-                    );
+        const int         estat = srt_epoll_wait(eid,
+                                         NULL,
+                                         NULL, // IN/ACCEPT
+                                         &ready[0],
+                                         &len, // OUT/CONNECT
+                                         -1, // indefinitely (FIXME Check if it needs to REGARD CONNECTION TIMEOUT!)
+                                         NULL,
+                                         NULL,
+                                         NULL,
+                                         NULL);
 
         // Sanity check. Shouldn't happen if subs are in sync with spawned.
         if (estat == -1)
@@ -1682,8 +1686,9 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             CUDTException& x = CUDT::getlasterror();
             if (x.getErrorCode() != SRT_EPOLLEMPTY)
             {
-                LOGC(aclog.Error, log << "groupConnect: srt_epoll_wait failed not because empty, unexpected IPE:"
-                        << x.getErrorMessage());
+                LOGC(aclog.Error,
+                     log << "groupConnect: srt_epoll_wait failed not because empty, unexpected IPE:"
+                         << x.getErrorMessage());
             }
 #endif
             HLOGC(aclog.Debug, log << "groupConnect: srt_epoll_wait failed - breaking the wait loop");
@@ -1695,20 +1700,21 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
         // lock the groups so that no one messes up with something here
         // in the meantime.
 
-        ScopedLock lock (*g.exp_groupLock());
+        ScopedLock lock(*g.exp_groupLock());
 
         // NOTE: UNDER m_GroupLock, NO API FUNCTION CALLS DARE TO HAPPEN BELOW!
 
         // Check first if a socket wasn't closed in the meantime. It will be
         // automatically removed from all EIDs, but there's no sense in keeping
         // them in 'spawned' map.
-        for (map<SRTSOCKET, CUDTSocket*>::iterator y = spawned.begin();
-                y != spawned.end(); ++y)
+        for (map<SRTSOCKET, CUDTSocket*>::iterator y = spawned.begin(); y != spawned.end(); ++y)
         {
             SRTSOCKET sid = y->first;
             if (y->second->getStatus() >= SRTS_BROKEN)
             {
-                HLOGC(aclog.Debug, log << "groupConnect: Socket @" << sid << " got BROKEN in the meantine during the check, remove from candidates");
+                HLOGC(aclog.Debug,
+                      log << "groupConnect: Socket @" << sid
+                          << " got BROKEN in the meantine during the check, remove from candidates");
                 // Remove from spawned and try again
                 broken.push_back(sid);
 
@@ -1737,15 +1743,17 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
                 continue;
             }
 
-            SRTSOCKET sid = x->first;
-            CUDTSocket* s = x->second;
+            SRTSOCKET   sid = x->first;
+            CUDTSocket* s   = x->second;
 
             // Check status. If failed, remove from spawned
             // and try again.
             SRT_SOCKSTATUS st = s->getStatus();
             if (st >= SRTS_BROKEN)
             {
-                HLOGC(aclog.Debug, log << "groupConnect: Socket @" << sid << " got BROKEN during background connect, remove & TRY AGAIN");
+                HLOGC(aclog.Debug,
+                      log << "groupConnect: Socket @" << sid
+                          << " got BROKEN during background connect, remove & TRY AGAIN");
                 // Remove from spawned and try again
                 if (spawned.erase(sid))
                     broken.push_back(sid);
@@ -1759,9 +1767,10 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
 
             if (st == SRTS_CONNECTED)
             {
-                HLOGC(aclog.Debug, log << "groupConnect: Socket @" << sid << " got CONNECTED as first in the group - reporting");
-                retval = sid;
-                g.m_bConnected = true;
+                HLOGC(aclog.Debug,
+                      log << "groupConnect: Socket @" << sid << " got CONNECTED as first in the group - reporting");
+                retval           = sid;
+                g.m_bConnected   = true;
                 block_new_opened = false; // Interrupt also rolling epoll (outer loop)
 
                 // Remove this socket from SND EID because it doesn't need to
@@ -1774,8 +1783,9 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
             }
 
             // Spurious?
-            HLOGC(aclog.Debug, log << "groupConnect: Socket @" << sid << " got spurious wakeup in "
-                    << SockStatusStr(st) << " TRY AGAIN");
+            HLOGC(aclog.Debug,
+                  log << "groupConnect: Socket @" << sid << " got spurious wakeup in " << SockStatusStr(st)
+                      << " TRY AGAIN");
         }
         // END of m_GroupLock CS - you can safely use API functions now.
     }
@@ -1811,7 +1821,6 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
 }
 #endif
 
-
 int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_t forced_isn)
 {
     ScopedLock cg(s->m_ControlLock);
@@ -1831,10 +1840,10 @@ int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, i
         // the binding parameters are autoselected.
 
         s->core().open();
-        sockaddr_any autoselect_sa (target_addr.family());
+        sockaddr_any autoselect_sa(target_addr.family());
         // This will create such a sockaddr_any that
-        // will return true from empty(). 
-        updateMux(s, autoselect_sa);  // <<---- updateMux
+        // will return true from empty().
+        updateMux(s, autoselect_sa); // <<---- updateMux
         // -> C(Snd|Rcv)Queue::init
         // -> pthread_create(...C(Snd|Rcv)Queue::worker...)
         s->m_Status = SRTS_OPENED;
@@ -1851,7 +1860,6 @@ int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, i
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
         }
     }
-
 
     // connect_complete() may be called before connect() returns.
     // So we need to update the status before connect() is called,
@@ -1877,13 +1885,12 @@ int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, i
     return 0;
 }
 
-
 int srt::CUDTUnited::close(const SRTSOCKET u)
 {
 #if ENABLE_EXPERIMENTAL_BONDING
     if (u & SRTGROUP_MASK)
     {
-        GroupKeeper k (*this, u, ERH_THROW);
+        GroupKeeper k(*this, u, ERH_THROW);
         k.group->close();
         deleteGroup(k.group);
         return 0;
@@ -1901,7 +1908,7 @@ void srt::CUDTUnited::deleteGroup(CUDTGroup* g)
 {
     using srt_logging::gmlog;
 
-    srt::sync::ScopedLock cg (m_GlobControlLock);
+    srt::sync::ScopedLock cg(m_GlobControlLock);
     return deleteGroup_LOCKED(g);
 }
 
@@ -1918,28 +1925,26 @@ void srt::CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
     // it may potentially be deleted. Make sure no socket points
     // to it. Actually all sockets should have been already removed
     // from the group container, so if any does, it's invalid.
-    for (sockets_t::iterator i = m_Sockets.begin();
-            i != m_Sockets.end(); ++ i)
+    for (sockets_t::iterator i = m_Sockets.begin(); i != m_Sockets.end(); ++i)
     {
         CUDTSocket* s = i->second;
         if (s->m_GroupOf == g)
         {
             HLOGC(smlog.Debug, log << "deleteGroup: IPE: existing @" << s->m_SocketID << " points to a dead group!");
-            s->m_GroupOf = NULL;
+            s->m_GroupOf         = NULL;
             s->m_GroupMemberData = NULL;
         }
     }
 
     // Just in case, do it in closed sockets, too, although this should be
     // always done before moving to it.
-    for (sockets_t::iterator i = m_ClosedSockets.begin();
-            i != m_ClosedSockets.end(); ++ i)
+    for (sockets_t::iterator i = m_ClosedSockets.begin(); i != m_ClosedSockets.end(); ++i)
     {
         CUDTSocket* s = i->second;
         if (s->m_GroupOf == g)
         {
             HLOGC(smlog.Debug, log << "deleteGroup: IPE: closed @" << s->m_SocketID << " points to a dead group!");
-            s->m_GroupOf = NULL;
+            s->m_GroupOf         = NULL;
             s->m_GroupMemberData = NULL;
         }
     }
@@ -1948,395 +1953,386 @@ void srt::CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
 
 int srt::CUDTUnited::close(CUDTSocket* s)
 {
-   HLOGC(smlog.Debug, log << s->core().CONID() << " CLOSE. Acquiring control lock");
-   ScopedLock socket_cg(s->m_ControlLock);
-   HLOGC(smlog.Debug, log << s->core().CONID() << " CLOSING (removing from listening, closing CUDT)");
+    HLOGC(smlog.Debug, log << s->core().CONID() << " CLOSE. Acquiring control lock");
+    ScopedLock socket_cg(s->m_ControlLock);
+    HLOGC(smlog.Debug, log << s->core().CONID() << " CLOSING (removing from listening, closing CUDT)");
 
-   const bool synch_close_snd = s->core().m_config.bSynSending;
+    const bool synch_close_snd = s->core().m_config.bSynSending;
 
-   SRTSOCKET u = s->m_SocketID;
+    SRTSOCKET u = s->m_SocketID;
 
-   if (s->m_Status == SRTS_LISTENING)
-   {
-      if (s->core().m_bBroken)
-         return 0;
+    if (s->m_Status == SRTS_LISTENING)
+    {
+        if (s->core().m_bBroken)
+            return 0;
 
-      s->m_tsClosureTimeStamp = steady_clock::now();
-      s->core().m_bBroken    = true;
+        s->m_tsClosureTimeStamp = steady_clock::now();
+        s->core().m_bBroken     = true;
 
-      // Change towards original UDT: 
-      // Leave all the closing activities for garbageCollect to happen,
-      // however remove the listener from the RcvQueue IMMEDIATELY.
-      // Even though garbageCollect would eventually remove the listener
-      // as well, there would be some time interval between now and the
-      // moment when it's done, and during this time the application will
-      // be unable to bind to this port that the about-to-delete listener
-      // is currently occupying (due to blocked slot in the RcvQueue).
+        // Change towards original UDT:
+        // Leave all the closing activities for garbageCollect to happen,
+        // however remove the listener from the RcvQueue IMMEDIATELY.
+        // Even though garbageCollect would eventually remove the listener
+        // as well, there would be some time interval between now and the
+        // moment when it's done, and during this time the application will
+        // be unable to bind to this port that the about-to-delete listener
+        // is currently occupying (due to blocked slot in the RcvQueue).
 
-      HLOGC(smlog.Debug, log << s->core().CONID() << " CLOSING (removing listener immediately)");
-      s->core().notListening();
+        HLOGC(smlog.Debug, log << s->core().CONID() << " CLOSING (removing listener immediately)");
+        s->core().notListening();
 
-      // broadcast all "accept" waiting
-      CSync::lock_broadcast(s->m_AcceptCond, s->m_AcceptLock);
-   }
-   else
-   {
-       // Note: this call may be done on a socket that hasn't finished
-       // sending all packets scheduled for sending, which means, this call
-       // may block INDEFINITELY. As long as it's acceptable to block the
-       // call to srt_close(), and all functions in all threads where this
-       // very socket is used, this shall not block the central database.
-       s->core().closeInternal();
+        // broadcast all "accept" waiting
+        CSync::lock_broadcast(s->m_AcceptCond, s->m_AcceptLock);
+    }
+    else
+    {
+        // Note: this call may be done on a socket that hasn't finished
+        // sending all packets scheduled for sending, which means, this call
+        // may block INDEFINITELY. As long as it's acceptable to block the
+        // call to srt_close(), and all functions in all threads where this
+        // very socket is used, this shall not block the central database.
+        s->core().closeInternal();
 
-       // synchronize with garbage collection.
-       HLOGC(smlog.Debug, log << "@" << u << "U::close done. GLOBAL CLOSE: " << s->core().CONID() << ". Acquiring GLOBAL control lock");
-       ScopedLock manager_cg(m_GlobControlLock);
-       // since "s" is located before m_GlobControlLock, locate it again in case
-       // it became invalid
-       // XXX This is very weird; if we state that the CUDTSocket object
-       // could not be deleted between locks, then definitely it couldn't
-       // also change the pointer value. There's no other reason for getting
-       // this iterator but to obtain the 's' pointer, which is impossible to
-       // be different than previous 's' (m_Sockets is a map that stores pointers
-       // transparently). This iterator isn't even later used to delete the socket
-       // from the container, though it would be more efficient.
-       // FURTHER RESEARCH REQUIRED.
-       sockets_t::iterator i = m_Sockets.find(u);
-       if ((i == m_Sockets.end()) || (i->second->m_Status == SRTS_CLOSED))
-       {
-           HLOGC(smlog.Debug, log << "@" << u << "U::close: NOT AN ACTIVE SOCKET, returning.");
-           return 0;
-       }
-       s = i->second;
-       s->setClosed();
+        // synchronize with garbage collection.
+        HLOGC(smlog.Debug,
+              log << "@" << u << "U::close done. GLOBAL CLOSE: " << s->core().CONID()
+                  << ". Acquiring GLOBAL control lock");
+        ScopedLock manager_cg(m_GlobControlLock);
+        // since "s" is located before m_GlobControlLock, locate it again in case
+        // it became invalid
+        // XXX This is very weird; if we state that the CUDTSocket object
+        // could not be deleted between locks, then definitely it couldn't
+        // also change the pointer value. There's no other reason for getting
+        // this iterator but to obtain the 's' pointer, which is impossible to
+        // be different than previous 's' (m_Sockets is a map that stores pointers
+        // transparently). This iterator isn't even later used to delete the socket
+        // from the container, though it would be more efficient.
+        // FURTHER RESEARCH REQUIRED.
+        sockets_t::iterator i = m_Sockets.find(u);
+        if ((i == m_Sockets.end()) || (i->second->m_Status == SRTS_CLOSED))
+        {
+            HLOGC(smlog.Debug, log << "@" << u << "U::close: NOT AN ACTIVE SOCKET, returning.");
+            return 0;
+        }
+        s = i->second;
+        s->setClosed();
 
 #if ENABLE_EXPERIMENTAL_BONDING
-       if (s->m_GroupOf)
-       {
-           HLOGC(smlog.Debug, log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
-           s->removeFromGroup(true);
-       }
+        if (s->m_GroupOf)
+        {
+            HLOGC(smlog.Debug,
+                  log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
+            s->removeFromGroup(true);
+        }
 #endif
 
-       m_Sockets.erase(s->m_SocketID);
-       m_ClosedSockets[s->m_SocketID] = s;
-       HLOGC(smlog.Debug, log << "@" << u << "U::close: Socket MOVED TO CLOSED for collecting later.");
+        m_Sockets.erase(s->m_SocketID);
+        m_ClosedSockets[s->m_SocketID] = s;
+        HLOGC(smlog.Debug, log << "@" << u << "U::close: Socket MOVED TO CLOSED for collecting later.");
 
-       CGlobEvent::triggerEvent();
-   }
+        CGlobEvent::triggerEvent();
+    }
 
-   HLOGC(smlog.Debug, log << "@" << u << ": GLOBAL: CLOSING DONE");
+    HLOGC(smlog.Debug, log << "@" << u << ": GLOBAL: CLOSING DONE");
 
-   // Check if the ID is still in closed sockets before you access it
-   // (the last triggerEvent could have deleted it).
-   if ( synch_close_snd )
-   {
+    // Check if the ID is still in closed sockets before you access it
+    // (the last triggerEvent could have deleted it).
+    if (synch_close_snd)
+    {
 #if SRT_ENABLE_CLOSE_SYNCH
 
-       HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: sync-waiting for releasing sender resources...");
-       for (;;)
-       {
-           CSndBuffer* sb = s->core().m_pSndBuffer;
+        HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: sync-waiting for releasing sender resources...");
+        for (;;)
+        {
+            CSndBuffer* sb = s->core().m_pSndBuffer;
 
-           // Disconnected from buffer - nothing more to check.
-           if (!sb)
-           {
-               HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: sending buffer disconnected. Allowed to close.");
-               break;
-           }
+            // Disconnected from buffer - nothing more to check.
+            if (!sb)
+            {
+                HLOGC(smlog.Debug,
+                      log << "@" << u << " GLOBAL CLOSING: sending buffer disconnected. Allowed to close.");
+                break;
+            }
 
-           // Sender buffer empty
-           if (sb->getCurrBufSize() == 0)
-           {
-               HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: sending buffer depleted. Allowed to close.");
-               break;
-           }
+            // Sender buffer empty
+            if (sb->getCurrBufSize() == 0)
+            {
+                HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: sending buffer depleted. Allowed to close.");
+                break;
+            }
 
-           // Ok, now you are keeping GC thread hands off the internal data.
-           // You can check then if it has already deleted the socket or not.
-           // The socket is either in m_ClosedSockets or is already gone.
+            // Ok, now you are keeping GC thread hands off the internal data.
+            // You can check then if it has already deleted the socket or not.
+            // The socket is either in m_ClosedSockets or is already gone.
 
-           // Done the other way, but still done. You can stop waiting.
-           bool isgone = false;
-           {
-               ScopedLock manager_cg(m_GlobControlLock);
-               isgone = m_ClosedSockets.count(u) == 0;
-           }
-           if (!isgone)
-           {
-               isgone = !s->core().m_bOpened;
-           }
-           if (isgone)
-           {
-               HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: ... gone in the meantime, whatever. Exiting close().");
-               break;
-           }
+            // Done the other way, but still done. You can stop waiting.
+            bool isgone = false;
+            {
+                ScopedLock manager_cg(m_GlobControlLock);
+                isgone = m_ClosedSockets.count(u) == 0;
+            }
+            if (!isgone)
+            {
+                isgone = !s->core().m_bOpened;
+            }
+            if (isgone)
+            {
+                HLOGC(smlog.Debug,
+                      log << "@" << u << " GLOBAL CLOSING: ... gone in the meantime, whatever. Exiting close().");
+                break;
+            }
 
-           HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: ... still waiting for any update.");
-           // How to handle a possible error here?
-           CGlobEvent::waitForEvent();
+            HLOGC(smlog.Debug, log << "@" << u << " GLOBAL CLOSING: ... still waiting for any update.");
+            // How to handle a possible error here?
+            CGlobEvent::waitForEvent();
 
-           // Continue waiting in case when an event happened or 1s waiting time passed for checkpoint.
-       }
+            // Continue waiting in case when an event happened or 1s waiting time passed for checkpoint.
+        }
 #endif
-   }
+    }
 
-   /*
-      This code is PUT ASIDE for now.
-      Most likely this will be never required.
-      It had to hold the closing activity until the time when the receiver buffer is depleted.
-      However the closing of the socket should only happen when the receiver has received
-      an information about that the reading is no longer possible (error report from recv/recvfile).
-      When this happens, the receiver buffer is definitely depleted already and there's no need to check
-      anything.
+    /*
+       This code is PUT ASIDE for now.
+       Most likely this will be never required.
+       It had to hold the closing activity until the time when the receiver buffer is depleted.
+       However the closing of the socket should only happen when the receiver has received
+       an information about that the reading is no longer possible (error report from recv/recvfile).
+       When this happens, the receiver buffer is definitely depleted already and there's no need to check
+       anything.
 
-      Should there appear any other conditions in future under which the closing process should be
-      delayed until the receiver buffer is empty, this code can be filled here.
+       Should there appear any other conditions in future under which the closing process should be
+       delayed until the receiver buffer is empty, this code can be filled here.
 
-   if ( synch_close_rcv )
-   {
-   ...
-   }
-   */
+    if ( synch_close_rcv )
+    {
+    ...
+    }
+    */
 
-   return 0;
+    return 0;
 }
 
 void srt::CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
 {
-   if (!pw_name || !pw_namelen)
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    if (!pw_name || !pw_namelen)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   if (getStatus(u) != SRTS_CONNECTED)
-      throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
+    if (getStatus(u) != SRTS_CONNECTED)
+        throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
 
-   CUDTSocket* s = locateSocket(u);
+    CUDTSocket* s = locateSocket(u);
 
-   if (!s)
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+    if (!s)
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
-   if (!s->core().m_bConnected || s->core().m_bBroken)
-      throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
+    if (!s->core().m_bConnected || s->core().m_bBroken)
+        throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
 
-   const int len = s->m_PeerAddr.size();
-   if (*pw_namelen < len)
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    const int len = s->m_PeerAddr.size();
+    if (*pw_namelen < len)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   memcpy((pw_name), &s->m_PeerAddr.sa, len);
-   *pw_namelen = len;
+    memcpy((pw_name), &s->m_PeerAddr.sa, len);
+    *pw_namelen = len;
 }
 
 void srt::CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
 {
-   if (!pw_name || !pw_namelen)
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    if (!pw_name || !pw_namelen)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   CUDTSocket* s = locateSocket(u);
+    CUDTSocket* s = locateSocket(u);
 
-   if (!s)
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+    if (!s)
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
-   if (s->core().m_bBroken)
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+    if (s->core().m_bBroken)
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
-   if (s->m_Status == SRTS_INIT)
-      throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
+    if (s->m_Status == SRTS_INIT)
+        throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
 
-   const int len = s->m_SelfAddr.size();
-   if (*pw_namelen < len)
-       throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+    const int len = s->m_SelfAddr.size();
+    if (*pw_namelen < len)
+        throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-   memcpy((pw_name), &s->m_SelfAddr.sa, len);
-   *pw_namelen = len;
+    memcpy((pw_name), &s->m_SelfAddr.sa, len);
+    *pw_namelen = len;
 }
 
-int srt::CUDTUnited::select(
-   UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout)
-{
-   const steady_clock::time_point entertime = steady_clock::now();
-
-   const int64_t timeo_us = timeout
-       ? static_cast<int64_t>(timeout->tv_sec) * 1000000 + timeout->tv_usec
-       : -1;
-   const steady_clock::duration timeo(microseconds_from(timeo_us));
-
-   // initialize results
-   int count = 0;
-   set<SRTSOCKET> rs, ws, es;
-
-   // retrieve related UDT sockets
-   vector<CUDTSocket*> ru, wu, eu;
-   CUDTSocket* s;
-   if (readfds)
-      for (set<SRTSOCKET>::iterator i1 = readfds->begin();
-         i1 != readfds->end(); ++ i1)
-      {
-         if (getStatus(*i1) == SRTS_BROKEN)
-         {
-            rs.insert(*i1);
-            ++ count;
-         }
-         else if (!(s = locateSocket(*i1)))
-            throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
-         else
-            ru.push_back(s);
-      }
-   if (writefds)
-      for (set<SRTSOCKET>::iterator i2 = writefds->begin();
-         i2 != writefds->end(); ++ i2)
-      {
-         if (getStatus(*i2) == SRTS_BROKEN)
-         {
-            ws.insert(*i2);
-            ++ count;
-         }
-         else if (!(s = locateSocket(*i2)))
-            throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
-         else
-            wu.push_back(s);
-      }
-   if (exceptfds)
-      for (set<SRTSOCKET>::iterator i3 = exceptfds->begin();
-         i3 != exceptfds->end(); ++ i3)
-      {
-         if (getStatus(*i3) == SRTS_BROKEN)
-         {
-            es.insert(*i3);
-            ++ count;
-         }
-         else if (!(s = locateSocket(*i3)))
-            throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
-         else
-            eu.push_back(s);
-      }
-
-   do
-   {
-      // query read sockets
-      for (vector<CUDTSocket*>::iterator j1 = ru.begin(); j1 != ru.end(); ++ j1)
-      {
-         s = *j1;
-
-         if (s->readReady() || s->m_Status == SRTS_CLOSED)
-         {
-            rs.insert(s->m_SocketID);
-            ++ count;
-         }
-      }
-
-      // query write sockets
-      for (vector<CUDTSocket*>::iterator j2 = wu.begin(); j2 != wu.end(); ++ j2)
-      {
-         s = *j2;
-
-         if (s->writeReady() || s->m_Status == SRTS_CLOSED)
-         {
-            ws.insert(s->m_SocketID);
-            ++ count;
-         }
-      }
-
-      // query exceptions on sockets
-      for (vector<CUDTSocket*>::iterator j3 = eu.begin(); j3 != eu.end(); ++ j3)
-      {
-         // check connection request status, not supported now
-      }
-
-      if (0 < count)
-         break;
-
-      CGlobEvent::waitForEvent();
-   } while (timeo > steady_clock::now() - entertime);
-
-   if (readfds)
-      *readfds = rs;
-
-   if (writefds)
-      *writefds = ws;
-
-   if (exceptfds)
-      *exceptfds = es;
-
-   return count;
-}
-
-int srt::CUDTUnited::selectEx(
-   const vector<SRTSOCKET>& fds,
-   vector<SRTSOCKET>* readfds,
-   vector<SRTSOCKET>* writefds,
-   vector<SRTSOCKET>* exceptfds,
-   int64_t msTimeOut)
+int srt::CUDTUnited::select(UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout)
 {
     const steady_clock::time_point entertime = steady_clock::now();
 
-    const int64_t timeo_us = msTimeOut >= 0
-        ? msTimeOut * 1000
-        : -1;
+    const int64_t timeo_us = timeout ? static_cast<int64_t>(timeout->tv_sec) * 1000000 + timeout->tv_usec : -1;
     const steady_clock::duration timeo(microseconds_from(timeo_us));
 
-   // initialize results
-   int count = 0;
-   if (readfds)
-      readfds->clear();
-   if (writefds)
-      writefds->clear();
-   if (exceptfds)
-      exceptfds->clear();
+    // initialize results
+    int            count = 0;
+    set<SRTSOCKET> rs, ws, es;
 
-   do
-   {
-      for (vector<SRTSOCKET>::const_iterator i = fds.begin();
-         i != fds.end(); ++ i)
-      {
-         CUDTSocket* s = locateSocket(*i);
-
-         if ((!s) || s->core().m_bBroken || (s->m_Status == SRTS_CLOSED))
-         {
-            if (exceptfds)
+    // retrieve related UDT sockets
+    vector<CUDTSocket*> ru, wu, eu;
+    CUDTSocket*         s;
+    if (readfds)
+        for (set<SRTSOCKET>::iterator i1 = readfds->begin(); i1 != readfds->end(); ++i1)
+        {
+            if (getStatus(*i1) == SRTS_BROKEN)
             {
-               exceptfds->push_back(*i);
-               ++ count;
+                rs.insert(*i1);
+                ++count;
             }
-            continue;
-         }
-
-         if (readfds)
-         {
-            if ((s->core().m_bConnected
-                  && s->core().m_pRcvBuffer->isRcvDataReady()
-               )
-               || (s->core().m_bListening
-                  && (s->m_QueuedSockets.size() > 0)))
+            else if (!(s = locateSocket(*i1)))
+                throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+            else
+                ru.push_back(s);
+        }
+    if (writefds)
+        for (set<SRTSOCKET>::iterator i2 = writefds->begin(); i2 != writefds->end(); ++i2)
+        {
+            if (getStatus(*i2) == SRTS_BROKEN)
             {
-               readfds->push_back(s->m_SocketID);
-               ++ count;
+                ws.insert(*i2);
+                ++count;
             }
-         }
-
-         if (writefds)
-         {
-            if (s->core().m_bConnected
-               && (s->core().m_pSndBuffer->getCurrBufSize()
-                  < s->core().m_config.iSndBufSize))
+            else if (!(s = locateSocket(*i2)))
+                throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+            else
+                wu.push_back(s);
+        }
+    if (exceptfds)
+        for (set<SRTSOCKET>::iterator i3 = exceptfds->begin(); i3 != exceptfds->end(); ++i3)
+        {
+            if (getStatus(*i3) == SRTS_BROKEN)
             {
-               writefds->push_back(s->m_SocketID);
-               ++ count;
+                es.insert(*i3);
+                ++count;
             }
-         }
-      }
+            else if (!(s = locateSocket(*i3)))
+                throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+            else
+                eu.push_back(s);
+        }
 
-      if (count > 0)
-         break;
+    do
+    {
+        // query read sockets
+        for (vector<CUDTSocket*>::iterator j1 = ru.begin(); j1 != ru.end(); ++j1)
+        {
+            s = *j1;
 
-      CGlobEvent::waitForEvent();
-   } while (timeo > steady_clock::now() - entertime);
+            if (s->readReady() || s->m_Status == SRTS_CLOSED)
+            {
+                rs.insert(s->m_SocketID);
+                ++count;
+            }
+        }
 
-   return count;
+        // query write sockets
+        for (vector<CUDTSocket*>::iterator j2 = wu.begin(); j2 != wu.end(); ++j2)
+        {
+            s = *j2;
+
+            if (s->writeReady() || s->m_Status == SRTS_CLOSED)
+            {
+                ws.insert(s->m_SocketID);
+                ++count;
+            }
+        }
+
+        // query exceptions on sockets
+        for (vector<CUDTSocket*>::iterator j3 = eu.begin(); j3 != eu.end(); ++j3)
+        {
+            // check connection request status, not supported now
+        }
+
+        if (0 < count)
+            break;
+
+        CGlobEvent::waitForEvent();
+    } while (timeo > steady_clock::now() - entertime);
+
+    if (readfds)
+        *readfds = rs;
+
+    if (writefds)
+        *writefds = ws;
+
+    if (exceptfds)
+        *exceptfds = es;
+
+    return count;
+}
+
+int srt::CUDTUnited::selectEx(const vector<SRTSOCKET>& fds,
+                              vector<SRTSOCKET>*       readfds,
+                              vector<SRTSOCKET>*       writefds,
+                              vector<SRTSOCKET>*       exceptfds,
+                              int64_t                  msTimeOut)
+{
+    const steady_clock::time_point entertime = steady_clock::now();
+
+    const int64_t                timeo_us = msTimeOut >= 0 ? msTimeOut * 1000 : -1;
+    const steady_clock::duration timeo(microseconds_from(timeo_us));
+
+    // initialize results
+    int count = 0;
+    if (readfds)
+        readfds->clear();
+    if (writefds)
+        writefds->clear();
+    if (exceptfds)
+        exceptfds->clear();
+
+    do
+    {
+        for (vector<SRTSOCKET>::const_iterator i = fds.begin(); i != fds.end(); ++i)
+        {
+            CUDTSocket* s = locateSocket(*i);
+
+            if ((!s) || s->core().m_bBroken || (s->m_Status == SRTS_CLOSED))
+            {
+                if (exceptfds)
+                {
+                    exceptfds->push_back(*i);
+                    ++count;
+                }
+                continue;
+            }
+
+            if (readfds)
+            {
+                if ((s->core().m_bConnected && s->core().m_pRcvBuffer->isRcvDataReady()) ||
+                    (s->core().m_bListening && (s->m_QueuedSockets.size() > 0)))
+                {
+                    readfds->push_back(s->m_SocketID);
+                    ++count;
+                }
+            }
+
+            if (writefds)
+            {
+                if (s->core().m_bConnected &&
+                    (s->core().m_pSndBuffer->getCurrBufSize() < s->core().m_config.iSndBufSize))
+                {
+                    writefds->push_back(s->m_SocketID);
+                    ++count;
+                }
+            }
+        }
+
+        if (count > 0)
+            break;
+
+        CGlobEvent::waitForEvent();
+    } while (timeo > steady_clock::now() - entertime);
+
+    return count;
 }
 
 int srt::CUDTUnited::epoll_create()
 {
-   return m_EPoll.create();
+    return m_EPoll.create();
 }
 
 int srt::CUDTUnited::epoll_clear_usocks(int eid)
@@ -2344,31 +2340,30 @@ int srt::CUDTUnited::epoll_clear_usocks(int eid)
     return m_EPoll.clear_usocks(eid);
 }
 
-int srt::CUDTUnited::epoll_add_usock(
-   const int eid, const SRTSOCKET u, const int* events)
+int srt::CUDTUnited::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
 {
-   int ret = -1;
+    int ret = -1;
 #if ENABLE_EXPERIMENTAL_BONDING
-   if (u & SRTGROUP_MASK)
-   {
-       GroupKeeper k (*this, u, ERH_THROW);
-       ret = m_EPoll.update_usock(eid, u, events);
-       k.group->addEPoll(eid);
-       return 0;
-   }
+    if (u & SRTGROUP_MASK)
+    {
+        GroupKeeper k(*this, u, ERH_THROW);
+        ret = m_EPoll.update_usock(eid, u, events);
+        k.group->addEPoll(eid);
+        return 0;
+    }
 #endif
 
-   CUDTSocket* s = locateSocket(u);
-   if (s)
-   {
-      ret = epoll_add_usock_INTERNAL(eid, s, events);
-   }
-   else
-   {
-      throw CUDTException(MJ_NOTSUP, MN_SIDINVAL);
-   }
+    CUDTSocket* s = locateSocket(u);
+    if (s)
+    {
+        ret = epoll_add_usock_INTERNAL(eid, s, events);
+    }
+    else
+    {
+        throw CUDTException(MJ_NOTSUP, MN_SIDINVAL);
+    }
 
-   return ret;
+    return ret;
 }
 
 // NOTE: WILL LOCK (serially):
@@ -2381,16 +2376,14 @@ int srt::CUDTUnited::epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, cons
     return ret;
 }
 
-int srt::CUDTUnited::epoll_add_ssock(
-   const int eid, const SYSSOCKET s, const int* events)
+int srt::CUDTUnited::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
-   return m_EPoll.add_ssock(eid, s, events);
+    return m_EPoll.add_ssock(eid, s, events);
 }
 
-int srt::CUDTUnited::epoll_update_ssock(
-   const int eid, const SYSSOCKET s, const int* events)
+int srt::CUDTUnited::epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
-   return m_EPoll.update_ssock(eid, s, events);
+    return m_EPoll.update_ssock(eid, s, events);
 }
 
 template <class EntityType>
@@ -2410,7 +2403,7 @@ int srt::CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
 
     HLOGC(ealog.Debug, log << "epoll_remove_usock: CLEARING subscription on E" << eid << " of @" << ent->id());
     int no_events = 0;
-    int ret = m_EPoll.update_usock(eid, ent->id(), &no_events);
+    int ret       = m_EPoll.update_usock(eid, ent->id(), &no_events);
 
     return ret;
 }
@@ -2430,42 +2423,38 @@ int srt::CUDTUnited::epoll_remove_group_INTERNAL(const int eid, CUDTGroup* g)
 
 int srt::CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
 {
-   CUDTSocket* s = 0;
+    CUDTSocket* s = 0;
 
 #if ENABLE_EXPERIMENTAL_BONDING
-   CUDTGroup* g = 0;
-   if (u & SRTGROUP_MASK)
-   {
-       GroupKeeper k (*this, u, ERH_THROW);
-       g = k.group;
-       return epoll_remove_entity(eid, g);
-   }
-   else
+    CUDTGroup* g = 0;
+    if (u & SRTGROUP_MASK)
+    {
+        GroupKeeper k(*this, u, ERH_THROW);
+        g = k.group;
+        return epoll_remove_entity(eid, g);
+    }
+    else
 #endif
-   {
-       s = locateSocket(u);
-       if (s)
-           return epoll_remove_entity(eid, &s->core());
-   }
+    {
+        s = locateSocket(u);
+        if (s)
+            return epoll_remove_entity(eid, &s->core());
+    }
 
-   LOGC(ealog.Error, log << "remove_usock: @" << u
-           << " not found as either socket or group. Removing only from epoll system.");
-   int no_events = 0;
-   return m_EPoll.update_usock(eid, u, &no_events);
+    LOGC(ealog.Error,
+         log << "remove_usock: @" << u << " not found as either socket or group. Removing only from epoll system.");
+    int no_events = 0;
+    return m_EPoll.update_usock(eid, u, &no_events);
 }
 
 int srt::CUDTUnited::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
-   return m_EPoll.remove_ssock(eid, s);
+    return m_EPoll.remove_ssock(eid, s);
 }
 
-int srt::CUDTUnited::epoll_uwait(
-   const int eid,
-   SRT_EPOLL_EVENT* fdsSet,
-   int fdsSize, 
-   int64_t msTimeOut)
+int srt::CUDTUnited::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
-   return m_EPoll.uwait(eid, fdsSet, fdsSize, msTimeOut);
+    return m_EPoll.uwait(eid, fdsSet, fdsSize, msTimeOut);
 }
 
 int32_t srt::CUDTUnited::epoll_set(int eid, int32_t flags)
@@ -2475,12 +2464,12 @@ int32_t srt::CUDTUnited::epoll_set(int eid, int32_t flags)
 
 int srt::CUDTUnited::epoll_release(const int eid)
 {
-   return m_EPoll.release(eid);
+    return m_EPoll.release(eid);
 }
 
 srt::CUDTSocket* srt::CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling erh)
 {
-    ScopedLock cg (m_GlobControlLock);
+    ScopedLock  cg(m_GlobControlLock);
     CUDTSocket* s = locateSocket_LOCKED(u);
     if (!s)
     {
@@ -2508,339 +2497,331 @@ srt::CUDTSocket* srt::CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
 #if ENABLE_EXPERIMENTAL_BONDING
 srt::CUDTGroup* srt::CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling erh)
 {
-   ScopedLock cg (m_GlobControlLock);
+    ScopedLock cg(m_GlobControlLock);
 
-   const groups_t::iterator i = m_Groups.find(u);
-   if ( i == m_Groups.end() )
-   {
-       if (erh == ERH_THROW)
-           throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
-       return NULL;
-   }
+    const groups_t::iterator i = m_Groups.find(u);
+    if (i == m_Groups.end())
+    {
+        if (erh == ERH_THROW)
+            throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
+        return NULL;
+    }
 
-   ScopedLock cgroup (*i->second->exp_groupLock());
-   i->second->apiAcquire();
-   return i->second;
+    ScopedLock cgroup(*i->second->exp_groupLock());
+    i->second->apiAcquire();
+    return i->second;
 }
 
 srt::CUDTGroup* srt::CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
 {
-   ScopedLock cg (m_GlobControlLock);
-   CUDTGroup* g = s->m_GroupOf;
-   if (!g)
-       return NULL;
+    ScopedLock cg(m_GlobControlLock);
+    CUDTGroup* g = s->m_GroupOf;
+    if (!g)
+        return NULL;
 
-   // With m_GlobControlLock locked, we are sure the group
-   // still exists, if it wasn't removed from this socket.
-   g->apiAcquire();
-   return g;
+    // With m_GlobControlLock locked, we are sure the group
+    // still exists, if it wasn't removed from this socket.
+    g->apiAcquire();
+    return g;
 }
 #endif
 
-srt::CUDTSocket* srt::CUDTUnited::locatePeer(
-   const sockaddr_any& peer,
-   const SRTSOCKET id,
-   int32_t isn)
+srt::CUDTSocket* srt::CUDTUnited::locatePeer(const sockaddr_any& peer, const SRTSOCKET id, int32_t isn)
 {
-   ScopedLock cg(m_GlobControlLock);
+    ScopedLock cg(m_GlobControlLock);
 
-   map<int64_t, set<SRTSOCKET> >::iterator i = m_PeerRec.find(
-      CUDTSocket::getPeerSpec(id, isn));
-   if (i == m_PeerRec.end())
-      return NULL;
+    map<int64_t, set<SRTSOCKET> >::iterator i = m_PeerRec.find(CUDTSocket::getPeerSpec(id, isn));
+    if (i == m_PeerRec.end())
+        return NULL;
 
-   for (set<SRTSOCKET>::iterator j = i->second.begin();
-      j != i->second.end(); ++ j)
-   {
-      sockets_t::iterator k = m_Sockets.find(*j);
-      // this socket might have been closed and moved m_ClosedSockets
-      if (k == m_Sockets.end())
-         continue;
+    for (set<SRTSOCKET>::iterator j = i->second.begin(); j != i->second.end(); ++j)
+    {
+        sockets_t::iterator k = m_Sockets.find(*j);
+        // this socket might have been closed and moved m_ClosedSockets
+        if (k == m_Sockets.end())
+            continue;
 
-      if (k->second->m_PeerAddr == peer)
-      {
-         return k->second;
-      }
-   }
+        if (k->second->m_PeerAddr == peer)
+        {
+            return k->second;
+        }
+    }
 
-   return NULL;
+    return NULL;
 }
 
 void srt::CUDTUnited::checkBrokenSockets()
 {
-   ScopedLock cg(m_GlobControlLock);
+    ScopedLock cg(m_GlobControlLock);
 
 #if ENABLE_EXPERIMENTAL_BONDING
-   vector<SRTSOCKET> delgids;
+    vector<SRTSOCKET> delgids;
 
-   for (groups_t::iterator i = m_ClosedGroups.begin(); i != m_ClosedGroups.end(); ++i)
-   {
-       // isStillBusy requires lock on the group, so only after an API
-       // function that uses it returns, and so clears the busy flag,
-       // a new API function won't be called anyway until it can acquire
-       // GlobControlLock, and all functions that have already seen this
-       // group as closing will not continue with the API and return.
-       // If we caught some API function still using the closed group,
-       // it's not going to wait, will be checked next time.
-       if (i->second->isStillBusy())
-           continue;
-
-       delgids.push_back(i->first);
-       delete i->second;
-       i->second = NULL; // just for a case, avoid a dangling pointer
-   }
-
-   for (vector<SRTSOCKET>::iterator di = delgids.begin(); di != delgids.end(); ++di)
-   {
-       m_ClosedGroups.erase(*di);
-   }
-#endif
-
-   // set of sockets To Be Closed and To Be Removed
-   vector<SRTSOCKET> tbc;
-   vector<SRTSOCKET> tbr;
-
-   for (sockets_t::iterator i = m_Sockets.begin(); i != m_Sockets.end(); ++ i)
-   {
-      CUDTSocket* s = i->second;
-      if (!s->core().m_bBroken)
-         continue;
-
-      if (s->m_Status == SRTS_LISTENING)
-      {
-         const steady_clock::duration elapsed = steady_clock::now() - s->m_tsClosureTimeStamp;
-         // A listening socket should wait an extra 3 seconds
-         // in case a client is connecting.
-         if (elapsed < milliseconds_from(CUDT::COMM_CLOSE_BROKEN_LISTENER_TIMEOUT_MS))
+    for (groups_t::iterator i = m_ClosedGroups.begin(); i != m_ClosedGroups.end(); ++i)
+    {
+        // isStillBusy requires lock on the group, so only after an API
+        // function that uses it returns, and so clears the busy flag,
+        // a new API function won't be called anyway until it can acquire
+        // GlobControlLock, and all functions that have already seen this
+        // group as closing will not continue with the API and return.
+        // If we caught some API function still using the closed group,
+        // it's not going to wait, will be checked next time.
+        if (i->second->isStillBusy())
             continue;
-      }
-      else if ((s->core().m_pRcvBuffer != NULL)
-         // FIXED: calling isRcvDataAvailable() just to get the information
-         // whether there are any data waiting in the buffer,
-         // NOT WHETHER THEY ARE ALSO READY TO PLAY at the time when
-         // this function is called (isRcvDataReady also checks if the
-         // available data is "ready to play").
-#if ENABLE_NEW_RCVBUFFER
-         && s->core().m_pRcvBuffer->hasAvailablePackets())
-#else
-         && s->core().m_pRcvBuffer->isRcvDataAvailable())
+
+        delgids.push_back(i->first);
+        delete i->second;
+        i->second = NULL; // just for a case, avoid a dangling pointer
+    }
+
+    for (vector<SRTSOCKET>::iterator di = delgids.begin(); di != delgids.end(); ++di)
+    {
+        m_ClosedGroups.erase(*di);
+    }
 #endif
-      {
+
+    // set of sockets To Be Closed and To Be Removed
+    vector<SRTSOCKET> tbc;
+    vector<SRTSOCKET> tbr;
+
+    for (sockets_t::iterator i = m_Sockets.begin(); i != m_Sockets.end(); ++i)
+    {
+        CUDTSocket* s = i->second;
+        if (!s->core().m_bBroken)
+            continue;
+
+        if (s->m_Status == SRTS_LISTENING)
+        {
+            const steady_clock::duration elapsed = steady_clock::now() - s->m_tsClosureTimeStamp;
+            // A listening socket should wait an extra 3 seconds
+            // in case a client is connecting.
+            if (elapsed < milliseconds_from(CUDT::COMM_CLOSE_BROKEN_LISTENER_TIMEOUT_MS))
+                continue;
+        }
+        else if ((s->core().m_pRcvBuffer != NULL)
+        // FIXED: calling isRcvDataAvailable() just to get the information
+        // whether there are any data waiting in the buffer,
+        // NOT WHETHER THEY ARE ALSO READY TO PLAY at the time when
+        // this function is called (isRcvDataReady also checks if the
+        // available data is "ready to play").
+#if ENABLE_NEW_RCVBUFFER
+                 && s->core().m_pRcvBuffer->hasAvailablePackets())
+#else
+                 && s->core().m_pRcvBuffer->isRcvDataAvailable())
+#endif
+        {
             const int bc = s->core().m_iBrokenCounter.load();
             if (bc > 0)
             {
-               // if there is still data in the receiver buffer, wait longer
-               s->core().m_iBrokenCounter.store(bc - 1);
-               continue;
+                // if there is still data in the receiver buffer, wait longer
+                s->core().m_iBrokenCounter.store(bc - 1);
+                continue;
             }
-      }
+        }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-      if (s->m_GroupOf)
-      {
-         LOGC(smlog.Note, log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
-         s->removeFromGroup(true);
-      }
+        if (s->m_GroupOf)
+        {
+            LOGC(smlog.Note,
+                 log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
+            s->removeFromGroup(true);
+        }
 #endif
 
-      HLOGC(smlog.Debug, log << "checkBrokenSockets: moving BROKEN socket to CLOSED: @" << i->first);
+        HLOGC(smlog.Debug, log << "checkBrokenSockets: moving BROKEN socket to CLOSED: @" << i->first);
 
-      //close broken connections and start removal timer
-      s->setClosed();
-      tbc.push_back(i->first);
-      m_ClosedSockets[i->first] = s;
+        // close broken connections and start removal timer
+        s->setClosed();
+        tbc.push_back(i->first);
+        m_ClosedSockets[i->first] = s;
 
-      // remove from listener's queue
-      sockets_t::iterator ls = m_Sockets.find(s->m_ListenSocket);
-      if (ls == m_Sockets.end())
-      {
-         ls = m_ClosedSockets.find(s->m_ListenSocket);
-         if (ls == m_ClosedSockets.end())
-            continue;
-      }
+        // remove from listener's queue
+        sockets_t::iterator ls = m_Sockets.find(s->m_ListenSocket);
+        if (ls == m_Sockets.end())
+        {
+            ls = m_ClosedSockets.find(s->m_ListenSocket);
+            if (ls == m_ClosedSockets.end())
+                continue;
+        }
 
-      enterCS(ls->second->m_AcceptLock);
-      ls->second->m_QueuedSockets.erase(s->m_SocketID);
-      leaveCS(ls->second->m_AcceptLock);
-   }
+        enterCS(ls->second->m_AcceptLock);
+        ls->second->m_QueuedSockets.erase(s->m_SocketID);
+        leaveCS(ls->second->m_AcceptLock);
+    }
 
-   for (sockets_t::iterator j = m_ClosedSockets.begin();
-      j != m_ClosedSockets.end(); ++ j)
-   {
-      // HLOGF(smlog.Debug, "checking CLOSED socket: %d\n", j->first);
-      if (!is_zero(j->second->core().m_tsLingerExpiration))
-      {
-         // asynchronous close:
-         if ((!j->second->core().m_pSndBuffer)
-            || (0 == j->second->core().m_pSndBuffer->getCurrBufSize())
-            || (j->second->core().m_tsLingerExpiration <= steady_clock::now()))
-         {
-            HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << j->second->m_SocketID);
-            j->second->core().m_tsLingerExpiration = steady_clock::time_point();
-            j->second->core().m_bClosing = true;
-            j->second->m_tsClosureTimeStamp = steady_clock::now();
-         }
-      }
+    for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
+    {
+        // HLOGF(smlog.Debug, "checking CLOSED socket: %d\n", j->first);
+        if (!is_zero(j->second->core().m_tsLingerExpiration))
+        {
+            // asynchronous close:
+            if ((!j->second->core().m_pSndBuffer) || (0 == j->second->core().m_pSndBuffer->getCurrBufSize()) ||
+                (j->second->core().m_tsLingerExpiration <= steady_clock::now()))
+            {
+                HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << j->second->m_SocketID);
+                j->second->core().m_tsLingerExpiration = steady_clock::time_point();
+                j->second->core().m_bClosing           = true;
+                j->second->m_tsClosureTimeStamp        = steady_clock::now();
+            }
+        }
 
-      // timeout 1 second to destroy a socket AND it has been removed from
-      // RcvUList
-      const steady_clock::time_point now = steady_clock::now();
-      const steady_clock::duration closed_ago = now - j->second->m_tsClosureTimeStamp;
-      if (closed_ago > seconds_from(1))
-      {
-          CRNode* rnode = j->second->core().m_pRNode;
-          if (!rnode || !rnode->m_bOnList)
-          {
-              HLOGC(smlog.Debug, log << "checkBrokenSockets: @" << j->second->m_SocketID << " closed "
-                      << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
+        // timeout 1 second to destroy a socket AND it has been removed from
+        // RcvUList
+        const steady_clock::time_point now        = steady_clock::now();
+        const steady_clock::duration   closed_ago = now - j->second->m_tsClosureTimeStamp;
+        if (closed_ago > seconds_from(1))
+        {
+            CRNode* rnode = j->second->core().m_pRNode;
+            if (!rnode || !rnode->m_bOnList)
+            {
+                HLOGC(smlog.Debug,
+                      log << "checkBrokenSockets: @" << j->second->m_SocketID << " closed "
+                          << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
 
-              // HLOGF(smlog.Debug, "will unref socket: %d\n", j->first);
-              tbr.push_back(j->first);
-          }
-      }
-   }
+                // HLOGF(smlog.Debug, "will unref socket: %d\n", j->first);
+                tbr.push_back(j->first);
+            }
+        }
+    }
 
-   // move closed sockets to the ClosedSockets structure
-   for (vector<SRTSOCKET>::iterator k = tbc.begin(); k != tbc.end(); ++ k)
-      m_Sockets.erase(*k);
+    // move closed sockets to the ClosedSockets structure
+    for (vector<SRTSOCKET>::iterator k = tbc.begin(); k != tbc.end(); ++k)
+        m_Sockets.erase(*k);
 
-   // remove those timeout sockets
-   for (vector<SRTSOCKET>::iterator l = tbr.begin(); l != tbr.end(); ++ l)
-      removeSocket(*l);
+    // remove those timeout sockets
+    for (vector<SRTSOCKET>::iterator l = tbr.begin(); l != tbr.end(); ++l)
+        removeSocket(*l);
 }
 
 // [[using locked(m_GlobControlLock)]]
 void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
 {
-   sockets_t::iterator i = m_ClosedSockets.find(u);
+    sockets_t::iterator i = m_ClosedSockets.find(u);
 
-   // invalid socket ID
-   if (i == m_ClosedSockets.end())
-      return;
+    // invalid socket ID
+    if (i == m_ClosedSockets.end())
+        return;
 
-   CUDTSocket* const s = i->second;
+    CUDTSocket* const s = i->second;
 
-   // The socket may be in the trashcan now, but could
-   // still be under processing in the sender/receiver worker
-   // threads. If that's the case, SKIP IT THIS TIME. The
-   // socket will be checked next time the GC rollover starts.
-   CSNode* sn = s->core().m_pSNode;
-   if (sn && sn->m_iHeapLoc != -1)
-       return;
+    // The socket may be in the trashcan now, but could
+    // still be under processing in the sender/receiver worker
+    // threads. If that's the case, SKIP IT THIS TIME. The
+    // socket will be checked next time the GC rollover starts.
+    CSNode* sn = s->core().m_pSNode;
+    if (sn && sn->m_iHeapLoc != -1)
+        return;
 
-   CRNode* rn = s->core().m_pRNode;
-   if (rn && rn->m_bOnList)
-       return;
-
+    CRNode* rn = s->core().m_pRNode;
+    if (rn && rn->m_bOnList)
+        return;
 
 #if ENABLE_EXPERIMENTAL_BONDING
-   if (s->m_GroupOf)
-   {
-       HLOGC(smlog.Debug, log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
-       s->removeFromGroup(true);
-   }
+    if (s->m_GroupOf)
+    {
+        HLOGC(smlog.Debug,
+              log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
+        s->removeFromGroup(true);
+    }
 #endif
-   // decrease multiplexer reference count, and remove it if necessary
-   const int mid = s->m_iMuxID;
+    // decrease multiplexer reference count, and remove it if necessary
+    const int mid = s->m_iMuxID;
 
-   {
-      ScopedLock cg(s->m_AcceptLock);
+    {
+        ScopedLock cg(s->m_AcceptLock);
 
-      // if it is a listener, close all un-accepted sockets in its queue
-      // and remove them later
-      for (set<SRTSOCKET>::iterator q = s->m_QueuedSockets.begin();
-         q != s->m_QueuedSockets.end(); ++ q)
-      {
-         sockets_t::iterator si = m_Sockets.find(*q);
-         if (si == m_Sockets.end())
-         {
-            // gone in the meantime
-            LOGC(smlog.Error, log << "removeSocket: IPE? socket @" << (*q)
-                    << " being queued for listener socket @" << s->m_SocketID
-                    << " is GONE in the meantime ???");
-            continue;
-         }
+        // if it is a listener, close all un-accepted sockets in its queue
+        // and remove them later
+        for (set<SRTSOCKET>::iterator q = s->m_QueuedSockets.begin(); q != s->m_QueuedSockets.end(); ++q)
+        {
+            sockets_t::iterator si = m_Sockets.find(*q);
+            if (si == m_Sockets.end())
+            {
+                // gone in the meantime
+                LOGC(smlog.Error,
+                     log << "removeSocket: IPE? socket @" << (*q) << " being queued for listener socket @"
+                         << s->m_SocketID << " is GONE in the meantime ???");
+                continue;
+            }
 
-         CUDTSocket* as = si->second;
+            CUDTSocket* as = si->second;
 
-         as->breakSocket_LOCKED();
-         m_ClosedSockets[*q] = as;
-         m_Sockets.erase(*q);
-      }
-   }
+            as->breakSocket_LOCKED();
+            m_ClosedSockets[*q] = as;
+            m_Sockets.erase(*q);
+        }
+    }
 
-   // remove from peer rec
-   map<int64_t, set<SRTSOCKET> >::iterator j = m_PeerRec.find(
-      s->getPeerSpec());
-   if (j != m_PeerRec.end())
-   {
-      j->second.erase(u);
-      if (j->second.empty())
-         m_PeerRec.erase(j);
-   }
+    // remove from peer rec
+    map<int64_t, set<SRTSOCKET> >::iterator j = m_PeerRec.find(s->getPeerSpec());
+    if (j != m_PeerRec.end())
+    {
+        j->second.erase(u);
+        if (j->second.empty())
+            m_PeerRec.erase(j);
+    }
 
-   /*
-   * Socket may be deleted while still having ePoll events set that would
-   * remains forever causing epoll_wait to unblock continuously for inexistent
-   * sockets. Get rid of all events for this socket.
-   */
-   m_EPoll.update_events(u, s->core().m_sPollID,
-      SRT_EPOLL_IN|SRT_EPOLL_OUT|SRT_EPOLL_ERR, false);
+    /*
+     * Socket may be deleted while still having ePoll events set that would
+     * remains forever causing epoll_wait to unblock continuously for inexistent
+     * sockets. Get rid of all events for this socket.
+     */
+    m_EPoll.update_events(u, s->core().m_sPollID, SRT_EPOLL_IN | SRT_EPOLL_OUT | SRT_EPOLL_ERR, false);
 
-   // delete this one
-   m_ClosedSockets.erase(i);
+    // delete this one
+    m_ClosedSockets.erase(i);
 
-   HLOGC(smlog.Debug, log << "GC/removeSocket: closing associated UDT @" << u);
-   s->core().closeInternal();
-   HLOGC(smlog.Debug, log << "GC/removeSocket: DELETING SOCKET @" << u);
-   delete s;
+    HLOGC(smlog.Debug, log << "GC/removeSocket: closing associated UDT @" << u);
+    s->core().closeInternal();
+    HLOGC(smlog.Debug, log << "GC/removeSocket: DELETING SOCKET @" << u);
+    delete s;
 
-   if (mid == -1)
-       return;
+    if (mid == -1)
+        return;
 
-   map<int, CMultiplexer>::iterator m;
-   m = m_mMultiplexer.find(mid);
-   if (m == m_mMultiplexer.end())
-   {
-      LOGC(smlog.Fatal, log << "IPE: For socket @" << u << " MUXER id=" << mid << " NOT FOUND!");
-      return;
-   }
+    map<int, CMultiplexer>::iterator m;
+    m = m_mMultiplexer.find(mid);
+    if (m == m_mMultiplexer.end())
+    {
+        LOGC(smlog.Fatal, log << "IPE: For socket @" << u << " MUXER id=" << mid << " NOT FOUND!");
+        return;
+    }
 
-   CMultiplexer& mx = m->second;
+    CMultiplexer& mx = m->second;
 
-   mx.m_iRefCount --;
-   // HLOGF(smlog.Debug, "unrefing underlying socket for %u: %u\n",
-   //    u, mx.m_iRefCount);
-   if (0 == mx.m_iRefCount)
-   {
-       HLOGC(smlog.Debug, log << "MUXER id=" << mid << " lost last socket @"
-           << u << " - deleting muxer bound to port "
-           << mx.m_pChannel->bindAddressAny().hport());
-      // The channel has no access to the queues and
-      // it looks like the multiplexer is the master of all of them.
-      // The queues must be silenced before closing the channel
-      // because this will cause error to be returned in any operation
-      // being currently done in the queues, if any.
-      mx.m_pSndQueue->setClosing();
-      mx.m_pRcvQueue->setClosing();
-      mx.destroy();
-      m_mMultiplexer.erase(m);
-   }
+    mx.m_iRefCount--;
+    // HLOGF(smlog.Debug, "unrefing underlying socket for %u: %u\n",
+    //    u, mx.m_iRefCount);
+    if (0 == mx.m_iRefCount)
+    {
+        HLOGC(smlog.Debug,
+              log << "MUXER id=" << mid << " lost last socket @" << u << " - deleting muxer bound to port "
+                  << mx.m_pChannel->bindAddressAny().hport());
+        // The channel has no access to the queues and
+        // it looks like the multiplexer is the master of all of them.
+        // The queues must be silenced before closing the channel
+        // because this will cause error to be returned in any operation
+        // being currently done in the queues, if any.
+        mx.m_pSndQueue->setClosing();
+        mx.m_pRcvQueue->setClosing();
+        mx.destroy();
+        m_mMultiplexer.erase(m);
+    }
 }
 
 void srt::CUDTUnited::configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int af)
 {
-   w_m.m_mcfg = s->core().m_config;
-   w_m.m_iIPversion = af;
-   w_m.m_iRefCount = 1;
-   w_m.m_iID = s->m_SocketID;
+    w_m.m_mcfg       = s->core().m_config;
+    w_m.m_iIPversion = af;
+    w_m.m_iRefCount  = 1;
+    w_m.m_iID        = s->m_SocketID;
 }
 
 uint16_t srt::CUDTUnited::installMuxer(CUDTSocket* w_s, CMultiplexer& fw_sm)
 {
     w_s->core().m_pSndQueue = fw_sm.m_pSndQueue;
     w_s->core().m_pRcvQueue = fw_sm.m_pRcvQueue;
-    w_s->m_iMuxID = fw_sm.m_iID;
+    w_s->m_iMuxID           = fw_sm.m_iID;
     sockaddr_any sa;
     fw_sm.m_pChannel->getSockAddr((sa));
     w_s->m_SelfAddr = sa; // Will be also completed later, but here it's needed for later checks
@@ -2865,20 +2846,20 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
     {
         // If not, we need to see if there exist already a multiplexer bound
         // to the same endpoint.
-        const int port = addr.hport();
+        const int         port      = addr.hport();
         const CSrtConfig& cfgSocket = s->core().m_config;
 
         bool reuse_attempt = false;
-        for (map<int, CMultiplexer>::iterator i = m_mMultiplexer.begin();
-                i != m_mMultiplexer.end(); ++ i)
+        for (map<int, CMultiplexer>::iterator i = m_mMultiplexer.begin(); i != m_mMultiplexer.end(); ++i)
         {
             CMultiplexer& m = i->second;
 
             // First, we need to find a multiplexer with the same port.
             if (m.m_iPort != port)
             {
-                HLOGC(smlog.Debug, log << "bind: muxer @" << m.m_iID << " found, but for port "
-                        << m.m_iPort << " (requested port: " << port << ")");
+                HLOGC(smlog.Debug,
+                      log << "bind: muxer @" << m.m_iID << " found, but for port " << m.m_iPort
+                          << " (requested port: " << port << ")");
                 continue;
             }
 
@@ -2889,15 +2870,17 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
             sockaddr_any sa;
             m.m_pChannel->getSockAddr((sa));
 
-            HLOGC(smlog.Debug, log << "bind: Found existing muxer @" << m.m_iID << " : " << sa.str()
-                    << " - check against " << addr.str());
+            HLOGC(smlog.Debug,
+                  log << "bind: Found existing muxer @" << m.m_iID << " : " << sa.str() << " - check against "
+                      << addr.str());
 
             if (sa.isany())
             {
                 if (!addr.isany())
                 {
-                    LOGC(smlog.Error, log << "bind: Address: " << addr.str()
-                            << " conflicts with existing wildcard binding: " << sa.str());
+                    LOGC(smlog.Error,
+                         log << "bind: Address: " << addr.str()
+                             << " conflicts with existing wildcard binding: " << sa.str());
                     throw CUDTException(MJ_NOTSUP, MN_BUSYPORT, 0);
                 }
 
@@ -2905,17 +2888,18 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
                 // for families.
                 if (m.m_mcfg.iIpV6Only != -1 && m.m_mcfg.iIpV6Only != cfgSocket.iIpV6Only)
                 {
-                    LOGC(smlog.Error, log << "bind: Address: " << addr.str()
-                            << " conflicts with existing IPv6 wildcard binding: " << sa.str());
+                    LOGC(smlog.Error,
+                         log << "bind: Address: " << addr.str()
+                             << " conflicts with existing IPv6 wildcard binding: " << sa.str());
                     throw CUDTException(MJ_NOTSUP, MN_BUSYPORT, 0);
                 }
 
                 if ((m.m_mcfg.iIpV6Only == 0 || cfgSocket.iIpV6Only == 0) && m.m_iIPversion != addr.family())
                 {
-                    LOGC(smlog.Error, log << "bind: Address: " << addr.str()
-                            << " conflicts with IPv6 wildcard binding: " << sa.str()
-                            << " : family " << (m.m_iIPversion == AF_INET ? "IPv4" : "IPv6")
-                            << " vs. " << (addr.family() == AF_INET ? "IPv4" : "IPv6"));
+                    LOGC(smlog.Error,
+                         log << "bind: Address: " << addr.str() << " conflicts with IPv6 wildcard binding: " << sa.str()
+                             << " : family " << (m.m_iIPversion == AF_INET ? "IPv4" : "IPv6") << " vs. "
+                             << (addr.family() == AF_INET ? "IPv4" : "IPv6"));
                     throw CUDTException(MJ_NOTSUP, MN_BUSYPORT, 0);
                 }
                 reuse_attempt = true;
@@ -2923,8 +2907,9 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
             }
             else if (addr.isany() && addr.family() == sa.family())
             {
-                LOGC(smlog.Error, log << "bind: Wildcard address: " << addr.str()
-                        << " conflicts with existting IP binding: " << sa.str());
+                LOGC(smlog.Error,
+                     log << "bind: Wildcard address: " << addr.str()
+                         << " conflicts with existting IP binding: " << sa.str());
                 throw CUDTException(MJ_NOTSUP, MN_BUSYPORT, 0);
             }
             // If this is bound to a certain address, AND:
@@ -2950,15 +2935,16 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
                 {
                     HLOGC(smlog.Debug, log << "bind: reusing multiplexer for port " << port);
                     // reuse the existing multiplexer
-                    ++ i->second.m_iRefCount;
+                    ++i->second.m_iRefCount;
                     installMuxer((s), (i->second));
                     return;
                 }
                 else
                 {
                     //   - if not, it's a conflict
-                    LOGC(smlog.Error, log << "bind: Address: " << addr.str()
-                            << " conflicts with binding: " << sa.str() << " due to channel settings");
+                    LOGC(smlog.Error,
+                         log << "bind: Address: " << addr.str() << " conflicts with binding: " << sa.str()
+                             << " due to channel settings");
                     throw CUDTException(MJ_NOTSUP, MN_BUSYPORT, 0);
                 }
             }
@@ -2970,63 +2956,61 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
         }
     }
 
-   // a new multiplexer is needed
-   CMultiplexer m;
-   configureMuxer((m), s, addr.family());
+    // a new multiplexer is needed
+    CMultiplexer m;
+    configureMuxer((m), s, addr.family());
 
-   try
-   {
-       m.m_pChannel = new CChannel();
-       m.m_pChannel->setConfig(m.m_mcfg);
+    try
+    {
+        m.m_pChannel = new CChannel();
+        m.m_pChannel->setConfig(m.m_mcfg);
 
-       if (udpsock)
-       {
-           // In this case, addr contains the address
-           // that has been extracted already from the
-           // given socket
-           m.m_pChannel->attach(*udpsock, addr);
-       }
-       else if (addr.empty())
-       {
-           // The case of previously used case of a NULL address.
-           // This here is used to pass family only, in this case
-           // just automatically bind to the "0" address to autoselect
-           // everything.
-           m.m_pChannel->open(addr.family());
-       }
-       else
-       {
-           // If at least the IP address is specified, then bind to that
-           // address, but still possibly autoselect the outgoing port, if the
-           // port was specified as 0.
-           m.m_pChannel->open(addr);
-       }
+        if (udpsock)
+        {
+            // In this case, addr contains the address
+            // that has been extracted already from the
+            // given socket
+            m.m_pChannel->attach(*udpsock, addr);
+        }
+        else if (addr.empty())
+        {
+            // The case of previously used case of a NULL address.
+            // This here is used to pass family only, in this case
+            // just automatically bind to the "0" address to autoselect
+            // everything.
+            m.m_pChannel->open(addr.family());
+        }
+        else
+        {
+            // If at least the IP address is specified, then bind to that
+            // address, but still possibly autoselect the outgoing port, if the
+            // port was specified as 0.
+            m.m_pChannel->open(addr);
+        }
 
-       m.m_pTimer = new CTimer;
-       m.m_pSndQueue = new CSndQueue;
-       m.m_pSndQueue->init(m.m_pChannel, m.m_pTimer);
-       m.m_pRcvQueue = new CRcvQueue;
-       m.m_pRcvQueue->init(
-               32, s->core().maxPayloadSize(), m.m_iIPversion, 1024,
-               m.m_pChannel, m.m_pTimer);
+        m.m_pTimer    = new CTimer;
+        m.m_pSndQueue = new CSndQueue;
+        m.m_pSndQueue->init(m.m_pChannel, m.m_pTimer);
+        m.m_pRcvQueue = new CRcvQueue;
+        m.m_pRcvQueue->init(32, s->core().maxPayloadSize(), m.m_iIPversion, 1024, m.m_pChannel, m.m_pTimer);
 
-       // Rewrite the port here, as it might be only known upon return
-       // from CChannel::open.
-       m.m_iPort = installMuxer((s), m);
-       m_mMultiplexer[m.m_iID] = m;
-   }
-   catch (const CUDTException&)
-   {
-       m.destroy();
-       throw;
-   }
-   catch (...)
-   {
-       m.destroy();
-       throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
+        // Rewrite the port here, as it might be only known upon return
+        // from CChannel::open.
+        m.m_iPort               = installMuxer((s), m);
+        m_mMultiplexer[m.m_iID] = m;
+    }
+    catch (const CUDTException&)
+    {
+        m.destroy();
+        throw;
+    }
+    catch (...)
+    {
+        m.destroy();
+        throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
 
-   HLOGC(smlog.Debug, log << "bind: creating new multiplexer for port " << m.m_iPort);
+    HLOGC(smlog.Debug, log << "bind: creating new multiplexer for port " << m.m_iPort);
 }
 
 // This function is going to find a multiplexer for the port contained
@@ -3036,206 +3020,200 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& addr, const U
 // multiplexer wasn't found by id, the search by port number continues.
 bool srt::CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
 {
-   ScopedLock cg(m_GlobControlLock);
-   const int port = ls->m_SelfAddr.hport();
+    ScopedLock cg(m_GlobControlLock);
+    const int  port = ls->m_SelfAddr.hport();
 
-   HLOGC(smlog.Debug, log << "updateListenerMux: finding muxer of listener socket @"
-           << ls->m_SocketID << " muxid=" << ls->m_iMuxID
-           << " bound=" << ls->m_SelfAddr.str()
-           << " FOR @" << s->m_SocketID << " addr="
-           << s->m_SelfAddr.str() << "_->_" << s->m_PeerAddr.str());
+    HLOGC(smlog.Debug,
+          log << "updateListenerMux: finding muxer of listener socket @" << ls->m_SocketID << " muxid=" << ls->m_iMuxID
+              << " bound=" << ls->m_SelfAddr.str() << " FOR @" << s->m_SocketID << " addr=" << s->m_SelfAddr.str()
+              << "_->_" << s->m_PeerAddr.str());
 
-   // First thing that should be certain here is that there should exist
-   // a muxer with the ID written in the listener socket's mux ID.
+    // First thing that should be certain here is that there should exist
+    // a muxer with the ID written in the listener socket's mux ID.
 
-   CMultiplexer* mux = map_getp(m_mMultiplexer, ls->m_iMuxID);
+    CMultiplexer* mux = map_getp(m_mMultiplexer, ls->m_iMuxID);
 
-   // NOTE:
-   // THIS BELOW CODE is only for a highly unlikely, and probably buggy,
-   // situation when the Multiplexer wasn't found by ID recorded in the listener.
-   CMultiplexer* fallback = NULL;
-   if (!mux)
-   {
-       LOGC(smlog.Error, log << "updateListenerMux: IPE? listener muxer not found by ID, trying by port");
+    // NOTE:
+    // THIS BELOW CODE is only for a highly unlikely, and probably buggy,
+    // situation when the Multiplexer wasn't found by ID recorded in the listener.
+    CMultiplexer* fallback = NULL;
+    if (!mux)
+    {
+        LOGC(smlog.Error, log << "updateListenerMux: IPE? listener muxer not found by ID, trying by port");
 
-       // To be used as first found with different IP version
+        // To be used as first found with different IP version
 
-       // find the listener's address
-       for (map<int, CMultiplexer>::iterator i = m_mMultiplexer.begin();
-               i != m_mMultiplexer.end(); ++ i)
-       {
-           CMultiplexer& m = i->second;
+        // find the listener's address
+        for (map<int, CMultiplexer>::iterator i = m_mMultiplexer.begin(); i != m_mMultiplexer.end(); ++i)
+        {
+            CMultiplexer& m = i->second;
 
 #if ENABLE_HEAVY_LOGGING
-           ostringstream that_muxer;
-           that_muxer << "id=" << m.m_iID
-               << " port=" << m.m_iPort
-               << " ip=" << (m.m_iIPversion == AF_INET ? "v4" : "v6");
+            ostringstream that_muxer;
+            that_muxer << "id=" << m.m_iID << " port=" << m.m_iPort
+                       << " ip=" << (m.m_iIPversion == AF_INET ? "v4" : "v6");
 #endif
 
-           if (m.m_iPort == port)
-           {
-               HLOGC(smlog.Debug, log << "updateListenerMux: reusing muxer: " << that_muxer.str());
-               if (m.m_iIPversion == s->m_PeerAddr.family())
-               {
-                   mux = &m; // best match
-                   break;
-               }
-               else
-               {
-                   fallback = &m;
-               }
-           }
-           else
-           {
-               HLOGC(smlog.Debug, log << "updateListenerMux: SKIPPING muxer: " << that_muxer.str());
-           }
-       }
+            if (m.m_iPort == port)
+            {
+                HLOGC(smlog.Debug, log << "updateListenerMux: reusing muxer: " << that_muxer.str());
+                if (m.m_iIPversion == s->m_PeerAddr.family())
+                {
+                    mux = &m; // best match
+                    break;
+                }
+                else
+                {
+                    fallback = &m;
+                }
+            }
+            else
+            {
+                HLOGC(smlog.Debug, log << "updateListenerMux: SKIPPING muxer: " << that_muxer.str());
+            }
+        }
 
-       if (!mux && fallback)
-       {
-           // It is allowed to reuse this multiplexer, but the socket must allow both IPv4 and IPv6
-           if (fallback->m_mcfg.iIpV6Only == 0)
-           {
-               HLOGC(smlog.Warn, log << "updateListenerMux: reusing multiplexer from different family");
-               mux = fallback;
-           }
-       }
-   }
+        if (!mux && fallback)
+        {
+            // It is allowed to reuse this multiplexer, but the socket must allow both IPv4 and IPv6
+            if (fallback->m_mcfg.iIpV6Only == 0)
+            {
+                HLOGC(smlog.Warn, log << "updateListenerMux: reusing multiplexer from different family");
+                mux = fallback;
+            }
+        }
+    }
 
-   // Checking again because the above procedure could have set it
-   if (mux)
-   {
-       // reuse the existing multiplexer
-       ++ mux->m_iRefCount;
-       s->core().m_pSndQueue = mux->m_pSndQueue;
-       s->core().m_pRcvQueue = mux->m_pRcvQueue;
-       s->m_iMuxID = mux->m_iID;
-       return true;
-   }
+    // Checking again because the above procedure could have set it
+    if (mux)
+    {
+        // reuse the existing multiplexer
+        ++mux->m_iRefCount;
+        s->core().m_pSndQueue = mux->m_pSndQueue;
+        s->core().m_pRcvQueue = mux->m_pRcvQueue;
+        s->m_iMuxID           = mux->m_iID;
+        return true;
+    }
 
-   return false;
+    return false;
 }
 
 void* srt::CUDTUnited::garbageCollect(void* p)
 {
-   CUDTUnited* self = (CUDTUnited*)p;
+    CUDTUnited* self = (CUDTUnited*)p;
 
-   THREAD_STATE_INIT("SRT:GC");
+    THREAD_STATE_INIT("SRT:GC");
 
-   UniqueLock gclock(self->m_GCStopLock);
+    UniqueLock gclock(self->m_GCStopLock);
 
-   while (!self->m_bClosing)
-   {
-       INCREMENT_THREAD_ITERATIONS();
-       self->checkBrokenSockets();
+    while (!self->m_bClosing)
+    {
+        INCREMENT_THREAD_ITERATIONS();
+        self->checkBrokenSockets();
 
-       HLOGC(inlog.Debug, log << "GC: sleep 1 s");
-       self->m_GCStopCond.wait_for(gclock, seconds_from(1));
-   }
+        HLOGC(inlog.Debug, log << "GC: sleep 1 s");
+        self->m_GCStopCond.wait_for(gclock, seconds_from(1));
+    }
 
-   // remove all sockets and multiplexers
-   HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all pending sockets. Acquring control lock...");
+    // remove all sockets and multiplexers
+    HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all pending sockets. Acquring control lock...");
 
-   {
-       ScopedLock glock (self->m_GlobControlLock);
+    {
+        ScopedLock glock(self->m_GlobControlLock);
 
-       for (sockets_t::iterator i = self->m_Sockets.begin();
-               i != self->m_Sockets.end(); ++ i)
-       {
-           CUDTSocket* s = i->second;
-           s->breakSocket_LOCKED();
+        for (sockets_t::iterator i = self->m_Sockets.begin(); i != self->m_Sockets.end(); ++i)
+        {
+            CUDTSocket* s = i->second;
+            s->breakSocket_LOCKED();
 
 #if ENABLE_EXPERIMENTAL_BONDING
-           if (s->m_GroupOf)
-           {
-               HLOGC(smlog.Debug, log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " (IPE?) - REMOVING FROM GROUP");
-               s->removeFromGroup(false);
-           }
+            if (s->m_GroupOf)
+            {
+                HLOGC(smlog.Debug,
+                      log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id()
+                          << " (IPE?) - REMOVING FROM GROUP");
+                s->removeFromGroup(false);
+            }
 #endif
-           self->m_ClosedSockets[i->first] = s;
+            self->m_ClosedSockets[i->first] = s;
 
-           // remove from listener's queue
-           sockets_t::iterator ls = self->m_Sockets.find(
-                   s->m_ListenSocket);
-           if (ls == self->m_Sockets.end())
-           {
-               ls = self->m_ClosedSockets.find(s->m_ListenSocket);
-               if (ls == self->m_ClosedSockets.end())
-                   continue;
-           }
+            // remove from listener's queue
+            sockets_t::iterator ls = self->m_Sockets.find(s->m_ListenSocket);
+            if (ls == self->m_Sockets.end())
+            {
+                ls = self->m_ClosedSockets.find(s->m_ListenSocket);
+                if (ls == self->m_ClosedSockets.end())
+                    continue;
+            }
 
-           enterCS(ls->second->m_AcceptLock);
-           ls->second->m_QueuedSockets.erase(s->m_SocketID);
-           leaveCS(ls->second->m_AcceptLock);
-       }
-       self->m_Sockets.clear();
+            enterCS(ls->second->m_AcceptLock);
+            ls->second->m_QueuedSockets.erase(s->m_SocketID);
+            leaveCS(ls->second->m_AcceptLock);
+        }
+        self->m_Sockets.clear();
 
-       for (sockets_t::iterator j = self->m_ClosedSockets.begin();
-               j != self->m_ClosedSockets.end(); ++ j)
-       {
-           j->second->m_tsClosureTimeStamp = steady_clock::time_point();
-       }
-   }
+        for (sockets_t::iterator j = self->m_ClosedSockets.begin(); j != self->m_ClosedSockets.end(); ++j)
+        {
+            j->second->m_tsClosureTimeStamp = steady_clock::time_point();
+        }
+    }
 
-   HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all CLOSED sockets.");
-   while (true)
-   {
-      self->checkBrokenSockets();
+    HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all CLOSED sockets.");
+    while (true)
+    {
+        self->checkBrokenSockets();
 
-      enterCS(self->m_GlobControlLock);
-      bool empty = self->m_ClosedSockets.empty();
-      leaveCS(self->m_GlobControlLock);
+        enterCS(self->m_GlobControlLock);
+        bool empty = self->m_ClosedSockets.empty();
+        leaveCS(self->m_GlobControlLock);
 
-      if (empty)
-         break;
+        if (empty)
+            break;
 
-      srt::sync::this_thread::sleep_for(milliseconds_from(1));
-   }
+        srt::sync::this_thread::sleep_for(milliseconds_from(1));
+    }
 
-   THREAD_EXIT();
-   return NULL;
+    THREAD_EXIT();
+    return NULL;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 int srt::CUDT::startup()
 {
-   return uglobal().startup();
+    return uglobal().startup();
 }
 
 int srt::CUDT::cleanup()
 {
-   return uglobal().cleanup();
+    return uglobal().cleanup();
 }
 
 SRTSOCKET srt::CUDT::socket()
 {
-   if (!uglobal().m_bGCStatus)
-      uglobal().startup();
+    if (!uglobal().m_bGCStatus)
+        uglobal().startup();
 
-   try
-   {
-      return uglobal().newSocket();
-   }
-   catch (const CUDTException& e)
-   {
-      SetThreadLocalError(e);
-      return INVALID_SOCK;
-   }
-   catch (const bad_alloc&)
-   {
-      SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
-      return INVALID_SOCK;
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "socket: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name()
-         << ": " << ee.what());
-      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
-      return INVALID_SOCK;
-   }
+    try
+    {
+        return uglobal().newSocket();
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return INVALID_SOCK;
+    }
+    catch (const bad_alloc&)
+    {
+        SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+        return INVALID_SOCK;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "socket: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return INVALID_SOCK;
+    }
 }
 
 srt::CUDT::APIError::APIError(const CUDTException& e)
@@ -3269,7 +3247,7 @@ SRTSOCKET srt::CUDT::createGroup(SRT_GROUP_TYPE gt)
 
     try
     {
-        srt::sync::ScopedLock globlock (uglobal().m_GlobControlLock);
+        srt::sync::ScopedLock globlock(uglobal().m_GlobControlLock);
         return newGroup(gt).id();
         // Note: potentially, after this function exits, the group
         // could be deleted, immediately, from a separate thread (tho
@@ -3289,19 +3267,18 @@ SRTSOCKET srt::CUDT::createGroup(SRT_GROUP_TYPE gt)
     return SRT_INVALID_SOCK;
 }
 
-
 int srt::CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
 {
     // Check if socket and group have been set correctly.
     int32_t sid = socket & ~SRTGROUP_MASK;
-    int32_t gm = group & SRTGROUP_MASK;
+    int32_t gm  = group & SRTGROUP_MASK;
 
-    if ( sid != socket || gm == 0 )
+    if (sid != socket || gm == 0)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
     // Find the socket and the group
-    CUDTSocket* s = uglobal().locateSocket(socket);
-    CUDTUnited::GroupKeeper k (uglobal(), group, CUDTUnited::ERH_RETURN);
+    CUDTSocket*             s = uglobal().locateSocket(socket);
+    CUDTUnited::GroupKeeper k(uglobal(), group, CUDTUnited::ERH_RETURN);
 
     if (!s || !k.group)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
@@ -3321,8 +3298,8 @@ int srt::CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
         g->set_managed(false);
     }
 
-    ScopedLock cg (s->m_ControlLock);
-    ScopedLock cglob (uglobal().m_GlobControlLock);
+    ScopedLock cg(s->m_ControlLock);
+    ScopedLock cglob(uglobal().m_GlobControlLock);
     if (g->closing())
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
@@ -3333,11 +3310,11 @@ int srt::CUDT::addSocketToGroup(SRTSOCKET socket, SRTSOCKET group)
         // XXX This is internal error. Report it, but continue
         LOGC(aclog.Error, log << "IPE (non-fatal): the socket is in the group, but has no clue about it!");
         s->m_GroupMemberData = f;
-        s->m_GroupOf = g;
+        s->m_GroupOf         = g;
         return 0;
     }
     s->m_GroupMemberData = g->add(srt::groups::prepareSocketData(s));
-    s->m_GroupOf = g;
+    s->m_GroupOf         = g;
 
     return 0;
 }
@@ -3353,8 +3330,8 @@ int srt::CUDT::removeSocketFromGroup(SRTSOCKET socket)
     if (!s->m_GroupOf)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
-    ScopedLock cg (s->m_ControlLock);
-    ScopedLock glob_grd (uglobal().m_GlobControlLock);
+    ScopedLock cg(s->m_ControlLock);
+    ScopedLock glob_grd(uglobal().m_GlobControlLock);
     s->removeFromGroup(false);
     return 0;
 }
@@ -3371,7 +3348,7 @@ void srt::CUDTSocket::removeFromGroup(bool broken)
         // a short moment between removal from the group container and the end,
         // while the GroupLock would be already taken out. It is safer to reset
         // it to a NULL iterator before removal.
-        m_GroupOf = NULL;
+        m_GroupOf         = NULL;
         m_GroupMemberData = NULL;
 
         bool still_have = g->remove(m_SocketID);
@@ -3385,8 +3362,9 @@ void srt::CUDTSocket::removeFromGroup(bool broken)
             g->activateUpdateEvent(still_have);
         }
 
-        HLOGC(smlog.Debug, log << "removeFromGroup: socket @" << m_SocketID << " NO LONGER A MEMBER of $" << g->id() << "; group is "
-                << (still_have ? "still ACTIVE" : "now EMPTY"));
+        HLOGC(smlog.Debug,
+              log << "removeFromGroup: socket @" << m_SocketID << " NO LONGER A MEMBER of $" << g->id() << "; group is "
+                  << (still_have ? "still ACTIVE" : "now EMPTY"));
     }
 }
 
@@ -3394,7 +3372,7 @@ SRTSOCKET srt::CUDT::getGroupOfSocket(SRTSOCKET socket)
 {
     // Lock this for the whole function as we need the group
     // to persist the call.
-    ScopedLock glock (uglobal().m_GlobControlLock);
+    ScopedLock  glock(uglobal().m_GlobControlLock);
     CUDTSocket* s = uglobal().locateSocket_LOCKED(socket);
     if (!s || !s->m_GroupOf)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
@@ -3404,12 +3382,12 @@ SRTSOCKET srt::CUDT::getGroupOfSocket(SRTSOCKET socket)
 
 int srt::CUDT::configureGroup(SRTSOCKET groupid, const char* str)
 {
-    if ( (groupid & SRTGROUP_MASK) == 0)
+    if ((groupid & SRTGROUP_MASK) == 0)
     {
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
     }
 
-    CUDTUnited::GroupKeeper k (uglobal(), groupid, CUDTUnited::ERH_RETURN);
+    CUDTUnited::GroupKeeper k(uglobal(), groupid, CUDTUnited::ERH_RETURN);
     if (!k.group)
     {
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
@@ -3425,7 +3403,7 @@ int srt::CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t*
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
     }
 
-    CUDTUnited::GroupKeeper k (uglobal(), groupid, CUDTUnited::ERH_RETURN);
+    CUDTUnited::GroupKeeper k(uglobal(), groupid, CUDTUnited::ERH_RETURN);
     if (!k.group)
     {
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
@@ -3438,38 +3416,36 @@ int srt::CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t*
 
 int srt::CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
 {
-   try
-   {
-       sockaddr_any sa (name, namelen);
-       if (sa.len == 0)
-       {
-           // This happens if the namelen check proved it to be
-           // too small for particular family, or that family is
-           // not recognized (is none of AF_INET, AF_INET6).
-           // This is a user error.
-           return APIError(MJ_NOTSUP, MN_INVAL, 0);
-       }
-       CUDTSocket* s = uglobal().locateSocket(u);
-       if (!s)
-           return APIError(MJ_NOTSUP, MN_INVAL, 0);
+    try
+    {
+        sockaddr_any sa(name, namelen);
+        if (sa.len == 0)
+        {
+            // This happens if the namelen check proved it to be
+            // too small for particular family, or that family is
+            // not recognized (is none of AF_INET, AF_INET6).
+            // This is a user error.
+            return APIError(MJ_NOTSUP, MN_INVAL, 0);
+        }
+        CUDTSocket* s = uglobal().locateSocket(u);
+        if (!s)
+            return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
-       return uglobal().bind(s, sa);
-   }
-   catch (const CUDTException& e)
-   {
-       return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-       return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "bind: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name()
-         << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+        return uglobal().bind(s, sa);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "bind: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
@@ -3492,115 +3468,108 @@ int srt::CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
     }
     catch (const std::exception& ee)
     {
-        LOGC(aclog.Fatal, log << "bind/udp: UNEXPECTED EXCEPTION: "
-                << typeid(ee).name() << ": " << ee.what());
+        LOGC(aclog.Fatal, log << "bind/udp: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
         return APIError(MJ_UNKNOWN, MN_NONE, 0);
     }
 }
 
 int srt::CUDT::listen(SRTSOCKET u, int backlog)
 {
-   try
-   {
-      return uglobal().listen(u, backlog);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "listen: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().listen(u, backlog);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "listen: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-SRTSOCKET srt::CUDT::accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut)
+SRTSOCKET srt::CUDT::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut)
 {
-   try
-   {
-      return uglobal().accept_bond(listeners, lsize, msTimeOut);
-   }
-   catch (const CUDTException& e)
-   {
-      SetThreadLocalError(e);
-      return INVALID_SOCK;
-   }
-   catch (bad_alloc&)
-   {
-      SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
-      return INVALID_SOCK;
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "accept_bond: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
-      return INVALID_SOCK;
-   }
+    try
+    {
+        return uglobal().accept_bond(listeners, lsize, msTimeOut);
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return INVALID_SOCK;
+    }
+    catch (bad_alloc&)
+    {
+        SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+        return INVALID_SOCK;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "accept_bond: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return INVALID_SOCK;
+    }
 }
 
 SRTSOCKET srt::CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
 {
-   try
-   {
-      return uglobal().accept(u, addr, addrlen);
-   }
-   catch (const CUDTException& e)
-   {
-      SetThreadLocalError(e);
-      return INVALID_SOCK;
-   }
-   catch (const bad_alloc&)
-   {
-      SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
-      return INVALID_SOCK;
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "accept: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
-      return INVALID_SOCK;
-   }
+    try
+    {
+        return uglobal().accept(u, addr, addrlen);
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return INVALID_SOCK;
+    }
+    catch (const bad_alloc&)
+    {
+        SetThreadLocalError(CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0));
+        return INVALID_SOCK;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "accept: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return INVALID_SOCK;
+    }
 }
 
-int srt::CUDT::connect(
-    SRTSOCKET u, const sockaddr* name, const sockaddr* tname, int namelen)
+int srt::CUDT::connect(SRTSOCKET u, const sockaddr* name, const sockaddr* tname, int namelen)
 {
-   try
-   {
-      return uglobal().connect(u, name, tname, namelen);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "connect: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().connect(u, name, tname, namelen);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "connect: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
-int srt::CUDT::connectLinks(SRTSOCKET grp,
-        SRT_SOCKGROUPCONFIG targets [], int arraysize)
+int srt::CUDT::connectLinks(SRTSOCKET grp, SRT_SOCKGROUPCONFIG targets[], int arraysize)
 {
     if (arraysize <= 0)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
-    if ( (grp & SRTGROUP_MASK) == 0)
+    if ((grp & SRTGROUP_MASK) == 0)
     {
         // connectLinks accepts only GROUP id, not socket id.
         return APIError(MJ_NOTSUP, MN_SIDINVAL, 0);
@@ -3621,94 +3590,87 @@ int srt::CUDT::connectLinks(SRTSOCKET grp,
     }
     catch (std::exception& ee)
     {
-        LOGC(aclog.Fatal, log << "connect: UNEXPECTED EXCEPTION: "
-                << typeid(ee).name() << ": " << ee.what());
+        LOGC(aclog.Fatal, log << "connect: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
         return APIError(MJ_UNKNOWN, MN_NONE, 0);
     }
 }
 #endif
 
-int srt::CUDT::connect(
-   SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
+int srt::CUDT::connect(SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
-   try
-   {
-      return uglobal().connect(u, name, namelen, forced_isn);
-   }
-   catch (const CUDTException &e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "connect: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().connect(u, name, namelen, forced_isn);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "connect: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::close(SRTSOCKET u)
 {
-   try
-   {
-      return uglobal().close(u);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "close: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().close(u);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "close: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
 {
-   try
-   {
-      uglobal().getpeername(u, name, namelen);
-      return 0;
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "getpeername: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        uglobal().getpeername(u, name, namelen);
+        return 0;
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "getpeername: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
 {
-   try
-   {
-      uglobal().getsockname(u, name, namelen);
-      return 0;
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "getsockname: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        uglobal().getsockname(u, name, namelen);
+        return 0;
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "getsockname: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::getsockopt(
-   SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_optval, int* pw_optlen)
+int srt::CUDT::getsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_optval, int* pw_optlen)
 {
     if (!pw_optval || !pw_optlen)
     {
@@ -3736,42 +3698,40 @@ int srt::CUDT::getsockopt(
     }
     catch (const std::exception& ee)
     {
-        LOGC(aclog.Fatal, log << "getsockopt: UNEXPECTED EXCEPTION: "
-                << typeid(ee).name() << ": " << ee.what());
+        LOGC(aclog.Fatal, log << "getsockopt: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
         return APIError(MJ_UNKNOWN, MN_NONE, 0);
     }
 }
 
 int srt::CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, int optlen)
 {
-   if (!optval)
-       return APIError(MJ_NOTSUP, MN_INVAL, 0);
+    if (!optval)
+        return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
-   try
-   {
+    try
+    {
 #if ENABLE_EXPERIMENTAL_BONDING
-       if (u & SRTGROUP_MASK)
-       {
-           CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
-           k.group->setOpt(optname, optval, optlen);
-           return 0;
-       }
+        if (u & SRTGROUP_MASK)
+        {
+            CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
+            k.group->setOpt(optname, optval, optlen);
+            return 0;
+        }
 #endif
 
-       CUDT& udt = uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
-       udt.setOpt(optname, optval, optlen);
-       return 0;
-   }
-   catch (const CUDTException& e)
-   {
-       return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-       LOGC(aclog.Fatal, log << "setsockopt: UNEXPECTED EXCEPTION: "
-               << typeid(ee).name() << ": " << ee.what());
-       return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+        CUDT& udt = uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
+        udt.setOpt(optname, optval, optlen);
+        return 0;
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "setsockopt: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::send(SRTSOCKET u, const char* buf, int len, int)
@@ -3782,507 +3742,468 @@ int srt::CUDT::send(SRTSOCKET u, const char* buf, int len, int)
 
 // --> CUDT::recv moved down
 
-int srt::CUDT::sendmsg(
-   SRTSOCKET u, const char* buf, int len, int ttl, bool inorder,
-   int64_t srctime)
+int srt::CUDT::sendmsg(SRTSOCKET u, const char* buf, int len, int ttl, bool inorder, int64_t srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
-    mctrl.msgttl = ttl;
-    mctrl.inorder = inorder;
-    mctrl.srctime = srctime;
+    mctrl.msgttl      = ttl;
+    mctrl.inorder     = inorder;
+    mctrl.srctime     = srctime;
     return sendmsg2(u, buf, len, (mctrl));
 }
 
-int srt::CUDT::sendmsg2(
-   SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
+int srt::CUDT::sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
 {
-   try
-   {
+    try
+    {
 #if ENABLE_EXPERIMENTAL_BONDING
-       if (u & SRTGROUP_MASK)
-       {
-           CUDTUnited::GroupKeeper k (uglobal(), u, CUDTUnited::ERH_THROW);
-           return k.group->send(buf, len, (w_m));
-       }
+        if (u & SRTGROUP_MASK)
+        {
+            CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
+            return k.group->send(buf, len, (w_m));
+        }
 #endif
 
-       return uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core().sendmsg2(buf, len, (w_m));
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "sendmsg: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+        return uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core().sendmsg2(buf, len, (w_m));
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "sendmsg: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::recv(SRTSOCKET u, char* buf, int len, int)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
-    int ret = recvmsg2(u, buf, len, (mctrl));
+    int         ret   = recvmsg2(u, buf, len, (mctrl));
     return ret;
 }
 
 int srt::CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
-    int ret = recvmsg2(u, buf, len, (mctrl));
-    srctime = mctrl.srctime;
+    int         ret   = recvmsg2(u, buf, len, (mctrl));
+    srctime           = mctrl.srctime;
     return ret;
 }
 
 int srt::CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
 {
-   try
-   {
+    try
+    {
 #if ENABLE_EXPERIMENTAL_BONDING
-      if (u & SRTGROUP_MASK)
-      {
-          CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
-          return k.group->recv(buf, len, (w_m));
-      }
+        if (u & SRTGROUP_MASK)
+        {
+            CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
+            return k.group->recv(buf, len, (w_m));
+        }
 #endif
 
-      return uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core().recvmsg2(buf, len, (w_m));
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "recvmsg: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+        return uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core().recvmsg2(buf, len, (w_m));
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "recvmsg: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int64_t srt::CUDT::sendfile(
-   SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
+int64_t srt::CUDT::sendfile(SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
 {
-   try
-   {
-      CUDT& udt = uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
-      return udt.sendfile(ifs, offset, size, block);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "sendfile: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        CUDT& udt = uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
+        return udt.sendfile(ifs, offset, size, block);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "sendfile: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int64_t srt::CUDT::recvfile(
-   SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
+int64_t srt::CUDT::recvfile(SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
 {
-   try
-   {
-       return uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core().recvfile(ofs, offset, size, block);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "recvfile: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core().recvfile(ofs, offset, size, block);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "recvfile: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::select(
-   int,
-   UDT::UDSET* readfds,
-   UDT::UDSET* writefds,
-   UDT::UDSET* exceptfds,
-   const timeval* timeout)
+int srt::CUDT::select(int, UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout)
 {
-   if ((!readfds) && (!writefds) && (!exceptfds))
-   {
-      return APIError(MJ_NOTSUP, MN_INVAL, 0);
-   }
+    if ((!readfds) && (!writefds) && (!exceptfds))
+    {
+        return APIError(MJ_NOTSUP, MN_INVAL, 0);
+    }
 
-   try
-   {
-      return uglobal().select(readfds, writefds, exceptfds, timeout);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "select: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().select(readfds, writefds, exceptfds, timeout);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "select: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::selectEx(
-   const vector<SRTSOCKET>& fds,
-   vector<SRTSOCKET>* readfds,
-   vector<SRTSOCKET>* writefds,
-   vector<SRTSOCKET>* exceptfds,
-   int64_t msTimeOut)
+int srt::CUDT::selectEx(const vector<SRTSOCKET>& fds,
+                        vector<SRTSOCKET>*       readfds,
+                        vector<SRTSOCKET>*       writefds,
+                        vector<SRTSOCKET>*       exceptfds,
+                        int64_t                  msTimeOut)
 {
-   if ((!readfds) && (!writefds) && (!exceptfds))
-   {
-      return APIError(MJ_NOTSUP, MN_INVAL, 0);
-   }
+    if ((!readfds) && (!writefds) && (!exceptfds))
+    {
+        return APIError(MJ_NOTSUP, MN_INVAL, 0);
+    }
 
-   try
-   {
-      return uglobal().selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (bad_alloc&)
-   {
-      return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "selectEx: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN);
-   }
+    try
+    {
+        return uglobal().selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (bad_alloc&)
+    {
+        return APIError(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "selectEx: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN);
+    }
 }
 
 int srt::CUDT::epoll_create()
 {
-   try
-   {
-      return uglobal().epoll_create();
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_create: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_create();
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_create: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::epoll_clear_usocks(int eid)
 {
-   try
-   {
-      return uglobal().epoll_clear_usocks(eid);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_clear_usocks: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_clear_usocks(eid);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (std::exception& ee)
+    {
+        LOGC(aclog.Fatal,
+             log << "epoll_clear_usocks: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
 {
-   try
-   {
-      return uglobal().epoll_add_usock(eid, u, events);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_add_usock: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_add_usock(eid, u, events);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_add_usock: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
-   try
-   {
-      return uglobal().epoll_add_ssock(eid, s, events);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_add_ssock: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_add_ssock(eid, s, events);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_add_ssock: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::epoll_update_usock(
-   const int eid, const SRTSOCKET u, const int* events)
+int srt::CUDT::epoll_update_usock(const int eid, const SRTSOCKET u, const int* events)
 {
-   try
-   {
-      return uglobal().epoll_add_usock(eid, u, events);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_update_usock: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_add_usock(eid, u, events);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal,
+             log << "epoll_update_usock: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::epoll_update_ssock(
-   const int eid, const SYSSOCKET s, const int* events)
+int srt::CUDT::epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
-   try
-   {
-      return uglobal().epoll_update_ssock(eid, s, events);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_update_ssock: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_update_ssock(eid, s, events);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal,
+             log << "epoll_update_ssock: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
-
 
 int srt::CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
 {
-   try
-   {
-      return uglobal().epoll_remove_usock(eid, u);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_remove_usock: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_remove_usock(eid, u);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal,
+             log << "epoll_remove_usock: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
-   try
-   {
-      return uglobal().epoll_remove_ssock(eid, s);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_remove_ssock: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_remove_ssock(eid, s);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal,
+             log << "epoll_remove_ssock: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::epoll_wait(
-   const int eid,
-   set<SRTSOCKET>* readfds,
-   set<SRTSOCKET>* writefds,
-   int64_t msTimeOut,
-   set<SYSSOCKET>* lrfds,
-   set<SYSSOCKET>* lwfds)
+int srt::CUDT::epoll_wait(const int       eid,
+                          set<SRTSOCKET>* readfds,
+                          set<SRTSOCKET>* writefds,
+                          int64_t         msTimeOut,
+                          set<SYSSOCKET>* lrfds,
+                          set<SYSSOCKET>* lwfds)
 {
-   try
-   {
-      return uglobal().epoll_ref().wait(
-              eid, readfds, writefds, msTimeOut, lrfds, lwfds);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_wait: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_ref().wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_wait: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int srt::CUDT::epoll_uwait(
-   const int eid,
-   SRT_EPOLL_EVENT* fdsSet,
-   int fdsSize,
-   int64_t msTimeOut)
+int srt::CUDT::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
-   try
-   {
-      return uglobal().epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_uwait: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_uwait: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
-int32_t srt::CUDT::epoll_set(
-   const int eid,
-   int32_t flags)
+int32_t srt::CUDT::epoll_set(const int eid, int32_t flags)
 {
-   try
-   {
-      return uglobal().epoll_set(eid, flags);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_set: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_set(eid, flags);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_set: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 int srt::CUDT::epoll_release(const int eid)
 {
-   try
-   {
-      return uglobal().epoll_release(eid);
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "epoll_release: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        return uglobal().epoll_release(eid);
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "epoll_release: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 CUDTException& srt::CUDT::getlasterror()
 {
-   return GetThreadLocalError();
+    return GetThreadLocalError();
 }
 
 int srt::CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
 {
 #if ENABLE_EXPERIMENTAL_BONDING
-   if (u & SRTGROUP_MASK)
-       return groupsockbstats(u, perf, clear);
+    if (u & SRTGROUP_MASK)
+        return groupsockbstats(u, perf, clear);
 #endif
 
-   try
-   {
-      CUDT& udt = uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
-      udt.bstats(perf, clear, instantaneous);
-      return 0;
-   }
-   catch (const CUDTException& e)
-   {
-      return APIError(e);
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "bstats: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      return APIError(MJ_UNKNOWN, MN_NONE, 0);
-   }
+    try
+    {
+        CUDT& udt = uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
+        udt.bstats(perf, clear, instantaneous);
+        return 0;
+    }
+    catch (const CUDTException& e)
+    {
+        return APIError(e);
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "bstats: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        return APIError(MJ_UNKNOWN, MN_NONE, 0);
+    }
 }
 
 #if ENABLE_EXPERIMENTAL_BONDING
 int srt::CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
 {
-   try
-   {
-      CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
-      k.group->bstatsSocket(perf, clear);
-      return 0;
-   }
-   catch (const CUDTException& e)
-   {
-      SetThreadLocalError(e);
-      return ERROR;
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "bstats: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
-      return ERROR;
-   }
+    try
+    {
+        CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
+        k.group->bstatsSocket(perf, clear);
+        return 0;
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return ERROR;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "bstats: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return ERROR;
+    }
 }
 #endif
 
 srt::CUDT* srt::CUDT::getUDTHandle(SRTSOCKET u)
 {
-   try
-   {
-      return &uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
-   }
-   catch (const CUDTException& e)
-   {
-      SetThreadLocalError(e);
-      return NULL;
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "getUDTHandle: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
-      return NULL;
-   }
+    try
+    {
+        return &uglobal().locateSocket(u, CUDTUnited::ERH_THROW)->core();
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return NULL;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "getUDTHandle: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return NULL;
+    }
 }
 
 vector<SRTSOCKET> srt::CUDT::existingSockets()
 {
     vector<SRTSOCKET> out;
-    for (CUDTUnited::sockets_t::iterator i = uglobal().m_Sockets.begin();
-            i != uglobal().m_Sockets.end(); ++i)
+    for (CUDTUnited::sockets_t::iterator i = uglobal().m_Sockets.begin(); i != uglobal().m_Sockets.end(); ++i)
     {
         out.push_back(i->first);
     }
@@ -4291,29 +4212,28 @@ vector<SRTSOCKET> srt::CUDT::existingSockets()
 
 SRT_SOCKSTATUS srt::CUDT::getsockstate(SRTSOCKET u)
 {
-   try
-   {
+    try
+    {
 #if ENABLE_EXPERIMENTAL_BONDING
-      if (isgroup(u))
-      {
-          CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
-          return k.group->getStatus();
-      }
+        if (isgroup(u))
+        {
+            CUDTUnited::GroupKeeper k(uglobal(), u, CUDTUnited::ERH_THROW);
+            return k.group->getStatus();
+        }
 #endif
-      return uglobal().getStatus(u);
-   }
-   catch (const CUDTException& e)
-   {
-      SetThreadLocalError(e);
-      return SRTS_NONEXIST;
-   }
-   catch (const std::exception& ee)
-   {
-      LOGC(aclog.Fatal, log << "getsockstate: UNEXPECTED EXCEPTION: "
-         << typeid(ee).name() << ": " << ee.what());
-      SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
-      return SRTS_NONEXIST;
-   }
+        return uglobal().getStatus(u);
+    }
+    catch (const CUDTException& e)
+    {
+        SetThreadLocalError(e);
+        return SRTS_NONEXIST;
+    }
+    catch (const std::exception& ee)
+    {
+        LOGC(aclog.Fatal, log << "getsockstate: UNEXPECTED EXCEPTION: " << typeid(ee).name() << ": " << ee.what());
+        SetThreadLocalError(CUDTException(MJ_UNKNOWN, MN_NONE, 0));
+        return SRTS_NONEXIST;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -4323,172 +4243,140 @@ namespace UDT
 
 int startup()
 {
-   return srt::CUDT::startup();
+    return srt::CUDT::startup();
 }
 
 int cleanup()
 {
-   return srt::CUDT::cleanup();
+    return srt::CUDT::cleanup();
 }
 
 int bind(SRTSOCKET u, const struct sockaddr* name, int namelen)
 {
-   return srt::CUDT::bind(u, name, namelen);
+    return srt::CUDT::bind(u, name, namelen);
 }
 
 int bind2(SRTSOCKET u, UDPSOCKET udpsock)
 {
-   return srt::CUDT::bind(u, udpsock);
+    return srt::CUDT::bind(u, udpsock);
 }
 
 int listen(SRTSOCKET u, int backlog)
 {
-   return srt::CUDT::listen(u, backlog);
+    return srt::CUDT::listen(u, backlog);
 }
 
 SRTSOCKET accept(SRTSOCKET u, struct sockaddr* addr, int* addrlen)
 {
-   return srt::CUDT::accept(u, addr, addrlen);
+    return srt::CUDT::accept(u, addr, addrlen);
 }
 
 int connect(SRTSOCKET u, const struct sockaddr* name, int namelen)
 {
-   return srt::CUDT::connect(u, name, namelen, SRT_SEQNO_NONE);
+    return srt::CUDT::connect(u, name, namelen, SRT_SEQNO_NONE);
 }
 
 int close(SRTSOCKET u)
 {
-   return srt::CUDT::close(u);
+    return srt::CUDT::close(u);
 }
 
 int getpeername(SRTSOCKET u, struct sockaddr* name, int* namelen)
 {
-   return srt::CUDT::getpeername(u, name, namelen);
+    return srt::CUDT::getpeername(u, name, namelen);
 }
 
 int getsockname(SRTSOCKET u, struct sockaddr* name, int* namelen)
 {
-   return srt::CUDT::getsockname(u, name, namelen);
+    return srt::CUDT::getsockname(u, name, namelen);
 }
 
-int getsockopt(
-   SRTSOCKET u, int level, SRT_SOCKOPT optname, void* optval, int* optlen)
+int getsockopt(SRTSOCKET u, int level, SRT_SOCKOPT optname, void* optval, int* optlen)
 {
-   return srt::CUDT::getsockopt(u, level, optname, optval, optlen);
+    return srt::CUDT::getsockopt(u, level, optname, optval, optlen);
 }
 
-int setsockopt(
-   SRTSOCKET u, int level, SRT_SOCKOPT optname, const void* optval, int optlen)
+int setsockopt(SRTSOCKET u, int level, SRT_SOCKOPT optname, const void* optval, int optlen)
 {
-   return srt::CUDT::setsockopt(u, level, optname, optval, optlen);
+    return srt::CUDT::setsockopt(u, level, optname, optval, optlen);
 }
 
 // DEVELOPER API
 
-int connect_debug(
-   SRTSOCKET u, const struct sockaddr* name, int namelen, int32_t forced_isn)
+int connect_debug(SRTSOCKET u, const struct sockaddr* name, int namelen, int32_t forced_isn)
 {
-   return srt::CUDT::connect(u, name, namelen, forced_isn);
+    return srt::CUDT::connect(u, name, namelen, forced_isn);
 }
 
 int send(SRTSOCKET u, const char* buf, int len, int flags)
 {
-   return srt::CUDT::send(u, buf, len, flags);
+    return srt::CUDT::send(u, buf, len, flags);
 }
 
 int recv(SRTSOCKET u, char* buf, int len, int flags)
 {
-   return srt::CUDT::recv(u, buf, len, flags);
+    return srt::CUDT::recv(u, buf, len, flags);
 }
 
-
-int sendmsg(
-   SRTSOCKET u, const char* buf, int len, int ttl, bool inorder,
-   int64_t srctime)
+int sendmsg(SRTSOCKET u, const char* buf, int len, int ttl, bool inorder, int64_t srctime)
 {
-   return srt::CUDT::sendmsg(u, buf, len, ttl, inorder, srctime);
+    return srt::CUDT::sendmsg(u, buf, len, ttl, inorder, srctime);
 }
 
 int recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
 {
-   return srt::CUDT::recvmsg(u, buf, len, srctime);
+    return srt::CUDT::recvmsg(u, buf, len, srctime);
 }
 
 int recvmsg(SRTSOCKET u, char* buf, int len)
 {
-   int64_t srctime;
-   return srt::CUDT::recvmsg(u, buf, len, srctime);
+    int64_t srctime;
+    return srt::CUDT::recvmsg(u, buf, len, srctime);
 }
 
-int64_t sendfile(
-   SRTSOCKET u,
-   fstream& ifs,
-   int64_t& offset,
-   int64_t size,
-   int block)
+int64_t sendfile(SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
 {
-   return srt::CUDT::sendfile(u, ifs, offset, size, block);
+    return srt::CUDT::sendfile(u, ifs, offset, size, block);
 }
 
-int64_t recvfile(
-   SRTSOCKET u,
-   fstream& ofs,
-   int64_t& offset,
-   int64_t size,
-   int block)
+int64_t recvfile(SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
 {
-   return srt::CUDT::recvfile(u, ofs, offset, size, block);
+    return srt::CUDT::recvfile(u, ofs, offset, size, block);
 }
 
-int64_t sendfile2(
-   SRTSOCKET u,
-   const char* path,
-   int64_t* offset,
-   int64_t size,
-   int block)
+int64_t sendfile2(SRTSOCKET u, const char* path, int64_t* offset, int64_t size, int block)
 {
-   fstream ifs(path, ios::binary | ios::in);
-   int64_t ret = srt::CUDT::sendfile(u, ifs, *offset, size, block);
-   ifs.close();
-   return ret;
+    fstream ifs(path, ios::binary | ios::in);
+    int64_t ret = srt::CUDT::sendfile(u, ifs, *offset, size, block);
+    ifs.close();
+    return ret;
 }
 
-int64_t recvfile2(
-   SRTSOCKET u,
-   const char* path,
-   int64_t* offset,
-   int64_t size,
-   int block)
+int64_t recvfile2(SRTSOCKET u, const char* path, int64_t* offset, int64_t size, int block)
 {
-   fstream ofs(path, ios::binary | ios::out);
-   int64_t ret = srt::CUDT::recvfile(u, ofs, *offset, size, block);
-   ofs.close();
-   return ret;
+    fstream ofs(path, ios::binary | ios::out);
+    int64_t ret = srt::CUDT::recvfile(u, ofs, *offset, size, block);
+    ofs.close();
+    return ret;
 }
 
-int select(
-   int nfds,
-   UDSET* readfds,
-   UDSET* writefds,
-   UDSET* exceptfds,
-   const struct timeval* timeout)
+int select(int nfds, UDSET* readfds, UDSET* writefds, UDSET* exceptfds, const struct timeval* timeout)
 {
-   return srt::CUDT::select(nfds, readfds, writefds, exceptfds, timeout);
+    return srt::CUDT::select(nfds, readfds, writefds, exceptfds, timeout);
 }
 
-int selectEx(
-   const vector<SRTSOCKET>& fds,
-   vector<SRTSOCKET>* readfds,
-   vector<SRTSOCKET>* writefds,
-   vector<SRTSOCKET>* exceptfds,
-   int64_t msTimeOut)
+int selectEx(const vector<SRTSOCKET>& fds,
+             vector<SRTSOCKET>*       readfds,
+             vector<SRTSOCKET>*       writefds,
+             vector<SRTSOCKET>*       exceptfds,
+             int64_t                  msTimeOut)
 {
-   return srt::CUDT::selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
+    return srt::CUDT::selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
 }
 
 int epoll_create()
 {
-   return srt::CUDT::epoll_create();
+    return srt::CUDT::epoll_create();
 }
 
 int epoll_clear_usocks(int eid)
@@ -4498,49 +4386,48 @@ int epoll_clear_usocks(int eid)
 
 int epoll_add_usock(int eid, SRTSOCKET u, const int* events)
 {
-   return srt::CUDT::epoll_add_usock(eid, u, events);
+    return srt::CUDT::epoll_add_usock(eid, u, events);
 }
 
 int epoll_add_ssock(int eid, SYSSOCKET s, const int* events)
 {
-   return srt::CUDT::epoll_add_ssock(eid, s, events);
+    return srt::CUDT::epoll_add_ssock(eid, s, events);
 }
 
 int epoll_update_usock(int eid, SRTSOCKET u, const int* events)
 {
-   return srt::CUDT::epoll_update_usock(eid, u, events);
+    return srt::CUDT::epoll_update_usock(eid, u, events);
 }
 
 int epoll_update_ssock(int eid, SYSSOCKET s, const int* events)
 {
-   return srt::CUDT::epoll_update_ssock(eid, s, events);
+    return srt::CUDT::epoll_update_ssock(eid, s, events);
 }
 
 int epoll_remove_usock(int eid, SRTSOCKET u)
 {
-   return srt::CUDT::epoll_remove_usock(eid, u);
+    return srt::CUDT::epoll_remove_usock(eid, u);
 }
 
 int epoll_remove_ssock(int eid, SYSSOCKET s)
 {
-   return srt::CUDT::epoll_remove_ssock(eid, s);
+    return srt::CUDT::epoll_remove_ssock(eid, s);
 }
 
-int epoll_wait(
-   int eid,
-   set<SRTSOCKET>* readfds,
-   set<SRTSOCKET>* writefds,
-   int64_t msTimeOut,
-   set<SYSSOCKET>* lrfds,
-   set<SYSSOCKET>* lwfds)
+int epoll_wait(int             eid,
+               set<SRTSOCKET>* readfds,
+               set<SRTSOCKET>* writefds,
+               int64_t         msTimeOut,
+               set<SYSSOCKET>* lrfds,
+               set<SYSSOCKET>* lwfds)
 {
-   return srt::CUDT::epoll_wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
+    return srt::CUDT::epoll_wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
 }
 
 template <class SOCKTYPE>
 inline void set_result(set<SOCKTYPE>* val, int* num, SOCKTYPE* fds)
 {
-    if ( !val || !num || !fds )
+    if (!val || !num || !fds)
         return;
 
     if (*num > int(val->size()))
@@ -4548,110 +4435,111 @@ inline void set_result(set<SOCKTYPE>* val, int* num, SOCKTYPE* fds)
     int count = 0;
 
     // This loop will run 0 times if val->empty()
-    for (typename set<SOCKTYPE>::const_iterator it = val->begin(); it != val->end(); ++ it)
+    for (typename set<SOCKTYPE>::const_iterator it = val->begin(); it != val->end(); ++it)
     {
         if (count >= *num)
             break;
-        fds[count ++] = *it;
+        fds[count++] = *it;
     }
 }
 
-int epoll_wait2(
-   int eid, SRTSOCKET* readfds,
-   int* rnum, SRTSOCKET* writefds,
-   int* wnum,
-   int64_t msTimeOut,
-   SYSSOCKET* lrfds,
-   int* lrnum,
-   SYSSOCKET* lwfds,
-   int* lwnum)
+int epoll_wait2(int        eid,
+                SRTSOCKET* readfds,
+                int*       rnum,
+                SRTSOCKET* writefds,
+                int*       wnum,
+                int64_t    msTimeOut,
+                SYSSOCKET* lrfds,
+                int*       lrnum,
+                SYSSOCKET* lwfds,
+                int*       lwnum)
 {
-   // This API is an alternative format for epoll_wait, created for
-   // compatability with other languages. Users need to pass in an array
-   // for holding the returned sockets, with the maximum array length
-   // stored in *rnum, etc., which will be updated with returned number
-   // of sockets.
+    // This API is an alternative format for epoll_wait, created for
+    // compatability with other languages. Users need to pass in an array
+    // for holding the returned sockets, with the maximum array length
+    // stored in *rnum, etc., which will be updated with returned number
+    // of sockets.
 
-   set<SRTSOCKET> readset;
-   set<SRTSOCKET> writeset;
-   set<SYSSOCKET> lrset;
-   set<SYSSOCKET> lwset;
-   set<SRTSOCKET>* rval = NULL;
-   set<SRTSOCKET>* wval = NULL;
-   set<SYSSOCKET>* lrval = NULL;
-   set<SYSSOCKET>* lwval = NULL;
-   if ((readfds != NULL) && (rnum != NULL))
-      rval = &readset;
-   if ((writefds != NULL) && (wnum != NULL))
-      wval = &writeset;
-   if ((lrfds != NULL) && (lrnum != NULL))
-      lrval = &lrset;
-   if ((lwfds != NULL) && (lwnum != NULL))
-      lwval = &lwset;
+    set<SRTSOCKET>  readset;
+    set<SRTSOCKET>  writeset;
+    set<SYSSOCKET>  lrset;
+    set<SYSSOCKET>  lwset;
+    set<SRTSOCKET>* rval  = NULL;
+    set<SRTSOCKET>* wval  = NULL;
+    set<SYSSOCKET>* lrval = NULL;
+    set<SYSSOCKET>* lwval = NULL;
+    if ((readfds != NULL) && (rnum != NULL))
+        rval = &readset;
+    if ((writefds != NULL) && (wnum != NULL))
+        wval = &writeset;
+    if ((lrfds != NULL) && (lrnum != NULL))
+        lrval = &lrset;
+    if ((lwfds != NULL) && (lwnum != NULL))
+        lwval = &lwset;
 
-   int ret = srt::CUDT::epoll_wait(eid, rval, wval, msTimeOut, lrval, lwval);
-   if (ret > 0)
-   {
-      //set<SRTSOCKET>::const_iterator i;
-      //SET_RESULT(rval, rnum, readfds, i);
-      set_result(rval, rnum, readfds);
-      //SET_RESULT(wval, wnum, writefds, i);
-      set_result(wval, wnum, writefds);
+    int ret = srt::CUDT::epoll_wait(eid, rval, wval, msTimeOut, lrval, lwval);
+    if (ret > 0)
+    {
+        // set<SRTSOCKET>::const_iterator i;
+        // SET_RESULT(rval, rnum, readfds, i);
+        set_result(rval, rnum, readfds);
+        // SET_RESULT(wval, wnum, writefds, i);
+        set_result(wval, wnum, writefds);
 
-      //set<SYSSOCKET>::const_iterator j;
-      //SET_RESULT(lrval, lrnum, lrfds, j);
-      set_result(lrval, lrnum, lrfds);
-      //SET_RESULT(lwval, lwnum, lwfds, j);
-      set_result(lwval, lwnum, lwfds);
-   }
-   return ret;
+        // set<SYSSOCKET>::const_iterator j;
+        // SET_RESULT(lrval, lrnum, lrfds, j);
+        set_result(lrval, lrnum, lrfds);
+        // SET_RESULT(lwval, lwnum, lwfds, j);
+        set_result(lwval, lwnum, lwfds);
+    }
+    return ret;
 }
 
 int epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
-   return srt::CUDT::epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
+    return srt::CUDT::epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
 }
 
 int epoll_release(int eid)
 {
-   return srt::CUDT::epoll_release(eid);
+    return srt::CUDT::epoll_release(eid);
 }
 
 ERRORINFO& getlasterror()
 {
-   return srt::CUDT::getlasterror();
+    return srt::CUDT::getlasterror();
 }
 
 int getlasterror_code()
 {
-   return srt::CUDT::getlasterror().getErrorCode();
+    return srt::CUDT::getlasterror().getErrorCode();
 }
 
 const char* getlasterror_desc()
 {
-   return srt::CUDT::getlasterror().getErrorMessage();
+    return srt::CUDT::getlasterror().getErrorMessage();
 }
 
 int getlasterror_errno()
 {
-   return srt::CUDT::getlasterror().getErrno();
+    return srt::CUDT::getlasterror().getErrno();
 }
 
 // Get error string of a given error code
 const char* geterror_desc(int code, int err)
 {
-   CUDTException e (CodeMajor(code/1000), CodeMinor(code%1000), err);
-   return(e.getErrorMessage());
+    CUDTException e(CodeMajor(code / 1000), CodeMinor(code % 1000), err);
+    return (e.getErrorMessage());
 }
 
 int bstats(SRTSOCKET u, SRT_TRACEBSTATS* perf, bool clear)
 {
-   return srt::CUDT::bstats(u, perf, clear);
+    return srt::CUDT::bstats(u, perf, clear);
 }
 
 SRT_SOCKSTATUS getsockstate(SRTSOCKET u)
 {
-   return srt::CUDT::getsockstate(u);
+    return srt::CUDT::getsockstate(u);
 }
 
 } // namespace UDT
@@ -4702,7 +4590,7 @@ void setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler)
 {
     ScopedLock gg(srt_logger_config.mutex);
     srt_logger_config.loghandler_opaque = opaque;
-    srt_logger_config.loghandler_fn = handler;
+    srt_logger_config.loghandler_fn     = handler;
 }
 
 void setlogflags(int flags)
@@ -4730,4 +4618,4 @@ int setrejectreason(SRTSOCKET u, int value)
     return CUDT::rejectReason(u, value);
 }
 
-}  // namespace srt
+} // namespace srt

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -1,11 +1,11 @@
 /*
  * SRT - Secure, Reliable, Transport
  * Copyright (c) 2018 Haivision Systems Inc.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- * 
+ *
  */
 
 /*****************************************************************************
@@ -45,14 +45,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*****************************************************************************
 written by
-   Yunhong Gu, last updated 09/28/2010
+    Yunhong Gu, last updated 09/28/2010
 modified by
-   Haivision Systems Inc.
+    Haivision Systems Inc.
 *****************************************************************************/
 
 #ifndef INC_SRT_API_H
 #define INC_SRT_API_H
-
 
 #include <map>
 #include <vector>
@@ -72,7 +71,8 @@ modified by
 // Please refer to structure and locking information provided in the
 // docs/dev/low-level-info.md document.
 
-namespace srt {
+namespace srt
+{
 
 class CUDT;
 
@@ -81,406 +81,401 @@ class CUDT;
 class CUDTSocket
 {
 public:
-   CUDTSocket()
-       : m_Status(SRTS_INIT)
-       , m_SocketID(0)
-       , m_ListenSocket(0)
-       , m_PeerID(0)
+    CUDTSocket()
+        : m_Status(SRTS_INIT)
+        , m_SocketID(0)
+        , m_ListenSocket(0)
+        , m_PeerID(0)
 #if ENABLE_EXPERIMENTAL_BONDING
-       , m_GroupMemberData()
-       , m_GroupOf()
+        , m_GroupMemberData()
+        , m_GroupOf()
 #endif
-       , m_iISN(0)
-       , m_UDT(this)
-       , m_AcceptCond()
-       , m_AcceptLock()
-       , m_uiBackLog(0)
-       , m_iMuxID(-1)
-   {
-       construct();
-   }
+        , m_iISN(0)
+        , m_UDT(this)
+        , m_AcceptCond()
+        , m_AcceptLock()
+        , m_uiBackLog(0)
+        , m_iMuxID(-1)
+    {
+        construct();
+    }
 
-   CUDTSocket(const CUDTSocket& ancestor)
-       : m_Status(SRTS_INIT)
-       , m_SocketID(0)
-       , m_ListenSocket(0)
-       , m_PeerID(0)
+    CUDTSocket(const CUDTSocket& ancestor)
+        : m_Status(SRTS_INIT)
+        , m_SocketID(0)
+        , m_ListenSocket(0)
+        , m_PeerID(0)
 #if ENABLE_EXPERIMENTAL_BONDING
-       , m_GroupMemberData()
-       , m_GroupOf()
+        , m_GroupMemberData()
+        , m_GroupOf()
 #endif
-       , m_iISN(0)
-       , m_UDT(this, ancestor.m_UDT)
-       , m_AcceptCond()
-       , m_AcceptLock()
-       , m_uiBackLog(0)
-       , m_iMuxID(-1)
-   {
-       construct();
-   }
+        , m_iISN(0)
+        , m_UDT(this, ancestor.m_UDT)
+        , m_AcceptCond()
+        , m_AcceptLock()
+        , m_uiBackLog(0)
+        , m_iMuxID(-1)
+    {
+        construct();
+    }
 
-   ~CUDTSocket();
+    ~CUDTSocket();
 
-   void construct();
+    void construct();
 
-   SRT_ATTR_GUARDED_BY(m_ControlLock)
-   sync::atomic<SRT_SOCKSTATUS> m_Status;                  //< current socket state
+    SRT_ATTR_GUARDED_BY(m_ControlLock)
+    sync::atomic<SRT_SOCKSTATUS> m_Status; //< current socket state
 
-   /// Time when the socket is closed.
-   /// When the socket is closed, it is not removed immediately from the list
-   /// of sockets in order to prevent other methods from accessing invalid address.
-   /// A timer is started and the socket will be removed after approximately
-   /// 1 second (see CUDTUnited::checkBrokenSockets()).
-   sync::steady_clock::time_point m_tsClosureTimeStamp;
+    /// Time when the socket is closed.
+    /// When the socket is closed, it is not removed immediately from the list
+    /// of sockets in order to prevent other methods from accessing invalid address.
+    /// A timer is started and the socket will be removed after approximately
+    /// 1 second (see CUDTUnited::checkBrokenSockets()).
+    sync::steady_clock::time_point m_tsClosureTimeStamp;
 
-   sockaddr_any m_SelfAddr;                  //< local address of the socket
-   sockaddr_any m_PeerAddr;                  //< peer address of the socket
+    sockaddr_any m_SelfAddr; //< local address of the socket
+    sockaddr_any m_PeerAddr; //< peer address of the socket
 
-   SRTSOCKET m_SocketID;                     //< socket ID
-   SRTSOCKET m_ListenSocket;                 //< ID of the listener socket; 0 means this is an independent socket
+    SRTSOCKET m_SocketID;     //< socket ID
+    SRTSOCKET m_ListenSocket; //< ID of the listener socket; 0 means this is an independent socket
 
-   SRTSOCKET m_PeerID;                       //< peer socket ID
+    SRTSOCKET m_PeerID; //< peer socket ID
 #if ENABLE_EXPERIMENTAL_BONDING
-   groups::SocketData* m_GroupMemberData; //< Pointer to group member data, or NULL if not a group member
-   CUDTGroup* m_GroupOf;                       //< Group this socket is a member of, or NULL if it isn't
+    groups::SocketData* m_GroupMemberData; //< Pointer to group member data, or NULL if not a group member
+    CUDTGroup*          m_GroupOf;         //< Group this socket is a member of, or NULL if it isn't
 #endif
 
-   int32_t m_iISN;                           //< initial sequence number, used to tell different connection from same IP:port
+    int32_t m_iISN; //< initial sequence number, used to tell different connection from same IP:port
 
 private:
-   CUDT m_UDT;                               //< internal SRT socket logic
+    CUDT m_UDT; //< internal SRT socket logic
 
 public:
-   std::set<SRTSOCKET> m_QueuedSockets;      //< set of connections waiting for accept()
+    std::set<SRTSOCKET> m_QueuedSockets; //< set of connections waiting for accept()
 
-   sync::Condition m_AcceptCond;             //< used to block "accept" call
-   sync::Mutex m_AcceptLock;                 //< mutex associated to m_AcceptCond
+    sync::Condition m_AcceptCond; //< used to block "accept" call
+    sync::Mutex     m_AcceptLock; //< mutex associated to m_AcceptCond
 
-   unsigned int m_uiBackLog;                 //< maximum number of connections in queue
+    unsigned int m_uiBackLog; //< maximum number of connections in queue
 
-   // XXX A refactoring might be needed here.
+    // XXX A refactoring might be needed here.
 
-   // There are no reasons found why the socket can't contain a list iterator to a
-   // multiplexer INSTEAD of m_iMuxID. There's no danger in this solution because
-   // the multiplexer is never deleted until there's at least one socket using it.
-   //
-   // The multiplexer may even physically be contained in the CUDTUnited object,
-   // just track the multiple users of it (the listener and the accepted sockets).
-   // When deleting, you simply "unsubscribe" yourself from the multiplexer, which
-   // will unref it and remove the list element by the iterator kept by the
-   // socket.
-   int m_iMuxID;                        //< multiplexer ID
+    // There are no reasons found why the socket can't contain a list iterator to a
+    // multiplexer INSTEAD of m_iMuxID. There's no danger in this solution because
+    // the multiplexer is never deleted until there's at least one socket using it.
+    //
+    // The multiplexer may even physically be contained in the CUDTUnited object,
+    // just track the multiple users of it (the listener and the accepted sockets).
+    // When deleting, you simply "unsubscribe" yourself from the multiplexer, which
+    // will unref it and remove the list element by the iterator kept by the
+    // socket.
+    int m_iMuxID; //< multiplexer ID
 
-   sync::Mutex m_ControlLock;           //< lock this socket exclusively for control APIs: bind/listen/connect
+    sync::Mutex m_ControlLock; //< lock this socket exclusively for control APIs: bind/listen/connect
 
-   CUDT& core() { return m_UDT; }
-   const CUDT& core() const { return m_UDT; }
+    CUDT&       core() { return m_UDT; }
+    const CUDT& core() const { return m_UDT; }
 
-   static int64_t getPeerSpec(SRTSOCKET id, int32_t isn)
-   {
-       return (int64_t(id) << 30) + isn;
-   }
-   int64_t getPeerSpec()
-   {
-       return getPeerSpec(m_PeerID, m_iISN);
-   }
+    static int64_t getPeerSpec(SRTSOCKET id, int32_t isn) { return (int64_t(id) << 30) + isn; }
+    int64_t        getPeerSpec() { return getPeerSpec(m_PeerID, m_iISN); }
 
-   SRT_SOCKSTATUS getStatus();
+    SRT_SOCKSTATUS getStatus();
 
-   /// This function shall be called always wherever
-   /// you'd like to call cudtsocket->m_pUDT->close(),
-   /// from within the GC thread only (that is, only when
-   /// the socket should be no longer visible in the
-   /// connection, including for sending remaining data).
-   void breakSocket_LOCKED();
+    /// This function shall be called always wherever
+    /// you'd like to call cudtsocket->m_pUDT->close(),
+    /// from within the GC thread only (that is, only when
+    /// the socket should be no longer visible in the
+    /// connection, including for sending remaining data).
+    void breakSocket_LOCKED();
 
+    /// This makes the socket no longer capable of performing any transmission
+    /// operation, but continues to be responsive in the connection in order
+    /// to finish sending the data that were scheduled for sending so far.
+    void setClosed();
 
-   /// This makes the socket no longer capable of performing any transmission
-   /// operation, but continues to be responsive in the connection in order
-   /// to finish sending the data that were scheduled for sending so far.
-   void setClosed();
+    /// This does the same as setClosed, plus sets the m_bBroken to true.
+    /// Such a socket can still be read from so that remaining data from
+    /// the receiver buffer can be read, but no longer sends anything.
+    void setBrokenClosed();
+    void removeFromGroup(bool broken);
 
-   /// This does the same as setClosed, plus sets the m_bBroken to true.
-   /// Such a socket can still be read from so that remaining data from
-   /// the receiver buffer can be read, but no longer sends anything.
-   void setBrokenClosed();
-   void removeFromGroup(bool broken);
-
-   // Instrumentally used by select() and also required for non-blocking
-   // mode check in groups
-   bool readReady();
-   bool writeReady() const;
-   bool broken() const;
+    // Instrumentally used by select() and also required for non-blocking
+    // mode check in groups
+    bool readReady();
+    bool writeReady() const;
+    bool broken() const;
 
 private:
-   CUDTSocket& operator=(const CUDTSocket&);
+    CUDTSocket& operator=(const CUDTSocket&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 class CUDTUnited
 {
-friend class CUDT;
-friend class CUDTGroup;
-friend class CRendezvousQueue;
+    friend class CUDT;
+    friend class CUDTGroup;
+    friend class CRendezvousQueue;
 
 public:
-   CUDTUnited();
-   ~CUDTUnited();
+    CUDTUnited();
+    ~CUDTUnited();
 
-   // Public constants
-   static const int32_t MAX_SOCKET_VAL = SRTGROUP_MASK - 1;    // maximum value for a regular socket
+    // Public constants
+    static const int32_t MAX_SOCKET_VAL = SRTGROUP_MASK - 1; // maximum value for a regular socket
 
 public:
+    enum ErrorHandling
+    {
+        ERH_RETURN,
+        ERH_THROW,
+        ERH_ABORT
+    };
+    static std::string CONID(SRTSOCKET sock);
 
-   enum ErrorHandling { ERH_RETURN, ERH_THROW, ERH_ABORT };
-   static std::string CONID(SRTSOCKET sock);
+    /// initialize the UDT library.
+    /// @return 0 if success, otherwise -1 is returned.
+    int startup();
 
-      /// initialize the UDT library.
-      /// @return 0 if success, otherwise -1 is returned.
+    /// release the UDT library.
+    /// @return 0 if success, otherwise -1 is returned.
+    int cleanup();
 
-   int startup();
+    /// Create a new UDT socket.
+    /// @param [out] pps Variable (optional) to which the new socket will be written, if succeeded
+    /// @return The new UDT socket ID, or INVALID_SOCK.
+    SRTSOCKET newSocket(CUDTSocket** pps = NULL);
 
-      /// release the UDT library.
-      /// @return 0 if success, otherwise -1 is returned.
+    /// Create a new UDT connection.
+    /// @param [in] listen the listening UDT socket;
+    /// @param [in] peer peer address.
+    /// @param [in,out] hs handshake information from peer side (in), negotiated value (out);
+    /// @param [out] w_error error code when failed
+    /// @param [out] w_acpu entity of accepted socket, if connection already exists
+    /// @return If the new connection is successfully created: 1 success, 0 already exist, -1 error.
+    int newConnection(const SRTSOCKET     listen,
+                      const sockaddr_any& peer,
+                      const CPacket&      hspkt,
+                      CHandShake&         w_hs,
+                      int&                w_error,
+                      CUDT*&              w_acpu);
 
-   int cleanup();
+    int installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);
+    int installConnectHook(const SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq);
 
-      /// Create a new UDT socket.
-      /// @param [out] pps Variable (optional) to which the new socket will be written, if succeeded
-      /// @return The new UDT socket ID, or INVALID_SOCK.
+    /// Check the status of the UDT socket.
+    /// @param [in] u the UDT socket ID.
+    /// @return UDT socket status, or NONEXIST if not found.
+    SRT_SOCKSTATUS getStatus(const SRTSOCKET u);
 
-   SRTSOCKET newSocket(CUDTSocket** pps = NULL);
+    // socket APIs
 
-      /// Create a new UDT connection.
-      /// @param [in] listen the listening UDT socket;
-      /// @param [in] peer peer address.
-      /// @param [in,out] hs handshake information from peer side (in), negotiated value (out);
-      /// @param [out] w_error error code when failed
-      /// @param [out] w_acpu entity of accepted socket, if connection already exists
-      /// @return If the new connection is successfully created: 1 success, 0 already exist, -1 error.
-
-   int newConnection(const SRTSOCKET listen, const sockaddr_any& peer, const CPacket& hspkt,
-           CHandShake& w_hs, int& w_error, CUDT*& w_acpu);
-
-   int installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);
-   int installConnectHook(const SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq);
-
-      /// Check the status of the UDT socket.
-      /// @param [in] u the UDT socket ID.
-      /// @return UDT socket status, or NONEXIST if not found.
-
-   SRT_SOCKSTATUS getStatus(const SRTSOCKET u);
-
-      // socket APIs
-
-   int bind(CUDTSocket* u, const sockaddr_any& name);
-   int bind(CUDTSocket* u, UDPSOCKET udpsock);
-   int listen(const SRTSOCKET u, int backlog);
-   SRTSOCKET accept(const SRTSOCKET listen, sockaddr* addr, int* addrlen);
-   SRTSOCKET accept_bond(const SRTSOCKET listeners [], int lsize, int64_t msTimeOut);
-   int connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int tarlen);
-   int connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
-   int connectIn(CUDTSocket* s, const sockaddr_any& target, int32_t forced_isn);
+    int       bind(CUDTSocket* u, const sockaddr_any& name);
+    int       bind(CUDTSocket* u, UDPSOCKET udpsock);
+    int       listen(const SRTSOCKET u, int backlog);
+    SRTSOCKET accept(const SRTSOCKET listen, sockaddr* addr, int* addrlen);
+    SRTSOCKET accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut);
+    int       connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int tarlen);
+    int       connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn);
+    int       connectIn(CUDTSocket* s, const sockaddr_any& target, int32_t forced_isn);
 #if ENABLE_EXPERIMENTAL_BONDING
-   int groupConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG targets [], int arraysize);
-   int singleMemberConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG* target);
+    int groupConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG targets[], int arraysize);
+    int singleMemberConnect(CUDTGroup* g, SRT_SOCKGROUPCONFIG* target);
 #endif
-   int close(const SRTSOCKET u);
-   int close(CUDTSocket* s);
-   void getpeername(const SRTSOCKET u, sockaddr* name, int* namelen);
-   void getsockname(const SRTSOCKET u, sockaddr* name, int* namelen);
-   int select(UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout);
-   int selectEx(const std::vector<SRTSOCKET>& fds, std::vector<SRTSOCKET>* readfds, std::vector<SRTSOCKET>* writefds, std::vector<SRTSOCKET>* exceptfds, int64_t msTimeOut);
-   int epoll_create();
-   int epoll_clear_usocks(int eid);
-   int epoll_add_usock(const int eid, const SRTSOCKET u, const int* events = NULL);
-   int epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, const int* events);
-   int epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
-   int epoll_remove_usock(const int eid, const SRTSOCKET u);
-   template <class EntityType>
-   int epoll_remove_entity(const int eid, EntityType* ent);
-   int epoll_remove_socket_INTERNAL(const int eid, CUDTSocket* ent);
+    int  close(const SRTSOCKET u);
+    int  close(CUDTSocket* s);
+    void getpeername(const SRTSOCKET u, sockaddr* name, int* namelen);
+    void getsockname(const SRTSOCKET u, sockaddr* name, int* namelen);
+    int  select(UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout);
+    int  selectEx(const std::vector<SRTSOCKET>& fds,
+                  std::vector<SRTSOCKET>*       readfds,
+                  std::vector<SRTSOCKET>*       writefds,
+                  std::vector<SRTSOCKET>*       exceptfds,
+                  int64_t                       msTimeOut);
+    int  epoll_create();
+    int  epoll_clear_usocks(int eid);
+    int  epoll_add_usock(const int eid, const SRTSOCKET u, const int* events = NULL);
+    int  epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, const int* events);
+    int  epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
+    int  epoll_remove_usock(const int eid, const SRTSOCKET u);
+    template <class EntityType>
+    int epoll_remove_entity(const int eid, EntityType* ent);
+    int epoll_remove_socket_INTERNAL(const int eid, CUDTSocket* ent);
 #if ENABLE_EXPERIMENTAL_BONDING
-   int epoll_remove_group_INTERNAL(const int eid, CUDTGroup* ent);
+    int epoll_remove_group_INTERNAL(const int eid, CUDTGroup* ent);
 #endif
-   int epoll_remove_ssock(const int eid, const SYSSOCKET s);
-   int epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
-   int epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
-   int32_t epoll_set(const int eid, int32_t flags);
-   int epoll_release(const int eid);
-
-#if ENABLE_EXPERIMENTAL_BONDING
-   // [[using locked(m_GlobControlLock)]]
-   CUDTGroup& addGroup(SRTSOCKET id, SRT_GROUP_TYPE type)
-   {
-       // This only ensures that the element exists.
-       // If the element was newly added, it will be NULL.
-       CUDTGroup*& g = m_Groups[id];
-       if (!g)
-       {
-           // This is a reference to the cell, so it will
-           // rewrite it into the map.
-           g = new CUDTGroup(type);
-       }
-
-       // Now we are sure that g is not NULL,
-       // and persistence of this object is in the map.
-       // The reference to the object can be safely returned here.
-       return *g;
-   }
-
-   void deleteGroup(CUDTGroup* g);
-   void deleteGroup_LOCKED(CUDTGroup* g);
-
-   // [[using locked(m_GlobControlLock)]]
-   CUDTGroup* findPeerGroup_LOCKED(SRTSOCKET peergroup)
-   {
-       for (groups_t::iterator i = m_Groups.begin();
-               i != m_Groups.end(); ++i)
-       {
-           if (i->second->peerid() == peergroup)
-               return i->second;
-       }
-       return NULL;
-   }
-#endif
-
-   CEPoll& epoll_ref() { return m_EPoll; }
-
-private:
-   /// Generates a new socket ID. This function starts from a randomly
-   /// generated value (at initialization time) and goes backward with
-   /// with next calls. The possible values come from the range without
-   /// the SRTGROUP_MASK bit, and the group bit is set when the ID is
-   /// generated for groups. It is also internally checked if the
-   /// newly generated ID isn't already used by an existing socket or group.
-   /// 
-   /// Socket ID value range.
-   /// - [0]: reserved for handshake procedure. If the destination Socket ID is 0
-   ///   (destination Socket ID unknown) the packet will be sent to the listening socket
-   ///   or to a socket that is in the rendezvous connection phase.
-   /// - [1; 2 ^ 30): single socket ID range.
-   /// - (2 ^ 30; 2 ^ 31): group socket ID range. Effectively any positive number
-   ///   from [1; 2 ^ 30) with bit 30 set to 1. Bit 31 is zero.
-   /// The most significant bit 31 (sign bit) is left unused so that checking for a value <= 0 identifies an invalid socket ID.
-   ///
-   /// @param group The socket id should be for socket group.
-   /// @return The new socket ID.
-   /// @throw CUDTException if after rolling over all possible ID values nothing can be returned
-   SRTSOCKET generateSocketID(bool group = false);
-
-private:
-   typedef std::map<SRTSOCKET, CUDTSocket*> sockets_t;       // stores all the socket structures
-   sockets_t m_Sockets;
+    int     epoll_remove_ssock(const int eid, const SYSSOCKET s);
+    int     epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
+    int     epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
+    int32_t epoll_set(const int eid, int32_t flags);
+    int     epoll_release(const int eid);
 
 #if ENABLE_EXPERIMENTAL_BONDING
-   typedef std::map<SRTSOCKET, CUDTGroup*> groups_t;
-   groups_t m_Groups;
+    // [[using locked(m_GlobControlLock)]]
+    CUDTGroup& addGroup(SRTSOCKET id, SRT_GROUP_TYPE type)
+    {
+        // This only ensures that the element exists.
+        // If the element was newly added, it will be NULL.
+        CUDTGroup*& g = m_Groups[id];
+        if (!g)
+        {
+            // This is a reference to the cell, so it will
+            // rewrite it into the map.
+            g = new CUDTGroup(type);
+        }
+
+        // Now we are sure that g is not NULL,
+        // and persistence of this object is in the map.
+        // The reference to the object can be safely returned here.
+        return *g;
+    }
+
+    void deleteGroup(CUDTGroup* g);
+    void deleteGroup_LOCKED(CUDTGroup* g);
+
+    // [[using locked(m_GlobControlLock)]]
+    CUDTGroup* findPeerGroup_LOCKED(SRTSOCKET peergroup)
+    {
+        for (groups_t::iterator i = m_Groups.begin(); i != m_Groups.end(); ++i)
+        {
+            if (i->second->peerid() == peergroup)
+                return i->second;
+        }
+        return NULL;
+    }
 #endif
 
-   sync::Mutex m_GlobControlLock;               // used to synchronize UDT API
-
-   sync::Mutex m_IDLock;                        // used to synchronize ID generation
-
-   SRTSOCKET m_SocketIDGenerator;               // seed to generate a new unique socket ID
-   SRTSOCKET m_SocketIDGenerator_init;          // Keeps track of the very first one
-
-   std::map<int64_t, std::set<SRTSOCKET> > m_PeerRec;// record sockets from peers to avoid repeated connection request, int64_t = (socker_id << 30) + isn
+    CEPoll& epoll_ref() { return m_EPoll; }
 
 private:
-   friend struct FLookupSocketWithEvent_LOCKED;
+    /// Generates a new socket ID. This function starts from a randomly
+    /// generated value (at initialization time) and goes backward with
+    /// with next calls. The possible values come from the range without
+    /// the SRTGROUP_MASK bit, and the group bit is set when the ID is
+    /// generated for groups. It is also internally checked if the
+    /// newly generated ID isn't already used by an existing socket or group.
+    ///
+    /// Socket ID value range.
+    /// - [0]: reserved for handshake procedure. If the destination Socket ID is 0
+    ///   (destination Socket ID unknown) the packet will be sent to the listening socket
+    ///   or to a socket that is in the rendezvous connection phase.
+    /// - [1; 2 ^ 30): single socket ID range.
+    /// - (2 ^ 30; 2 ^ 31): group socket ID range. Effectively any positive number
+    ///   from [1; 2 ^ 30) with bit 30 set to 1. Bit 31 is zero.
+    /// The most significant bit 31 (sign bit) is left unused so that checking for a value <= 0 identifies an invalid
+    /// socket ID.
+    ///
+    /// @param group The socket id should be for socket group.
+    /// @return The new socket ID.
+    /// @throw CUDTException if after rolling over all possible ID values nothing can be returned
+    SRTSOCKET generateSocketID(bool group = false);
 
-   CUDTSocket* locateSocket(SRTSOCKET u, ErrorHandling erh = ERH_RETURN);
-   // This function does the same as locateSocket, except that:
-   // - lock on m_GlobControlLock is expected (so that you don't unlock between finding and using)
-   // - only return NULL if not found
-   CUDTSocket* locateSocket_LOCKED(SRTSOCKET u);
-   CUDTSocket* locatePeer(const sockaddr_any& peer, const SRTSOCKET id, int32_t isn);
+private:
+    typedef std::map<SRTSOCKET, CUDTSocket*> sockets_t; // stores all the socket structures
+    sockets_t                                m_Sockets;
 
 #if ENABLE_EXPERIMENTAL_BONDING
-   CUDTGroup* locateAcquireGroup(SRTSOCKET u, ErrorHandling erh = ERH_RETURN);
-   CUDTGroup* acquireSocketsGroup(CUDTSocket* s);
-
-   struct GroupKeeper
-   {
-       CUDTGroup* group;
-
-       // This is intended for API functions to lock the group's existence
-       // for the lifetime of their call.
-       GroupKeeper(CUDTUnited& glob, SRTSOCKET id, ErrorHandling erh)
-       {
-           group = glob.locateAcquireGroup(id, erh);
-       }
-
-       // This is intended for TSBPD thread that should lock the group's
-       // existence until it exits.
-       GroupKeeper(CUDTUnited& glob, CUDTSocket* s)
-       {
-           group = glob.acquireSocketsGroup(s);
-       }
-
-       ~GroupKeeper()
-       {
-           if (group)
-           {
-               // We have a guarantee that if `group` was set
-               // as non-NULL here, it is also acquired and will not
-               // be deleted until this busy flag is set back to false.
-               sync::ScopedLock cgroup (*group->exp_groupLock());
-               group->apiRelease();
-               // Only now that the group lock is lifted, can the
-               // group be now deleted and this pointer potentially dangling
-           }
-       }
-   };
-
+    typedef std::map<SRTSOCKET, CUDTGroup*> groups_t;
+    groups_t                                m_Groups;
 #endif
-   void updateMux(CUDTSocket* s, const sockaddr_any& addr, const UDPSOCKET* = NULL);
-   bool updateListenerMux(CUDTSocket* s, const CUDTSocket* ls);
 
-   // Utility functions for updateMux
-   void configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int af);
-   uint16_t installMuxer(CUDTSocket* w_s, CMultiplexer& sm);
+    sync::Mutex m_GlobControlLock; // used to synchronize UDT API
 
-   /// @brief Checks if channel configuration matches the socket configuration.
-   /// @param cfgMuxer multiplexer configuration.
-   /// @param cfgSocket socket configuration.
-   /// @return tru if configurations match, false otherwise.
-   static bool channelSettingsMatch(const CSrtMuxerConfig& cfgMuxer, const CSrtConfig& cfgSocket);
+    sync::Mutex m_IDLock; // used to synchronize ID generation
+
+    SRTSOCKET m_SocketIDGenerator;      // seed to generate a new unique socket ID
+    SRTSOCKET m_SocketIDGenerator_init; // Keeps track of the very first one
+
+    std::map<int64_t, std::set<SRTSOCKET> >
+        m_PeerRec; // record sockets from peers to avoid repeated connection request, int64_t = (socker_id << 30) + isn
 
 private:
-   std::map<int, CMultiplexer> m_mMultiplexer;		// UDP multiplexer
-   sync::Mutex            m_MultiplexerLock;
+    friend struct FLookupSocketWithEvent_LOCKED;
 
-private:
-   CCache<CInfoBlock>* m_pCache;			// UDT network information cache
+    CUDTSocket* locateSocket(SRTSOCKET u, ErrorHandling erh = ERH_RETURN);
+    // This function does the same as locateSocket, except that:
+    // - lock on m_GlobControlLock is expected (so that you don't unlock between finding and using)
+    // - only return NULL if not found
+    CUDTSocket* locateSocket_LOCKED(SRTSOCKET u);
+    CUDTSocket* locatePeer(const sockaddr_any& peer, const SRTSOCKET id, int32_t isn);
 
-private:
-   srt::sync::atomic<bool> m_bClosing;
-   sync::Mutex m_GCStopLock;
-   sync::Condition m_GCStopCond;
-
-   sync::Mutex m_InitLock;
-   int m_iInstanceCount;				// number of startup() called by application
-   bool m_bGCStatus;					// if the GC thread is working (true)
-
-   sync::CThread m_GCThread;
-   static void* garbageCollect(void*);
-
-   sockets_t m_ClosedSockets;   // temporarily store closed sockets
 #if ENABLE_EXPERIMENTAL_BONDING
-   groups_t m_ClosedGroups;
+    CUDTGroup* locateAcquireGroup(SRTSOCKET u, ErrorHandling erh = ERH_RETURN);
+    CUDTGroup* acquireSocketsGroup(CUDTSocket* s);
+
+    struct GroupKeeper
+    {
+        CUDTGroup* group;
+
+        // This is intended for API functions to lock the group's existence
+        // for the lifetime of their call.
+        GroupKeeper(CUDTUnited& glob, SRTSOCKET id, ErrorHandling erh) { group = glob.locateAcquireGroup(id, erh); }
+
+        // This is intended for TSBPD thread that should lock the group's
+        // existence until it exits.
+        GroupKeeper(CUDTUnited& glob, CUDTSocket* s) { group = glob.acquireSocketsGroup(s); }
+
+        ~GroupKeeper()
+        {
+            if (group)
+            {
+                // We have a guarantee that if `group` was set
+                // as non-NULL here, it is also acquired and will not
+                // be deleted until this busy flag is set back to false.
+                sync::ScopedLock cgroup(*group->exp_groupLock());
+                group->apiRelease();
+                // Only now that the group lock is lifted, can the
+                // group be now deleted and this pointer potentially dangling
+            }
+        }
+    };
+
 #endif
+    void updateMux(CUDTSocket* s, const sockaddr_any& addr, const UDPSOCKET* = NULL);
+    bool updateListenerMux(CUDTSocket* s, const CUDTSocket* ls);
 
-   void checkBrokenSockets();
-   void removeSocket(const SRTSOCKET u);
+    // Utility functions for updateMux
+    void     configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int af);
+    uint16_t installMuxer(CUDTSocket* w_s, CMultiplexer& sm);
 
-   CEPoll m_EPoll;                                     // handling epoll data structures and events
+    /// @brief Checks if channel configuration matches the socket configuration.
+    /// @param cfgMuxer multiplexer configuration.
+    /// @param cfgSocket socket configuration.
+    /// @return tru if configurations match, false otherwise.
+    static bool channelSettingsMatch(const CSrtMuxerConfig& cfgMuxer, const CSrtConfig& cfgSocket);
 
 private:
-   CUDTUnited(const CUDTUnited&);
-   CUDTUnited& operator=(const CUDTUnited&);
+    std::map<int, CMultiplexer> m_mMultiplexer; // UDP multiplexer
+    sync::Mutex                 m_MultiplexerLock;
+
+private:
+    CCache<CInfoBlock>* m_pCache; // UDT network information cache
+
+private:
+    srt::sync::atomic<bool> m_bClosing;
+    sync::Mutex             m_GCStopLock;
+    sync::Condition         m_GCStopCond;
+
+    sync::Mutex m_InitLock;
+    int         m_iInstanceCount; // number of startup() called by application
+    bool        m_bGCStatus;      // if the GC thread is working (true)
+
+    sync::CThread m_GCThread;
+    static void*  garbageCollect(void*);
+
+    sockets_t m_ClosedSockets; // temporarily store closed sockets
+#if ENABLE_EXPERIMENTAL_BONDING
+    groups_t m_ClosedGroups;
+#endif
+
+    void checkBrokenSockets();
+    void removeSocket(const SRTSOCKET u);
+
+    CEPoll m_EPoll; // handling epoll data structures and events
+
+private:
+    CUDTUnited(const CUDTUnited&);
+    CUDTUnited& operator=(const CUDTUnited&);
 };
 
 } // namespace srt


### PR DESCRIPTION
These formatting changes anticipate the upcoming (potential) refactoring and fixes of certain functionality located in the `api.cpp` and `api.h` modules. For example, the `CUDTUnited::newConnection(..)` has to be refactored, as it does too many things (finds existing associated connection, creates the new one, sends HS conclusion response, etc.).