### PR TITLE
[docs] Fixed retransmitalgo naming plus added the link for Medium article

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -1268,12 +1268,14 @@ procedure of `srt_bind` and then `srt_connect` (or `srt_rendezvous`) to one anot
 
 An SRT sender option to choose between two retransmission algorithms:
 
-- 0 - an intensive retransmission algorithm (default until SRT v1.4.4), and
-- 1 - a new efficient retransmission algorithm (introduced in SRT v1.4.2; default since SRT v1.4.4).
+- 0 - aggressive retransmission algorithm (default until SRT v1.4.4), and
+- 1 - efficient retransmission algorithm (introduced in SRT v1.4.2; default since SRT v1.4.4).
 
-The intensive retransmission algorithm causes the SRT sender to schedule a packet for retransmission each time it receives a negative acknowledgement (NAK). On a network characterized by low packet loss levels and link capacity high enough to accommodate extra retransmission overhead, this algorithm increases the chances of recovering from packet loss with a minimum delay, and may better suit end-to-end latency constraints.
+The aggressive retransmission algorithm causes the SRT sender to schedule a packet for retransmission each time it receives a negative acknowledgement (NAK). On a network characterized by low packet loss levels and link capacity high enough to accommodate extra retransmission overhead, this algorithm increases the chances of recovering from packet loss with a minimum delay, and may better suit end-to-end latency constraints.
 
 The new efficient algorithm optimizes the bandwidth usage by producing fewer retransmissions per lost packet. It takes SRT statistics into account to determine if a retransmitted packet is still in flight and could reach the receiver in time, so that some of the NAK reports are ignored by the sender. This algorithm better fits general use cases, as well as cases where channel bandwidth is limited.
+
+To learn more about the algorithms, read ["Improving SRT Retransmissions — Experiments with Simulated Live Streaming (Part 1)"](https://medium.com/innovation-labs-blog/improving-srt-retransmissions-experiments-with-simulated-live-streaming-part-1-7d192483bba4) article.
 
 NOTE: This option is effective only on the sending side. It influences the decision
 as to whether a particular reported lost packet should be retransmitted at a


### PR DESCRIPTION
Fixed retransmit algorithms naming plus added the link for Medium article.