### PR TITLE
Prevents costly casting

### DIFF
--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -345,7 +345,7 @@ int srt::sync::genRandomInt(int minVal, int maxVal)
     // When rand_0_1 is 0.0 it's better to return early and prevents costly casting
     if (rand_0_1 == 0.0)
     {
-        return min(minVal, maxVal);
+        return minVal;
     }
 
     // Map onto [minVal, maxVal].

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -341,6 +341,12 @@ int srt::sync::genRandomInt(int minVal, int maxVal)
     // Therefore, rand_0_1 belongs to [0.0, 1.0].
     const double rand_0_1 = double(rand_r(getRandSeed())) / RAND_MAX;
 #endif
+    
+    // When rand_0_1 is 0.0 it's better to return early and prevents costly casting
+    if (rand_0_1 == 0.0)
+    {
+        return min(minVal, maxVal);
+    }
 
     // Map onto [minVal, maxVal].
     // Note. There is a minuscule probablity to get maxVal+1 as the result.


### PR DESCRIPTION
It is possible that `rand_0_1` returns the value 0.0, then is it better to return earlier and prevent costly casting.