### PR TITLE
[core] Introduced the CSharedResource

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -1963,6 +1963,7 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
         // and the appropriate message must be constructed for sending.
         // No further processing required
         {
+            CScopedResourceLock cg(m_ConnectionResources);
             uint32_t srtdata_out[SRTDATA_MAXSIZE];
             size_t   len_out = 0;
             res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4,
@@ -8922,7 +8923,6 @@ void srt::CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
 
 void srt::CUDT::processCtrl(const CPacket &ctrlpkt)
 {
-    CScopedResourceLock cg(m_ConnectionResources);
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
     const steady_clock::time_point currtime = steady_clock::now();

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8922,6 +8922,7 @@ void srt::CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
 
 void srt::CUDT::processCtrl(const CPacket &ctrlpkt)
 {
+    CScopedResourceLock cg(m_ConnectionResources);
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
     const steady_clock::time_point currtime = steady_clock::now();

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -448,7 +448,7 @@ void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
         std::vector<CUDTSocket*> ps_vec;
         {
             // Do copy to avoid deadlock. CUDT::setOpt() cannot be called directly inside this loop, because
-            // CUDT::setOpt() will lock m_ConnectionLock, which should be locked before m_GroupLock.
+            // CUDT::setOpt() will lock m_ConnectionResources, which should be locked before m_GroupLock.
             ScopedLock gg(m_GroupLock);
             for (gli_t gi = m_Group.begin(); gi != m_Group.end(); ++gi)
             {

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -994,7 +994,7 @@ void srt::CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst
         // because the next CUDT::close will not remove it from the queue when m_bConnecting = false,
         // and may crash on next pass.
         //
-        // TODO: maybe lock i->u->m_ConnectionLock?
+        // TODO: maybe lock i->u->m_ConnectionResources?
         i->u->m_bConnecting = false;
         remove(i->u->m_SocketID);
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -785,6 +785,11 @@ public: // Observers
         {
             return pthread_equal(value, second.value) != 0;
         }
+
+        inline bool operator!=(const id& second) const
+        {
+            return pthread_equal(value, second.value) == 0;
+        }
     };
 
     /// Returns the id of the current thread.
@@ -960,7 +965,7 @@ public:
             m_rsrc.release();
     }
 
-    explicit operator bool() const { return m_isAcquired; }
+    operator bool() const { return m_isAcquired; }
 
     bool operator!() const { return !m_isAcquired; }
 

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -498,7 +498,7 @@ static const char* const socket_state_array[] = {
 const char* const* g_socket_state = socket_state_array + 1;
 
 #if 0
-// No socket option can be set in blocking mode because m_ConnectionLock is required by both srt_setsockopt and srt_connect
+// No socket option can be set in blocking mode because m_ConnectionResources is required by both srt_setsockopt and srt_connect
 // TODO: Use non-blocking mode
 TEST_F(TestSocketOptions, RestrictionCallerConnecting)
 {


### PR DESCRIPTION
NB! The description is outdated, as now issue #2234 is being addressed in this PR.

Introducing the `CSharedResource` class. Not yet used in the code. Potentially the `m_ConnectionLock` can be converted to the `CSharedResource`.