### PR TITLE
Resolved symbol name Leakage/polution

### DIFF
--- a/apps/apputil.cpp
+++ b/apps/apputil.cpp
@@ -22,6 +22,7 @@
 #include "srt_compat.h"
 
 using namespace std;
+using namespace srt;
 
 
 // NOTE: MINGW currently does not include support for inet_pton(). See
@@ -355,25 +356,25 @@ string OptionHelpItem(const OptionName& o)
 
 const char* SRTClockTypeStr()
 {
-	const int clock_type = srt_clock_type();
+    const int clock_type = srt_clock_type();
 
-	switch (clock_type)
-	{
-	case SRT_SYNC_CLOCK_STDCXX_STEADY:
-		return "CXX11_STEADY";
-	case SRT_SYNC_CLOCK_GETTIME_MONOTONIC:
-		return "GETTIME_MONOTONIC";
-	case SRT_SYNC_CLOCK_WINQPC:
-		return "WIN_QPC";
-	case SRT_SYNC_CLOCK_MACH_ABSTIME:
-		return "MACH_ABSTIME";
-	case SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY:
-		return "POSIX_GETTIMEOFDAY";
-	default:
-		break;
-	}
-	
-	return "UNKNOWN VALUE";
+    switch (clock_type)
+    {
+    case SRT_SYNC_CLOCK_STDCXX_STEADY:
+        return "CXX11_STEADY";
+    case SRT_SYNC_CLOCK_GETTIME_MONOTONIC:
+        return "GETTIME_MONOTONIC";
+    case SRT_SYNC_CLOCK_WINQPC:
+        return "WIN_QPC";
+    case SRT_SYNC_CLOCK_MACH_ABSTIME:
+        return "MACH_ABSTIME";
+    case SRT_SYNC_CLOCK_POSIX_GETTIMEOFDAY:
+        return "POSIX_GETTIMEOFDAY";
+    default:
+        break;
+    }
+    
+    return "UNKNOWN VALUE";
 }
 
 void PrintLibVersion()

--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -85,7 +85,7 @@ inline int SysError() { return errno; }
 const int SysAGAIN = EAGAIN;
 #endif
 
-sockaddr_any CreateAddr(const std::string& name, unsigned short port = 0, int pref_family = AF_UNSPEC);
+srt::sockaddr_any CreateAddr(const std::string& name, unsigned short port = 0, int pref_family = AF_UNSPEC);
 std::string Join(const std::vector<std::string>& in, std::string sep);
 
 template <class VarType, class ValType>
@@ -210,11 +210,11 @@ struct OptionScheme
     enum Args { ARG_NONE, ARG_ONE, ARG_VAR } type;
 
     OptionScheme(const OptionScheme&) = default;
-	OptionScheme(OptionScheme&& src)
-		: pid(src.pid)
-		, type(src.type)
-	{
-	}
+    OptionScheme(OptionScheme&& src)
+        : pid(src.pid)
+        , type(src.type)
+    {
+    }
 
     OptionScheme(const OptionName& id, Args tp);
 

--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -59,6 +59,7 @@ testmedia.cpp
 */
 
 using namespace std;
+using namespace srt;
 
 const srt_logging::LogFA SRT_LOGFA_APP = 10;
 namespace srt_logging

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -38,6 +38,7 @@
 #include "verbose.hpp"
 
 using namespace std;
+using namespace srt;
 
 bool g_stats_are_printed_to_stdout = false;
 bool transmit_total_stats = false;
@@ -401,7 +402,7 @@ void SrtCommon::ConnectClient(string host, int port)
 {
 
     sockaddr_any sa = CreateAddr(host, port);
-	sockaddr* psa = sa.get();
+    sockaddr* psa = sa.get();
 
     Verb() << "Connecting to " << host << ":" << port;
 

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -4051,7 +4051,7 @@ int srt::CUDT::epoll_release(const int eid)
     }
 }
 
-CUDTException& srt::CUDT::getlasterror()
+srt::CUDTException& srt::CUDT::getlasterror()
 {
     return GetThreadLocalError();
 }
@@ -4450,7 +4450,7 @@ int getlasterror_errno()
 // Get error string of a given error code
 const char* geterror_desc(int code, int err)
 {
-    CUDTException e(CodeMajor(code / 1000), CodeMinor(code % 1000), err);
+    srt::CUDTException e(CodeMajor(code / 1000), CodeMinor(code % 1000), err);
     return (e.getErrorMessage());
 }
 

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -47,7 +47,7 @@ written by
 
 using namespace std;
 
-CInfoBlock& CInfoBlock::copyFrom(const CInfoBlock& obj)
+srt::CInfoBlock& srt::CInfoBlock::copyFrom(const CInfoBlock& obj)
 {
    std::copy(obj.m_piIP, obj.m_piIP + 4, m_piIP);
    m_iIPversion       = obj.m_iIPversion;
@@ -62,7 +62,7 @@ CInfoBlock& CInfoBlock::copyFrom(const CInfoBlock& obj)
    return *this;
 }
 
-bool CInfoBlock::operator==(const CInfoBlock& obj)
+bool srt::CInfoBlock::operator==(const CInfoBlock& obj)
 {
    if (m_iIPversion != obj.m_iIPversion)
       return false;
@@ -79,7 +79,7 @@ bool CInfoBlock::operator==(const CInfoBlock& obj)
    return true;
 }
 
-CInfoBlock* CInfoBlock::clone()
+srt::CInfoBlock* srt::CInfoBlock::clone()
 {
    CInfoBlock* obj = new CInfoBlock;
 
@@ -96,7 +96,7 @@ CInfoBlock* CInfoBlock::clone()
    return obj;
 }
 
-int CInfoBlock::getKey()
+int srt::CInfoBlock::getKey()
 {
    if (m_iIPversion == AF_INET)
       return m_piIP[0];
@@ -104,7 +104,7 @@ int CInfoBlock::getKey()
    return m_piIP[0] + m_piIP[1] + m_piIP[2] + m_piIP[3];
 }
 
-void CInfoBlock::convert(const sockaddr_any& addr, uint32_t aw_ip[4])
+void srt::CInfoBlock::convert(const sockaddr_any& addr, uint32_t aw_ip[4])
 {
    if (addr.family() == AF_INET)
    {

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -48,6 +48,9 @@ written by
 #include "netinet_any.h"
 #include "udt.h"
 
+namespace srt
+{
+
 class CCacheItem
 {
 public:
@@ -265,5 +268,6 @@ public:
    static void convert(const sockaddr_any& addr, uint32_t ip[4]);
 };
 
+} // namespace srt
 
 #endif

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -700,7 +700,7 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet) const
     return res;
 }
 
-EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
+srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
 {
     EReadStatus status    = RST_OK;
     int         msg_flags = 0;

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -70,16 +70,23 @@ modified by
 
 #include <srt_compat.h> // SysStrError
 
-using namespace srt;
+using namespace std;
 using namespace srt::sync;
-
-namespace srt_logging {
-    extern Logger inlog;
-}
-
 using namespace srt_logging;
 
-CUDTException::CUDTException(CodeMajor major, CodeMinor minor, int err):
+namespace srt_logging
+{
+extern Logger inlog;
+}
+
+namespace srt
+{
+
+const char* strerror_get_message(size_t major, size_t minor);
+} // namespace srt
+
+
+srt::CUDTException::CUDTException(CodeMajor major, CodeMinor minor, int err):
 m_iMajor(major),
 m_iMinor(minor)
 {
@@ -89,34 +96,30 @@ m_iMinor(minor)
       m_iErrno = err;
 }
 
-namespace srt {
-const char* strerror_get_message(size_t major, size_t minor);
-}
-
-const char* CUDTException::getErrorMessage() const ATR_NOTHROW
+const char* srt::CUDTException::getErrorMessage() const ATR_NOTHROW
 {
-    return srt::strerror_get_message(m_iMajor, m_iMinor);
+    return strerror_get_message(m_iMajor, m_iMinor);
 }
 
-std::string CUDTException::getErrorString() const
+std::string srt::CUDTException::getErrorString() const
 {
     return getErrorMessage();
 }
 
 #define UDT_XCODE(mj, mn) (int(mj)*1000)+int(mn)
 
-int CUDTException::getErrorCode() const
+int srt::CUDTException::getErrorCode() const
 {
     return UDT_XCODE(m_iMajor, m_iMinor);
 }
 
-int CUDTException::getErrno() const
+int srt::CUDTException::getErrno() const
 {
    return m_iErrno;
 }
 
 
-void CUDTException::clear()
+void srt::CUDTException::clear()
 {
    m_iMajor = MJ_SUCCESS;
    m_iMinor = MN_NONE;
@@ -126,7 +129,7 @@ void CUDTException::clear()
 #undef UDT_XCODE
 
 //
-bool CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver)
+bool srt::CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver)
 {
    if (AF_INET == ver)
    {
@@ -154,7 +157,7 @@ bool CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver)
    return false;
 }
 
-void CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
+void srt::CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
 {
     if (addr.family() == AF_INET)
     {
@@ -173,6 +176,7 @@ void CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
     }
 }
 
+namespace srt {
 bool checkMappedIPv4(const uint16_t* addr)
 {
     static const uint16_t ipv4on6_model [8] =
@@ -187,11 +191,13 @@ bool checkMappedIPv4(const uint16_t* addr)
 
     return std::equal(mbegin, mend, addr);
 }
+}
 
 // XXX This has void return and the first argument is passed by reference.
 // Consider simply returning sockaddr_any by value.
-void CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const sockaddr_any& peer)
+void srt::CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const sockaddr_any& peer)
 {
+    //using ::srt_logging::inlog;
     uint32_t* target_ipv4_addr = NULL;
 
     if (peer.family() == AF_INET)
@@ -308,8 +314,8 @@ void CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const sockaddr
     }
 }
 
-using namespace std;
 
+namespace srt {
 static string ShowIP4(const sockaddr_in* sin)
 {
     ostringstream os;
@@ -361,9 +367,10 @@ string CIPAddress::show(const sockaddr* adr)
     else
         return "(unsupported sockaddr type)";
 }
+} // namespace srt
 
 //
-void CMD5::compute(const char* input, unsigned char result[16])
+void srt::CMD5::compute(const char* input, unsigned char result[16])
 {
    md5_state_t state;
 
@@ -372,6 +379,7 @@ void CMD5::compute(const char* input, unsigned char result[16])
    md5_finish(&state, result);
 }
 
+namespace srt {
 std::string MessageTypeStr(UDTMessageType mt, uint32_t extt)
 {
     using std::string;
@@ -470,6 +478,7 @@ bool SrtParseConfig(string s, SrtConfig& w_config)
 
     return true;
 }
+} // namespace srt
 
 namespace srt_logging
 {
@@ -535,7 +544,7 @@ std::string MemberStatusStr(SRT_MEMBERSTATUS s)
 
 #if ENABLE_LOGGING
 
-LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabled(that.CheckEnabled())
+srt::logging::LogDispatcher::Proxy::Proxy(LogDispatcher& guy) : that(guy), that_enabled(that.CheckEnabled())
 {
     if (that_enabled)
     {
@@ -555,6 +564,7 @@ LogDispatcher::Proxy LogDispatcher::operator()()
 void LogDispatcher::CreateLogLinePrefix(std::ostringstream& serr)
 {
     using namespace std;
+    using namespace srt;
 
     SRT_STATIC_ASSERT(ThreadName::BUFSIZE >= sizeof("hh:mm:ss.") * 2, // multiply 2 for some margin
                       "ThreadName::BUFSIZE is too small to be used for strftime");

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -93,6 +93,17 @@ modified by
 
 #include <exception>
 
+namespace srt_logging
+{
+    std::string SockStatusStr(SRT_SOCKSTATUS s);
+#if ENABLE_EXPERIMENTAL_BONDING
+    std::string MemberStatusStr(SRT_MEMBERSTATUS s);
+#endif
+}
+
+namespace srt
+{
+
 // Class CUDTException exposed for C++ API.
 // This is actually useless, unless you'd use a DIRECT C++ API,
 // however there's no such API so far. The current C++ API for UDT/SRT
@@ -312,9 +323,7 @@ enum EInitEvent
     TEV_INIT_OHEADBW
 };
 
-namespace srt {
-    class CPacket;
-}
+class CPacket;
 
 // XXX Use some more standard less hand-crafted solution, if possible
 // XXX Consider creating a mapping between TEV_* values and associated types,
@@ -1375,14 +1384,6 @@ public:
     }
 };
 
-namespace srt_logging
-{
-std::string SockStatusStr(SRT_SOCKSTATUS s);
-#if ENABLE_EXPERIMENTAL_BONDING
-std::string MemberStatusStr(SRT_MEMBERSTATUS s);
-#endif
-}
-
 // Version parsing
 inline ATR_CONSTEXPR uint32_t SrtVersion(int major, int minor, int patch)
 {
@@ -1413,6 +1414,8 @@ inline std::string SrtVersionString(int version)
     return buf;
 }
 
-bool SrtParseConfig(std::string s, srt::SrtConfig& w_config);
+bool SrtParseConfig(std::string s, SrtConfig& w_config);
+
+} // namespace srt
 
 #endif

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -27,7 +27,6 @@ written by
 #include "logging.h"
 #include "core.h"
 
-using namespace srt;
 using namespace srt_logging;
 
 #define SRT_MAX_KMRETRY     10
@@ -71,7 +70,7 @@ std::string KmStateStr(SRT_KM_STATE state)
 using srt_logging::KmStateStr;
 
 #if ENABLE_LOGGING
-std::string CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srtlen)
+std::string srt::CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srtlen)
 {
     std::ostringstream os;
     os << hdr << ": cmd=" << cmd << "(" << (cmd == SRT_CMD_KMREQ ? "KMREQ":"KMRSP") <<") len="
@@ -82,7 +81,7 @@ std::string CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srt
 }
 #endif
 
-void CCryptoControl::updateKmState(int cmd, size_t srtlen SRT_ATR_UNUSED)
+void srt::CCryptoControl::updateKmState(int cmd, size_t srtlen SRT_ATR_UNUSED)
 {
     if (cmd == SRT_CMD_KMREQ)
     {
@@ -98,7 +97,7 @@ void CCryptoControl::updateKmState(int cmd, size_t srtlen SRT_ATR_UNUSED)
     }
 }
 
-void CCryptoControl::createFakeSndContext()
+void srt::CCryptoControl::createFakeSndContext()
 {
     if (!m_iSndKmKeyLen)
         m_iSndKmKeyLen = 16;
@@ -110,7 +109,7 @@ void CCryptoControl::createFakeSndContext()
     }
 }
 
-int CCryptoControl::processSrtMsg_KMREQ(
+int srt::CCryptoControl::processSrtMsg_KMREQ(
         const uint32_t* srtdata SRT_ATR_UNUSED,
         size_t bytelen SRT_ATR_UNUSED,
         int hsv SRT_ATR_UNUSED,
@@ -243,7 +242,7 @@ int CCryptoControl::processSrtMsg_KMREQ(
 
     // Configure the sender context also, if it succeeded to configure the
     // receiver context and we are using bidirectional mode.
-    if ( bidirectional )
+    if (bidirectional)
     {
         // Note: 'bidirectional' means that we want a bidirectional key update,
         // which happens only and exclusively with HSv5 handshake - not when the
@@ -321,7 +320,7 @@ HSv4_ErrorReport:
     return SRT_CMD_KMRSP;
 }
 
-int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int /* XXX unused? hsv*/)
+int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int /* XXX unused? hsv*/)
 {
     /* All 32-bit msg fields (if present) swapped on reception
      * But HaiCrypt expect network order message
@@ -420,7 +419,7 @@ int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int
     return retstatus;
 }
 
-void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen SRT_ATR_UNUSED)
+void srt::CCryptoControl::sendKeysToPeer(Whether2RegenKm regen SRT_ATR_UNUSED)
 {
     if ( !m_hSndCrypto || m_SndKmState == SRT_KM_S_UNSECURED)
     {
@@ -467,7 +466,7 @@ void CCryptoControl::sendKeysToPeer(Whether2RegenKm regen SRT_ATR_UNUSED)
 }
 
 #ifdef SRT_ENABLE_ENCRYPTION
-void CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
+void srt::CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
 {
     if (!m_hSndCrypto)
         return;
@@ -545,16 +544,16 @@ void CCryptoControl::regenCryptoKm(bool sendit, bool bidirectional)
 }
 #endif
 
-CCryptoControl::CCryptoControl(CUDT* parent, SRTSOCKET id):
-m_parent(parent), // should be initialized in createCC()
-m_SocketID(id),
-m_iSndKmKeyLen(0),
-m_iRcvKmKeyLen(0),
-m_SndKmState(SRT_KM_S_UNSECURED),
-m_RcvKmState(SRT_KM_S_UNSECURED),
-m_KmRefreshRatePkt(0),
-m_KmPreAnnouncePkt(0),
-m_bErrorReported(false)
+srt::CCryptoControl::CCryptoControl(CUDT* parent, SRTSOCKET id)
+    : m_parent(parent) // should be initialized in createCC()
+    , m_SocketID(id)
+    , m_iSndKmKeyLen(0)
+    , m_iRcvKmKeyLen(0)
+    , m_SndKmState(SRT_KM_S_UNSECURED)
+    , m_RcvKmState(SRT_KM_S_UNSECURED)
+    , m_KmRefreshRatePkt(0)
+    , m_KmPreAnnouncePkt(0)
+    , m_bErrorReported(false)
 {
 
     m_KmSecret.len = 0;
@@ -568,7 +567,7 @@ m_bErrorReported(false)
     m_hRcvCrypto = NULL;
 }
 
-bool CCryptoControl::init(HandshakeSide side, bool bidirectional SRT_ATR_UNUSED)
+bool srt::CCryptoControl::init(HandshakeSide side, bool bidirectional SRT_ATR_UNUSED)
 {
     // NOTE: initiator creates m_hSndCrypto. When bidirectional,
     // it creates also m_hRcvCrypto with the same key length.
@@ -645,15 +644,15 @@ bool CCryptoControl::init(HandshakeSide side, bool bidirectional SRT_ATR_UNUSED)
     return true;
 }
 
-void CCryptoControl::close() 
+void srt::CCryptoControl::close() 
 {
     /* Wipeout secrets */
     memset(&m_KmSecret, 0, sizeof(m_KmSecret));
 }
 
-std::string CCryptoControl::CONID() const
+std::string srt::CCryptoControl::CONID() const
 {
-    if ( m_SocketID == 0 )
+    if (m_SocketID == 0)
         return "";
 
     std::ostringstream os;
@@ -665,6 +664,7 @@ std::string CCryptoControl::CONID() const
 #ifdef SRT_ENABLE_ENCRYPTION
 
 #if ENABLE_HEAVY_LOGGING
+namespace srt {
 static std::string CryptoFlags(int flg)
 {
     using namespace std;
@@ -681,9 +681,10 @@ static std::string CryptoFlags(int flg)
     copy(f.begin(), f.end(), ostream_iterator<string>(os, "|"));
     return os.str();
 }
+} // namespace srt
 #endif // ENABLE_HEAVY_LOGGING
 
-bool CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir, HaiCrypt_Handle& w_hCrypto)
+bool srt::CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir, HaiCrypt_Handle& w_hCrypto)
 {
 
     if (w_hCrypto)
@@ -732,14 +733,14 @@ bool CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir, Hai
     return true;
 }
 #else
-bool CCryptoControl::createCryptoCtx(size_t, HaiCrypt_CryptoDir, HaiCrypt_Handle&)
+bool srt::CCryptoControl::createCryptoCtx(size_t, HaiCrypt_CryptoDir, HaiCrypt_Handle&)
 {
     return false;
 }
-#endif
+#endif // SRT_ENABLE_ENCRYPTION
 
 
-EncryptionStatus CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNUSED)
+srt::EncryptionStatus srt::CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNUSED)
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     // Encryption not enabled - do nothing.
@@ -764,7 +765,7 @@ EncryptionStatus CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNUSED)
 #endif
 }
 
-EncryptionStatus CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNUSED)
+srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNUSED)
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     if (w_packet.getMsgCryptoFlags() == EK_NOENC)
@@ -840,7 +841,7 @@ EncryptionStatus CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNUSED)
 }
 
 
-CCryptoControl::~CCryptoControl()
+srt::CCryptoControl::~CCryptoControl()
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     close();

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -856,38 +856,3 @@ srt::CCryptoControl::~CCryptoControl()
     }
 #endif
 }
-
-
-std::string SrtFlagString(int32_t flags)
-{
-#define LEN(arr) (sizeof (arr)/(sizeof ((arr)[0])))
-
-    std::string output;
-    static std::string namera[] = { "TSBPD-snd", "TSBPD-rcv", "haicrypt", "TLPktDrop", "NAKReport", "ReXmitFlag", "StreamAPI" };
-
-    size_t i = 0;
-    for ( ; i < LEN(namera); ++i )
-    {
-        if ( (flags & 1) == 1 )
-        {
-            output += "+" + namera[i] + " ";
-        }
-        else
-        {
-            output += "-" + namera[i] + " ";
-        }
-
-        flags >>= 1;
-       //if ( flags == 0 )
-       //    break;
-    }
-
-#undef LEN
-
-    if ( flags != 0 )
-    {
-        output += "+unknown";
-    }
-
-    return output;
-}

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -40,8 +40,7 @@ extern Logger cnlog;
 
 namespace srt
 {
-    class CUDT;
-}
+class CUDT;
 
 
 // For KMREQ/KMRSP. Only one field is used.
@@ -54,11 +53,11 @@ enum Whether2RegenKm {DONT_REGEN_KM = 0, REGEN_KM = 1};
 
 class CCryptoControl
 {
-    srt::CUDT*  m_parent;
-    SRTSOCKET   m_SocketID;
+    CUDT*     m_parent;
+    SRTSOCKET m_SocketID;
 
-    size_t      m_iSndKmKeyLen;        //Key length
-    size_t      m_iRcvKmKeyLen;        //Key length from rx KM
+    size_t    m_iSndKmKeyLen;        //Key length
+    size_t    m_iRcvKmKeyLen;        //Key length from rx KM
 
     // Temporarily allow these to be accessed.
 public:
@@ -73,7 +72,7 @@ private:
 
     HaiCrypt_Secret m_KmSecret;     //Key material shared secret
     // Sender
-    srt::sync::steady_clock::time_point     m_SndKmLastTime;
+    sync::steady_clock::time_point m_SndKmLastTime;
     struct {
         unsigned char Msg[HCRYPT_MSG_KM_MAX_SZ];
         size_t MsgLen;
@@ -166,7 +165,7 @@ public:
         using srt_logging::cnlog;
 #endif
 
-        m_SndKmLastTime = srt::sync::steady_clock::now();
+        m_SndKmLastTime = sync::steady_clock::now();
         if (runtime)
         {
             m_SndKmMsg[ki].iPeerRetry--;
@@ -196,7 +195,7 @@ public:
         return false;
     }
 
-    CCryptoControl(srt::CUDT* parent, SRTSOCKET id);
+    CCryptoControl(CUDT* parent, SRTSOCKET id);
 
     // DEBUG PURPOSES:
     std::string CONID() const;
@@ -258,16 +257,18 @@ public:
     /// the encryption will fail.
     /// XXX Encryption flags in the PH_MSGNO
     /// field in the header must be correctly set before calling.
-    EncryptionStatus encrypt(srt::CPacket& w_packet);
+    EncryptionStatus encrypt(CPacket& w_packet);
 
     /// Decrypts the packet. If the packet has ENCKEYSPEC part
     /// in PH_MSGNO set to EK_NOENC, it does nothing. It decrypts
     /// only if the encryption correctly configured, otherwise it
     /// fails. After successful decryption, the ENCKEYSPEC part
     // in PH_MSGNO is set to EK_NOENC.
-    EncryptionStatus decrypt(srt::CPacket& w_packet);
+    EncryptionStatus decrypt(CPacket& w_packet);
 
     ~CCryptoControl();
 };
+
+} // namespace srt
 
 #endif // SRT_CONGESTION_CONTROL_H

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -71,7 +71,9 @@ using namespace std;
 using namespace srt::sync;
 
 #if ENABLE_HEAVY_LOGGING
+namespace srt {
 static ostream& PrintEpollEvent(ostream& os, int events, int et_events = 0);
+}
 #endif
 
 namespace srt_logging
@@ -85,19 +87,19 @@ using namespace srt_logging;
 #define IF_DIRNAME(tested, flag, name) (tested & flag ? name : "")
 #endif
 
-CEPoll::CEPoll():
+srt::CEPoll::CEPoll():
 m_iIDSeed(0)
 {
    // Exception -> CUDTUnited ctor.
    setupMutex(m_EPollLock, "EPoll");
 }
 
-CEPoll::~CEPoll()
+srt::CEPoll::~CEPoll()
 {
    releaseMutex(m_EPollLock);
 }
 
-int CEPoll::create(CEPollDesc** pout)
+int srt::CEPoll::create(CEPollDesc** pout)
 {
    ScopedLock pg(m_EPollLock);
 
@@ -162,7 +164,7 @@ ENOMEM: There was insufficient memory to create the kernel object.
    return m_iIDSeed;
 }
 
-int CEPoll::clear_usocks(int eid)
+int srt::CEPoll::clear_usocks(int eid)
 {
     // This should remove all SRT sockets from given eid.
    ScopedLock pg (m_EPollLock);
@@ -179,7 +181,7 @@ int CEPoll::clear_usocks(int eid)
 }
 
 
-void CEPoll::clear_ready_usocks(CEPollDesc& d, int direction)
+void srt::CEPoll::clear_ready_usocks(CEPollDesc& d, int direction)
 {
     if ((direction & ~SRT_EPOLL_EVENTTYPES) != 0)
     {
@@ -216,7 +218,7 @@ void CEPoll::clear_ready_usocks(CEPollDesc& d, int direction)
         d.removeSubscription(cleared[i]);
 }
 
-int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
+int srt::CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
 {
    ScopedLock pg(m_EPollLock);
 
@@ -288,7 +290,7 @@ int CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)
    return 0;
 }
 
-int CEPoll::remove_ssock(const int eid, const SYSSOCKET& s)
+int srt::CEPoll::remove_ssock(const int eid, const SYSSOCKET& s)
 {
    ScopedLock pg(m_EPollLock);
 
@@ -319,7 +321,7 @@ int CEPoll::remove_ssock(const int eid, const SYSSOCKET& s)
 }
 
 // Need this to atomically modify polled events (ex: remove write/keep read)
-int CEPoll::update_usock(const int eid, const SRTSOCKET& u, const int* events)
+int srt::CEPoll::update_usock(const int eid, const SRTSOCKET& u, const int* events)
 {
     ScopedLock pg(m_EPollLock);
     IF_HEAVY_LOGGING(ostringstream evd);
@@ -391,7 +393,7 @@ int CEPoll::update_usock(const int eid, const SRTSOCKET& u, const int* events)
     return 0;
 }
 
-int CEPoll::update_ssock(const int eid, const SYSSOCKET& s, const int* events)
+int srt::CEPoll::update_ssock(const int eid, const SYSSOCKET& s, const int* events)
 {
    ScopedLock pg(m_EPollLock);
 
@@ -462,7 +464,7 @@ int CEPoll::update_ssock(const int eid, const SYSSOCKET& s, const int* events)
    return 0;
 }
 
-int CEPoll::setflags(const int eid, int32_t flags)
+int srt::CEPoll::setflags(const int eid, int32_t flags)
 {
     ScopedLock pg(m_EPollLock);
     map<int, CEPollDesc>::iterator p = m_mPolls.find(eid);
@@ -487,7 +489,7 @@ int CEPoll::setflags(const int eid, int32_t flags)
     return oflags;
 }
 
-int CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
+int srt::CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
     // It is allowed to call this function witn fdsSize == 0
     // and therefore also NULL fdsSet. This will then only report
@@ -552,7 +554,7 @@ int CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t m
     return 0;
 }
 
-int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefds, int64_t msTimeOut, set<SYSSOCKET>* lrfds, set<SYSSOCKET>* lwfds)
+int srt::CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefds, int64_t msTimeOut, set<SYSSOCKET>* lrfds, set<SYSSOCKET>* lwfds)
 {
     // if all fields is NULL and waiting time is infinite, then this would be a deadlock
     if (!readfds && !writefds && !lrfds && !lwfds && (msTimeOut < 0))
@@ -749,7 +751,7 @@ int CEPoll::wait(const int eid, set<SRTSOCKET>* readfds, set<SRTSOCKET>* writefd
     return 0;
 }
 
-int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, bool report_by_exception)
+int srt::CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, bool report_by_exception)
 {
     {
         ScopedLock lg (m_EPollLock);
@@ -836,13 +838,13 @@ int CEPoll::swait(CEPollDesc& d, map<SRTSOCKET, int>& st, int64_t msTimeOut, boo
     return 0;
 }
 
-bool CEPoll::empty(const CEPollDesc& d) const
+bool srt::CEPoll::empty(const CEPollDesc& d) const
 {
     ScopedLock lg (m_EPollLock);
     return d.watch_empty();
 }
 
-int CEPoll::release(const int eid)
+int srt::CEPoll::release(const int eid)
 {
    ScopedLock pg(m_EPollLock);
 
@@ -863,7 +865,7 @@ int CEPoll::release(const int eid)
 }
 
 
-int CEPoll::update_events(const SRTSOCKET& uid, std::set<int>& eids, const int events, const bool enable)
+int srt::CEPoll::update_events(const SRTSOCKET& uid, std::set<int>& eids, const int events, const bool enable)
 {
     // As event flags no longer contain only event types, check now.
     if ((events & ~SRT_EPOLL_EVENTTYPES) != 0)
@@ -950,6 +952,9 @@ int CEPoll::update_events(const SRTSOCKET& uid, std::set<int>& eids, const int e
 
 // Debug use only.
 #if ENABLE_HEAVY_LOGGING
+namespace srt
+{
+
 static ostream& PrintEpollEvent(ostream& os, int events, int et_events)
 {
     static pair<int, const char*> const namemap [] = {
@@ -1001,5 +1006,7 @@ string CEPollDesc::DisplayEpollWatch()
 
     return os.str();
 }
+
+} // namespace srt
 
 #endif

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -59,6 +59,13 @@ modified by
 #include <list>
 #include "udt.h"
 
+namespace srt
+{
+
+class CUDT;
+class CRendezvousQueue;
+class CUDTGroup;
+
 
 class CEPollDesc
 {
@@ -348,13 +355,6 @@ std::string DisplayEpollWatch();
    }
 };
 
-namespace srt
-{
-    class CUDT;
-    class CRendezvousQueue;
-    class CUDTGroup;
-}
-
 class CEPoll
 {
 friend class srt::CUDT;
@@ -499,6 +499,8 @@ private:
 #if ENABLE_HEAVY_LOGGING
 std::string DisplayEpollResults(const std::map<SRTSOCKET, int>& sockset);
 #endif
+
+} // namespace srt
 
 
 #endif

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -61,7 +61,7 @@ using namespace std;
 using namespace srt;
 
 
-CHandShake::CHandShake()
+srt::CHandShake::CHandShake()
     : m_iVersion(0)
     , m_iType(0) // Universal: UDT_UNDEFINED or no flags
     , m_iISN(0)
@@ -76,7 +76,7 @@ CHandShake::CHandShake()
       m_piPeerIP[i] = 0;
 }
 
-int CHandShake::store_to(char* buf, size_t& w_size)
+int srt::CHandShake::store_to(char* buf, size_t& w_size)
 {
    if (w_size < m_iContentSize)
       return -1;
@@ -98,7 +98,7 @@ int CHandShake::store_to(char* buf, size_t& w_size)
    return 0;
 }
 
-int CHandShake::load_from(const char* buf, size_t size)
+int srt::CHandShake::load_from(const char* buf, size_t size)
 {
    if (size < m_iContentSize)
       return -1;
@@ -121,6 +121,8 @@ int CHandShake::load_from(const char* buf, size_t size)
 
 #ifdef ENABLE_LOGGING
 
+namespace srt
+{
 const char* srt_rejectreason_name [] = {
     "UNKNOWN",
     "SYSTEM",
@@ -138,8 +140,9 @@ const char* srt_rejectreason_name [] = {
     "CONGESTION",
     "FILTER",
 };
+}
 
-std::string RequestTypeStr(UDTRequestType rq)
+std::string srt::RequestTypeStr(UDTRequestType rq)
 {
     if (rq >= URQ_FAILURE_TYPES)
     {
@@ -172,7 +175,7 @@ std::string RequestTypeStr(UDTRequestType rq)
     }
 }
 
-string CHandShake::RdvStateStr(CHandShake::RendezvousState s)
+string srt::CHandShake::RdvStateStr(CHandShake::RendezvousState s)
 {
     switch (s)
     {
@@ -188,7 +191,7 @@ string CHandShake::RdvStateStr(CHandShake::RendezvousState s)
 }
 #endif
 
-bool CHandShake::valid()
+bool srt::CHandShake::valid()
 {
     if (m_iVersion < CUDT::HS_VERSION_UDT4
             || m_iISN < 0 || m_iISN >= CSeqNo::m_iMaxSeqNo
@@ -199,7 +202,7 @@ bool CHandShake::valid()
     return true;
 }
 
-string CHandShake::show()
+string srt::CHandShake::show()
 {
     ostringstream so;
 
@@ -231,7 +234,7 @@ string CHandShake::show()
     return so.str();
 }
 
-string CHandShake::ExtensionFlagStr(int32_t fl)
+string srt::CHandShake::ExtensionFlagStr(int32_t fl)
 {
     std::ostringstream out;
     if ( fl & HS_EXT_HSREQ )
@@ -258,7 +261,7 @@ string CHandShake::ExtensionFlagStr(int32_t fl)
 // XXX This code isn't currently used. Left here because it can
 // be used in future, should any refactoring for the "manual word placement"
 // code be done.
-bool SrtHSRequest::serialize(char* buf, size_t size) const
+bool srt::SrtHSRequest::serialize(char* buf, size_t size) const
 {
     if (size < SRT_HS_SIZE)
         return false;
@@ -273,7 +276,7 @@ bool SrtHSRequest::serialize(char* buf, size_t size) const
 }
 
 
-bool SrtHSRequest::deserialize(const char* buf, size_t size)
+bool srt::SrtHSRequest::deserialize(const char* buf, size_t size)
 {
     m_iSrtVersion = 0; // just to let users recognize if it succeeded or not.
 
@@ -287,4 +290,36 @@ bool SrtHSRequest::deserialize(const char* buf, size_t size)
     m_iSrtTsbpd = (*p++);
     m_iSrtReserved = (*p++);
     return true;
+}
+
+std::string srt::SrtFlagString(int32_t flags)
+{
+#define LEN(arr) (sizeof (arr)/(sizeof ((arr)[0])))
+
+    std::string output;
+    static std::string namera[] = { "TSBPD-snd", "TSBPD-rcv", "haicrypt", "TLPktDrop", "NAKReport", "ReXmitFlag", "StreamAPI" };
+
+    size_t i = 0;
+    for (; i < LEN(namera); ++i)
+    {
+        if ((flags & 1) == 1)
+        {
+            output += "+" + namera[i] + " ";
+        }
+        else
+        {
+            output += "-" + namera[i] + " ";
+        }
+
+        flags >>= 1;
+    }
+
+#undef LEN
+
+    if (flags != 0)
+    {
+        output += "+unknown";
+    }
+
+    return output;
 }

--- a/srtcore/handshake.h
+++ b/srtcore/handshake.h
@@ -51,6 +51,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "crypto.h"
 #include "utilities.h"
 
+namespace srt
+{
+
 typedef Bits<31, 16> HS_CMDSPEC_CMD;
 typedef Bits<15, 0> HS_CMDSPEC_SIZE;
 
@@ -126,7 +129,6 @@ struct SrtHandshakeExtension
 // Implemented in core.cpp, so far
 void SrtExtractHandshakeExtensions(const char* bufbegin, size_t size,
         std::vector<SrtHandshakeExtension>& w_output);
-
 
 
 struct SrtHSRequest: public SrtHandshakeExtension
@@ -359,5 +361,6 @@ public:
 
 };
 
+} // namespace srt
 
 #endif

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -68,7 +68,7 @@ using srt_logging::qslog;
 
 using namespace srt::sync;
 
-CSndLossList::CSndLossList(int size)
+srt::CSndLossList::CSndLossList(int size)
     : m_caSeq()
     , m_iHead(-1)
     , m_iLength(0)
@@ -89,13 +89,13 @@ CSndLossList::CSndLossList(int size)
     setupMutex(m_ListLock, "LossList");
 }
 
-CSndLossList::~CSndLossList()
+srt::CSndLossList::~CSndLossList()
 {
     delete[] m_caSeq;
     releaseMutex(m_ListLock);
 }
 
-void CSndLossList::traceState() const
+void srt::CSndLossList::traceState() const
 {
     int pos = m_iHead;
     while (pos != SRT_SEQNO_NONE)
@@ -109,7 +109,7 @@ void CSndLossList::traceState() const
     std::cout << "\n";
 }
 
-int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
+int srt::CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 {
     if (seqno1 < 0 || seqno2 < 0 ) {
         LOGC(qslog.Error, log << "IPE: Tried to insert negative seqno " << seqno1 << ":" << seqno2
@@ -226,7 +226,7 @@ int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
     return m_iLength - origlen;
 }
 
-void CSndLossList::removeUpTo(int32_t seqno)
+void srt::CSndLossList::removeUpTo(int32_t seqno)
 {
     ScopedLock listguard(m_ListLock);
 
@@ -338,14 +338,14 @@ void CSndLossList::removeUpTo(int32_t seqno)
     }
 }
 
-int CSndLossList::getLossLength() const
+int srt::CSndLossList::getLossLength() const
 {
     ScopedLock listguard(m_ListLock);
 
     return m_iLength;
 }
 
-int32_t CSndLossList::popLostSeq()
+int32_t srt::CSndLossList::popLostSeq()
 {
     ScopedLock listguard(m_ListLock);
 
@@ -389,7 +389,7 @@ int32_t CSndLossList::popLostSeq()
     return seqno;
 }
 
-void CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
+void srt::CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
 {
     SRT_ASSERT(pos >= 0);
     m_caSeq[pos].seqstart = seqno1;
@@ -405,7 +405,7 @@ void CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
     m_iLength += CSeqNo::seqlen(seqno1, seqno2);
 }
 
-void CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2)
+void srt::CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2)
 {
     m_caSeq[pos].seqstart = seqno1;
     SRT_ASSERT(m_caSeq[pos].seqend == SRT_SEQNO_NONE);
@@ -419,7 +419,7 @@ void CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int32_t s
     m_iLength += CSeqNo::seqlen(seqno1, seqno2);
 }
 
-void CSndLossList::coalesce(int loc)
+void srt::CSndLossList::coalesce(int loc)
 {
     // coalesce with next node. E.g., [3, 7], ..., [6, 9] becomes [3, 9]
     while ((m_caSeq[loc].inext != -1) && (m_caSeq[loc].seqend != SRT_SEQNO_NONE))
@@ -455,7 +455,7 @@ void CSndLossList::coalesce(int loc)
     }
 }
 
-bool CSndLossList::updateElement(int pos, int32_t seqno1, int32_t seqno2)
+bool srt::CSndLossList::updateElement(int pos, int32_t seqno1, int32_t seqno2)
 {
     m_iLastInsertPos = pos;
 
@@ -481,7 +481,7 @@ bool CSndLossList::updateElement(int pos, int32_t seqno1, int32_t seqno2)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-CRcvLossList::CRcvLossList(int size)
+srt::CRcvLossList::CRcvLossList(int size)
     : m_caSeq()
     , m_iHead(-1)
     , m_iTail(-1)
@@ -499,12 +499,12 @@ CRcvLossList::CRcvLossList(int size)
     }
 }
 
-CRcvLossList::~CRcvLossList()
+srt::CRcvLossList::~CRcvLossList()
 {
     delete[] m_caSeq;
 }
 
-void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
+void srt::CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
 {
     // Data to be inserted must be larger than all those in the list
     if (m_iLargestSeq != SRT_SEQNO_NONE && CSeqNo::seqcmp(seqno1, m_iLargestSeq) <= 0)
@@ -578,7 +578,7 @@ void CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
     m_iLength += CSeqNo::seqlen(seqno1, seqno2);
 }
 
-bool CRcvLossList::remove(int32_t seqno)
+bool srt::CRcvLossList::remove(int32_t seqno)
 {
     if (m_iLargestSeq == SRT_SEQNO_NONE || CSeqNo::seqcmp(seqno, m_iLargestSeq) > 0)
         m_iLargestSeq = seqno;
@@ -713,7 +713,7 @@ bool CRcvLossList::remove(int32_t seqno)
     return true;
 }
 
-bool CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
+bool srt::CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
 {
     if (seqno1 <= seqno2)
     {
@@ -731,7 +731,7 @@ bool CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
     return true;
 }
 
-bool CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
+bool srt::CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
 {
     if (0 == m_iLength)
         return false;
@@ -752,12 +752,12 @@ bool CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
     return false;
 }
 
-int CRcvLossList::getLossLength() const
+int srt::CRcvLossList::getLossLength() const
 {
     return m_iLength;
 }
 
-int32_t CRcvLossList::getFirstLostSeq() const
+int32_t srt::CRcvLossList::getFirstLostSeq() const
 {
     if (0 == m_iLength)
         return SRT_SEQNO_NONE;
@@ -765,7 +765,7 @@ int32_t CRcvLossList::getFirstLostSeq() const
     return m_caSeq[m_iHead].seqstart;
 }
 
-void CRcvLossList::getLossArray(int32_t* array, int& len, int limit)
+void srt::CRcvLossList::getLossArray(int32_t* array, int& len, int limit)
 {
     len = 0;
 
@@ -788,7 +788,7 @@ void CRcvLossList::getLossArray(int32_t* array, int& len, int limit)
     }
 }
 
-CRcvFreshLoss::CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_age)
+srt::CRcvFreshLoss::CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_age)
     : ttl(initial_age)
     , timestamp(steady_clock::now())
 {
@@ -796,7 +796,7 @@ CRcvFreshLoss::CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_age)
     seq[1] = seqhi;
 }
 
-CRcvFreshLoss::Emod CRcvFreshLoss::revoke(int32_t sequence)
+srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t sequence)
 {
     int32_t diffbegin = CSeqNo::seqcmp(sequence, seq[0]);
     int32_t diffend   = CSeqNo::seqcmp(sequence, seq[1]);
@@ -827,7 +827,7 @@ CRcvFreshLoss::Emod CRcvFreshLoss::revoke(int32_t sequence)
     return SPLIT;
 }
 
-CRcvFreshLoss::Emod CRcvFreshLoss::revoke(int32_t lo, int32_t hi)
+srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t lo, int32_t hi)
 {
     // This should only if the range lo-hi is anyhow covered by seq[0]-seq[1].
 

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -56,6 +56,8 @@ modified by
 #include "udt.h"
 #include "common.h"
 
+namespace srt {
+
 class CSndLossList
 {
 public:
@@ -263,5 +265,7 @@ struct CRcvFreshLoss
     Emod revoke(int32_t sequence);
     Emod revoke(int32_t lo, int32_t hi);
 };
+
+} // namespace srt
 
 #endif

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -27,6 +27,9 @@ written by
 // You can use the instances of sockaddr_any in every place where sockaddr is
 // required.
 
+namespace srt
+{
+
 struct sockaddr_any
 {
     union
@@ -417,5 +420,7 @@ template <>
 inline sockaddr_any::TypeMap<AF_INET>::type& sockaddr_any::get<AF_INET>() { return sin; }
 template <>
 inline sockaddr_any::TypeMap<AF_INET6>::type& sockaddr_any::get<AF_INET6>() { return sin6; }
+
+} // namespace srt
 
 #endif

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -401,12 +401,12 @@ void srt::CPacket::toHL()
 }
 
 
-IOVector* srt::CPacket::getPacketVector()
+srt::IOVector* srt::CPacket::getPacketVector()
 {
    return m_PacketVector;
 }
 
-UDTMessageType srt::CPacket::getType() const
+srt::UDTMessageType srt::CPacket::getType() const
 {
     return UDTMessageType(SEQNO_MSGTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]));
 }
@@ -434,7 +434,7 @@ uint16_t srt::CPacket::getControlFlags() const
     return SEQNO_EXTTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]);
 }
 
-PacketBoundary srt::CPacket::getMsgBoundary() const
+srt::PacketBoundary srt::CPacket::getMsgBoundary() const
 {
     return PacketBoundary(MSGNO_PACKET_BOUNDARY::unwrap(m_nHeader[SRT_PH_MSGNO]));
 }
@@ -462,7 +462,7 @@ bool srt::CPacket::getRexmitFlag() const
     return 0 !=  MSGNO_REXMIT::unwrap(m_nHeader[SRT_PH_MSGNO]);
 }
 
-EncryptionKeySpec srt::CPacket::getMsgCryptoFlags() const
+srt::EncryptionKeySpec srt::CPacket::getMsgCryptoFlags() const
 {
     return EncryptionKeySpec(MSGNO_ENCKEYSPEC::unwrap(m_nHeader[SRT_PH_MSGNO]));
 }

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -59,6 +59,8 @@ modified by
 #include "netinet_any.h"
 #include "packetfilter_api.h"
 
+namespace srt {
+
 //////////////////////////////////////////////////////////////////////////////
 // The purpose of the IOVector class is to proide a platform-independet interface
 // to the WSABUF on Windows and iovec on Linux, that can be easilly converted
@@ -214,8 +216,6 @@ inline EncryptionKeySpec GetEncryptionKeySpec(int32_t msgno)
 
 const int32_t PUMASK_SEQNO_PROBE = 0xF;
 
-
-namespace srt {
 std::string PacketMessageFlagStr(uint32_t msgno_field);
 
 class CPacket
@@ -284,7 +284,7 @@ public:
 
    void setControl(UDTMessageType type)
    {
-       m_nHeader[srt::SRT_PH_SEQNO] = SEQNO_CONTROL::mask | SEQNO_MSGTYPE::wrap(type);
+       m_nHeader[SRT_PH_SEQNO] = SEQNO_CONTROL::mask | SEQNO_MSGTYPE::wrap(type);
    }
 
       /// Read the extended packet type.

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -857,7 +857,7 @@ srt::CRendezvousQueue::~CRendezvousQueue()
     m_lRendezvousID.clear();
 }
 
-void srt::CRendezvousQueue::insert(const SRTSOCKET&                id,
+void srt::CRendezvousQueue::insert(const SRTSOCKET&           id,
                               CUDT*                           u,
                               const sockaddr_any&             addr,
                               const steady_clock::time_point& ttl)
@@ -1345,7 +1345,7 @@ void* srt::CRcvQueue::worker(void* param)
     return NULL;
 }
 
-EReadStatus srt::CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
+srt::EReadStatus srt::CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
 {
 #if !USE_BUSY_WAITING
     // This might be not really necessary, and probably
@@ -1403,7 +1403,7 @@ EReadStatus srt::CRcvQueue::worker_RetrieveUnit(int32_t& w_id, CUnit*& w_unit, s
     return rst;
 }
 
-EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
+srt::EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
 {
     HLOGC(cnlog.Debug,
           log << "Got sockID=0 from " << addr.str() << " - trying to resolve it as a connection request...");
@@ -1446,7 +1446,7 @@ EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, cons
     return worker_TryAsyncRend_OrStore(0, unit, addr); // 0 id because the packet came in with that very ID.
 }
 
-EConnectStatus srt::CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& addr)
+srt::EConnectStatus srt::CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* unit, const sockaddr_any& addr)
 {
     CUDT* u = m_pHash->lookup(id);
     if (!u)
@@ -1498,7 +1498,7 @@ EConnectStatus srt::CRcvQueue::worker_ProcessAddressedPacket(int32_t id, CUnit* 
 // This function then tries to manage the packet as a rendezvous connection
 // request in ASYNC mode; when this is not applicable, it stores the packet
 // in the "receiving queue" so that it will be picked up in the "main" thread.
-EConnectStatus srt::CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& addr)
+srt::EConnectStatus srt::CRcvQueue::worker_TryAsyncRend_OrStore(int32_t id, CUnit* unit, const sockaddr_any& addr)
 {
     // This 'retrieve' requires that 'id' be either one of those
     // stored in the rendezvous queue (see CRcvQueue::registerConnector)

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -138,7 +138,7 @@ private:
     CUnit* m_pAvailUnit; // recent available unit
 
     int m_iSize;  // total size of the unit queue, in number of packets
-    srt::sync::atomic<int> m_iCount;        // total number of valid (occupied) packets in the queue
+    sync::atomic<int> m_iCount;        // total number of valid (occupied) packets in the queue
 
     int m_iMSS;       // unit buffer size
     int m_iIPversion; // IP version
@@ -153,7 +153,7 @@ struct CSNode
     CUDT*                          m_pUDT; // Pointer to the instance of CUDT socket
     sync::steady_clock::time_point m_tsTimeStamp;
 
-    srt::sync::atomic<int> m_iHeapLoc; // location on the heap, -1 means not on the heap
+    sync::atomic<int> m_iHeapLoc; // location on the heap, -1 means not on the heap
 };
 
 class CSndUList
@@ -240,7 +240,7 @@ struct CRNode
     CRNode* m_pPrev; // previous link
     CRNode* m_pNext; // next link
 
-    srt::sync::atomic<bool> m_bOnList;              // if the node is already on the list
+    sync::atomic<bool> m_bOnList; // if the node is already on the list
 };
 
 class CRcvUList
@@ -394,10 +394,10 @@ private:
 private:
     struct CRL
     {
-        SRTSOCKET                           m_iID;      // SRT socket ID (self)
-        CUDT*                               m_pUDT;     // CUDT instance
-        sockaddr_any                        m_PeerAddr; // SRT sonnection peer address
-        srt::sync::steady_clock::time_point m_tsTTL;    // the time that this request expires
+        SRTSOCKET                      m_iID;      // SRT socket ID (self)
+        CUDT*                          m_pUDT;     // CUDT instance
+        sockaddr_any                   m_PeerAddr; // SRT sonnection peer address
+        sync::steady_clock::time_point m_tsTTL;    // the time that this request expires
     };
     std::list<CRL> m_lRendezvousID; // The sockets currently in rendezvous mode
 
@@ -424,7 +424,7 @@ public:
     /// @param [in] c UDP channel to be associated to the queue
     /// @param [in] t Timer
 
-    void init(CChannel* c, srt::sync::CTimer* t);
+    void init(CChannel* c, sync::CTimer* t);
 
     /// Send out a packet to a given address.
     /// @param [in] addr destination address
@@ -454,15 +454,15 @@ public:
     void setClosing() { m_bClosing = true; }
 
 private:
-    static void*       worker(void* param);
-    srt::sync::CThread m_WorkerThread;
+    static void*  worker(void* param);
+    sync::CThread m_WorkerThread;
 
 private:
-    CSndUList*         m_pSndUList; // List of UDT instances for data sending
-    CChannel*          m_pChannel;  // The UDP channel for data sending
-    srt::sync::CTimer* m_pTimer;    // Timing facility
+    CSndUList*    m_pSndUList; // List of UDT instances for data sending
+    CChannel*     m_pChannel;  // The UDP channel for data sending
+    sync::CTimer* m_pTimer;    // Timing facility
 
-    srt::sync::atomic<bool> m_bClosing;            // closing the worker
+    sync::atomic<bool> m_bClosing;            // closing the worker
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE) //>>debug high freq worker
     uint64_t m_ullDbgPeriod;
@@ -542,7 +542,7 @@ private:
 
     size_t m_szPayloadSize; // packet payload size
 
-    srt::sync::atomic<bool> m_bClosing;            // closing the worker
+    sync::atomic<bool> m_bClosing; // closing the worker
 #if ENABLE_LOGGING
     static int m_counter;
 #endif

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -73,6 +73,9 @@ written by
 // NOTE: SRT_VERSION is primarily defined in the build file.
 extern const int32_t SRT_DEF_VERSION;
 
+namespace srt
+{
+
 struct CSrtMuxerConfig
 {
     static const int DEF_UDP_BUFFER_SIZE = 65536;
@@ -308,37 +311,6 @@ struct CSrtConfig: CSrtMuxerConfig
     int set(SRT_SOCKOPT optName, const void* val, int size);
 };
 
-
-#if ENABLE_EXPERIMENTAL_BONDING
-
-struct SRT_SocketOptionObject
-{
-    struct SingleOption
-    {
-        uint16_t      option;
-        uint16_t      length;
-        unsigned char storage[1]; // NOTE: Variable length object!
-    };
-
-
-    std::vector<SingleOption*> options;
-
-    SRT_SocketOptionObject() {}
-
-    ~SRT_SocketOptionObject()
-    {
-        for (size_t i = 0; i < options.size(); ++i)
-        {
-            // Convert back
-            unsigned char* mem = reinterpret_cast<unsigned char*>(options[i]);
-            delete[] mem;
-        }
-    }
-
-    bool add(SRT_SOCKOPT optname, const void* optval, size_t optlen);
-};
-#endif
-
 template <typename T>
 inline T cast_optval(const void* optval)
 {
@@ -373,5 +345,36 @@ inline bool cast_optval(const void* optval, int optlen)
     }
     return false;
 }
+
+} // namespace srt
+
+#if ENABLE_EXPERIMENTAL_BONDING
+struct SRT_SocketOptionObject
+{
+    struct SingleOption
+    {
+        uint16_t      option;
+        uint16_t      length;
+        unsigned char storage[1]; // NOTE: Variable length object!
+    };
+
+
+    std::vector<SingleOption*> options;
+
+    SRT_SocketOptionObject() {}
+
+    ~SRT_SocketOptionObject()
+    {
+        for (size_t i = 0; i < options.size(); ++i)
+        {
+            // Convert back
+            unsigned char* mem = reinterpret_cast<unsigned char*>(options[i]);
+            delete[] mem;
+        }
+    }
+
+    bool add(SRT_SOCKOPT optname, const void* optval, size_t optlen);
+};
+#endif
 
 #endif

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -243,8 +243,8 @@ int srt_getlasterror(int* loc_errno)
 
 const char* srt_strerror(int code, int err)
 {
-    static CUDTException e;
-    e = CUDTException(CodeMajor(code/1000), CodeMinor(code%1000), err);
+    static srt::CUDTException e;
+    e = srt::CUDTException(CodeMajor(code/1000), CodeMinor(code%1000), err);
     return(e.getErrorMessage());
 }
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -54,10 +54,12 @@
 #include "utilities.h"
 #include "srt_attr_defs.h"
 
-class CUDTException;    // defined in common.h
 
 namespace srt
 {
+
+class CUDTException;    // defined in common.h
+
 namespace sync
 {
 
@@ -741,7 +743,7 @@ typedef std::system_error CThreadException;
 using CThread = std::thread;
 namespace this_thread = std::this_thread;
 #else // pthreads wrapper version
-typedef ::CUDTException CThreadException;
+typedef CUDTException CThreadException;
 
 class CThread
 {

--- a/srtcore/sync_cxx11.cpp
+++ b/srtcore/sync_cxx11.cpp
@@ -94,14 +94,14 @@ void srt::sync::Condition::notify_all()
 
 // Threal local error will be used by CUDTUnited
 // with a static scope, therefore static thread_local
-static thread_local CUDTException s_thErr;
+static thread_local srt::CUDTException s_thErr;
 
-void srt::sync::SetThreadLocalError(const CUDTException& e)
+void srt::sync::SetThreadLocalError(const srt::CUDTException& e)
 {
     s_thErr = e;
 }
 
-CUDTException& srt::sync::GetThreadLocalError()
+srt::CUDTException& srt::sync::GetThreadLocalError()
 {
     return s_thErr;
 }

--- a/srtcore/threadname.h
+++ b/srtcore/threadname.h
@@ -163,7 +163,7 @@ class ThreadName
         {
             // The default implementation will simply try to get the thread ID
             std::ostringstream bs;
-            bs << "T" << srt::sync::this_thread::get_id();
+            bs << "T" << sync::this_thread::get_id();
             size_t s  = bs.str().copy(output, BUFSIZE - 1);
             output[s] = '\0';
             return true;

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -148,12 +148,12 @@ typedef SRTSOCKET UDTSOCKET; //legacy alias
 
 #ifdef __cplusplus
 
-class CUDTException;
+namespace srt { class CUDTException; }
 
 namespace UDT
 {
 
-typedef CUDTException ERRORINFO;
+typedef srt::CUDTException ERRORINFO;
 typedef CPerfMon TRACEINFO;
 
 // This facility is used only for select() function.

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -61,6 +61,8 @@ modified by
 using namespace std;
 using namespace srt::sync;
 
+namespace srt
+{
 namespace ACKWindowTools
 {
 
@@ -138,11 +140,12 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
    return -1;
 }
 
-}
+} // namespace AckTools
+} // namespace srt
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeWindow, int* r_bytesWindow, size_t asize, size_t psize)
+void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeWindow, int* r_bytesWindow, size_t asize, size_t psize)
 {
    for (size_t i = 0; i < asize; ++ i)
       r_pktWindow[i] = 1000000;   //1 sec -> 1 pkt/sec
@@ -155,7 +158,7 @@ void CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeW
 }
 
 
-int CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, int& bytesps)
+int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, int& bytesps)
 {
    // get median value, but cannot change the original value order in the window
    std::copy(window, window + asize, replica);
@@ -199,7 +202,7 @@ int CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, cons
    }
 }
 
-int CPktTimeWindowTools::getBandwidth_in(const int* window, int* replica, size_t psize)
+int srt::CPktTimeWindowTools::getBandwidth_in(const int* window, int* replica, size_t psize)
 {
     // This calculation does more-less the following:
     //

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -233,7 +233,7 @@ public:
    /// Shortcut to test a packet for possible probe 1 or 2
    void probeArrival(const srt::CPacket& pkt, bool unordered)
    {
-       const int inorder16 = pkt.m_iSeqNo & PUMASK_SEQNO_PROBE;
+       const int inorder16 = pkt.m_iSeqNo & srt::PUMASK_SEQNO_PROBE;
 
        // for probe1, we want 16th packet
        if (inorder16 == 0)
@@ -279,7 +279,7 @@ public:
        // expected packet pair, behave as if the 17th packet was lost.
 
        // no start point yet (or was reset) OR not very next packet
-       if (m_Probe1Sequence == SRT_SEQNO_NONE || CSeqNo::incseq(m_Probe1Sequence) != pkt.m_iSeqNo)
+       if (m_Probe1Sequence == SRT_SEQNO_NONE || srt::CSeqNo::incseq(m_Probe1Sequence) != pkt.m_iSeqNo)
            return;
 
        // Grab the current time before trying to acquire

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -61,17 +61,20 @@ modified by
 #include "packet.h"
 #include "udt.h"
 
+namespace srt
+{
+
 namespace ACKWindowTools
 {
    struct Seq
    {
        int32_t iACKSeqNo;                                   // Seq. No. of the ACK packet
        int32_t iACK;                                        // Data packet Seq. No. carried by the ACK packet
-       srt::sync::steady_clock::time_point tsTimeStamp;     // The timestamp when the ACK was sent
+       sync::steady_clock::time_point tsTimeStamp;     // The timestamp when the ACK was sent
    };
 
    void store(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t ack);
-   int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack, const srt::sync::steady_clock::time_point& currtime);
+   int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int32_t seq, int32_t& r_ack, const sync::steady_clock::time_point& currtime);
 }
 
 template <size_t SIZE>
@@ -104,7 +107,7 @@ public:
       /// @param [in] currtime The timestamp of ACKACK packet reception by the receiver
       /// @return RTT
 
-   int acknowledge(int32_t seq, int32_t& r_ack, const srt::sync::steady_clock::time_point& currtime)
+   int acknowledge(int32_t seq, int32_t& r_ack, const sync::steady_clock::time_point& currtime)
    {
        return ACKWindowTools::acknowledge(m_aSeq, SIZE, m_iHead, m_iTail, seq, r_ack, currtime);
    }
@@ -145,14 +148,14 @@ public:
         m_iProbeWindowPtr(0),
         m_iLastSentTime(0),
         m_iMinPktSndInt(1000000),
-        m_tsLastArrTime(srt::sync::steady_clock::now()),
+        m_tsLastArrTime(sync::steady_clock::now()),
         m_tsCurrArrTime(),
         m_tsProbeTime(),
         m_Probe1Sequence(SRT_SEQNO_NONE)
     {
         // Exception: up to CUDT ctor
-        srt::sync::setupMutex(m_lockPktWindow, "PktWindow");
-        srt::sync::setupMutex(m_lockProbeWindow, "ProbeWindow");
+        sync::setupMutex(m_lockPktWindow, "PktWindow");
+        sync::setupMutex(m_lockProbeWindow, "ProbeWindow");
         CPktTimeWindowTools::initializeWindowArrays(m_aPktWindow, m_aProbeWindow, m_aBytesWindow, ASIZE, PSIZE);
     }
 
@@ -172,7 +175,7 @@ public:
    int getPktRcvSpeed(int& w_bytesps) const
    {
        // Lock access to the packet Window
-       srt::sync::ScopedLock cg(m_lockPktWindow);
+       sync::ScopedLock cg(m_lockPktWindow);
 
        int pktReplica[ASIZE];          // packet information window (inter-packet time)
        return getPktRcvSpeed_in(m_aPktWindow, pktReplica, m_aBytesWindow, ASIZE, (w_bytesps));
@@ -190,7 +193,7 @@ public:
    int getBandwidth() const
    {
        // Lock access to the packet Window
-       srt::sync::ScopedLock cg(m_lockProbeWindow);
+       sync::ScopedLock cg(m_lockProbeWindow);
 
        int probeReplica[PSIZE];
        return getBandwidth_in(m_aProbeWindow, probeReplica, PSIZE);
@@ -213,12 +216,12 @@ public:
 
    void onPktArrival(int pktsz = 0)
    {
-       srt::sync::ScopedLock cg(m_lockPktWindow);
+       sync::ScopedLock cg(m_lockPktWindow);
 
-       m_tsCurrArrTime = srt::sync::steady_clock::now();
+       m_tsCurrArrTime = sync::steady_clock::now();
 
        // record the packet interval between the current and the last one
-       m_aPktWindow[m_iPktWindowPtr] = (int) srt::sync::count_microseconds(m_tsCurrArrTime - m_tsLastArrTime);
+       m_aPktWindow[m_iPktWindowPtr] = (int) sync::count_microseconds(m_tsCurrArrTime - m_tsLastArrTime);
        m_aBytesWindow[m_iPktWindowPtr] = pktsz;
 
        // the window is logically circular
@@ -231,9 +234,9 @@ public:
    }
 
    /// Shortcut to test a packet for possible probe 1 or 2
-   void probeArrival(const srt::CPacket& pkt, bool unordered)
+   void probeArrival(const CPacket& pkt, bool unordered)
    {
-       const int inorder16 = pkt.m_iSeqNo & srt::PUMASK_SEQNO_PROBE;
+       const int inorder16 = pkt.m_iSeqNo & PUMASK_SEQNO_PROBE;
 
        // for probe1, we want 16th packet
        if (inorder16 == 0)
@@ -252,7 +255,7 @@ public:
    }
 
    /// Record the arrival time of the first probing packet.
-   void probe1Arrival(const srt::CPacket& pkt, bool unordered)
+   void probe1Arrival(const CPacket& pkt, bool unordered)
    {
        if (unordered && pkt.m_iSeqNo == m_Probe1Sequence)
        {
@@ -263,13 +266,13 @@ public:
            return;
        }
 
-       m_tsProbeTime = srt::sync::steady_clock::now();
+       m_tsProbeTime = sync::steady_clock::now();
        m_Probe1Sequence = pkt.m_iSeqNo; // Record the sequence where 16th packet probe was taken
    }
 
    /// Record the arrival time of the second probing packet and the interval between packet pairs.
 
-   void probe2Arrival(const srt::CPacket& pkt)
+   void probe2Arrival(const CPacket& pkt)
    {
        // Reject probes that don't refer to the very next packet
        // towards the one that was lately notified by probe1Arrival.
@@ -279,16 +282,16 @@ public:
        // expected packet pair, behave as if the 17th packet was lost.
 
        // no start point yet (or was reset) OR not very next packet
-       if (m_Probe1Sequence == SRT_SEQNO_NONE || srt::CSeqNo::incseq(m_Probe1Sequence) != pkt.m_iSeqNo)
+       if (m_Probe1Sequence == SRT_SEQNO_NONE || CSeqNo::incseq(m_Probe1Sequence) != pkt.m_iSeqNo)
            return;
 
        // Grab the current time before trying to acquire
        // a mutex. This might add extra delay and therefore
        // screw up the measurement.
-       const srt::sync::steady_clock::time_point now = srt::sync::steady_clock::now();
+       const sync::steady_clock::time_point now = sync::steady_clock::now();
 
        // Lock access to the packet Window
-       srt::sync::ScopedLock cg(m_lockProbeWindow);
+       sync::ScopedLock cg(m_lockProbeWindow);
 
        m_tsCurrArrTime = now;
 
@@ -298,8 +301,8 @@ public:
 
        // record the probing packets interval
        // Adjust the time for what a complete packet would have take
-       const int64_t timediff = srt::sync::count_microseconds(m_tsCurrArrTime - m_tsProbeTime);
-       const int64_t timediff_times_pl_size = timediff * srt::CPacket::SRT_MAX_PAYLOAD_SIZE;
+       const int64_t timediff = sync::count_microseconds(m_tsCurrArrTime - m_tsProbeTime);
+       const int64_t timediff_times_pl_size = timediff * CPacket::SRT_MAX_PAYLOAD_SIZE;
 
        // Let's take it simpler than it is coded here:
        // (stating that a packet has never zero size)
@@ -325,27 +328,28 @@ public:
    }
 
 private:
-   int m_aPktWindow[ASIZE];                                 // Packet information window (inter-packet time)
+   int m_aPktWindow[ASIZE];                            // Packet information window (inter-packet time)
    int m_aBytesWindow[ASIZE];
-   int m_iPktWindowPtr;                                     // Position pointer of the packet info. window
-   mutable srt::sync::Mutex m_lockPktWindow;                // Used to synchronize access to the packet window
+   int m_iPktWindowPtr;                                // Position pointer of the packet info. window
+   mutable sync::Mutex m_lockPktWindow;                // Used to synchronize access to the packet window
 
-   int m_aProbeWindow[PSIZE];                               // Record inter-packet time for probing packet pairs
-   int m_iProbeWindowPtr;                                   // Position pointer to the probing window
-   mutable srt::sync::Mutex m_lockProbeWindow;              // Used to synchronize access to the probe window
+   int m_aProbeWindow[PSIZE];                          // Record inter-packet time for probing packet pairs
+   int m_iProbeWindowPtr;                              // Position pointer to the probing window
+   mutable sync::Mutex m_lockProbeWindow;              // Used to synchronize access to the probe window
 
-   int m_iLastSentTime;                                     // Last packet sending time
-   int m_iMinPktSndInt;                                     // Minimum packet sending interval
+   int m_iLastSentTime;                                // Last packet sending time
+   int m_iMinPktSndInt;                                // Minimum packet sending interval
 
-   srt::sync::steady_clock::time_point m_tsLastArrTime;     // Last packet arrival time
-   srt::sync::steady_clock::time_point m_tsCurrArrTime;     // Current packet arrival time
-   srt::sync::steady_clock::time_point m_tsProbeTime;       // Arrival time of the first probing packet
-   int32_t m_Probe1Sequence;                                // Sequence number for which the arrival time was notified
+   sync::steady_clock::time_point m_tsLastArrTime;     // Last packet arrival time
+   sync::steady_clock::time_point m_tsCurrArrTime;     // Current packet arrival time
+   sync::steady_clock::time_point m_tsProbeTime;       // Arrival time of the first probing packet
+   int32_t m_Probe1Sequence;                           // Sequence number for which the arrival time was notified
 
 private:
    CPktTimeWindow(const CPktTimeWindow&);
    CPktTimeWindow &operator=(const CPktTimeWindow&);
 };
 
+} // namespace srt
 
 #endif

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -98,7 +98,7 @@ void listening_thread(bool should_read)
     ASSERT_GT(fds_len, 0);
     ASSERT_EQ(fds[0], server_sock);
 
-    sockaddr_any scl;
+    srt::sockaddr_any scl;
     int acp = srt_accept(server_sock, (scl.get()), (&scl.len));
     ASSERT_NE(acp & SRTGROUP_MASK, 0);
 

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -34,7 +34,7 @@ void test_cipaddress_pton(const char* peer_ip, int family, const uint32_t (&ip)[
     sockaddr_any host(family);
     host.hport(port);
 
-    CIPAddress::pton(host, ip, peer);
+    srt::CIPAddress::pton(host, ip, peer);
     EXPECT_EQ(peer, host) << "Peer " << peer.str() << " host " << host.str();
 }
 

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -5,6 +5,8 @@
 #include "utilities.h"
 #include "common.h"
 
+using namespace srt;
+
 void test_cipaddress_pton(const char* peer_ip, int family, const uint32_t (&ip)[4])
 {
     const int port = 4200;

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -9,6 +9,7 @@
 
 
 using namespace std;
+using namespace srt;
 
 
 TEST(CEPoll, InfiniteWait)

--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -4,6 +4,8 @@
 #include "srt.h"
 #include "netinet_any.h"
 
+using srt::sockaddr_any;
+
 class TestIPv6
     : public ::testing::Test
 {

--- a/test/test_list.cpp
+++ b/test/test_list.cpp
@@ -1,9 +1,10 @@
 #include <iostream>
 #include "gtest/gtest.h"
 #include "common.h"
+#include "list.h"
 
 using namespace std;
-#include "list.h"
+using namespace srt;
 
 class CSndLossListTest
     : public ::testing::Test

--- a/test/test_many_connections.cpp
+++ b/test/test_many_connections.cpp
@@ -22,6 +22,7 @@ typedef int SOCKET;
 #include "api.h"
 
 using namespace std;
+using srt::sockaddr_any;
 
 
 class TestConnection

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -8,6 +8,8 @@
 #include "srt.h"
 #include "udt.h"
 
+using srt::sockaddr_any;
+
 // Copied from ../apps/apputil.cpp, can't really link this file here.
 sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_family = AF_INET)
 {
@@ -218,8 +220,8 @@ void serverSocket(std::string ip, int port, bool expect_success)
     int yes = 1;
     int no = 0;
 
-	SRTSOCKET m_bindsock = srt_create_socket();
-	ASSERT_NE(m_bindsock, SRT_ERROR);
+    SRTSOCKET m_bindsock = srt_create_socket();
+    ASSERT_NE(m_bindsock, SRT_ERROR);
 
     ASSERT_NE(srt_setsockopt(m_bindsock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
     ASSERT_NE(srt_setsockopt(m_bindsock, 0, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
@@ -251,33 +253,33 @@ void serverSocket(std::string ip, int port, bool expect_success)
     std::thread client(clientSocket, ip, port, expect_success);
 
     { // wait for connection from client
-	    int rlen = 2;
-	    SRTSOCKET read[2];
+        int rlen = 2;
+        SRTSOCKET read[2];
 
-	    int wlen = 2;
-	    SRTSOCKET write[2];
+        int wlen = 2;
+        SRTSOCKET write[2];
 
         ASSERT_NE(srt_epoll_wait(server_pollid,
-	                                     read,  &rlen,
-	                                     write, &wlen,
-	                                     3000, // -1 is set for debuging purpose.
-	                                         // in case of production we need to set appropriate value
-	                                     0, 0, 0, 0), SRT_ERROR );
+                                         read,  &rlen,
+                                         write, &wlen,
+                                         3000, // -1 is set for debuging purpose.
+                                             // in case of production we need to set appropriate value
+                                         0, 0, 0, 0), SRT_ERROR );
 
 
-	    ASSERT_EQ(rlen, 1); // get exactly one read event without writes
-	    ASSERT_EQ(wlen, 0); // get exactly one read event without writes
-	    ASSERT_EQ(read[0], m_bindsock); // read event is for bind socket    	
+        ASSERT_EQ(rlen, 1); // get exactly one read event without writes
+        ASSERT_EQ(wlen, 0); // get exactly one read event without writes
+        ASSERT_EQ(read[0], m_bindsock); // read event is for bind socket    	
     }
 
     sockaddr_any scl;
 
-	SRTSOCKET m_sock = srt_accept(m_bindsock, scl.get(), &scl.len);
+    SRTSOCKET m_sock = srt_accept(m_bindsock, scl.get(), &scl.len);
     if (m_sock == -1)
     {
         std::cout << "srt_accept: " << srt_getlasterror_str() << std::endl;
     }
-	ASSERT_NE(m_sock, SRT_INVALID_SOCK);
+    ASSERT_NE(m_sock, SRT_INVALID_SOCK);
 
     sockaddr_any showacp = (sockaddr*)&scl;
     std::cout << "Accepted from: " << showacp.str() << std::endl;
@@ -308,7 +310,7 @@ void serverSocket(std::string ip, int port, bool expect_success)
     char pattern[4] = {1, 2, 3, 4};
 
     ASSERT_EQ(srt_recvmsg(m_sock, buffer, sizeof buffer),
-    	      1316);
+              1316);
 
     EXPECT_EQ(memcmp(pattern, buffer, sizeof pattern), 0);
 

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -21,6 +21,7 @@
 #include "srt.h"
 
 using namespace std;
+using namespace srt;
 
 
 class TestSocketOptions

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -9,6 +9,7 @@
 #include "common.h"
 
 using namespace std;
+using namespace srt;
 
 
 // To test CircularBuffer

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -49,7 +49,7 @@ void OnINT_SetIntState(int)
     mpbond_int_state = true;
 }
 
-
+using namespace srt;
 
 
 int main( int argc, char** argv )

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -42,6 +42,7 @@
 #include "verbose.hpp"
 
 using namespace std;
+using namespace srt;
 
 using srt_logging::KmStateStr;
 using srt_logging::SockStatusStr;

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -452,7 +452,7 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
         string v = par["minversion"];
         if (v.find('.') != string::npos)
         {
-            int version = SrtParseVersion(v.c_str());
+            int version = srt::SrtParseVersion(v.c_str());
             if (version == 0)
             {
                 throw std::runtime_error(Sprint("Value for 'minversion' doesn't specify a valid version: ", v));

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -61,8 +61,8 @@ protected:
         int port;
         int weight = 0;
         SRTSOCKET socket = SRT_INVALID_SOCK;
-        sockaddr_any source;
-        sockaddr_any target;
+        srt::sockaddr_any source;
+        srt::sockaddr_any target;
         int token = -1;
 
         ConnectionBase(string h, int p): host(h), port(p), source(AF_INET) {}
@@ -305,7 +305,7 @@ class UdpCommon
 {
 protected:
     int m_sock = -1;
-    sockaddr_any sadr;
+    srt::sockaddr_any sadr;
     std::string adapter;
     std::map<std::string, std::string> m_options;
     void Setup(std::string host, int port, std::map<std::string,std::string> attr);

--- a/testing/utility-test.cpp
+++ b/testing/utility-test.cpp
@@ -18,6 +18,8 @@
 #include <crypto.h>
 #include <common.h>
 
+using namespace srt;
+
 void ShowDistance(int32_t s1, int32_t s2)
 {
     using namespace std;


### PR DESCRIPTION
Placed inside the `srt` namespace:
- [x] CEpoll, CEPollDesc, etc.,
- [x] CHandShake, etc.,
- [x] CIPAddress, CInfoBlock, CMD5, etc.,
- [x] CRcvLossList, CSndLossList, etc.,
- [x] CUDTException
- [x] CCryptoControl
- [x] sockaddr_any
- [x] CWindow

Fixes #1924