### PR TITLE
[core] Fixed CRcvBufferNew::strFullnessState(..).

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -1002,11 +1002,11 @@ string CRcvBufferNew::strFullnessState(int iFirstUnackSeqNo, const time_point& t
     ss << " pkts. ";
     if (m_tsbpd.isEnabled() && m_iMaxPosInc > 0)
     {
+        const PacketInfo nextValidPkt = getFirstValidPacketInfo();
         ss << " (TSBPD ready in ";
-        if (m_entries[m_iStartPos].pUnit)
+        if (!is_zero(nextValidPkt.tsbpd_time))
         {
-            const uint32_t usPktTimestamp = m_entries[m_iStartPos].pUnit->m_Packet.getMsgTimeStamp();
-            ss << count_milliseconds(m_tsbpd.getPktTsbPdTime(usPktTimestamp) - tsNow);
+            ss << count_milliseconds(nextValidPkt.tsbpd_time - tsNow);
         }
         else
         {
@@ -1017,7 +1017,7 @@ string CRcvBufferNew::strFullnessState(int iFirstUnackSeqNo, const time_point& t
         if (m_entries[iLastPos].pUnit)
         {
             ss << ":";
-            const uint32_t usPktTimestamp = m_entries[m_iStartPos].pUnit->m_Packet.getMsgTimeStamp();
+            const uint32_t usPktTimestamp = m_entries[iLastPos].pUnit->m_Packet.getMsgTimeStamp();
             ss << count_milliseconds(m_tsbpd.getPktTsbPdTime(usPktTimestamp) - tsNow);
             ss << " ms";
         }

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -1003,29 +1003,25 @@ string CRcvBufferNew::strFullnessState(int iFirstUnackSeqNo, const time_point& t
     if (m_tsbpd.isEnabled() && m_iMaxPosInc > 0)
     {
         const PacketInfo nextValidPkt = getFirstValidPacketInfo();
-        ss << " (TSBPD ready in ";
+        ss << "(TSBPD ready in ";
         if (!is_zero(nextValidPkt.tsbpd_time))
         {
-            ss << count_milliseconds(nextValidPkt.tsbpd_time - tsNow);
+            ss << count_milliseconds(nextValidPkt.tsbpd_time - tsNow) << "ms";
+            const int iLastPos = incPos(m_iStartPos, m_iMaxPosInc - 1);
+            if (m_entries[iLastPos].pUnit)
+            {
+                ss << ", timespan ";
+                const uint32_t usPktTimestamp = m_entries[iLastPos].pUnit->m_Packet.getMsgTimeStamp();
+                ss << count_milliseconds(m_tsbpd.getPktTsbPdTime(usPktTimestamp) - nextValidPkt.tsbpd_time);
+                ss << " ms";
+            }
         }
         else
         {
             ss << "n/a";
         }
 
-        const int iLastPos = incPos(m_iStartPos, m_iMaxPosInc - 1);
-        if (m_entries[iLastPos].pUnit)
-        {
-            ss << ":";
-            const uint32_t usPktTimestamp = m_entries[iLastPos].pUnit->m_Packet.getMsgTimeStamp();
-            ss << count_milliseconds(m_tsbpd.getPktTsbPdTime(usPktTimestamp) - tsNow);
-            ss << " ms";
-        }
-        else
-        {
-            ss << ":n/a ms";
-        }
-        ss << ". ";
+        ss << "). ";
     }
 
     ss << SRT_SYNC_CLOCK_STR " drift " << getDrift() / 1000 << " ms.";


### PR DESCRIPTION
1. Fixed possible null pointer object call. Checking `iLastPos`, but accessing the `m_iStartPos` potentially `NULL`.
```c++
if (m_entries[iLastPos].pUnit)
{
    ss << ":";
    const uint32_t usPktTimestamp = m_entries[m_iStartPos].pUnit->m_Packet.getMsgTimeStamp();
    ss << count_milliseconds(m_tsbpd.getPktTsbPdTime(usPktTimestamp) - tsNow);
    ss << " ms";
}
```

2. Show the first valid packet info `getFirstValidPacketInfo()` instead of `m_iStartPos` - the very first position in the buffer. Even if there is a gap in the beginning.

3. Show receiver buffer timespan instead of the TSBPD ready time span.