### PR TITLE
Update TSBPD base time and clock drift on an idle connection.

### DIFF
--- a/srtcore/buffer.cpp
+++ b/srtcore/buffer.cpp
@@ -1886,9 +1886,9 @@ void CRcvBuffer::setRcvTsbPdMode(const steady_clock::time_point& timebase, const
     m_tsbpd.setTsbPdMode(timebase, no_wrap_check, delay);
 }
 
-bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, int rtt)
+bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t timestamp_us, const time_point& tsPktArrival, int rtt)
 {
-    return m_tsbpd.addDriftSample(timestamp_us, rtt);
+    return m_tsbpd.addDriftSample(timestamp_us, tsPktArrival, rtt);
 }
 
 int CRcvBuffer::readMsg(char* data, int len)

--- a/srtcore/buffer.h
+++ b/srtcore/buffer.h
@@ -449,8 +449,9 @@ public:
 
     /// Add packet timestamp for drift caclculation and compensation
     /// @param [in] timestamp packet time stamp
+    /// @param [in] tsPktArrival arrival time of the packet used to extract the drift sample.
     /// @param [in] rtt RTT sample
-    bool addRcvTsbPdDriftSample(uint32_t timestamp, int rtt);
+    bool addRcvTsbPdDriftSample(uint32_t timestamp, const time_point& tsPktArrival, int rtt);
 
 #ifdef SRT_DEBUG_TSBPD_DRIFT
     void printDriftHistogram(int64_t iDrift);

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -968,9 +968,9 @@ int CRcvBufferNew::scanNotInOrderMessageLeft(const int startPos, int msgNo) cons
     return -1;
 }
 
-bool CRcvBufferNew::addRcvTsbPdDriftSample(uint32_t usTimestamp, int usRTTSample)
+bool CRcvBufferNew::addRcvTsbPdDriftSample(uint32_t usTimestamp, const time_point& tsPktArrival, int usRTTSample)
 {
-    return m_tsbpd.addDriftSample(usTimestamp, usRTTSample);
+    return m_tsbpd.addDriftSample(usTimestamp, tsPktArrival, usRTTSample);
 }
 
 void CRcvBufferNew::setTsbPdMode(const steady_clock::time_point& timebase, bool wrap, duration delay)

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -337,7 +337,7 @@ public: // TSBPD public functions
 
     void applyGroupDrift(const time_point& timebase, bool wrp, const duration& udrift);
 
-    bool addRcvTsbPdDriftSample(uint32_t usTimestamp, int usRTTSample);
+    bool addRcvTsbPdDriftSample(uint32_t usTimestamp, const time_point& tsPktArrival, int usRTTSample);
 
     time_point getPktTsbPdTime(uint32_t usPktTimestamp) const;
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11755,8 +11755,10 @@ void srt::CUDT::processKeepalive(const CPacket& ctrlpkt, const time_point& tsArr
     }
 #endif
 
+#if ENABLE_NEW_RCVBUFFER
     ScopedLock lck(m_RcvBufferLock);
     m_pRcvBuffer->updateTsbPdTimeBase(ctrlpkt.getMsgTimeStamp());
     if (m_config.bDriftTracer)
         m_pRcvBuffer->addRcvTsbPdDriftSample(ctrlpkt.getMsgTimeStamp(), tsArrival, -1);
+#endif
 }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -829,13 +829,13 @@ private: // Timers
     duration   m_tdNAKInterval;                  // NAK interval
     SRT_ATTR_GUARDED_BY(m_RecvAckLock)
     atomic_time_point m_tsLastRspTime;           // Timestamp of last response from the peer
-    time_point m_tsLastRspAckTime;               // Timestamp of last ACK from the peer
+    time_point m_tsLastRspAckTime;               // (SND) Timestamp of last ACK from the peer
     atomic_time_point m_tsLastSndTime;           // Timestamp of last data/ctrl sent (in system ticks)
     time_point m_tsLastWarningTime;              // Last time that a warning message is sent
     atomic_time_point m_tsLastReqTime;           // last time when a connection request is sent
     time_point m_tsRcvPeerStartTime;
     time_point m_tsLingerExpiration;             // Linger expiration time (for GC to close a socket with data in sending buffer)
-    time_point m_tsLastAckTime;                  // Timestamp of last ACK
+    time_point m_tsLastAckTime;                  // (RCV) Timestamp of last ACK
     duration m_tdMinNakInterval;                 // NAK timeout lower bound; too small value can cause unnecessary retransmission
     duration m_tdMinExpInterval;                 // Timeout lower bound threshold: too small timeout can cause problem
 
@@ -915,9 +915,9 @@ private: // Receiving related data
     int32_t m_iDebugPrevLastAck;
 #endif
     int32_t m_iRcvLastSkipAck;                   // Last dropped sequence ACK
-    int32_t m_iRcvLastAckAck;                    // Last sent ACK that has been acknowledged
+    int32_t m_iRcvLastAckAck;                    // (RCV) Latest packet seqno in a sent ACK acknowledged by ACKACK. RcvQTh (sendCtrlAck {r}, processCtrlAckAck {r}, processCtrlAck {r}, connection {w}).
     int32_t m_iAckSeqNo;                         // Last ACK sequence number
-    sync::atomic<int32_t> m_iRcvCurrSeqNo;       // Largest received sequence number
+    sync::atomic<int32_t> m_iRcvCurrSeqNo;       // (RCV) Largest received sequence number. RcvQTh, TSBPDTh.
     int32_t m_iRcvCurrPhySeqNo;                  // Same as m_iRcvCurrSeqNo, but physical only (disregarding a filter)
 
     int32_t m_iPeerISN;                          // Initial Sequence Number of the peer side
@@ -1087,7 +1087,7 @@ private: // Generation and processing of packets
     void dropToGroupRecvBase();
 #endif
 
-    void handleKeepalive(const char* data, size_t lenghth);
+    void processKeepalive(const CPacket& ctrlpkt, const time_point& tsArrival);
 
     /// Locks m_RcvBufferLock and retrieves the available size of the receiver buffer.
     SRT_ATTR_EXCLUDES(m_RcvBufferLock)

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -4472,7 +4472,7 @@ void CUDTGroup::ackMessage(int32_t msgno)
     m_iSndAckedMsgNo = msgno;
 }
 
-void CUDTGroup::handleKeepalive(CUDTGroup::SocketData* gli)
+void CUDTGroup::processKeepalive(CUDTGroup::SocketData* gli)
 {
     // received keepalive for that group member
     // In backup group it means that the link went IDLE.

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -391,7 +391,7 @@ public:
 #endif
 
     void ackMessage(int32_t msgno);
-    void handleKeepalive(SocketData*);
+    void processKeepalive(SocketData*);
     void internalKeepalive(SocketData*);
 
 private:

--- a/srtcore/tsbpd_time.cpp
+++ b/srtcore/tsbpd_time.cpp
@@ -103,12 +103,10 @@ drift_logger g_drift_logger;
 
 #endif // SRT_DEBUG_TRACE_DRIFT
 
-bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, int usRTTSample)
+bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, const time_point& tsPktArrival, int usRTTSample)
 {
     if (!m_bTsbPdMode)
         return false;
-
-    const time_point tsNow = steady_clock::now();
 
     ScopedLock lck(m_mtxRW);
 
@@ -123,9 +121,9 @@ bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, int usRTTSample)
     // A change in network delay has to be taken into account. The only way to get some estimation of it
     // is to estimate RTT change and assume that the change of the one way network delay is
     // approximated by the half of the RTT change.
-    const duration               tdRTTDelta    = microseconds_from((usRTTSample - m_iFirstRTT) / 2);
+    const duration               tdRTTDelta    = usRTTSample >= 0 ? microseconds_from((usRTTSample - m_iFirstRTT) / 2) : duration(0);
     const time_point             tsPktBaseTime = getPktTsbPdBaseTime(usPktTimestamp);
-    const steady_clock::duration tdDrift       = tsNow - tsPktBaseTime - tdRTTDelta;
+    const steady_clock::duration tdDrift       = tsPktArrival - tsPktBaseTime - tdRTTDelta;
 
     const bool updated = m_DriftTracer.update(count_microseconds(tdDrift));
 

--- a/srtcore/tsbpd_time.h
+++ b/srtcore/tsbpd_time.h
@@ -66,10 +66,11 @@ public:
     /// and can be used to estimate clock drift.
     /// 
     /// @param [in] pktTimestamp Timestamp of the arrived ACKACK packet.
-    /// @param [in] usRTTSample RTT sample from an ACK-ACKACK pair.
+    /// @param [in] tsPktArrival packet arrival time.
+    /// @param [in] usRTTSample RTT sample from an ACK-ACKACK pair. If no sample, pass '-1'.
     /// 
     /// @return true if TSBPD base time has changed, false otherwise.
-    bool addDriftSample(uint32_t pktTimestamp, int usRTTSample);
+    bool addDriftSample(uint32_t pktTimestamp, const time_point& tsPktArrival, int usRTTSample);
 
     /// @brief Handle timestamp of data packet when 32-bit integer carryover is about to happen.
     /// When packet timestamp approaches CPacket::MAX_TIMESTAMP, the TSBPD base time should be


### PR DESCRIPTION
Normally [the TSBPD base time](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-01#section-4.5) is updated on the receiver side based on timestamps of incoming SRT data packets.
Clock drift estimate is updated based on ACK-ACKACK packet pairs, on the receiver side.

### Note

TSBPD base time update with this PR happens only if [the new receiver buffer](https://github.com/Haivision/srt/blob/v1.5.0/docs/build/build-options.md#enable_new_rcvbuffer) is used.

### 1. Idle Connection

In case of an idle connection only KEEPALIVE packets are being sent to the peer. They must be used to track the TSBPD base time carryover. The carryover happens every 01:11:35 (HH:MM::SS) hours once the `timestamp` field of an SRT packet no longer has enough bits to represent a packet timestamp based on the current TSBPD time base.

A keepalive packet is sent every 1 second if a connection is idle. The TSBPD wrapping period starts 30 seconds before reaching the maximum timestamp value of a packet and ends once the packet with timestamp within (30, 60) seconds interval is delivered (read from the buffer). Therefore the keepalive period should be enough to properly handle the carryover of the timestamp.

Clock drift also has to be updated. In case of KEEPALIVE packets there is not RTT estimate available, thus deviations in network delay may affect the tracing.
Also currently drift tracer accumulated 1k samples to perform an update. In case of keepalive packets a new sample is added every 1 second, and drift update would take quite a long time.

### 2. SRT Sender

Addressed in PR #2435.

### TODO

- [ ] The drift value is updated every 1k samples. In case of tracking drift with KEEPALIVE packets it would be happening quite infrequently. This requires changing the drift tracing model.
- [x] Do not use Lite ACK to track drift, because it would be too often. Only use full ACK.
- [ ] If an idle socket is a member of a group, just use the TSBPD and drift updates from an active member (if there is one).

Addresses #1936