### PR TITLE
[core] Fixed setting group type on a socket accepted w/o listener callback

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3236,6 +3236,7 @@ SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint3
 
     s->m_GroupMemberData = gp->add(groups::prepareSocketData(s));
     s->m_GroupOf = gp;
+    m_HSGroupType = gtp;
 
     // Record the remote address in the group data.
 


### PR DESCRIPTION
The `m_HSGroupType` is set in `CUDT::runAcceptHook(..)`. But if listener callback is not configured, the `CUDT::runAcceptHook(..)` is never called, and  `m_HSGroupType` remains undefined.

Fixes #2175.