### PR TITLE
[core] fix `volatile` in `group.h`

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -85,7 +85,7 @@ bool CUDTGroup::applyGroupSequences(SRTSOCKET target, int32_t& w_snd_isn, int32_
 
             // SndCurrSeqNo is initially set to ISN-1, this next one is
             // the sequence that is about to be stamped on the next sent packet
-            // over that socket. Using this field is safer because it is volatile
+            // over that socket. Using this field is safer because it is atomic
             // and its affinity is to the same thread as the sending function.
 
             // NOTE: the groupwise scheduling sequence might have been set

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -611,10 +611,10 @@ public:
 
 private:
     // Fields required for SRT_GTYPE_BACKUP groups.
-    senderBuffer_t   m_SenderBuffer;
-    int32_t          m_iSndOldestMsgNo; // oldest position in the sender buffer
-    volatile int32_t m_iSndAckedMsgNo;
-    uint32_t         m_uOPT_MinStabilityTimeout_us;
+    senderBuffer_t        m_SenderBuffer;
+    int32_t               m_iSndOldestMsgNo; // oldest position in the sender buffer
+    sync::atomic<int32_t> m_iSndAckedMsgNo;
+    uint32_t              m_uOPT_MinStabilityTimeout_us;
 
     // THIS function must be called only in a function for a group type
     // that does use sender buffer.
@@ -671,7 +671,7 @@ private:
     // This is the sequence number of a packet that has been previously
     // delivered. Initially it should be set to SRT_SEQNO_NONE so that the sequence read
     // from the first delivering socket will be taken as a good deal.
-    volatile int32_t m_RcvBaseSeqNo;
+    sync::atomic<int32_t> m_RcvBaseSeqNo;
 
     bool m_bOpened;    // Set to true when at least one link is at least pending
     bool m_bConnected; // Set to true on first link confirmed connected
@@ -685,10 +685,10 @@ private:
 
     // Signal for the blocking user thread that the packet
     // is ready to deliver.
-    srt::sync::Condition m_RcvDataCond;
-    srt::sync::Mutex     m_RcvDataLock;
-    volatile int32_t     m_iLastSchedSeqNo; // represetnts the value of CUDT::m_iSndNextSeqNo for each running socket
-    volatile int32_t     m_iLastSchedMsgNo;
+    sync::Condition       m_RcvDataCond;
+    sync::Mutex           m_RcvDataLock;
+    sync::atomic<int32_t> m_iLastSchedSeqNo; // represetnts the value of CUDT::m_iSndNextSeqNo for each running socket
+    sync::atomic<int32_t> m_iLastSchedMsgNo;
     // Statistics
 
     struct Stats


### PR DESCRIPTION
Replace `volatile` with `srt::sync::atomic` for concurrency.
Fix https://github.com/Haivision/srt/pull/2264#issuecomment-1098023860