### PR TITLE
Fixed crash in craftKmResponse due to CryptoControl being NULL

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -246,13 +246,16 @@ public:
     /// @return The new UDT socket ID, or INVALID_SOCK.
     SRTSOCKET newSocket(CUDTSocket** pps = NULL);
 
-    /// Create a new UDT connection.
-    /// @param [in] listen the listening UDT socket;
+    /// Create (listener-side) a new socket associated with the incoming connection request.
+    /// @param [in] listen the listening socket ID.
     /// @param [in] peer peer address.
     /// @param [in,out] hs handshake information from peer side (in), negotiated value (out);
-    /// @param [out] w_error error code when failed
-    /// @param [out] w_acpu entity of accepted socket, if connection already exists
-    /// @return If the new connection is successfully created: 1 success, 0 already exist, -1 error.
+    /// @param [out] w_error error code in case of failure.
+    /// @param [out] w_acpu reference to the existing associated socket if already exists.
+    /// @return  1: if the new connection was successfully created (accepted), @a w_acpu is NULL;
+    ///          0: the connection already exists (reference to the corresponding socket is returned in @a w_acpu).
+    ///         -1: The connection processing failed due to memory alloation error, exceeding listener's backlog,
+    ///             any error propagated from CUDT::open and CUDT::acceptAndRespond.
     int newConnection(const SRTSOCKET     listen,
                       const sockaddr_any& peer,
                       const CPacket&      hspkt,

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -316,7 +316,7 @@ public:
     int32_t m_iMSS;              // maximum segment size
     int32_t m_iFlightFlagSize;   // flow control window size
     UDTRequestType m_iReqType;   // handshake stage
-    int32_t m_iID;		// socket ID
+    int32_t m_iID;               // SRT socket ID of HS sender
     int32_t m_iCookie;		// cookie
     uint32_t m_piPeerIP[4];	// The IP address that the peer's UDP port is bound to
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -344,7 +344,7 @@ class SRT_ATTR_SCOPED_CAPABILITY ScopedLock
 {
 public:
     SRT_ATTR_ACQUIRE(m)
-    ScopedLock(Mutex& m);
+    explicit ScopedLock(Mutex& m);
 
     SRT_ATTR_RELEASE()
     ~ScopedLock();
@@ -362,7 +362,7 @@ class SRT_ATTR_SCOPED_CAPABILITY UniqueLock
 
 public:
     SRT_ATTR_ACQUIRE(m)
-    UniqueLock(Mutex &m);
+    explicit UniqueLock(Mutex &m);
 
     SRT_ATTR_RELEASE()
     ~UniqueLock();


### PR DESCRIPTION
1. Check if `CryptoControl` exists in `craftKmResponse(..)`. Fixes #2231.
2. Cleaned up the `CUDT::processConnectRequest(..)` function.
   - ⚠️  Update listener write-ready only after the new connection. Was changed in #1650, but must not be done at all #1831.


