### PR TITLE
[core] fix sendBroadcast() use the size of blocked sockets as the size of buf to send

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -1517,8 +1517,6 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
             CUDT::uglobal().epoll_add_usock_INTERNAL(m_SndEID, (*b)->ps, &modes);
         }
 
-        const int blocklen = blocked.size();
-
         int            blst = 0;
         CEPoll::fmap_t sready;
 
@@ -1582,8 +1580,8 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
                     // This must be wrapped in try-catch because on error it throws an exception.
                     // Possible return values are only 0, in case when len was passed 0, or a positive
                     // >0 value that defines the size of the data that it has sent, that is, in case
-                    // of Live mode, equal to 'blocklen'.
-                    stat = d->ps->core().sendmsg2(buf, blocklen, (w_mc));
+                    // of Live mode, equal to 'len'.
+                    stat = d->ps->core().sendmsg2(buf, len, (w_mc));
                 }
                 catch (CUDTException& e)
                 {
@@ -1605,7 +1603,7 @@ int CUDTGroup::sendBroadcast(const char* buf, int len, SRT_MSGCTRL& w_mc)
             // NOTE: m_GroupLock is continuously locked - you can safely use Sendstate::it field.
             for (vector<Sendstate>::iterator is = sendstates.begin(); is != sendstates.end(); ++is)
             {
-                if (is->stat == blocklen)
+                if (is->stat == len)
                 {
                     // Successful.
                     successful.push_back(is->mb);


### PR DESCRIPTION
The original code
```
    vector<SocketData*> successful, blocked;
    const int blocklen = blocked.size();
    stat = d->ps->core().sendmsg2(buf, blocklen, (w_mc));
```
is weird, correct me if I'm wrong :)