### PR TITLE
[core] Rethrow an exception without copying it.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1870,7 +1870,7 @@ int srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, i
     catch (CUDTException& e) // Interceptor, just to change the state.
     {
         s->m_Status = SRTS_OPENED;
-        throw e;
+        throw;
     }
 
     return 0;


### PR DESCRIPTION
Fixes #2380.