### PR TITLE
[docs] Fixed SRTO_LINGER default values.

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -216,7 +216,7 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_KMREFRESHRATE`](#SRTO_KMREFRESHRATE)             | 1.3.2 | pre      | `int32_t` | pkts    | 0: 2<sup>24</sup> | 0..      | RW  | GSD   |
 | [`SRTO_KMSTATE`](#SRTO_KMSTATE)                         | 1.0.2 |          | `int32_t` | enum    |                   |          | R   | S     |
 | [`SRTO_LATENCY`](#SRTO_LATENCY)                         | 1.0.2 | pre      | `int32_t` | ms      | 120 \*            | 0..      | RW  | GSD   |
-| [`SRTO_LINGER`](#SRTO_LINGER)                           |       | post     | `linger`  | s       | on, 180           | 0..      | RW  | GSD   |
+| [`SRTO_LINGER`](#SRTO_LINGER)                           |       | post     | `linger`  | s       | off \*            | 0..      | RW  | GSD   |
 | [`SRTO_LOSSMAXTTL`](#SRTO_LOSSMAXTTL)                   | 1.2.0 | post     | `int32_t` | packets | 0                 | 0..      | RW  | GSD+  |
 | [`SRTO_MAXBW`](#SRTO_MAXBW)                             |       | post     | `int64_t` | B/s     | -1                | -1..     | RW  | GSD   |
 | [`SRTO_MESSAGEAPI`](#SRTO_MESSAGEAPI)                   | 1.3.0 | pre      | `bool`    |         | true              |          | W   | GSD   |
@@ -709,9 +709,13 @@ be sender and receiver at the same time, and `SRTO_SENDER` became redundant.
 
 | OptName              | Since | Restrict | Type       | Units  | Default  | Range  | Dir | Entity |
 | -------------------- | ----- | -------- | ---------- | ------ | -------- | ------ | --- | ------ |
-| `SRTO_LINGER`        |       | pre      | `linger`   | s      | on, 180  | 0..    | RW  | GSD    |
+| `SRTO_LINGER`        |       | pre      | `linger`   | s      | off \*   | 0..    | RW  | GSD    |
 
-Linger time on close (see [SO\_LINGER](http://man7.org/linux/man-pages/man7/socket.7.html)).
+SRT socket linger time on close (similar to [SO\_LINGER](http://man7.org/linux/man-pages/man7/socket.7.html)).
+The defulat value in [the live streaming configuration](./API.md#transmission-types) is OFF. In this type of workflow there is no point for wait for all the data
+to be delivered after a connection is closed.
+The default value in [the file transfer configuration](./API.md#transmission-types) is 180 s.
+
 
 *SRT recommended value*: off (0).
 

--- a/docs/API/API.md
+++ b/docs/API/API.md
@@ -525,6 +525,7 @@ Setting `SRTO_TRANSTYPE` to `SRTT_LIVE` sets the following [socket options](API-
 - [`SRTO_RCVLATENCY`](API-socket-options.md#SRTO_RCVLATENCY) = 120
 - [`SRTO_PEERLATENCY`](API-socket-options.md#SRTO_PEERLATENCY) = 0
 - [`SRTO_TLPKTDROP`](API-socket-options.md#SRTO_TLPKTDROP) = true
+- [`SRTO_LINGER`](API-socket-options.md#SRTO_LINGER) = 0
 - [`SRTO_MESSAGEAPI`](API-socket-options.md#SRTO_MESSAGEAPI) = true
 - [`SRTO_NAKREPORT`](API-socket-options.md#SRTO_NAKREPORT) = true
 - [`SRTO_RETRANSMITALGO`](API-socket-options.md#SRTO_RETRANSMITALGO) = 1
@@ -607,6 +608,7 @@ Setting `SRTO_TRANSTYPE` to `SRTT_FILE` sets the following [socket options](API-
 - [`SRTO_RCVLATENCY`](API-socket-options.md#SRTO_RCVLATENCY) = 0
 - [`SRTO_PEERLATENCY`](API-socket-options.md#SRTO_PEERLATENCY) = 0
 - [`SRTO_TLPKTDROP`](API-socket-options.md#SRTO_TLPKTDROP) = false
+- [`SRTO_LINGER`](API-socket-options.md#SRTO_LINGER) = 180 s
 - [`SRTO_MESSAGEAPI`](API-socket-options.md#SRTO_MESSAGEAPI) = false
 - [`SRTO_NAKREPORT`](API-socket-options.md#SRTO_NAKREPORT) = false
 - [`SRTO_RETRANSMITALGO`](API-socket-options.md#SRTO_RETRANSMITALGO) = 0


### PR DESCRIPTION
Starting from some versions of SRT the `SRTO_LINGER` is disabled by default in the live configuration
The documentation misses this point.

The following sections/documents are updated in this PR:
- [API-socket-options.md#SRTO_LINGER](https://github.com/Haivision/srt/blob/master/docs/API/API-socket-options.md#SRTO_LINGER)
- [API.md#transmission-method-live](https://github.com/Haivision/srt/blob/master/docs/API/API.md#transmission-method-live)

Fixes #2289