### PR TITLE
[docs] Added Packet Managers section to Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Secure Reliable Transport (SRT) Protocol
 
-[About SRT](#what-is-srt) | [Features](#features) | [Getting Started](#getting-started-with-srt) | [Builds](#build-instructions) | [Sample Apps and Tools](#sample-applications-and-tools) | [Contribute](#contributing) | [License](#license) | [Releases](#release-history)
+[About SRT](#what-is-srt) | [Features](#features) | [Getting Started](#getting-started-with-srt) | [Build Instructions](#build-instructions) | [Sample Apps and Tools](#sample-applications-and-tools) | [Contribute](#contributing) | [License](#license) | [Releases](#release-history)
 
 <p align="left">
   <a href="http://srtalliance.org/">
@@ -29,7 +29,7 @@ SRT is applied to contribution and distribution endpoints as part of a video str
 | **R**eliable  | Recovers from severe packet loss                  |
 | **T**ransport | Dynamically adapts to changing network conditions |
 
-In live streaming configurations, the SRT protocol maintains a constant end-to-end latency. This allows the live stream’s signal characteristics to be recreated on the receiver side, reducing the need for buffering. As packets are streamed from source to destination, SRT detects and adapts to real-time network conditions between the two endpoints. It helps compensate for jitter and bandwidth fluctuations due to congestion over noisy networks.
+In live streaming configurations, the SRT protocol maintains a constant end-to-end latency. This allows the live stream's signal characteristics to be recreated on the receiver side, reducing the need for buffering. As packets are streamed from source to destination, SRT detects and adapts to real-time network conditions between the two endpoints. It helps compensate for jitter and bandwidth fluctuations due to congestion over noisy networks.
 
 [SRT implements AES encryption](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-01#section-6) to protect the payload of the media streams, and offers various error recovery mechanisms for minimizing the packet loss that is typical of Internet connections, of which Automatic Repeat reQuest (ARQ) is the primary method. With ARQ, when a receiver detects that a packet is missing it sends an alert to the sender requesting retransmission of this missing packet. [Forward Error Correction (FEC)](./docs/features/packet-filtering-and-fec.md) and [Connection Bonding](./docs/features/bonding-quick-start.md), which adds seamless stream protection and hitless failover, are also supported by the protocol.
 
@@ -157,7 +157,7 @@ In live streaming configurations, the SRT protocol maintains a constant end-to-e
 
 ## Build Instructions
 
-[Linux (Ubuntu/CentOS)](./docs/build/build-linux.md) | [Windows](./docs/build/build-win.md) | [macOS](./docs/build/build-macOS.md) | [iOS](./docs/build/build-iOS.md) | [Android](./docs/build/build-android.md)
+[Linux (Ubuntu/CentOS)](./docs/build/build-linux.md) | [Windows](./docs/build/build-win.md) | [macOS](./docs/build/build-macOS.md) | [iOS](./docs/build/build-iOS.md) | [Android](./docs/build/build-android.md) | [Package Managers](./docs/build/package-managers.md)
 
 ### Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,35 +2,36 @@
 
 ## SRT API Documents
 
-| Document Title                                         |            Folder             | File Name                                          | Description                                          |
-| :----------------------------------------------------- | :---------------------------- | :------------------------------------------------- | :--------------------------------------------------- |
-| [SRT API](API/API.md)                                  |          [API](API/)          | [API.md](API/API.md)                               | Detailed description of the SRT C API.               |
-| [SRT API Functions](API/API-functions.md)              |          [API](API/)          | [API-functions.md](API/API-functions.md)           | Reference document for SRT API functions.            |
-| [SRT API Socket Options](API/API-socket-options.md)    |          [API](API/)          | [API-socket-options.md](API/API-socket-options.md) | Instructions and list of socket options for SRT API. |
-| [SRT Statistics](API/statistics.md)                    |          [API](API/)          | [statistics.md](API/statistics.md)                 | How to use SRT socket and socket group statistics.   |
-| [Configuration Guidelines](API/configuration-guidelines.md) |     [API](API/)          | [configuration-guidelines.md](API/configuration-guidelines.md) | How to configure SRT buffers.            |
-| <img width=200px height=1px/>                          | <img width=100px height=1px/> | <img width=200px height=1px/>                      | <img width=500px height=1px/>                        |
+| Document Title                                              | Folder                        | File Name                                                      | Description                                          |
+| :---------------------------------------------------------- | :---------------------------- | :------------------------------------------------------------- | :--------------------------------------------------- |
+| [SRT API](API/API.md)                                       | [API](API/)                   | [API.md](API/API.md)                                           | Detailed description of the SRT C API.               |
+| [SRT API Functions](API/API-functions.md)                   | [API](API/)                   | [API-functions.md](API/API-functions.md)                       | Reference document for SRT API functions.            |
+| [SRT API Socket Options](API/API-socket-options.md)         | [API](API/)                   | [API-socket-options.md](API/API-socket-options.md)             | Instructions and list of socket options for SRT API. |
+| [SRT Statistics](API/statistics.md)                         | [API](API/)                   | [statistics.md](API/statistics.md)                             | How to use SRT socket and socket group statistics.   |
+| [Configuration Guidelines](API/configuration-guidelines.md) | [API](API/)                   | [configuration-guidelines.md](API/configuration-guidelines.md) | How to configure SRT buffers.                        |
+| <img width=200px height=1px/>                               | <img width=100px height=1px/> | <img width=200px height=1px/>                                  | <img width=500px height=1px/>                        |
 
 ## Build Instructions
 
-| Document Title                                               | Folder                        | File Name                                  | Description                                                  |
-| :----------------------------------------------------------- | :---------------------------- | :----------------------------------------- | :----------------------------------------------------------- |
-| [SRT Build Options](build/build-options.md)                  | [build](build/)               | [build-options.md](build/build-options.md) | Description of CMake build system, configure script, and build options. |
-| [Building SRT on Linux (Ubuntu/CentOS)](build/build-linux.md) | [build](build/)               | [build-linux.md](build/build-linux.md)     | Build instructions for Linux (Ubuntu/CentOS).                |
-| [Building SRT on Windows](build/build-win.md)               | [build](build/)               | [build-win.md](build/build-win.md)         | Build instructions for Windows.                              |
-| [Building SRT on macOS](build/build-macOS.md)               | [build](build/)               | [build-macOS.md](build/build-macOS.md)     | Build instructions for macOS.                                |
-| [Building SRT on iOS](build/build-iOS.md)                   | [build](build/)               | [build-iOS.md](build/build-iOS.md)         | Build instructions for iOS.                                  |
-| [Building SRT on Android](build/build-android.md)           | [build](build/)               | [build-android.md](build/build-android.md) | Build instructions for Android.                              |
-| <img width=200px height=1px/>                                | <img width=100px height=1px/> | <img width=200px height=1px/>              | <img width=500px height=1px/>                                |
+| Document Title                                                | Folder                        | File Name                                        | Description                                                             |
+| :------------------------------------------------------------ | :---------------------------- | :----------------------------------------------- | :---------------------------------------------------------------------- |
+| [SRT Build Options](build/build-options.md)                   | [build](build/)               | [build-options.md](build/build-options.md)       | Description of CMake build system, configure script, and build options. |
+| [Building SRT on Linux (Ubuntu/CentOS)](build/build-linux.md) | [build](build/)               | [build-linux.md](build/build-linux.md)           | Build instructions for Linux (Ubuntu/CentOS).                           |
+| [Building SRT on Windows](build/build-win.md)                 | [build](build/)               | [build-win.md](build/build-win.md)               | Build instructions for Windows.                                         |
+| [Building SRT on macOS](build/build-macOS.md)                 | [build](build/)               | [build-macOS.md](build/build-macOS.md)           | Build instructions for macOS.                                           |
+| [Building SRT on iOS](build/build-iOS.md)                     | [build](build/)               | [build-iOS.md](build/build-iOS.md)               | Build instructions for iOS.                                             |
+| [Building SRT on Android](build/build-android.md)             | [build](build/)               | [build-android.md](build/build-android.md)       | Build instructions for Android.                                         |
+| [Package Managers](build/package-managers.md)                 | [build](build/)               | [package-managers.md](build/package-managers.md) | Package managers supporting SRT library.                                |
+| <img width=200px height=1px/>                                 | <img width=100px height=1px/> | <img width=200px height=1px/>                    | <img width=500px height=1px/>                                           |
 
 ## Development Documents
 
-| Document Title                                   |            Folder             | File Name                                        | Description                                                  |
-| :----------------------------------------------- | :---------------------------- | :----------------------------------------------- | :----------------------------------------------------------- |
-| [SRT Developer's Guide](dev/developers-guide.md) |          [dev](dev/)          | [developers-guide.md](dev/developers-guide.md)   | Development setup, project structure, coding rules,<br />submitting issues & PRs, etc. |
-| [Low Level Info](dev/low-level-info.md)          |          [dev](dev/)          | [low-level-info.md](dev/low-level-info.md)       | Low level information for the SRT project (only<br />mutex locking). |
-| [Making SRT Better](dev/making-srt-better.md)    |          [dev](dev/)          | [making-srt-better.md](dev/making-srt-better.md) | Guidelines for problem reporting, collecting debug logs<br />and pcaps. |
-| <img width=200px height=1px/>                    | <img width=100px height=1px/> | <img width=200px height=1px/>                    | <img width=500px height=1px/>                                |
+| Document Title                                   | Folder                        | File Name                                        | Description                                                                            |
+| :----------------------------------------------- | :---------------------------- | :----------------------------------------------- | :------------------------------------------------------------------------------------- |
+| [SRT Developer's Guide](dev/developers-guide.md) | [dev](dev/)                   | [developers-guide.md](dev/developers-guide.md)   | Development setup, project structure, coding rules,<br />submitting issues & PRs, etc. |
+| [Low Level Info](dev/low-level-info.md)          | [dev](dev/)                   | [low-level-info.md](dev/low-level-info.md)       | Low level information for the SRT project (only<br />mutex locking).                   |
+| [Making SRT Better](dev/making-srt-better.md)    | [dev](dev/)                   | [making-srt-better.md](dev/making-srt-better.md) | Guidelines for problem reporting, collecting debug logs<br />and pcaps.                |
+| <img width=200px height=1px/>                    | <img width=100px height=1px/> | <img width=200px height=1px/>                    | <img width=500px height=1px/>                                                          |
 
 ## Features
 

--- a/docs/build/build-macOS.md
+++ b/docs/build/build-macOS.md
@@ -1,6 +1,6 @@
 # Building SRT on macOS
 
-[Homebrew](https://brew.sh/) supports the **srt** formula.
+[Homebrew](https://brew.sh/) supports the [`srt`](https://formulae.brew.sh/formula/srt) formula.
 
 ```shell
 brew update

--- a/docs/build/package-managers.md
+++ b/docs/build/package-managers.md
@@ -1,0 +1,31 @@
+# Package Managers
+
+The SRT library can be installed with the help of the following package managers:
+
+- [Vcpkg](https://github.com/Microsoft/vcpkg)
+
+  The SRT library package name is `libsrt`. For example, to install the library on Unix systems, run:
+
+  ```
+  ./vcpkg install libsrt
+  ```
+
+  The `libsrt` port in `vcpkg` is kept up to date by Microsoft team members and community contributors. If the SRT version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the `vcpkg` repository.
+
+- [Homebrew](https://brew.sh/)
+
+  The `Homebrew` formula is [`srt`](https://formulae.brew.sh/formula/srt). See also ["Building SRT on macOS"](./build-macOS.md).
+
+  ```
+  brew install srt
+  ```
+
+- [Apt](https://ubuntu.com/server/docs/package-management)
+
+  ```
+  sudo apt install libsrt
+  ```
+
+- [Conan](https://conan.io/)
+
+  The SRT library package name is [`srt`](https://conan.io/center/srt).


### PR DESCRIPTION
Added "Packet Managers" section to "Build Instructions" of main README. This PR is a replacement for PR #2453. 

Actually as the "Packet Managers" section is pretty long when we list all the managers, I've decided to put it as a [separate document](docs/build/package-managers.md) under `docs/build/` folder and add a link from the main README "Build Instructions".


Co-authored-by: Adela0814 <95600143+Adela0814@users.noreply.github.com>
Co-authored-by: maxsharabayko <maxlovic@gmail.com>