### PR TITLE
Fixed some warning

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7561,7 +7561,7 @@ bool srt::CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
         EInitEvent only_input = arg.get<EventVariant::INIT>();
         // false = TEV_INIT_RESET: in the beginning, or when MAXBW was changed.
 
-        if (only_input && m_config.llMaxBW)
+        if (only_input != TEV_INIT_RESET && m_config.llMaxBW)
         {
             HLOGC(rslog.Debug, log << CONID() << "updateCC/TEV_INIT: non-RESET stage and m_config.llMaxBW already set to " << m_config.llMaxBW);
             // Don't change
@@ -9705,7 +9705,7 @@ bool srt::CUDT::packUniqueData(CPacket& w_packet, time_point& w_origintime)
         // Note that the packet header must have a valid seqno set, as it is used as a counter for encryption.
         // Other fields of the data packet header (e.g. timestamp, destination socket ID) are not used for the counter.
         // Cypher may change packet length!
-        if (m_pCryptoControl->encrypt((w_packet)))
+        if (m_pCryptoControl->encrypt((w_packet)) != ENCS_CLEAR)
         {
             // Encryption failed
             //>>Add stats for crypto failure
@@ -10165,7 +10165,7 @@ int srt::CUDT::processData(CUnit* in_unit)
             {
                 IF_HEAVY_LOGGING(exc_type = "ACCEPTED");
                 excessive = false;
-                if (u->m_Packet.getMsgCryptoFlags())
+                if (u->m_Packet.getMsgCryptoFlags() != EK_NOENC)
                 {
                     EncryptionStatus rc = m_pCryptoControl ? m_pCryptoControl->decrypt((u->m_Packet)) : ENCS_NOTSUP;
                     if (rc != ENCS_CLEAR)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10067,9 +10067,9 @@ int srt::CUDT::processData(CUnit* in_unit)
         // Loop over all incoming packets that were filtered out.
         // In case when there is no filter, there's just one packet in 'incoming',
         // the one that came in the input of this function.
-        for (vector<CUnit *>::iterator i = incoming.begin(); i != incoming.end(); ++i)
+        for (vector<CUnit *>::iterator unitIt = incoming.begin(); unitIt != incoming.end(); ++unitIt)
         {
-            CUnit *  u    = *i;
+            CUnit *  u    = *unitIt;
             CPacket &rpkt = u->m_Packet;
 
             // m_iRcvLastSkipAck is the base sequence number for the receiver buffer.
@@ -10151,9 +10151,9 @@ int srt::CUDT::processData(CUnit* in_unit)
 
             bool adding_successful = true;
 #if ENABLE_NEW_RCVBUFFER
-            if (m_pRcvBuffer->insert(*i) < 0)
+            if (m_pRcvBuffer->insert(u) < 0)
 #else
-            if (m_pRcvBuffer->addData(*i, offset) < 0)
+            if (m_pRcvBuffer->addData(u, offset) < 0)
 #endif
             {
                 // addData returns -1 if at the m_iLastAckPos+offset position there already is a packet.

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -1472,8 +1472,7 @@ void FECFilterBuiltin::RcvRebuild(Group& g, int32_t seqno, Group::Type tp)
     if (tp == Group::SINGLE)
         return;
 
-    // This flips HORIZ/VERT
-    Group::Type crosstype = Group::Type(!tp);
+    Group::Type crosstype = Group::FlipType(tp);
     EHangStatus stat;
 
     if (crosstype == Group::HORIZ)

--- a/srtcore/fec.h
+++ b/srtcore/fec.h
@@ -70,6 +70,12 @@ public:
             SINGLE  // Horizontal-only with no recursion
         };
 
+        static Type FlipType(Type t)
+        {
+            SRT_ASSERT(t != SINGLE);
+            return (t == HORIZ) ? VERT : HORIZ;
+        }
+
     };
 
     struct RcvGroup: Group

--- a/srtcore/stats.h
+++ b/srtcore/stats.h
@@ -54,7 +54,7 @@ public:
         , m_packets(0)
     {}
 
-    BytesPackets(uint64_t bytes, size_t n = 1)
+    BytesPackets(uint64_t bytes, uint32_t n = 1)
         : m_bytes(bytes)
         , m_packets(n)
     {}

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -301,7 +301,7 @@ template<size_t R>
 struct BitsetMask<R, R, true>
 {
     static const bool correct = true;
-    static const uint32_t value = 1 << R;
+    static const uint32_t value = 1u << R;
 };
 
 // This is a trap for a case that BitsetMask::correct in the master template definition


### PR DESCRIPTION
- Explicitly compare with enum type. Fixes #2374.
- Fixed local variable 'i' hiding previous local declaration. Fixes #2371.
- Fixed 'false' value implicitly casting to an integer. Also some other minor warnings. Fixes #2372. Fixes #2370.


Partially addresses #1646.