### PR TITLE
[core] Fixed warning on SRT_ATTR_REQUIRES.

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -543,7 +543,7 @@ private:
 
     /// @brief Drop packets too late to be delivered if any.
     /// @returns the number of packets actually dropped.
-    SRT_ATTR_REQUIRES(m_RecvAckLock, m_StatsLock)
+    SRT_ATTR_REQUIRES2(m_RecvAckLock, m_StatsLock)
     int sndDropTooLate();
 
     /// @bried Allow packet retransmission.

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -172,7 +172,7 @@ public:
     // Things being done:
     // 1. The filter is individual, so don't copy it. Set NULL.
     // 2. This will be configued anyway basing on possibly a new rule set.
-    PacketFilter(const PacketFilter& source SRT_ATR_UNUSED): m_filter(), m_sndctlpkt(0), m_unitq() {}
+    PacketFilter(const PacketFilter& source SRT_ATR_UNUSED): m_filter(), m_parent(), m_sndctlpkt(0), m_unitq() {}
 
     // This function will be called by the parent CUDT
     // in appropriate time. It should select appropriate

--- a/srtcore/srt_attr_defs.h
+++ b/srtcore/srt_attr_defs.h
@@ -101,6 +101,7 @@ used by SRT library internally.
 #define SRT_ATTR_ACQUIRED_BEFORE(...)
 #define SRT_ATTR_ACQUIRED_AFTER(...)
 #define SRT_ATTR_REQUIRES(expr) _Requires_lock_held_(expr)
+#define SRT_ATTR_REQUIRES2(expr1, expr2) _Requires_lock_held_(expr1) _Requires_lock_held_(expr2)
 #define SRT_ATTR_REQUIRES_SHARED(...)
 #define SRT_ATTR_ACQUIRE(expr) _Acquires_nonreentrant_lock_(expr)
 #define SRT_ATTR_ACQUIRE_SHARED(...)
@@ -141,6 +142,9 @@ used by SRT library internally.
   THREAD_ANNOTATION_ATTRIBUTE__(acquired_after(__VA_ARGS__))
 
 #define SRT_ATTR_REQUIRES(...) \
+  THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define SRT_ATTR_REQUIRES2(...) \
   THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
 
 #define SRT_ATTR_REQUIRES_SHARED(...) \


### PR DESCRIPTION
SAL supports only one argument per function call. Added SRT_ATTR_REQUIRES2 to handle two independently.

Fixes #2362.