### PR TITLE
[core] Fixed CUDT::packUniqueData return value.

### DIFF
--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -226,7 +226,7 @@ public: // Used for testing
 private:
     inline int incPos(int pos, int inc = 1) const { return (pos + inc) % m_szSize; }
     inline int decPos(int pos) const { return (pos - 1) >= 0 ? (pos - 1) : int(m_szSize - 1); }
-    inline int offPos(int pos1, int pos2) const { return (pos2 >= pos1) ? (pos2 - pos1) : (m_szSize + pos2 - pos1); }
+    inline int offPos(int pos1, int pos2) const { return (pos2 >= pos1) ? (pos2 - pos1) : int(m_szSize + pos2 - pos1); }
 
 private:
     void countBytes(int pkts, int bytes);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9704,7 +9704,7 @@ bool srt::CUDT::packUniqueData(CPacket& w_packet, time_point& w_origintime)
             // Encryption failed
             //>>Add stats for crypto failure
             LOGC(qslog.Warn, log << "ENCRYPT FAILED - packet won't be sent, size=" << pld_size);
-            return -1;
+            return false;
         }
     }
 


### PR DESCRIPTION
Truncation from 'int' to 'bool'.

Fixes #2360.