### PR TITLE
[API] Deprecated srt_rejectreason_msg[].

### DIFF
--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -984,7 +984,9 @@ SRT_API int srt_getsndbuffer(SRTSOCKET sock, size_t* blocks, size_t* bytes);
 
 SRT_API int srt_getrejectreason(SRTSOCKET sock);
 SRT_API int srt_setrejectreason(SRTSOCKET sock, int value);
-SRT_API extern const char* const srt_rejectreason_msg [];
+// The srt_rejectreason_msg[] array is deprecated (as unsafe).
+// Planned removal: v1.6.0.
+SRT_API SRT_ATR_DEPRECATED extern const char* const srt_rejectreason_msg [];
 SRT_API const char* srt_rejectreason_str(int id);
 
 SRT_API uint32_t srt_getversion(void);


### PR DESCRIPTION
The array `srt_rejectreason_msg` is present in the SRT API (added in v1.3.4 in PR #720).
It is quite unsafe because someone may access it out of bounds by mistake.
The API function `srt_rejectreason_str()` should be used instead.

The array `srt_rejectreason_msg` is marked as deprecated. and to be removed in a further major release (v1.6.0?).

Fixes #2285