### PR TITLE
[core]: Fix name conflict with md5 functions

### DIFF
--- a/srtcore/md5.cpp
+++ b/srtcore/md5.cpp
@@ -54,6 +54,12 @@
 #include "md5.h"
 #include <string.h>
 
+/*
+ * All symbols have been put under the srt namespace
+ * to avoid potential linkage conflicts.
+ */
+namespace srt {
+
 #undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
 #  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
@@ -379,3 +385,5 @@ md5_finish(md5_state_t *pms, md5_byte_t digest[16])
     for (i = 0; i < 16; ++i)
 	digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
 }
+
+} // namespace srt

--- a/srtcore/md5.h
+++ b/srtcore/md5.h
@@ -51,6 +51,12 @@
 #  define md5_INCLUDED
 
 /*
+ * All symbols have been put under the srt namespace
+ * to avoid potential linkage conflicts.
+ */
+namespace srt {
+
+/*
  * This package supports both compile-time and run-time determination of CPU
  * byte order.  If ARCH_IS_BIG_ENDIAN is defined as 0, the code will be
  * compiled to run only on little-endian CPUs; if ARCH_IS_BIG_ENDIAN is
@@ -70,11 +76,6 @@ typedef struct md5_state_s {
     md5_byte_t buf[64];		/* accumulate block */
 } md5_state_t;
 
-#ifdef __cplusplus
-extern "C" 
-{
-#endif
-
 /* Initialize the algorithm. */
 void md5_init(md5_state_t *pms);
 
@@ -84,8 +85,6 @@ void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
 /* Finish the message and return the digest. */
 void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
 
-#ifdef __cplusplus
-}  /* end extern "C" */
-#endif
+} // namespace srt
 
 #endif /* md5_INCLUDED */


### PR DESCRIPTION
This renames the private md5 functions by adding srt_ prefix.
Otherwise, the md5 functions are shown as multiple definition
while static linking in presence of other libraries.