### PR TITLE
[API] Removed unused srt_include(..) and srt_exclude(..)

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -46,8 +46,6 @@
 | [SRT_SOCKGROUPDATA](#SRT_SOCKGROUPDATA)           | Most important structure for group member status                                                               |
 | [SRT_MEMBERSTATUS](#SRT_MEMBERSTATUS)             | Enumeration type that defines the state of a member connection in the group                                    |
 | [srt_create_group](#srt_create_group)             | Creates a new group of type `type`                                                                             |
-| [srt_include](#srt_include)                       | Adds a socket to a group                                                                                       |
-| [srt_exclude](#srt_exclude)                       | Removes a socket from a group to which it currently belongs                                                    |
 | [srt_groupof](#srt_groupof)                       | Returns the group ID of a socket, or `SRT_INVALID_SOCK`                                                        |
 | [srt_group_data](#srt_group_data)                 | Obtains the current member state of the group specified in `socketgroup`                                       |
 | [srt_connect_group](#srt_connect_group)           | Similar to calling [`srt_connect`](#srt_connect) or [`srt_connect_bind`](#srt_connect_bind) <br/> in a loop for every item in an array. |
@@ -1138,8 +1136,6 @@ become `SRT_GST_IDLE`).
 ### Functions to Be Used on Groups
 
   * [srt_create_group](#srt_create_group)
-  * [srt_include](#srt_include)
-  * [srt_exclude](#srt_exclude)
   * [srt_groupof](#srt_groupof)
   * [srt_group_data](#srt_group_data)
   * [srt_connect_group](#srt_connect_group)
@@ -1158,34 +1154,6 @@ Creates a new group of type `type`. This is typically called on the
 caller side to be next used for connecting to the listener peer side.
 The group ID is of the same domain as the socket ID, with the exception that
 the `SRTGROUP_MASK` bit is set on it, unlike for socket ID.
-
-
-[:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)
-
----  
-  
-#### srt_include
-
-```
-int srt_include(SRTSOCKET socket, SRTSOCKET group);
-```
-
-This function adds a socket to a group. This is only allowed for unmanaged
-groups. No such group type is currently implemented.
-
-
-[:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)
-
----  
-  
-#### srt_exclude
-
-```
-int srt_exclude(SRTSOCKET socket);
-```
-This function removes a socket from a group to which it currently belongs.
-This is only allowed for unmanaged groups. No such group type is currently
-implemented.
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -192,8 +192,6 @@ public: //API
     static SRTSOCKET socket();
 #if ENABLE_EXPERIMENTAL_BONDING
     static SRTSOCKET createGroup(SRT_GROUP_TYPE);
-    static int addSocketToGroup(SRTSOCKET socket, SRTSOCKET group);
-    static int removeSocketFromGroup(SRTSOCKET socket);
     static SRTSOCKET getGroupOfSocket(SRTSOCKET socket);
     static int getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize);
     static int configureGroup(SRTSOCKET groupid, const char* str);

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -437,7 +437,6 @@ private:
         void erase(gli_t it);
     };
     GroupContainer m_Group;
-    bool           m_selfManaged;
     bool           m_bSyncOnMsgNo;
     SRT_GROUP_TYPE m_type;
     CUDTSocket*    m_listener; // A "group" can only have one listener.
@@ -811,7 +810,6 @@ public:
     // Property accessors
     SRTU_PROPERTY_RW_CHAIN(CUDTGroup, SRTSOCKET, id, m_GroupID);
     SRTU_PROPERTY_RW_CHAIN(CUDTGroup, SRTSOCKET, peerid, m_PeerGroupID);
-    SRTU_PROPERTY_RW_CHAIN(CUDTGroup, bool, managed, m_selfManaged);
     SRTU_PROPERTY_RW_CHAIN(CUDTGroup, SRT_GROUP_TYPE, type, m_type);
     SRTU_PROPERTY_RW_CHAIN(CUDTGroup, int32_t, currentSchedSequence, m_iLastSchedSeqNo);
     SRTU_PROPERTY_RRW(std::set<int>&, epollset, m_sPollID);

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -815,8 +815,6 @@ typedef struct SRT_GroupMemberConfig_
 } SRT_SOCKGROUPCONFIG;
 
 SRT_API SRTSOCKET srt_create_group (SRT_GROUP_TYPE);
-SRT_API       int srt_include      (SRTSOCKET socket, SRTSOCKET group);
-SRT_API       int srt_exclude      (SRTSOCKET socket);
 SRT_API SRTSOCKET srt_groupof      (SRTSOCKET socket);
 SRT_API       int srt_group_data   (SRTSOCKET socketgroup, SRT_SOCKGROUPDATA* output, size_t* inoutlen);
 SRT_API       int srt_group_configure(SRTSOCKET socketgroup, const char* str);

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -39,8 +39,6 @@ SRTSOCKET srt_create_socket() { return CUDT::socket(); }
 #if ENABLE_EXPERIMENTAL_BONDING
 // Group management.
 SRTSOCKET srt_create_group(SRT_GROUP_TYPE gt) { return CUDT::createGroup(gt); }
-int srt_include(SRTSOCKET socket, SRTSOCKET group) { return CUDT::addSocketToGroup(socket, group); }
-int srt_exclude(SRTSOCKET socket) { return CUDT::removeSocketFromGroup(socket); }
 SRTSOCKET srt_groupof(SRTSOCKET socket) { return CUDT::getGroupOfSocket(socket); }
 int srt_group_data(SRTSOCKET socketgroup, SRT_SOCKGROUPDATA* output, size_t* inoutlen)
 {


### PR DESCRIPTION
Removed unused `srt_include(..)` and `srt_exclude(..)` for unimplemented externally managed groups.
No reason to have these API functions if they are not needed.

Blocks #2316