### PR TITLE
Fixed TestIPv6.v6_calls_v4 in case the system-default IPV6_V6ONLY is 1.

### DIFF
--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -31,6 +31,8 @@ protected:
 
         m_caller_sock = srt_create_socket();
         ASSERT_NE(m_caller_sock, SRT_ERROR);
+        // IPv6 calling IPv4 would otherwise fail if the system-default net.ipv6.bindv6only=1.
+        ASSERT_NE(srt_setsockflag(m_caller_sock, SRTO_IPV6ONLY, &no, sizeof no), SRT_ERROR);
 
         m_listener_sock = srt_create_socket();
         ASSERT_NE(m_listener_sock, SRT_ERROR);


### PR DESCRIPTION
The `TestIPv6.v6_calls_v4` test fails is the system-default value of the IPV6_V6ONLY is 1 (r.g. it is so on FreeBSD, see #2007).
Therefore, the required value (0) has to be set on the caller socket explicitly. It can be done with the `SRTO_IPV6ONLY` socket option.

### To Reproduce

**Required OS**: Linux.

```shell
(Change system-default to 1)
sysctl -w net.ipv6.bindv6only=1
(Check the value is set)
cat /proc/sys/net/ipv6/bindv6only

(Run IPv6 unit tests)
./test-srt --gtest_filter="TestIPv6*"
```

Result without the fix:

```shell
[ RUN      ] TestIPv6.v6_calls_v4
Calling: 0::FFFF:127.0.0.1(IPv6)
/srt/test/test_ipv6.cpp:58: Failure
Expected: (connect_res) != (SRT_ERROR), actual: -1 vs -1
srt_connect() failed with: Connection setup failure: connection timed out
CALLER Sock name: : :::56019 (IPv6)
CALLER Peer name: : :::56019 (IPv6)
16:12:24.926006/test-srt*E:SRT.cn: srt_accept: listener socket @41206758 is already closed
/srt/test/test_ipv6.cpp:78: Failure
Expected: (accepted_sock) != (SRT_INVALID_SOCK), actual: -1 vs -1
accept() failed with: Connection setup failure: socket closed during operation
/srt/test/test_ipv6.cpp:190: Failure
Expected equality of these values:
  sa_accepted.str()
    Which is: "unknown:0"
  "127.0.0.1:4200"
[  FAILED  ] TestIPv6.v6_calls_v4 (3004 ms)
```

### With the PR

```shell
[ RUN      ] TestIPv6.v6_calls_v4
Calling: 0::FFFF:127.0.0.1(IPv6)
ACCEPTED Sock name: : 127.0.0.1:4200 (IPv4)
ACCEPTED Peer name: : 127.0.0.1:32869 (IPv4)
CALLER Sock name: : ::ffff:127.0.0.1:32869 (IPv6)
CALLER Peer name: : ::ffff:127.0.0.1:32869 (IPv6)
[       OK ] TestIPv6.v6_calls_v4 (15 ms)
```

Fixes #2007.

### Follow-up Thoughts

From the [man page](https://man7.org/linux/man-pages/man7/ipv6.7.html):

> IPV6_V6ONLY:
If this flag is set to false (zero), then the socket can be used to send and receive packets to and from an IPv6 address or an IPv4-mapped IPv6 address.

In the `TestIPv6.v6_calls_v4` unit test the listener is bound to IPv4, and we can't set `IPPROTO_IPV6/IPV6_V6ONLY` on an IPv4 UDP socket.
Also, SRT would ignore it, see [the following condition](https://github.com/Haivision/srt/blob/v1.5.0/srtcore/channel.cpp#L184):
```c++
if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
{
    const int res SRT_ATR_UNUSED =
        ::setsockopt(m_iSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&m_mcfg.iIpV6Only, sizeof m_mcfg.iIpV6Only);
```

Setting `IPPROTO_IPV6/IPV6_V6ONLY` on the caller socket allows sending to and receiving from an IPv4-mapped IPv6 address.

