### PR TITLE
[core] Fixed updating new RCV buffer on ISN change.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -205,8 +205,8 @@ int CRcvBufferNew::dropAll()
     if (empty())
         return 0;
 
-    const int end_pos = incPos(m_iStartPos, m_iMaxPosInc);
-    return dropUpTo(end_pos);
+    const int end_seqno = CSeqNo::incseq(m_iStartSeqNo, m_iMaxPosInc);
+    return dropUpTo(end_seqno);
 }
 
 int CRcvBufferNew::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno)

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -205,28 +205,8 @@ int CRcvBufferNew::dropAll()
     if (empty())
         return 0;
 
-    int iDropCnt = 0;
     const int end_pos = incPos(m_iStartPos, m_iMaxPosInc);
-    for (int i = m_iStartPos; i != end_pos; i = incPos(i))
-    {
-        CUnit* pUnit = m_entries[i].pUnit;
-        if (!pUnit)
-            continue;
-
-        m_pUnitQueue->makeUnitFree(pUnit);
-        m_entries[i].pUnit = NULL;
-        ++iDropCnt;
-    }
-
-    // Reset buffer state
-    m_iStartPos = 0;
-    m_iFirstNonreadPos = 0;
-    m_iMaxPosInc = 0;
-    m_iNotch = 0;
-    m_numOutOfOrderPackets = 0;
-    m_iFirstReadableOutOfOrder = -1;
-
-    return iDropCnt;
+    return dropUpTo(end_pos);
 }
 
 int CRcvBufferNew::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno)

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -200,6 +200,27 @@ int CRcvBufferNew::dropUpTo(int32_t seqno)
     return iDropCnt;
 }
 
+int CRcvBufferNew::dropAll()
+{
+    if (empty())
+        return 0;
+
+    int iDropCnt = 0;
+    const int end_pos = incPos(m_iStartPos, m_iMaxPosInc);
+    for (int i = m_iStartPos; i != end_pos; i = incPos(i))
+    {
+        CUnit* pUnit = m_entries[i].pUnit;
+        if (!pUnit)
+            continue;
+
+        m_pUnitQueue->makeUnitFree(pUnit);
+        m_entries[i].pUnit = NULL;
+        ++iDropCnt;
+    }
+
+    return iDropCnt;
+}
+
 int CRcvBufferNew::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno)
 {
     IF_RCVBUF_DEBUG(ScopedLog scoped_log);

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -218,6 +218,14 @@ int CRcvBufferNew::dropAll()
         ++iDropCnt;
     }
 
+    // Reset buffer state
+    m_iStartPos = 0;
+    m_iFirstNonreadPos = 0;
+    m_iMaxPosInc = 0;
+    m_iNotch = 0;
+    m_numOutOfOrderPackets = 0;
+    m_iFirstReadableOutOfOrder = -1;
+
     return iDropCnt;
 }
 

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -73,6 +73,10 @@ public:
     ///
     int dropUpTo(int32_t seqno);
 
+    /// @brief Drop all the packets in the receiver buffer. The starting position.
+    /// @return the number of dropped packets.
+    int dropAll();
+
     /// @brief Drop the whole message from the buffer.
     /// If message number is 0, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
     /// When one packet of the message is in the range of dropping, the whole message is to be dropped.
@@ -108,6 +112,10 @@ public:
 public:
     /// Get the starting position of the buffer as a packet sequence number.
     int getStartSeqNo() const { return m_iStartSeqNo; }
+
+    /// Sets the start seqno of the buffer.
+    /// Must be used with caution and only when the buffer is empty.
+    void setStartSeqNo(int seqno) { m_iStartSeqNo = seqno; }
 
     /// Given the sequence number of the first unacknowledged packet
     /// tells the size of the buffer available for packets.
@@ -324,8 +332,6 @@ public: // TSBPD public functions
     void setTsbPdMode(const time_point& timebase, bool wrap, duration delay);
 
     void setPeerRexmitFlag(bool flag) { m_bPeerRexmitFlag = flag; } 
-
-    void applyGroupISN(int rcv_isn) { m_iStartSeqNo = rcv_isn; }
 
     void applyGroupTime(const time_point& timebase, bool wrp, uint32_t delay, const duration& udrift);
 

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -70,10 +70,10 @@ public:
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number
     /// @return  number of dropped packets.
-    ///
     int dropUpTo(int32_t seqno);
 
-    /// @brief Drop all the packets in the receiver buffer. The starting position.
+    /// @brief Drop all the packets in the receiver buffer.
+    /// The starting position and seqno are shifted right after the last packet in the buffer.
     /// @return the number of dropped packets.
     int dropAll();
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -887,16 +887,7 @@ private: // Timers
         m_iSndLastAck2 = isn;
     }
 
-    void setInitialRcvSeq(int32_t isn)
-    {
-        m_iRcvLastAck = isn;
-#ifdef ENABLE_LOGGING
-        m_iDebugPrevLastAck = m_iRcvLastAck;
-#endif
-        m_iRcvLastSkipAck = m_iRcvLastAck;
-        m_iRcvLastAckAck = isn;
-        m_iRcvCurrSeqNo = CSeqNo::decseq(isn);
-    }
+    void setInitialRcvSeq(int32_t isn);
 
     int32_t m_iISN;                              // Initial Sequence Number
     bool m_bPeerTsbPd;                           // Peer accept TimeStamp-Based Rx mode


### PR DESCRIPTION
The new receiver buffer keeps track of the packet sequence number in the starting position to be independent from SRT receiver ACK position.
As the receiver buffer is created **before** the connection is actually being established (see #2268), the starting sequence number has to be updated afterward.
- In particular, in the rendezvous connection mode both parties come with its own ISN. The negotiated ISN is the one from the party that has become INITIATOR after the cookie contest. The ISN has to be updated. Fixes #2306.
- Another source of the update is group connections, each having its own receiver buffer, that has to be synchronized at the start (and already after an individual connection has been established).

This PR adds an update of the RCV buffer's starting seqno.