### PR TITLE
[BUILD] Synchronized changes in configure script with latest changes

### DIFF
--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -25,11 +25,11 @@
 
 # Options processed here internally, not passed to cmake
 set internal_options {
-	with-compiler-prefix=<prefix> "set C/C++ toolchains <prefix>gcc and <prefix>g++"
-	with-compiler-type=<name> "compiler type: gcc(default), cc, others simply add ++ for C++"
-	with-srt-name=<name> "Override srt library name"
-	with-haicrypt-name=<name> "Override haicrypt library name (if compiled separately)"
-	with-atomic=<spec> "Select implementation for atomics (compiler-intrinsics or sync-mutex)"
+    with-compiler-prefix=<prefix> "set C/C++ toolchains <prefix>gcc and <prefix>g++"
+    with-compiler-type=<name> "compiler type: gcc(default), cc, others simply add ++ for C++"
+    with-srt-name=<name> "Override srt library name"
+    with-haicrypt-name=<name> "Override haicrypt library name (if compiled separately)"
+    with-atomic=<spec> "Select implementation for atomics (compiler-intrinsics or sync-mutex)"
 }
 
 # Options that refer directly to variables used in CMakeLists.txt
@@ -47,7 +47,7 @@ set cmake_options {
     enable-static "Should libsrt be built as a static library (default: ON)"
     enable-relative-libpath "Should applications contain relative library paths, like ../lib (default: OFF)"
     enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
-	enable-unittests "Enable Unit Tests (will download Google UT) (default: OFF)"
+    enable-unittests "Enable Unit Tests (will download Google UT) (default: OFF)"
     enable-encryption "Should encryption features be enabled (default: ON)"
     enable-c++-deps "Extra library dependencies in srt.pc for C language (default: ON)"
     use-static-libstdc++ "Should use static rather than shared libstdc++ (default: OFF)"
@@ -55,19 +55,18 @@ set cmake_options {
     enable-code-coverage "Enable code coverage reporting (default: OFF)"
     enable-monotonic-clock "Enforced clock_gettime with monotonic clock on GC CV /temporary fix for #729/ (default: OFF)"
     enable-thread-check "Enable #include <threadcheck.h> that implements THREAD_* macros"
-	enable-stdc++-sync "Use standard C++11 chrono/threads instead of pthread wrapper (default: OFF, on Windows: ON)"
+    enable-stdc++-sync "Use standard C++11 chrono/threads instead of pthread wrapper (default: OFF, on Windows: ON)"
     use-openssl-pc "Use pkg-config to find OpenSSL libraries (default: ON)"
     use-busy-waiting "Enable more accurate sending times at a cost of potentially higher CPU load (default: OFF)"
     use-gnustl "Get c++ library/headers from the gnustl.pc"
-	enable-sock-cloexec "Enable setting SOCK_CLOEXEC on a socket (default: ON)"
-	enable-show-project-config "Enables use of ShowProjectConfig() in cmake (default: OFF)"
-	enable-new-rcvbuffer "Enables the new receiver buffer implementation (default: ON)"
-	enable-clang-tsa "Enable Clang's Thread-Safety-Analysis (default: OFF)"
-	atomic-use-srt-sync-mutex "Use mutex to implement atomics (alias: --with-atomic=sync-mutex) (default: OFF)"
+    enable-sock-cloexec "Enable setting SOCK_CLOEXEC on a socket (default: ON)"
+    enable-show-project-config "Enables use of ShowProjectConfig() in cmake (default: OFF)"
+    enable-new-rcvbuffer "Enables the new receiver buffer implementation (default: ON)"
+    enable-clang-tsa "Enable Clang's Thread-Safety-Analysis (default: OFF)"
+    atomic-use-srt-sync-mutex "Use mutex to implement atomics (alias: --with-atomic=sync-mutex) (default: OFF)"
 
     use-enclib "Encryption library to be used: openssl(default), gnutls, mbedtls"
     enable-debug=<0,1,2> "Enable debug mode (0=disabled, 1=debug, 2=rel-with-debug)"
-
     pkg-config-executable=<filepath> "pkg-config executable"
     openssl-crypto-library=<filepath> "OpenSSL: Path to a libcrypto library."
     openssl-include-dir=<path> "OpenSSL: Path to includes."

--- a/configure-data.tcl
+++ b/configure-data.tcl
@@ -29,44 +29,51 @@ set internal_options {
 	with-compiler-type=<name> "compiler type: gcc(default), cc, others simply add ++ for C++"
 	with-srt-name=<name> "Override srt library name"
 	with-haicrypt-name=<name> "Override haicrypt library name (if compiled separately)"
+	with-atomic=<spec> "Select implementation for atomics (compiler-intrinsics or sync-mutex)"
 }
 
 # Options that refer directly to variables used in CMakeLists.txt
 set cmake_options {
     cygwin-use-posix "Should the POSIX API be used for cygwin. Ignored if the system isn't cygwin. (default: OFF)"
-    enable-encryption "Should encryption features be enabled (default: ON)"
-    enable-c++11 "Should the c++11 parts (srt-live-transmit) be enabled (default: ON)"
+    enable-c++11 "Should the c++11 parts (srt-live-transmit) be enabled (default: ON, with gcc < 4.7 OFF)"
     enable-apps "Should the Support Applications be Built? (default: ON)"
+    enable-bonding "Enable 'bonding' SRT feature (default: OFF)"
     enable-testing "Should developer testing applications be built (default: OFF)"
-    enable-c++-deps "Extra library dependencies in srt.pc for C language (default: OFF)"
-    enable-heavy-logging "Should heavy debug logging be enabled (default: OFF)"
+    enable-profile "Should instrument the code for profiling. Ignored for non-GNU compiler. (default: OFF)"
     enable-logging "Should logging be enabled (default: ON)"
-    enable-debug=<0,1,2> "Enable debug mode (0=disabled, 1=debug, 2=rel-with-debug)"
+    enable-heavy-logging "Should heavy debug logging be enabled (default: OFF)"
     enable-haicrypt-logging "Should logging in haicrypt be enabled (default: OFF)"
+    enable-shared "Should libsrt be built as a shared library (default: ON)"
+    enable-static "Should libsrt be built as a static library (default: ON)"
+    enable-relative-libpath "Should applications contain relative library paths, like ../lib (default: OFF)"
+    enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
+	enable-unittests "Enable Unit Tests (will download Google UT) (default: OFF)"
+    enable-encryption "Should encryption features be enabled (default: ON)"
+    enable-c++-deps "Extra library dependencies in srt.pc for C language (default: ON)"
+    use-static-libstdc++ "Should use static rather than shared libstdc++ (default: OFF)"
     enable-inet-pton "Set to OFF to prevent usage of inet_pton when building against modern SDKs (default: ON)"
     enable-code-coverage "Enable code coverage reporting (default: OFF)"
     enable-monotonic-clock "Enforced clock_gettime with monotonic clock on GC CV /temporary fix for #729/ (default: OFF)"
-    enable-profile "Should instrument the code for profiling. Ignored for non-GNU compiler. (default: OFF)"
-    enable-relative-libpath "Should applications contain relative library paths, like ../lib (default: OFF)"
-    enable-shared "Should libsrt be built as a shared library (default: ON)"
-    enable-static "Should libsrt be built as a static library (default: ON)"
-    enable-suflip "Should suflip tool be built (default: OFF)"
-    enable-getnameinfo "In-logs sockaddr-to-string should do rev-dns (default: OFF)"
-    enable-unittests "Enable unit tests (default: OFF)"
     enable-thread-check "Enable #include <threadcheck.h> that implements THREAD_* macros"
-    enable-experimental-bonding "Enable experimental bonding (default: OFF)"
-    openssl-crypto-library=<filepath> "Path to a library."
-    openssl-include-dir=<path> "Path to a file."
-    openssl-ssl-library=<filepath> "Path to a library."
-    pkg-config-executable=<filepath> "pkg-config executable"
-    pthread-include-dir=<path> "Path to a file."
-    pthread-library=<filepath> "Path to a library."
+	enable-stdc++-sync "Use standard C++11 chrono/threads instead of pthread wrapper (default: OFF, on Windows: ON)"
+    use-openssl-pc "Use pkg-config to find OpenSSL libraries (default: ON)"
     use-busy-waiting "Enable more accurate sending times at a cost of potentially higher CPU load (default: OFF)"
     use-gnustl "Get c++ library/headers from the gnustl.pc"
+	enable-sock-cloexec "Enable setting SOCK_CLOEXEC on a socket (default: ON)"
+	enable-show-project-config "Enables use of ShowProjectConfig() in cmake (default: OFF)"
+	enable-new-rcvbuffer "Enables the new receiver buffer implementation (default: ON)"
+	enable-clang-tsa "Enable Clang's Thread-Safety-Analysis (default: OFF)"
+	atomic-use-srt-sync-mutex "Use mutex to implement atomics (alias: --with-atomic=sync-mutex) (default: OFF)"
+
     use-enclib "Encryption library to be used: openssl(default), gnutls, mbedtls"
-    use-gnutls "DEPRECATED. Use USE_ENCLIB=openssl|gnutls|mbedtls instead"
-    use-openssl-pc "Use pkg-config to find OpenSSL libraries (default: ON)"
-    use-static-libstdc++ "Should use static rather than shared libstdc++ (default: OFF)"
+    enable-debug=<0,1,2> "Enable debug mode (0=disabled, 1=debug, 2=rel-with-debug)"
+
+    pkg-config-executable=<filepath> "pkg-config executable"
+    openssl-crypto-library=<filepath> "OpenSSL: Path to a libcrypto library."
+    openssl-include-dir=<path> "OpenSSL: Path to includes."
+    openssl-ssl-library=<filepath> "OpenSSL: Path to a libssl library."
+    pthread-include-dir=<path> "PThread: Path to includes"
+    pthread-library=<filepath> "PThread: Path to the pthread library."
 }
 
 set options $internal_options$cmake_options
@@ -162,6 +169,24 @@ proc preprocess {} {
 	if { "--with-haicrypt-name" in $::optkeys } {
 		set ::haicrypt_name $::optval(--with-haicrypt-name)
 		unset ::optval(--with-haicrypt-name)
+	}
+
+	if { "--with-atomic" in $::optkeys } {
+		switch -- $::optval(--with-atomic) {
+			compiler-intrinsics {
+			}
+
+			sync-mutex {
+				set ::optval(--atomic-use-srt-sync-mutex) 1
+			}
+
+			default {
+				puts "ERROR: --with-atomic option accepts two values: compiler-intrinsics (default) or sync-mutex"
+				exit 1
+			}
+		}
+
+		unset ::optval(--with-atomic)
 	}
 }
 


### PR DESCRIPTION
1. Removed some no longer used options and added lacking cmake-option-reflexive options
2. Renamed experimental-bonding to bonding
3. Reordered options so that they match the order of option variables in cmake