### PR TITLE
[Build] Fix MacOS Build SDK-10.5.

### DIFF
--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -502,7 +502,7 @@ struct CSrtConfigSetter<SRTO_CONNTIMEO>
         if (val < 0)
             throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
-        using namespace sync;
+        using namespace srt::sync;
         co.tdConnTimeOut = milliseconds_from(val);
     }
 };


### PR DESCRIPTION
This PR fixes build on MacOS with `SDK-10.5`. The SDK confuses `namespace sync` with the POSIX `sync(3P)` e.g. `void sync(void);` function call. The intent of this code seems to be use `srt::sync::milliseconds_from()` method. So further qualifying the namespace disambiguates the intent.