### PR TITLE
[docs] Updated docs on release notes generation

### DIFF
--- a/scripts/release-notes/README.md
+++ b/scripts/release-notes/README.md
@@ -4,15 +4,24 @@ Script designed to generate release notes template with main sections, contribut
 
 In order to obtain the git log file since the previous release (e.g., v1.4.0), use the following command:
 
+```shell
+git log --pretty=format:"%h|%s|%an|%ae" v1.4.0...HEAD > commits.csv
 ```
-git log --pretty=format:"%h|%s|%an|%ae" v1.4.0...HEAD^ > commits.csv
+
+Use the produced `commits.csv` file as an input to the script:
+
+```shell
+python scripts/release-notes/generate-release-notes.py commits.csv
 ```
+
+The script produces `release-notes.md` as an output.
+
 
 ## Requirements
 
 * Python 3.6+
 
 To install Python libraries use:
-```
+```shell
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
The main change is fixing the following command line, as it excludes the very top commit (the HEAD itself):

```shell
git log --pretty=format:"%h|%s|%an|%ae" v1.4.0...HEAD^ > commits.csv
```

The rest is just about describing the missing steps.