### PR TITLE
[core] CSndUList use notify_one() instead of notify_all()

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -345,7 +345,7 @@ void srt::CSndUList::waitNonEmpty() const
 void srt::CSndUList::signalInterrupt() const
 {
     ScopedLock listguard(m_ListLock);
-    m_ListCond.notify_all();
+    m_ListCond.notify_one();
 }
 
 void srt::CSndUList::realloc_()
@@ -413,7 +413,7 @@ void srt::CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const
     if (0 == m_iLastEntry)
     {
         // m_ListLock is assumed to be locked.
-        m_ListCond.notify_all();
+        m_ListCond.notify_one();
     }
 }
 


### PR DESCRIPTION
The `CSndUList::signalInterrupt()` and `CSndUList::realloc_()` are using `Condition::notify_all()` (`pthread_cond_broadcast`) to notify the sending queue is non empty or needs to be interrupted and closed.
The only receiver of this notification is the `CSndQueue::worker(void*)` thread. As of now, there is only one instance of this thread, and there is no need to use the broadcast notification.

_Note. Can the `notify_all()` be less performant than the `notify_one()`?_

SRT version: SRT v1.4.4, after PR #2045.