### PR TITLE
Build: Add 'ENABLE BONDING' option to Windows PowerShell build script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,9 +14,9 @@ platform:
 build_script:
   - ps: $VSIMG = $Env:APPVEYOR_BUILD_WORKER_IMAGE; $CNFG = $Env:CONFIGURATION
   # use a few differing arguments depending on VS version to exercise different options during builds
-  - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON }
+  - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON -BONDING ON }
   - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON }
-  - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON }
+  - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON -BONDING ON}
   - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS OFF }
   - ps: if ($VSIMG -match '2013' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -CXX11 OFF -BUILD_APPS ON }
   - ps: if ($VSIMG -match '2013' -and $CNFG -eq "Debug")   { Exit-AppveyorBuild } # just skip 2013 debug build for speed

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -19,13 +19,14 @@ param (
     [Parameter()][String]$BUILD_APPS = "ON",
     [Parameter()][String]$UNIT_TESTS = "OFF",
     [Parameter()][String]$BUILD_DIR = "_build",
-    [Parameter()][String]$VCPKG_OPENSSL = "OFF"
+    [Parameter()][String]$VCPKG_OPENSSL = "OFF",
+    [Parameter()][String]$ENABLE_BONDING = "OFF"
 )
 
 # cmake can be optionally installed (useful when running interactively on a developer station).
 # The URL for automatic download is defined later in the script, but it should be possible to just vary the 
 # specific version set below and the URL should be stable enough to still work - you have been warned.
-$cmakeVersion = "3.17.3"
+$cmakeVersion = "3.23.2"
 
 # make all errors trigger a script stop, rather than just carry on
 $ErrorActionPreference = "Stop"
@@ -136,6 +137,7 @@ $cmakeFlags = "-DCMAKE_BUILD_TYPE=$CONFIGURATION " +
                 "-DENABLE_STDCXX_SYNC=$CXX11 " + 
                 "-DENABLE_APPS=$BUILD_APPS " + 
                 "-DENABLE_ENCRYPTION=$ENABLE_ENCRYPTION " +
+                "-DENABLE_BONDING=$ENABLE_BONDING " +
                 "-DENABLE_UNITTESTS=$UNIT_TESTS"
 
 # if VCPKG is flagged to provide OpenSSL, checkout VCPKG and install package

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -20,7 +20,7 @@ param (
     [Parameter()][String]$UNIT_TESTS = "OFF",
     [Parameter()][String]$BUILD_DIR = "_build",
     [Parameter()][String]$VCPKG_OPENSSL = "OFF",
-    [Parameter()][String]$ENABLE_BONDING = "OFF"
+    [Parameter()][String]$BONDING = "OFF"
 )
 
 # cmake can be optionally installed (useful when running interactively on a developer station).
@@ -137,7 +137,7 @@ $cmakeFlags = "-DCMAKE_BUILD_TYPE=$CONFIGURATION " +
                 "-DENABLE_STDCXX_SYNC=$CXX11 " + 
                 "-DENABLE_APPS=$BUILD_APPS " + 
                 "-DENABLE_ENCRYPTION=$ENABLE_ENCRYPTION " +
-                "-DENABLE_BONDING=$ENABLE_BONDING " +
+                "-DENABLE_BONDING=$BONDING " +
                 "-DENABLE_UNITTESTS=$UNIT_TESTS"
 
 # if VCPKG is flagged to provide OpenSSL, checkout VCPKG and install package


### PR DESCRIPTION
This PR adds an optiont to turn on bonding when using the Windows PowerShell build script - it is just a simple pass-through to the CMAKE arguments.

This change then allows the AppVeyor builds to enable bonding - I have set the Release builds of VS2015 and VS2019 to run with this now set to 'ON'.

A secondary small change is to bump the auto-installed CMAKE that the script offers (if not found) to a newer version - the prior version had some problems compiling SSL due to a known (and resolved) CMAKE script problem.