### PR TITLE
Allow non-C++11 examples to be compiled with C++11 disabled

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1084,6 +1084,12 @@ private: // Generation and processing of packets
     /// @param seq first unacknowledged packet sequence number.
     void ackDataUpTo(int32_t seq);
 
+#if ENABLE_EXPERIMENTAL_BONDING && ENABLE_NEW_RCVBUFFER
+    /// @brief Drop packets in the recv buffer behind group_recv_base.
+    /// Updates m_iRcvLastSkipAck if it's behind group_recv_base.
+    void dropToGroupRecvBase();
+#endif
+
     void handleKeepalive(const char* data, size_t lenghth);
 
     /// Locks m_RcvBufferLock and retrieves the available size of the receiver buffer.


### PR DESCRIPTION
There were several examples that did not require C++11, although some of them do.

This fix allows all examples that don't require C++11 to be compiled using the compiler-default standard, while those that require C++11 are turned off in case when C++11 is explicitly disabled. Examples that do require it are sendfile/recvfile because they make use of in-application logging configurtion.