### PR TITLE
[core] store available receive buffer size in more appropriate datatype

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10029,8 +10029,8 @@ int srt::CUDT::processData(CUnit* in_unit)
                 continue;
             }
 
-            const int avail_bufsize = getAvailRcvBufferSizeNoLock();
-            if (offset >= avail_bufsize)
+            const size_t avail_bufsize = getAvailRcvBufferSizeNoLock();
+            if (size_t(offset) >= avail_bufsize)
             {
                 // This is already a sequence discrepancy. Probably there could be found
                 // some way to make it continue reception by overriding the sequence and


### PR DESCRIPTION
As observed in issue #2306, the function `srt::CUDT::getAvailRcvBufferSizeNoLock()` whose return type is `size_t` can (on at least one platform (i.e mine)) overflow an `int`, which would cause the SRT Application to report a "Sequence discrepancy" where there in reality is no such discrepancy. When stored in a long, the one application I have tested (`srt-live-transmit`) works as expected instead of closing the connection.