### PR TITLE
[core] Fixed missing reject reason types (logging).

### DIFF
--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -151,7 +151,7 @@ std::string srt::RequestTypeStr(UDTRequestType rq)
         std::ostringstream rt;
         rt << "ERROR:";
         int id = RejectReasonForURQ(rq);
-        if (id < Size(srt_rejectreason_name))
+        if (id < (int) Size(srt_rejectreason_name))
             rt << srt_rejectreason_name[id];
         else if (id < SRT_REJC_USERDEFINED)
         {

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -139,6 +139,8 @@ const char* srt_rejectreason_name [] = {
     "MESSAGEAPI",
     "CONGESTION",
     "FILTER",
+    "GROUP",
+    "TIMEOUT"
 };
 }
 
@@ -149,7 +151,7 @@ std::string srt::RequestTypeStr(UDTRequestType rq)
         std::ostringstream rt;
         rt << "ERROR:";
         int id = RejectReasonForURQ(rq);
-        if (id < SRT_REJ_E_SIZE)
+        if (id < Size(srt_rejectreason_name))
             rt << srt_rejectreason_name[id];
         else if (id < SRT_REJC_USERDEFINED)
         {


### PR DESCRIPTION
Potential crash on out-of-bounds memory access.
However, it seems like luckily `RequestTypeStr(..)` is not called for GROUP and TIMEOUT rejection codes.