### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ In live streaming configurations, the SRT protocol maintains a constant end-to-e
 
 For detailed descriptions of the build system and options, please read the [SRT Build Options](./docs/build/build-options.md) document.
 
+## Installing srt using vcpkg
+You can download and install srt using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install libsrt
+```
+
+The libsrt port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Sample Applications and Tools
 
 The current repo provides [sample applications](./apps) and [code examples](./examples) that demonstrate the usage of the SRT library API. Among them are [`srt-live-transmit`](./apps/srt-live-transmit.cpp), [`srt-file-transmit`](./apps/srt-file-transmit.cpp), and other applications. The respective documentation can be found [here](./docs#sample-applications). Note that all samples are provided for instructional purposes, and should not be used in a production environment.


### PR DESCRIPTION
`libsrt` is available as a port in vcpkg, a C++ library manager that simplifies installation for `libsrt` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libsrt, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libsrt/portfile.cmake). We try to keep the library maintained as close as possible to the original library.