### PR TITLE
[core] Made CRcvQueue::m_counter atomic to avoid data race.

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1181,7 +1181,7 @@ srt::CRcvQueue::~CRcvQueue()
 }
 
 #if ENABLE_LOGGING
-int srt::CRcvQueue::m_counter = 0;
+srt::sync::atomic<int> srt::CRcvQueue::m_counter(0);
 #endif
 
 void srt::CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel* cc, CTimer* t)
@@ -1200,8 +1200,8 @@ void srt::CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CCh
     m_pRendezvousQueue = new CRendezvousQueue;
 
 #if ENABLE_LOGGING
-    ++m_counter;
-    const std::string thrname = "SRT:RcvQ:w" + Sprint(m_counter);
+    const int cnt = ++m_counter;
+    const std::string thrname = "SRT:RcvQ:w" + Sprint(cnt);
 #else
     const std::string thrname = "SRT:RcvQ:w";
 #endif

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -544,7 +544,7 @@ private:
 
     sync::atomic<bool> m_bClosing; // closing the worker
 #if ENABLE_LOGGING
-    static int m_counter;
+    static srt::sync::atomic<int> m_counter; // A static counter to log RcvQueue worker thread number.
 #endif
 
 private:


### PR DESCRIPTION
Used for setting the RcvQueue:: worker thread name for logging.

Data race between `CRcvQueue::init()` and starting `srt::CRcvQueue::worker(void*)`.