### PR TITLE
srt::FixedArray: define an iterator, changed exception throwing.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -92,14 +92,14 @@ CRcvBufferNew::CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, 
 
 CRcvBufferNew::~CRcvBufferNew()
 {
-    for (size_t i = 0; i < m_szSize; ++i)
+    // Can be optimized by only iterating m_iMaxPosInc from m_iStartPos.
+    for (FixedArray<Entry>::iterator it = m_entries.begin(); it != m_entries.end(); ++it)
     {
-        CUnit* unit = m_entries[i].pUnit;
-        if (unit != NULL)
-        {
-            m_pUnitQueue->makeUnitFree(unit);
-            m_entries[i].pUnit = NULL;
-        }
+        if (!it->pUnit)
+            continue;
+        
+        m_pUnitQueue->makeUnitFree(it->pUnit);
+        it->pUnit = NULL;
     }
 }
 

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -418,8 +418,7 @@ class FixedArray
 {
 public:
     FixedArray(size_t size)
-        : m_strIndexErr("FixedArray: invalid index")
-        , m_size(size)
+        : m_size(size)
         , m_entries(new T[size])
     {
     }
@@ -433,7 +432,7 @@ public:
     const T& operator[](size_t index) const
     {
         if (index >= m_size)
-            throw std::runtime_error(m_strIndexErr);
+            raise_expection(index);
 
         return m_entries[index];
     }
@@ -441,7 +440,7 @@ public:
     T& operator[](size_t index)
     {
         if (index >= m_size)
-            throw std::runtime_error(m_strIndexErr);
+            raise_expection(index);
 
         return m_entries[index];
     }
@@ -449,7 +448,7 @@ public:
     const T& operator[](int index) const
     {
         if (index < 0 || static_cast<size_t>(index) >= m_size)
-            throw std::runtime_error(m_strIndexErr);
+            raise_expection(index);
 
         return m_entries[index];
     }
@@ -457,7 +456,7 @@ public:
     T& operator[](int index)
     {
         if (index < 0 || static_cast<size_t>(index) >= m_size)
-            throw std::runtime_error(m_strIndexErr);
+            raise_expection(index);
 
         return m_entries[index];
     }
@@ -479,8 +478,14 @@ private:
     FixedArray(const FixedArray<T>& );
     FixedArray<T>& operator=(const FixedArray<T>&);
 
+    void raise_expection(int i) const
+    {
+        std::stringstream ss;
+        ss << "Index " << i << "out of range";
+        throw std::runtime_error(ss.str());
+    }
+
 private:
-    const char* m_strIndexErr;
     size_t      m_size;
     T* const    m_entries;
 };

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -462,7 +462,18 @@ public:
         return m_entries[index];
     }
 
-    size_t  size() const { return m_size; }
+    size_t size() const { return m_size; }
+
+    typedef T* iterator;
+    typedef const T* const_iterator;
+
+    iterator begin() { return m_entries; }
+    iterator end() { return m_entries + m_size; }
+
+    const_iterator cbegin() const { return m_entries; }
+    const_iterator cend() const { return m_entries + m_size; }
+
+    T* data() { return m_entries; }
 
 private:
     FixedArray(const FixedArray<T>& );


### PR DESCRIPTION
- Defined an iterator for the `srt::FixedArray`. Also fixes potentially throwing an exception from the `CRcvBufferNew` destructor because the `operator[]` was used.
- Removed the member variable holding the error string. Instead form the string dynamically.