### PR TITLE
Fixed build break when enabled SRT_ASSERT. Enabled _DEBUG in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ if (ENABLE_DEBUG EQUAL 2)
 	set (CMAKE_BUILD_TYPE "RelWithDebInfo")
 elseif (ENABLE_DEBUG) # 1, ON, YES, TRUE, Y, or any other non-zero number
 	set (CMAKE_BUILD_TYPE "Debug")
+
+	# Add _DEBUG macro in debug mode only, to enable SRT_ASSERT().
+	add_definitions(-D_DEBUG)
 else()
 	set (CMAKE_BUILD_TYPE "Release")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,18 +63,28 @@ if (NOT DEFINED ENABLE_DEBUG)
 	endif()
 endif()
 
-# Set CMAKE_BUILD_TYPE properly, now that you know
-# that ENABLE_DEBUG is set as it should.
+# XXX This is a kind of workaround - this part to set the build
+# type and associated other flags should not be done for build
+# systems (cmake generators) that generate a multi-configuration
+# build definition. At least it is known that MSVC does it and it
+# sets _DEBUG and NDEBUG flags itself, so this shouldn't be done
+# at all in this case.
+if (NOT MICROSOFT)
 
-if (ENABLE_DEBUG EQUAL 2)
-	set (CMAKE_BUILD_TYPE "RelWithDebInfo")
-elseif (ENABLE_DEBUG) # 1, ON, YES, TRUE, Y, or any other non-zero number
-	set (CMAKE_BUILD_TYPE "Debug")
+	# Set CMAKE_BUILD_TYPE properly, now that you know
+	# that ENABLE_DEBUG is set as it should.
+	if (ENABLE_DEBUG EQUAL 2)
+		set (CMAKE_BUILD_TYPE "RelWithDebInfo")
+		add_definitions(-DNDEBUG)
+	elseif (ENABLE_DEBUG) # 1, ON, YES, TRUE, Y, or any other non-zero number
+		set (CMAKE_BUILD_TYPE "Debug")
 
-	# Add _DEBUG macro in debug mode only, to enable SRT_ASSERT().
-	add_definitions(-D_DEBUG)
-else()
-	set (CMAKE_BUILD_TYPE "Release")
+		# Add _DEBUG macro in debug mode only, to enable SRT_ASSERT().
+		add_definitions(-D_DEBUG)
+	else()
+		set (CMAKE_BUILD_TYPE "Release")
+		add_definitions(-DNDEBUG)
+	endif()
 endif()
 
 message(STATUS "BUILD TYPE: ${CMAKE_BUILD_TYPE}")

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -88,7 +88,7 @@ CRcvBufferNew::CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, 
     , m_iPktsCount(0)
     , m_uAvgPayloadSz(SRT_LIVE_DEF_PLSIZE)
 {
-    SRT_ASSERT(size < std::numeric_limits<int>::max()); // All position pointers are integers
+    SRT_ASSERT(size < size_t(std::numeric_limits<int>::max())); // All position pointers are integers
 }
 
 CRcvBufferNew::~CRcvBufferNew()

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -1,5 +1,6 @@
 #if ENABLE_NEW_RCVBUFFER
 #include <cmath>
+#include <limits>
 #include "buffer_rcv.h"
 #include "logging.h"
 
@@ -87,7 +88,7 @@ CRcvBufferNew::CRcvBufferNew(int initSeqNo, size_t size, CUnitQueue* unitqueue, 
     , m_iPktsCount(0)
     , m_uAvgPayloadSz(SRT_LIVE_DEF_PLSIZE)
 {
-    SRT_ASSERT(size < INT_MAX); // All position pointers are integers
+    SRT_ASSERT(size < std::numeric_limits<int>::max()); // All position pointers are integers
 }
 
 CRcvBufferNew::~CRcvBufferNew()
@@ -135,7 +136,7 @@ int CRcvBufferNew::insert(CUnit* unit)
         m_iMaxPosInc = offset + 1;
 
     // Packet already exists
-    SRT_ASSERT(pos >= 0 && pos < m_szSize);
+    SRT_ASSERT(pos >= 0 && pos < int(m_szSize));
     if (m_entries[pos].status != EntryState_Empty)
     {
         IF_RCVBUF_DEBUG(scoped_log.ss << " returns -1");


### PR DESCRIPTION
Changes:

1. `INT_MAX` replaced with `std::numeric_limits<int>::max()`.
2. Added `<limits>` header in buffer_rcv.cpp
3. Added `-D_DEBUG` when `ENABLE_DEBUG` is on (debug only).
4. Added cast in a condition to clear out the warning