### PR TITLE
[tests] Minor fix for Bonding.CloseGroupAndSocket

### DIFF
--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -279,9 +279,10 @@ TEST(Bonding, CloseGroupAndSocket)
             0, 0, 0, 0);
 
         std::cout << "Epoll result: " << epoll_res << '\n';
-        ASSERT_GT(epoll_res, 0);
-
         std::cout << "Epoll rlen: " << rlen << ", wlen: " << wlen << '\n';
+        if (epoll_res < 0)
+            continue;
+
         for (int i = 0; i < rlen; ++i)
         {
             std::cout << "Epoll read[" << i << "]: " << read[i] << '\n';

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -279,6 +279,8 @@ TEST(Bonding, CloseGroupAndSocket)
             0, 0, 0, 0);
 
         std::cout << "Epoll result: " << epoll_res << '\n';
+        ASSERT_GT(epoll_res, 0);
+
         std::cout << "Epoll rlen: " << rlen << ", wlen: " << wlen << '\n';
         for (int i = 0; i < rlen; ++i)
         {

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -46,7 +46,7 @@ TEST(Bonding, SRTConnectGroup)
     }, ss);
 
     std::cout << "srt_connect_group calling " << std::endl;
-    const int st = srt_connect_group(ss, targets.data(), targets.size());
+    const int st = srt_connect_group(ss, targets.data(), (int) targets.size());
     std::cout << "srt_connect_group returned " << st << std::endl;
 
     closing_promise.wait();
@@ -264,15 +264,15 @@ TEST(Bonding, CloseGroupAndSocket)
     }
     std::cout << "Returned from connecting two sockets " << std::endl;
 
-    const int default_len = 3;
-    int rlen = default_len;
-    SRTSOCKET read[default_len];
-
-    int wlen = default_len;
-    SRTSOCKET write[default_len];
-
     for (int j = 0; j < 2; ++j)
     {
+        const int default_len = 3;
+        int rlen = default_len;
+        SRTSOCKET read[default_len];
+
+        int wlen = default_len;
+        SRTSOCKET write[default_len];
+
         const int epoll_res = srt_epoll_wait(poll_id, read, &rlen,
             write, &wlen,
             5000, /* timeout */


### PR DESCRIPTION
In the Bonding.CloseGroupAndSocket unit test (If a listener is not available) the following IPE situation can happen when sockets already removed from the epoll are being removed again.
Added ASSERT_GT(epoll_res, 0) to fail the test if epoll returns an error.

```shell
[ RUN      ] Bonding.CloseGroupAndSocket
22: Created group socket: 1405307167
22: Connecting two sockets 
22: Socket created: 331565342
22: Listen: wait for acceptability
22: Socket created: 331565340
22: Returned from connecting two sockets 
22: Listen: reported 1 acceptable and 0 errors
22: Listener will read packets...
22: Epoll result: 2
22: Epoll rlen: 0, wlen: 2
22: Epoll write[0]: 331565342 (removed from epoll)
22: Epoll write[1]: 1405307167 (removed from epoll)
22: Connect callback. Socket: 331565340, error: 1001, token: 2
22: 13:40:54.880000/T6716*E:SRT.ea: EID:3 no sockets to check, this would deadlock
22: Epoll result: -1
22: Epoll rlen: 0, wlen: 2
22: Epoll write[0]: 331565342 (removed from epoll)
22: 13:40:54.880000/T6716*E:SRT.ei: epoll/update: IPE: update struck E3 which is NOT SUBSCRIBED to @331565342
22: Epoll write[1]: 1405307167 (removed from epoll)
22: 13:40:54.880000/T6716*E:SRT.ei: epoll/update: IPE: update struck E3 which is NOT SUBSCRIBED to @1405307167
```