### PR TITLE
CCryptoControl: Partially removed dependency on CUDT.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5889,7 +5889,7 @@ bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     // Write back this value, when it was just determined.
     m_SrtHsSide = side;
 
-    m_pCryptoControl.reset(new CCryptoControl(this, m_SocketID));
+    m_pCryptoControl.reset(new CCryptoControl(m_SocketID));
 
     // XXX These below are a little bit controversial.
     // These data should probably be filled only upon
@@ -5903,7 +5903,7 @@ bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
         m_pCryptoControl->setCryptoKeylen(m_config.iSndCryptoKeyLen);
     }
 
-    return m_pCryptoControl->init(side, bidirectional);
+    return m_pCryptoControl->init(side, m_config, bidirectional);
 }
 
 SRT_REJECT_REASON srt::CUDT::setupCC()
@@ -6063,7 +6063,7 @@ void srt::CUDT::checkSndTimers(Whether2RegenKm regen)
         // if this side is RESPONDER. This shall be called only with
         // regeneration request, which is required by the sender.
         if (m_pCryptoControl)
-            m_pCryptoControl->sendKeysToPeer(regen);
+            m_pCryptoControl->sendKeysToPeer(this, SRTT(), regen);
     }
 }
 

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -485,7 +485,7 @@ void srt::CCryptoControl::regenCryptoKm(CUDT* sock, bool bidirectional)
     int sent = 0;
 
     HLOGC(cnlog.Debug, log << "regenCryptoKm: regenerating crypto keys nbo=" << nbo <<
-            " THEN=" << (sendit ? "SEND" : "KEEP") << " DIR=" << (bidirectional ? "BOTH" : "SENDER"));
+            " THEN=" << (sock ? "SEND" : "KEEP") << " DIR=" << (bidirectional ? "BOTH" : "SENDER"));
 
     for (int i = 0; i < nbo && i < 2; i++)
     {

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -41,7 +41,7 @@ extern Logger cnlog;
 namespace srt
 {
 class CUDT;
-class CSrtConfig;
+struct CSrtConfig;
 
 
 // For KMREQ/KMRSP. Only one field is used.
@@ -85,7 +85,6 @@ private:
     bool m_bErrorReported;
 
 public:
-
     static void globalInit();
 
     bool sendingAllowed()
@@ -111,9 +110,11 @@ public:
     }
 
 private:
-
 #ifdef SRT_ENABLE_ENCRYPTION
-    void regenCryptoKm(CUDT* sock, bool sendit, bool bidirectional);
+    /// Regenerate cryptographic key material.
+    /// @param[in] sock If not null, the socket will be used to send the KM message to the peer (e.g. KM refresh).
+    /// @param[in] bidirectional If true, the key material will be regenerated for both directions (receiver and sender).
+    void regenCryptoKm(CUDT* sock, bool bidirectional);
 #endif
 
 public:
@@ -206,16 +207,15 @@ public:
     bool init(HandshakeSide, const CSrtConfig&, bool);
     void close();
 
-    // This function is used in:
-    // - HSv4 (initial key material exchange - in HSv5 it's attached to handshake)
-    // - case of key regeneration, which should be then exchanged again
+    /// @return True if the handshake is in progress.
+    /// This function is used in:
+    /// - HSv4 (initial key material exchange - in HSv5 it's attached to handshake)
+    /// - case of key regeneration, which should be then exchanged again.
     void sendKeysToPeer(CUDT* sock, int iSRTT, Whether2RegenKm regen);
-
 
     void setCryptoSecret(const HaiCrypt_Secret& secret)
     {
         m_KmSecret = secret;
-        //memcpy(&m_KmSecret, &secret, sizeof(m_KmSecret));
     }
 
     void setCryptoKeylen(size_t keylen)

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -41,6 +41,7 @@ extern Logger cnlog;
 namespace srt
 {
 class CUDT;
+class CSrtConfig;
 
 
 // For KMREQ/KMRSP. Only one field is used.
@@ -53,7 +54,6 @@ enum Whether2RegenKm {DONT_REGEN_KM = 0, REGEN_KM = 1};
 
 class CCryptoControl
 {
-    CUDT*     m_parent;
     SRTSOCKET m_SocketID;
 
     size_t    m_iSndKmKeyLen;        //Key length
@@ -113,7 +113,7 @@ public:
 private:
 
 #ifdef SRT_ENABLE_ENCRYPTION
-    void regenCryptoKm(bool sendit, bool bidirectional);
+    void regenCryptoKm(CUDT* sock, bool sendit, bool bidirectional);
 #endif
 
 public:
@@ -197,19 +197,19 @@ public:
         return false;
     }
 
-    CCryptoControl(CUDT* parent, SRTSOCKET id);
+    CCryptoControl(SRTSOCKET id);
 
     // DEBUG PURPOSES:
     std::string CONID() const;
     std::string FormatKmMessage(std::string hdr, int cmd, size_t srtlen);
 
-    bool init(HandshakeSide, bool);
+    bool init(HandshakeSide, const CSrtConfig&, bool);
     void close();
 
     // This function is used in:
     // - HSv4 (initial key material exchange - in HSv5 it's attached to handshake)
     // - case of key regeneration, which should be then exchanged again
-    void sendKeysToPeer(Whether2RegenKm regen);
+    void sendKeysToPeer(CUDT* sock, int iSRTT, Whether2RegenKm regen);
 
 
     void setCryptoSecret(const HaiCrypt_Secret& secret)

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -318,7 +318,7 @@ static unsigned int* getRandSeed()
 int srt::sync::genRandomInt(int minVal, int maxVal)
 {
     // This Meyers singleton initialization is thread-safe since C++11, but is not thread-safe in C++03.
-    // A mutex to protect simulteneout access to the random device.
+    // A mutex to protect simultaneous access to the random device.
     // Thread-local storage could be used here instead to store the seed / random device.
     // However the generator is not used often (Initial Socket ID, Initial sequence number, FileCC),
     // so sharing a single seed among threads should not impact the performance.


### PR DESCRIPTION
`CCryptoControl` takes too much responsibility, and also handles sending of KM packets via a `CUDT` socket class.
Ideally, the CUDT should send everything itself, and only ask `CCryptoControl` if something has changed and an exchange of updated keys is required. However, it is not easy to decouple this logic straight away.
This PR removed reference to `CUDT` where possible. When `CUDT` asks `CCryptoControl` to send something, it just passes a pointer to itself so that `CCryptoControl` can call the sending function.
This should at least allow using `CCryptoControl` in a unit test without mocking `CUDT`.