### PR TITLE
[build] build openssl share library without version extesion for android

### DIFF
--- a/scripts/build-android/mkssl
+++ b/scripts/build-android/mkssl
@@ -45,8 +45,8 @@ export PATH=$ANDROID_NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin:$PATH
 build_the_thing() {
     make clean
     ./Configure $SSL_TARGET -D__ANDROID_API__=$API_LEVEL && \
-    make && \
-    make install DESTDIR=$DESTDIR || exit 128
+    make SHLIB_EXT=.so && \
+    make install SHLIB_EXT=.so DESTDIR=$DESTDIR || exit 128
 }
 
 ##### set variables according to build-tagret #####


### PR DESCRIPTION
The openssl share library file name always end with its version string, and then create soft link point to it. e.g.
libssl.so.1.1
libss.so -> libssl.so.1.1
libcrypto.so.1.1
libcrypto.so -> libcrypto.so.1.1
But in the Android NDK build, it only copy these .so extension files, that would cause crash because of it can not find the real xx.so.xx file.
Add the "SHLIB_EXT=.so" parameter to remove version extension file, this will make it easy to build with openssl .so file for android.
Please let me know if there is any question, thanks a lot.