### PR TITLE
Changed cond notification naming. Added and used new sync utilities.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -94,9 +94,19 @@ void srt::CUDTSocket::construct()
 
 srt::CUDTSocket::~CUDTSocket()
 {
+    // Perform lock-signal-unlock cycle to make sure no one is waiting on cond.
+
+    HLOGP(smlog.Debug, "GC/~CUDTSocket: performing lock-signal-unlock cycle on AcceptCond");
+    m_AcceptLock.lock();
+    m_AcceptCond.notify_all();
+    m_AcceptLock.unlock();
+
+    HLOGP(smlog.Debug, "GC/~CUDTSocket: destroying m_AcceptCond");
     releaseMutex(m_AcceptLock);
     releaseCond(m_AcceptCond);
     releaseMutex(m_ControlLock);
+
+    HLOGP(smlog.Debug, "GC/~CUDTSocket: done.");
 }
 
 SRT_SOCKSTATUS srt::CUDTSocket::getStatus()

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2785,6 +2785,7 @@ void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
     s->core().closeInternal();
     HLOGC(smlog.Debug, log << "GC/removeSocket: DELETING SOCKET @" << u);
     delete s;
+    HLOGC(smlog.Debug, log << "GC/removeSocket: socket @" << u << " DELETED. Checking muxer.");
 
     if (mid == -1)
     {
@@ -2793,6 +2794,7 @@ void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
     }
 
     map<int, CMultiplexer>::iterator m;
+    HLOGC(smlog.Debug, log << "GC/removeSocket: socket @" << u << " Finding muxer for " << mid);
     m = m_mMultiplexer.find(mid);
     if (m == m_mMultiplexer.end())
     {

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3156,6 +3156,8 @@ void* srt::CUDTUnited::garbageCollect(void* p)
     {
         self->checkBrokenSockets();
 
+        HLOGC(inlog.Debug, log << "GC: after checkBrokenSockets, check if all sockets were deleted:");
+
         enterCS(self->m_GlobControlLock);
         bool empty = self->m_ClosedSockets.empty();
         leaveCS(self->m_GlobControlLock);
@@ -3163,6 +3165,7 @@ void* srt::CUDTUnited::garbageCollect(void* p)
         if (empty)
             break;
 
+        HLOGC(inlog.Debug, log << "GC: checkBrokenSockets didn't wipe all sockets, repeating after 1s sleep");
         srt::sync::this_thread::sleep_for(milliseconds_from(1));
     }
 

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -300,7 +300,7 @@ int srt::CUDTUnited::cleanup()
     // after which the m_bClosing flag is cheched, which
     // is set here above. Worst case secenario, this
     // pthread_join() call will block for 1 second.
-    CSync::signal_relaxed(m_GCStopCond);
+    CSync::notify_one_relaxed(m_GCStopCond);
     m_GCThread.join();
 
     m_bGCStatus = false;
@@ -778,7 +778,7 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
         }
 
         // wake up a waiting accept() call
-        CSync::lock_signal(ls->m_AcceptCond, ls->m_AcceptLock);
+        CSync::lock_notify_one(ls->m_AcceptCond, ls->m_AcceptLock);
     }
     else
     {
@@ -1975,7 +1975,7 @@ int srt::CUDTUnited::close(CUDTSocket* s)
         s->core().notListening();
 
         // broadcast all "accept" waiting
-        CSync::lock_broadcast(s->m_AcceptCond, s->m_AcceptLock);
+        CSync::lock_notify_all(s->m_AcceptCond, s->m_AcceptLock);
     }
     else
     {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5170,9 +5170,8 @@ void * srt::CUDT::tsbpd(void* param)
     CUDTUnited::GroupKeeper gkeeper(self->uglobal(), self->m_parent);
 #endif
 
-    UniqueLock recv_lock(self->m_RecvLock);
-    CSync recvdata_cc(self->m_RecvDataCond, recv_lock);
-    CSync tsbpd_cc(self->m_RcvTsbPdCond, recv_lock);
+    CUniqueSync recvdata_lcc (self->m_RecvLock, self->m_RecvDataCond);
+    CSync tsbpd_cc(self->m_RcvTsbPdCond, recvdata_lcc.locker());
 
     self->m_bTsbPdAckWakeup = true;
     while (!self->m_bClosing)
@@ -5235,7 +5234,7 @@ void * srt::CUDT::tsbpd(void* param)
              */
             if (self->m_config.bSynRecving)
             {
-                recvdata_cc.notify_one_locked(recv_lock);
+                recvdata_lcc.notify_one();
             }
             /*
              * Set EPOLL_IN to wakeup any thread waiting on epoll
@@ -8070,17 +8069,15 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
         if (m_bTsbPd)
         {
             /* Newly acknowledged data, signal TsbPD thread */
-            UniqueLock rcvlock(m_RecvLock);
-            CSync tscond(m_RcvTsbPdCond, rcvlock);
+            CUniqueSync cc (m_RecvLock, m_RcvTsbPdCond);
             // m_bTsbPdAckWakeup is protected by m_RecvLock in the tsbpd() thread
             if (m_bTsbPdAckWakeup)
-                tscond.notify_one_locked(rcvlock);
+                cc.notify_one();
         }
         else
         {
             {
-                UniqueLock rdlock (m_RecvLock);
-                CSync      rdcond (m_RecvDataCond, rdlock);
+                CUniqueSync rdcc (m_RecvLock, m_RecvDataCond);
 
 #if ENABLE_NEW_RCVBUFFER
                 // Locks m_RcvBufferLock, which is unlocked above by InvertedLock un_bufflock.
@@ -8091,7 +8088,7 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
                     if (m_config.bSynRecving)
                     {
                         // signal a waiting "recv" call if there is any data available
-                        rdcond.notify_one_locked(rdlock);
+                        rdcc.notify_one();
                     }
                     // acknowledge any waiting epolls to read
                     // fix SRT_EPOLL_IN event loss but rcvbuffer still have data：
@@ -8903,7 +8900,7 @@ void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
     const int32_t* dropdata = (const int32_t*) ctrlpkt.m_pcData;
 
     {
-        UniqueLock rlock(m_RecvLock);
+        CUniqueSync rcvtscc (m_RecvLock, m_RcvTsbPdCond);
         // With both TLPktDrop and TsbPd enabled, a message always consists only of one packet.
         // It will be dropped as too late anyway. Not dropping it from the receiver buffer
         // in advance reduces false drops if the packet somehow manages to arrive.
@@ -8937,8 +8934,7 @@ void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
         if (m_bTsbPd)
         {
             HLOGP(inlog.Debug, "DROPREQ: signal TSBPD");
-            CSync cc(m_RcvTsbPdCond, rlock);
-            cc.notify_one_locked(rlock);
+            rcvtscc.notify_one();
         }
     }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8069,10 +8069,10 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
         if (m_bTsbPd)
         {
             /* Newly acknowledged data, signal TsbPD thread */
-            CUniqueSync cc (m_RecvLock, m_RcvTsbPdCond);
+            CUniqueSync tslcc (m_RecvLock, m_RcvTsbPdCond);
             // m_bTsbPdAckWakeup is protected by m_RecvLock in the tsbpd() thread
             if (m_bTsbPdAckWakeup)
-                cc.notify_one();
+                tslcc.notify_one();
         }
         else
         {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6588,12 +6588,12 @@ int srt::CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
 
         {
             // wait here during a blocking sending
-            UniqueLock sendblock_lock (m_SendBlockLock);
+            CUniqueSync sendblock_cc (m_SendBlockEv);
 
             if (m_config.iSndTimeOut < 0)
             {
                 while (stillConnected() && sndBuffersLeft() < minlen && m_bPeerHealth)
-                    m_SendBlockCond.wait(sendblock_lock);
+                    sendblock_cc.wait();
             }
             else
             {
@@ -6602,7 +6602,7 @@ int srt::CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
                 THREAD_PAUSED();
                 while (stillConnected() && sndBuffersLeft() < minlen && m_bPeerHealth)
                 {
-                    if (!m_SendBlockCond.wait_until(sendblock_lock, exptime))
+                    if (!sendblock_cc.wait_until(exptime))
                         break;
                 }
                 THREAD_RESUMED();
@@ -7186,11 +7186,11 @@ int64_t srt::CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int blo
         unitsize = int((tosend >= block) ? block : tosend);
 
         {
-            UniqueLock lock(m_SendBlockLock);
+            CUniqueSync sendblock_cc(m_SendBlockEv);
 
             THREAD_PAUSED();
             while (stillConnected() && (sndBuffersLeft() <= 0) && m_bPeerHealth)
-                m_SendBlockCond.wait(lock);
+                sendblock_cc.wait();
             THREAD_RESUMED();
         }
 
@@ -7653,8 +7653,8 @@ bool srt::CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
 
 void srt::CUDT::initSynch()
 {
-    setupMutex(m_SendBlockLock, "SendBlock");
-    setupCond(m_SendBlockCond, "SendBlock");
+    setupMutex(m_SendBlockEv.mutex(), "SendBlock");
+    setupCond(m_SendBlockEv.cond(), "SendBlock");
     setupCond(m_RecvDataCond, "RecvData");
     setupMutex(m_SendLock, "Send");
     setupMutex(m_RecvLock, "Recv");
@@ -7668,14 +7668,14 @@ void srt::CUDT::initSynch()
 
 void srt::CUDT::destroySynch()
 {
-    releaseMutex(m_SendBlockLock);
+    releaseMutex(m_SendBlockEv.mutex());
 
     // Just in case, signal the CV, on which some
     // other thread is possibly waiting, because a
     // process hanging on a pthread_cond_wait would
     // cause the call to destroy a CV hang up.
-    m_SendBlockCond.notify_all();
-    releaseCond(m_SendBlockCond);
+    m_SendBlockEv.notify_all();
+    releaseCond(m_SendBlockEv.cond());
 
     m_RecvDataCond.notify_all();
     releaseCond(m_RecvDataCond);
@@ -7695,7 +7695,7 @@ void srt::CUDT::releaseSynch()
 {
     SRT_ASSERT(m_bClosing);
     // wake up user calls
-    CSync::lock_notify_one(m_SendBlockCond, m_SendBlockLock);
+    m_SendBlockEv.lock_notify_one();
 
     enterCS(m_SendLock);
     leaveCS(m_SendLock);
@@ -8294,7 +8294,7 @@ void srt::CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
 
     if (m_config.bSynSending)
     {
-        CSync::lock_notify_one(m_SendBlockCond, m_SendBlockLock);
+        m_SendBlockEv.lock_notify_one();
     }
 
     // record total time used for sending

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -954,8 +954,7 @@ private:
 private: // synchronization: mutexes and conditions
     sync::Mutex m_ConnectionLock;                // used to synchronize connection operation
 
-    sync::Condition m_SendBlockCond;             // used to block "send" call
-    sync::Mutex m_SendBlockLock;                 // lock associated to m_SendBlockCond
+    sync::CEvent m_SendBlockEv;
 
     mutable sync::Mutex m_RcvBufferLock;         // Protects the state of the m_pRcvBuffer
     // Protects access to m_iSndCurrSeqNo, m_iSndLastAck

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -954,7 +954,8 @@ private:
 private: // synchronization: mutexes and conditions
     sync::Mutex m_ConnectionLock;                // used to synchronize connection operation
 
-    sync::CEvent m_SendBlockEv;
+    sync::Condition m_SendBlockCond;             // used to block "send" call
+    sync::Mutex m_SendBlockLock;                 // lock associated to m_SendBlockCond
 
     mutable sync::Mutex m_RcvBufferLock;         // Protects the state of the m_pRcvBuffer
     // Protects access to m_iSndCurrSeqNo, m_iSndLastAck

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -979,7 +979,7 @@ void CUDTGroup::close()
     // XXX This looks like a dead code. Group receiver functions
     // do not use any lock on m_RcvDataLock, it is likely a remainder
     // of the old, internal impementation. 
-    // CSync::lock_signal(m_RcvDataCond, m_RcvDataLock);
+    // CSync::lock_notify_one(m_RcvDataCond, m_RcvDataLock);
 }
 
 // [[using locked(m_Global->m_GlobControlLock)]]

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1737,7 +1737,7 @@ void srt::CRcvQueue::storePkt(int32_t id, CPacket* pkt)
     if (i == m_mBuffer.end())
     {
         m_mBuffer[id].push(pkt);
-        passcond.signal_locked(bufferlock);
+        passcond.notify_one_locked(bufferlock);
     }
     else
     {

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1599,8 +1599,7 @@ void srt::CRcvQueue::stopWorker()
 
 int srt::CRcvQueue::recvfrom(int32_t id, CPacket& w_packet)
 {
-    UniqueLock bufferlock(m_BufferLock);
-    CSync      buffercond(m_BufferCond, bufferlock);
+    CUniqueSync buffercond(m_BufferLock, m_BufferCond);
 
     map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 
@@ -1729,15 +1728,14 @@ srt::CUDT* srt::CRcvQueue::getNewEntry()
 
 void srt::CRcvQueue::storePkt(int32_t id, CPacket* pkt)
 {
-    UniqueLock bufferlock(m_BufferLock);
-    CSync      passcond(m_BufferCond, bufferlock);
+    CUniqueSync passcond(m_BufferLock, m_BufferCond);
 
     map<int32_t, std::queue<CPacket*> >::iterator i = m_mBuffer.find(id);
 
     if (i == m_mBuffer.end())
     {
         m_mBuffer[id].push(pkt);
-        passcond.notify_one_locked(bufferlock);
+        passcond.notify_one();
     }
     else
     {

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -585,6 +585,9 @@ public:
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+// XXX Do not use this class now, there's an unknown issue
+// connected to object management with the use of release* functions.
+// Until this is solved, stay with separate *Cond and *Lock fields.
 class CEvent
 {
 public:
@@ -651,14 +654,11 @@ private:
 };
 
 
-// This function binds together the functionality of
+// This class binds together the functionality of
 // UniqueLock and CSync. It provides a simple interface of CSync
 // while having already the UniqueLock applied in the scope,
-// so a safe statement can be made about the mutex being locked.
-//
-// With this class you can also use CEvent class as a holder
-// for the mutex and condition pair.
-
+// so a safe statement can be made about the mutex being locked
+// when signalling or waiting.
 class CUniqueSync: public CSync
 {
     UniqueLock m_ulock;

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -536,22 +536,46 @@ public:
     }
 
     // Static ad-hoc version
-    static void lock_signal(Condition& cond, Mutex& m)
+    SRT_ATR_DEPRECATED_PX static void lock_signal(Condition& cond, Mutex& m) SRT_ATR_DEPRECATED
     {
         ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
         cond.notify_one();
     }
 
-    static void lock_broadcast(Condition& cond, Mutex& m)
+    static void lock_notify_one(Condition& cond, Mutex& m)
+    {
+        ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
+        cond.notify_one();
+    }
+
+
+    SRT_ATR_DEPRECATED_PX static void lock_broadcast(Condition& cond, Mutex& m) SRT_ATR_DEPRECATED
+    {
+        ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
+        cond.notify_all();
+    }
+    static void lock_notify_all(Condition& cond, Mutex& m)
     {
         ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
         cond.notify_all();
     }
 
-    void signal_locked(UniqueLock& lk SRT_ATR_UNUSED)
+
+    SRT_ATR_DEPRECATED_PX  void signal_locked(UniqueLock& lk SRT_ATR_UNUSED) SRT_ATR_DEPRECATED
     {
         // EXPECTED: lk.mutex() is LOCKED.
         m_cond->notify_one();
+    }
+    void notify_one_locked(UniqueLock& lk SRT_ATR_UNUSED)
+    {
+        // EXPECTED: lk.mutex() is LOCKED.
+        m_cond->notify_one();
+    }
+
+    void notify_all_locked(UniqueLock& lk SRT_ATR_UNUSED)
+    {
+        // EXPECTED: lk.mutex() is LOCKED.
+        m_cond->notify_all();
     }
 
     // The signal_relaxed and broadcast_relaxed functions are to be used in case
@@ -567,9 +591,14 @@ public:
     // comment is provided to explain, why the use of the relaxed signaling is
     // correctly used.
 
-    void signal_relaxed() { signal_relaxed(*m_cond); }
-    static void signal_relaxed(Condition& cond) { cond.notify_one(); }
-    static void broadcast_relaxed(Condition& cond) { cond.notify_all(); }
+    SRT_ATR_DEPRECATED_PX void signal_relaxed() SRT_ATR_DEPRECATED { notify_one_relaxed(*m_cond); }
+    void notify_one_relaxed() { notify_one_relaxed(*m_cond); }
+
+    SRT_ATR_DEPRECATED_PX static void signal_relaxed(Condition& cond) SRT_ATR_DEPRECATED { cond.notify_one(); }
+    static void notify_one_relaxed(Condition& cond) { cond.notify_one(); }
+
+    SRT_ATR_DEPRECATED_PX static void broadcast_relaxed(Condition& cond) SRT_ATR_DEPRECATED { cond.notify_all(); }
+    static void notify_all_relaxed(Condition& cond) { cond.notify_all(); }
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -537,36 +537,18 @@ public:
     }
 
     // Static ad-hoc version
-    SRT_ATR_DEPRECATED_PX static void lock_signal(Condition& cond, Mutex& m) SRT_ATR_DEPRECATED
-    {
-        ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
-        cond.notify_one();
-    }
-
     static void lock_notify_one(Condition& cond, Mutex& m)
     {
         ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
         cond.notify_one();
     }
 
-
-    SRT_ATR_DEPRECATED_PX static void lock_broadcast(Condition& cond, Mutex& m) SRT_ATR_DEPRECATED
-    {
-        ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
-        cond.notify_all();
-    }
     static void lock_notify_all(Condition& cond, Mutex& m)
     {
         ScopedLock lk(m); // XXX with thread logging, don't use ScopedLock directly!
         cond.notify_all();
     }
 
-
-    SRT_ATR_DEPRECATED_PX  void signal_locked(UniqueLock& lk SRT_ATR_UNUSED) SRT_ATR_DEPRECATED
-    {
-        // EXPECTED: lk.mutex() is LOCKED.
-        m_cond->notify_one();
-    }
     void notify_one_locked(UniqueLock& lk SRT_ATR_UNUSED)
     {
         // EXPECTED: lk.mutex() is LOCKED.
@@ -579,26 +561,21 @@ public:
         m_cond->notify_all();
     }
 
-    // The signal_relaxed and broadcast_relaxed functions are to be used in case
-    // when you don't care whether the associated mutex is locked or not (you
-    // accept the case that a mutex isn't locked and the signal gets effectively
-    // missed), or you somehow know that the mutex is locked, but you don't have
-    // access to the associated UniqueLock object. This function, although it does
-    // the same thing as signal_locked() and broadcast_locked(), is here for
-    // the user to declare explicitly that the signal/broadcast is done without
-    // being prematurely certain that the associated mutex is locked.
+    // The *_relaxed functions are to be used in case when you don't care
+    // whether the associated mutex is locked or not (you accept the case that
+    // a mutex isn't locked and the condition notification gets effectively
+    // missed), or you somehow know that the mutex is locked, but you don't
+    // have access to the associated UniqueLock object. This function, although
+    // it does the same thing as CSync::notify_one_locked etc. here for the
+    // user to declare explicitly that notifying is done without being
+    // prematurely certain that the associated mutex is locked.
     //
     // It is then expected that whenever these functions are used, an extra
-    // comment is provided to explain, why the use of the relaxed signaling is
-    // correctly used.
+    // comment is provided to explain, why the use of the relaxed notification
+    // is correctly used.
 
-    SRT_ATR_DEPRECATED_PX void signal_relaxed() SRT_ATR_DEPRECATED { notify_one_relaxed(*m_cond); }
     void notify_one_relaxed() { notify_one_relaxed(*m_cond); }
-
-    SRT_ATR_DEPRECATED_PX static void signal_relaxed(Condition& cond) SRT_ATR_DEPRECATED { cond.notify_one(); }
     static void notify_one_relaxed(Condition& cond) { cond.notify_one(); }
-
-    SRT_ATR_DEPRECATED_PX static void broadcast_relaxed(Condition& cond) SRT_ATR_DEPRECATED { cond.notify_all(); }
     static void notify_all_relaxed(Condition& cond) { cond.notify_all(); }
 };
 

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -68,6 +68,8 @@ TEST(Bonding, SRTConnectGroup)
     }
 
     srt_cleanup();
+
+    srt_setloglevel(LOG_ERR);
 }
 
 

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -39,6 +39,8 @@ TEST(Bonding, SRTConnectGroup)
         targets.push_back(gd);
     }
 
+    srt_setloglevel(LOG_DEBUG);
+
     std::future<void> closing_promise = std::async(std::launch::async, [](int ss) {
         std::this_thread::sleep_for(std::chrono::seconds(2));
         std::cerr << "Closing group" << std::endl;

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -49,14 +49,19 @@ TEST(Bonding, SRTConnectGroup)
 
     std::cout << "srt_connect_group calling " << std::endl;
     const int st = srt_connect_group(ss, targets.data(), (int) targets.size());
-    std::cout << "srt_connect_group returned " << st << std::endl;
+    std::cout << "srt_connect_group returned " << st << ", waiting for srt_close() to finish" << std::endl;
 
     closing_promise.wait();
+
+    std::cout << "TEST: closing future has exit. Deleting all other resources\n";
+
     // Delete config objects before prospective exception
     for (auto& gd: targets)
         srt_delete_config(gd.config);
 
     int res = srt_close(ss);
+
+    std::cout << "TEST: closing ss has exit. Cleaning up\n";
     if (res == SRT_ERROR)
     {
         std::cerr << "srt_close: " << srt_getlasterror_str() << std::endl;

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -39,8 +39,6 @@ TEST(Bonding, SRTConnectGroup)
         targets.push_back(gd);
     }
 
-    srt_setloglevel(LOG_DEBUG);
-
     std::future<void> closing_promise = std::async(std::launch::async, [](int ss) {
         std::this_thread::sleep_for(std::chrono::seconds(2));
         std::cerr << "Closing group" << std::endl;
@@ -68,8 +66,6 @@ TEST(Bonding, SRTConnectGroup)
     }
 
     srt_cleanup();
-
-    srt_setloglevel(LOG_ERR);
 }
 
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -386,8 +386,8 @@ TEST(SyncEvent, WaitForNotifyOne)
     const steady_clock::duration timeout = seconds_from(5);
 
     auto wait_async = [](Condition* cond, Mutex* mutex, const steady_clock::duration& timeout) {
-        UniqueLock lock(*mutex);
-        return cond->wait_for(lock, timeout);
+        CUniqueSync cc (*mutex, *cond);
+        return cc.wait_for(timeout);
     };
     auto wait_async_res = async(launch::async, wait_async, &cond, &mutex, timeout);
 


### PR DESCRIPTION
1. All POSIX-like signal/broadcast names changed to notify_one/all to follow the naming used in the C++ standard.
2. Added a new CUniqueSync class that integrates CSync and UniqueLock and improved the CEvent class to make it more usable as a mutex/condition pair.