### PR TITLE
[build] Sendfile and recvfile examples don't need logsupport.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1250,10 +1250,10 @@ if (ENABLE_EXAMPLES)
 # Don't compile examples that do require C++11
 
 	if (ENABLE_CXX11)
-		srt_add_example(sendfile.cpp apps/logsupport.cpp)
+		srt_add_example(sendfile.cpp)
 		target_compile_options(sendfile PRIVATE ${CFLAGS_CXX_STANDARD})
-        
-		srt_add_example(recvfile.cpp apps/logsupport.cpp)
+		
+		srt_add_example(recvfile.cpp)
 		target_compile_options(recvfile PRIVATE ${CFLAGS_CXX_STANDARD})
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1247,16 +1247,9 @@ if (ENABLE_EXAMPLES)
 
 	srt_add_example(recvlive.cpp)
 
-# Don't compile examples that do require C++11
-
-	if (ENABLE_CXX11)
-		srt_add_example(sendfile.cpp)
-		target_compile_options(sendfile PRIVATE ${CFLAGS_CXX_STANDARD})
+	srt_add_example(sendfile.cpp)
 		
-		srt_add_example(recvfile.cpp)
-		target_compile_options(recvfile PRIVATE ${CFLAGS_CXX_STANDARD})
-	endif()
-
+	srt_add_example(recvfile.cpp)
 
 	srt_add_example(test-c-client.c)
 

--- a/examples/recvfile.cpp
+++ b/examples/recvfile.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
       return -1;
    }
 
-   // use this function to initialize the UDT library
+   // Use this function to initialize the UDT library
    srt_startup();
 
    srt_setloglevel(srt_logging::LogLevel::debug);
@@ -46,7 +46,7 @@ int main(int argc, char* argv[])
       return -1;
    }
 
-   // connect to the server, implicit bind
+   // Connect to the server, implicit bind.
    if (SRT_ERROR == srt_connect(fhandle, peer->ai_addr, peer->ai_addrlen))
    {
       cout << "connect: " << srt_getlasterror_str() << endl;
@@ -55,8 +55,7 @@ int main(int argc, char* argv[])
 
    freeaddrinfo(peer);
 
-
-   // send name information of the requested file
+   // Send name information of the requested file.
    int len = strlen(argv[3]);
 
    if (SRT_ERROR == srt_send(fhandle, (char*)&len, sizeof(int)))
@@ -71,7 +70,7 @@ int main(int argc, char* argv[])
       return -1;
    }
 
-   // get size information
+   // Get size information.
    int64_t size;
 
    if (SRT_ERROR == srt_recv(fhandle, (char*)&size, sizeof(int64_t)))
@@ -86,8 +85,7 @@ int main(int argc, char* argv[])
       return -1;
    }
 
-   // receive the file
-   //fstream ofs(argv[4], ios::out | ios::binary | ios::trunc);
+   // Receive the file.
    int64_t recvsize; 
    int64_t offset = 0;
 
@@ -108,9 +106,7 @@ int main(int argc, char* argv[])
 
    srt_close(fhandle);
 
-   //ofs.close();
-
-   // use this function to release the UDT library
+   // Signal to the SRT library to clean up all allocated sockets and resources.
    srt_cleanup();
 
    return 0;

--- a/examples/sendfile.cpp
+++ b/examples/sendfile.cpp
@@ -21,17 +21,14 @@ DWORD WINAPI sendfile(LPVOID);
 
 int main(int argc, char* argv[])
 {
-   //usage: sendfile [server_port]
    if ((2 < argc) || ((2 == argc) && (0 == atoi(argv[1]))))
    {
       cout << "usage: sendfile [server_port]" << endl;
       return 0;
    }
 
-   // use this function to initialize the UDT library
+   // Initialize the SRT library.
    srt_startup();
-
-   srt_setloglevel(srt_logging::LogLevel::debug);
 
    addrinfo hints;
    addrinfo* res;
@@ -66,9 +63,6 @@ int main(int argc, char* argv[])
    srt_setsockopt(serv, 0, SRTO_MSS, &mss, sizeof(int));
 #endif
 
-   //int64_t maxbw = 5000000;
-   //srt_setsockopt(serv, 0, SRTO_MAXBW, &maxbw, sizeof maxbw);
-
    if (SRT_ERROR == srt_bind(serv, res->ai_addr, res->ai_addrlen))
    {
       cout << "bind: " << srt_getlasterror_str() << endl;
@@ -78,7 +72,6 @@ int main(int argc, char* argv[])
    freeaddrinfo(res);
 
    cout << "server is ready at port: " << service << endl;
-
    srt_listen(serv, 10);
 
    sockaddr_storage clientaddr;
@@ -86,6 +79,7 @@ int main(int argc, char* argv[])
 
    SRTSOCKET fhandle;
 
+   // Accept multiple client connections.
    while (true)
    {
       if (SRT_INVALID_SOCK == (fhandle = srt_accept(serv, (sockaddr*)&clientaddr, &addrlen)))
@@ -99,18 +93,18 @@ int main(int argc, char* argv[])
       getnameinfo((sockaddr *)&clientaddr, addrlen, clienthost, sizeof(clienthost), clientservice, sizeof(clientservice), NI_NUMERICHOST|NI_NUMERICSERV);
       cout << "new connection: " << clienthost << ":" << clientservice << endl;
 
-      #ifndef _WIN32
-         pthread_t filethread;
-         pthread_create(&filethread, NULL, sendfile, new SRTSOCKET(fhandle));
-         pthread_detach(filethread);
-      #else
-         CreateThread(NULL, 0, sendfile, new SRTSOCKET(fhandle), 0, NULL);
-      #endif
+#ifndef _WIN32
+      pthread_t filethread;
+      pthread_create(&filethread, NULL, sendfile, new SRTSOCKET(fhandle));
+      pthread_detach(filethread);
+#else
+      CreateThread(NULL, 0, sendfile, new SRTSOCKET(fhandle), 0, NULL);
+#endif
    }
 
    srt_close(serv);
 
-   // use this function to release the UDT library
+   // Signal to the SRT library to clean up all allocated sockets and resources.
    srt_cleanup();
 
    return 0;
@@ -125,7 +119,7 @@ DWORD WINAPI sendfile(LPVOID usocket)
    SRTSOCKET fhandle = *(SRTSOCKET*)usocket;
    delete (SRTSOCKET*)usocket;
 
-   // aquiring file name information from client
+   // Acquiring file name information from client.
    char file[1024];
    int len;
 
@@ -142,15 +136,13 @@ DWORD WINAPI sendfile(LPVOID usocket)
    }
    file[len] = '\0';
 
-   // open the file (only to check the size)
+   // Open the file only to know its size.
    fstream ifs(file, ios::in | ios::binary);
-
    ifs.seekg(0, ios::end);
-   int64_t size = ifs.tellg();
-   //ifs.seekg(0, ios::beg);
+   const int64_t size = ifs.tellg();
    ifs.close();
 
-   // send file size information
+   // Send file size.
    if (SRT_ERROR == srt_send(fhandle, (char*)&size, sizeof(int64_t)))
    {
       cout << "send: " << srt_getlasterror_str() << endl;
@@ -160,7 +152,7 @@ DWORD WINAPI sendfile(LPVOID usocket)
    SRT_TRACEBSTATS trace;
    srt_bstats(fhandle, &trace, true);
 
-   // send the file
+   // Send the file itself.
    int64_t offset = 0;
    if (SRT_ERROR == srt_sendfile(fhandle, file, &offset, size, SRT_DEFAULT_SENDFILE_BLOCK))
    {
@@ -170,12 +162,10 @@ DWORD WINAPI sendfile(LPVOID usocket)
 
    srt_bstats(fhandle, &trace, true);
    cout << "speed = " << trace.mbpsSendRate << "Mbits/sec" << endl;
-   int losspercent = 100*trace.pktSndLossTotal/trace.pktSent;
-   cout << "loss = " << trace.pktSndLossTotal << "pkt (" << losspercent << "%)\n";
+   const int64_t losspercent = 100 * trace.pktSndLossTotal / trace.pktSent;
+   cout << "network loss = " << trace.pktSndLossTotal << "pkts (" << losspercent << "%)\n";
 
    srt_close(fhandle);
-
-   //ifs.close();
 
    #ifndef _WIN32
       return NULL;


### PR DESCRIPTION
`recvfile` and `sendfile` examples do not depend on `apps/logsupport.cpp`.

A follow-up fix after PR #2319.