### PR TITLE
[FR] Send out-of-band user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Ignore any folder starting from underscore
 _*/
+build/
 
 # Ignode Visual Studio Code temp folder
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1363,7 +1363,12 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-	find_package(GTest 1.8)
+	# Version ranges are only supported with CMake 3.19 or later.
+	if (${CMAKE_VERSION} VERSION_LESS "3.19.0")
+		find_package(GTest 1.8)
+	else()
+		find_package(GTest 1.8...1.12)
+	endif()
 	if (NOT GTEST_FOUND)
 		message(STATUS "GTEST not found! Fetching from git.")
 		include(googletest)

--- a/scripts/win-installer/build-win-installer.ps1
+++ b/scripts/win-installer/build-win-installer.ps1
@@ -162,7 +162,8 @@ foreach ($Platform in @("x64", "Win32")) {
         -DENABLE_STDCXX_SYNC=ON `
         -DOPENSSL_ROOT_DIR="$SRoot" `
         -DOPENSSL_LIBRARIES="$SRoot\lib\libssl_static.lib;$SRoot\lib\libcrypto_static.lib" `
-        -DOPENSSL_INCLUDE_DIR="$SRoot\include"
+        -DOPENSSL_INCLUDE_DIR="$SRoot\include" `
+        -DENABLE_BONDING=ON
 
     # Patch version string in version.h
     Get-Content "$BuildDir\version.h" |
@@ -201,7 +202,7 @@ if ($Missing -gt 0) {
 #-----------------------------------------------------------------------------
 
 $InstallExe = "$OutDir\libsrt-$Version.exe"
-$InstallZip = "$OutDir\libsrt-$Version-win-installer.zip"
+$InstallZip = "$OutDir\libsrt-bonding-$Version-win-installer.zip"
 
 Write-Output "Building installer ..."
 & $NSIS /V2 `

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -266,6 +266,7 @@ public:
 
     int installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);
     int installConnectHook(const SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq);
+    int installUserdataHook(const SRTSOCKET u, srt_userdata_callback_fn* hook, void* opaq);
 
     /// Check the status of the UDT socket.
     /// @param [in] u the UDT socket ID.

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -238,10 +238,10 @@ public:
 
     /// Pack a Control packet.
     /// @param pkttype [in] packet type filed.
-    /// @param lparam [in] pointer to the first data structure, explained by the packet type.
-    /// @param rparam [in] pointer to the second data structure, explained by the packet type.
+    /// @param lparam [in] 32 bits to be placed in the type specific information field.
+    /// @param rparam [in] pointer to the data to be placed in the content specific information field.
     /// @param size [in] size of rparam, in number of bytes;
-    void pack(UDTMessageType pkttype, const int32_t* lparam = NULL, void* rparam = NULL, size_t size = 0);
+    void pack(UDTMessageType pkttype, const int32_t* lparam = NULL, const void* rparam = NULL, size_t size = 0);
 
     /// Read the packet vector.
     /// @return Pointer to the packet vector.
@@ -258,6 +258,9 @@ public:
     bool isControl() const { return 0 != SEQNO_CONTROL::unwrap(m_nHeader[SRT_PH_SEQNO]); }
 
     void setControl(UDTMessageType type) { m_nHeader[SRT_PH_SEQNO] = SEQNO_CONTROL::mask | SEQNO_MSGTYPE::wrap(type); }
+
+    /// Set the extended packet type (subtype).
+    void setExtendedType(int ext_type);
 
     /// Read the extended packet type.
     /// @return extended packet type filed (0x000 ~ 0xFFF).

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -990,6 +990,24 @@ SRT_API int srt_config_add(SRT_SOCKOPT_CONFIG* config, SRT_SOCKOPT option, const
 SRT_API SRT_SOCKGROUPCONFIG srt_prepare_endpoint(const struct sockaddr* src /*nullable*/, const struct sockaddr* adr, int namelen);
 SRT_API       int srt_connect_group(SRTSOCKET group, SRT_SOCKGROUPCONFIG name[], int arraysize);
 
+// OOB userdata
+
+// A control structure with additional fields.
+typedef struct SRT_UserdataControl {
+    uint32_t timestamp;
+} SRT_USERDATACTRL;
+
+
+/// @param u SRT scoket with an established connection.
+/// @param buf data to send (must fit in one MTU!).
+/// @param len length of the data to send.
+/// @param udctrl control structure with additional fields, mainly for possible future extenstions.
+SRT_API int srt_senduserdata(SRTSOCKET u, const char* buf, int len, SRT_USERDATACTRL* udctrl);
+
+typedef int srt_userdata_callback_fn(void* opaq, SRTSOCKET u, const char* buf, int len, const SRT_USERDATACTRL* ctrl);
+SRT_API int srt_userdata_callback(SRTSOCKET u, srt_userdata_callback_fn* cb_fn, void* opaque);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -239,6 +239,16 @@ int srt_recvmsg2(SRTSOCKET u, char * buf, int len, SRT_MSGCTRL *mctrl)
     return CUDT::recvmsg2(u, buf, len, (mignore));
 }
 
+int srt_senduserdata(SRTSOCKET u, const char* buf, int len, SRT_USERDATACTRL* udctrl)
+{
+    // Allow NULL mctrl in the API, but not internally.
+    if (udctrl)
+        return CUDT::senduserdata(u, buf, len, (*udctrl));
+    SRT_USERDATACTRL mignore;
+    mignore.timestamp = 0;
+    return CUDT::senduserdata(u, buf, len, (mignore));
+}
+
 const char* srt_getlasterror_str() { return UDT::getlasterror().getErrorMessage(); }
 
 int srt_getlasterror(int* loc_errno)
@@ -399,6 +409,14 @@ int srt_connect_callback(SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opa
         return CUDT::APIError(MJ_NOTSUP, MN_INVAL);
 
     return CUDT::installConnectHook(lsn, hook, opaq);
+}
+
+int srt_userdata_callback(SRTSOCKET u, srt_userdata_callback_fn* hook, void* opaq)
+{
+    if (!hook)
+        return CUDT::APIError(MJ_NOTSUP, MN_INVAL);
+
+    return CUDT::installUserdataHook(u, hook, opaq);
 }
 
 uint32_t srt_getversion()

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -22,6 +22,7 @@ test_sync.cpp
 test_threadname.cpp
 test_timer.cpp
 test_unitqueue.cpp
+test_userdata.cpp
 test_utilities.cpp
 test_reuseaddr.cpp
 

--- a/test/test_userdata.cpp
+++ b/test/test_userdata.cpp
@@ -1,0 +1,76 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <string>
+#include <map>
+
+#ifdef _WIN32
+#define INC_SRT_WIN_WINTIME // exclude gettimeofday from srt headers
+#endif
+
+#include "srt.h"
+#include "utilities.h"
+
+int OnUserData(void* opaq, SRTSOCKET ns SRT_ATR_UNUSED, const char* buf, int len, const SRT_USERDATACTRL* ctrl);
+
+
+TEST(Core, Userdata) {
+
+    using namespace std;
+
+    ASSERT_EQ(srt_startup(), 0);
+
+    // Create server on 127.0.0.1:5555
+
+    const SRTSOCKET server_sock = srt_create_socket();
+    ASSERT_GT(server_sock, 0);    // socket_id should be > 0
+
+    sockaddr_in bind_sa;
+    memset(&bind_sa, 0, sizeof bind_sa);
+    bind_sa.sin_family = AF_INET;
+    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &bind_sa.sin_addr), 1);
+    bind_sa.sin_port = htons(5555);
+
+    ASSERT_NE(srt_bind(server_sock, (sockaddr*)&bind_sa, sizeof bind_sa), -1);
+    ASSERT_NE(srt_listen(server_sock, 5), -1);
+    EXPECT_EQ(srt_userdata_callback(server_sock, OnUserData, nullptr), SRT_SUCCESS);
+
+    // Create client to connect to the above server
+    sockaddr_in sa;
+    memset(&sa, 0, sizeof sa);
+    sa.sin_family = AF_INET;
+    sa.sin_port = htons(5555);
+    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr), 1);
+    sockaddr* psa = (sockaddr*)&sa;
+
+    SRTSOCKET client_sock = srt_create_socket();
+    ASSERT_GT(client_sock, 0);    // socket_id should be > 0
+
+    // EXPECTED RESULT: connected successfully
+    EXPECT_NE(srt_connect(client_sock, psa, sizeof sa), SRT_ERROR);
+
+    // TODO: align message on 32 bits (handle internally).
+    const string userdata = "Custom message";
+    EXPECT_EQ(srt_senduserdata(client_sock, userdata.c_str(), (int) userdata.size(), NULL), userdata.size());
+
+    // Close the socket
+    EXPECT_EQ(srt_close(client_sock), SRT_SUCCESS);
+
+    (void)srt_cleanup();
+}
+
+int OnUserData(void* opaq, SRTSOCKET ns SRT_ATR_UNUSED, const char* buf, int len, const SRT_USERDATACTRL* ctrl)
+{
+    using namespace std;
+
+    if (opaq)
+    {
+        cerr << "ERROR: opaq expected NULL, as passed\n";
+        return -1; // enforce EXPECT to fail
+    }
+
+    cerr << "OnUserData: " << buf << endl;
+    return 0;
+}
+
+
+


### PR DESCRIPTION
This PR is a PoC and WiP. Addresses #2397.

Allow sending some OOB user data bi-directionally over an existing SRT connection.

1. Unreliable delivery. If a packet is lost, neither the receiver nor the sender would ever know. An application's responsibility is to track losses and retransmissions of those packets if required.
2. These packets are sent just like other control packets: bypassing the data packet sending queue, and ignoring MAXBW limit and any kind of pacing from the SRT side.
3. Incoming packets are not buffered by the receiver, and outgoing packets are not buffered by the sender, thus it is not possible to send a message not fitting into a single packet.
4. **Encryption**: not yet implemented.
5. **Group connections** Currently not supported.
6. **Reading an incoming user data message blocks the receiving thread**❗ Thus must not take too much time. Alternatively the message has to be buffered by the SRT receiver to initiate the callback from a different thread.
7. `SRT_UDCTRL::timestamp` is ignored at the moment❗ 


## SRT API

```c
// A control structure with additional fields.
struct SRT_UDCTRL {
    uint32_t timestamp;
};

/// @param u SRT scoket with an established connection.
/// @param buf data to send (must fit in one MTU!).
/// @param len length of the data to send.
/// @param udctrl control structure with additional fields, mainly for possible future extenstions.
int srt_senduserdata(SRTSOCKET u,  const char* buf, int len, SRT_UDCTRL *udctrl);


typedef int srt_userdata_callback_fn   (void* opaq, SRTSOCKET u, const char* buf, int len, const SRT_UDCTRL* ctrl);
SRT_API       int srt_userdata_callback(SRTSOCKET u, srt_userdata_callback_fn* cb_fn, void* opaque);
```

- [ ] Should the sender get an additional field to provide the sequential packet ID?

## SRT Protocol

Extend [the User Data Control type packet](https://datatracker.ietf.org/doc/html/rfc7714#section-9.2):

```
+===================+==============+=========+===============+
| Packet Type       | Control Type | Subtype | Section       |
+===================+==============+=========+===============+
| (...)                  | (...)  | (..) |
+-------------------+--------------+---------+---------------+
| User-Defined Type |    0x7FFF    |    -    | N/A           |
+-------------------+--------------+---------+---------------+
              Table 1: SRT Control Packet Types
```

Control Type = 0x7FFF (User Defined Data, `UDTMessageType::UMSG_EXT`).
Subtype:
- 1 = HSREQ
- 2 = HSRSP
- 3 = KMREQ (encryption key material request)
- 4 = KMRSP (encryption key material response)
- **5 = User Data (Unreliable Delivery)**

The user-data packet itself has the following structure.
Some means to identify sequential packet number might be needed unless handled by the application.

- [ ] The "type-specific information" field may allow an application to define the type of packet instead of putting a marker inside the "free-form text" field.

```
 0                   1                   2                   3
 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+-+-+-+-+-+-+-+-+-+-+-+-+- SRT Header +-+-+-+-+-+-+-+-+-+-+-+-+-+
|1|   Control Type = 0x7FFF     |            Subtype = 5?          |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                   Type-specific Information                   |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                           Timestamp                           |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                     Destination Socket ID                     |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+- CIF -+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|                                                               |
+                      Free form text content                   +
                               ...
|                                                               |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```
