### PR TITLE
[build] Find GTest using version range 1.8-1.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1363,7 +1363,12 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-	find_package(GTest 1.8)
+	# Version ranges are only supported with CMake 3.19 or later.
+	if (${CMAKE_VERSION} VERSION_LESS "3.19.0")
+		find_package(GTest 1.8)
+	else()
+		find_package(GTest 1.8...1.12)
+	endif()
 	if (NOT GTEST_FOUND)
 		message(STATUS "GTEST not found! Fetching from git.")
 		include(googletest)


### PR DESCRIPTION
Version ranges are only supported with CMake 3.19 or later. Fallback to GTest v1.8 with older CMake versions.