### PR TITLE
Fixed CRcvLossList can not remove m_iMaxSeqNo.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -1004,12 +1004,18 @@ void CRcvBufferNew::updateTsbPdTimeBase(uint32_t usPktTimestamp)
     m_tsbpd.updateTsbPdTimeBase(usPktTimestamp);
 }
 
-string CRcvBufferNew::strFullnessState(int iFirstUnackSeqNo, const time_point& tsNow) const
+string CRcvBufferNew::strFullnessState(bool enable_debug_log, int iFirstUnackSeqNo, const time_point& tsNow) const
 {
     stringstream ss;
 
-    ss << "Space avail " << getAvailSize(iFirstUnackSeqNo) << "/" << m_szSize;
-    ss << " pkts. ";
+    if (enable_debug_log)
+    {
+        ss << "iFirstUnackSeqNo=" << iFirstUnackSeqNo << " m_iStartSeqNo=" << m_iStartSeqNo
+           << " m_iStartPos=" << m_iStartPos << " m_iMaxPosInc=" << m_iMaxPosInc << ". ";
+    }
+
+    ss << "Space avail " << getAvailSize(iFirstUnackSeqNo) << "/" << m_szSize << " pkts. ";
+
     if (m_tsbpd.isEnabled() && m_iMaxPosInc > 0)
     {
         const PacketInfo nextValidPkt = getFirstValidPacketInfo();
@@ -1030,7 +1036,6 @@ string CRcvBufferNew::strFullnessState(int iFirstUnackSeqNo, const time_point& t
         {
             ss << "n/a";
         }
-
         ss << "). ";
     }
 

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -346,7 +346,7 @@ public: // TSBPD public functions
 
     /// Form a string of the current buffer fullness state.
     /// number of packets acknowledged, TSBPD readiness, etc.
-    std::string strFullnessState(int iFirstUnackSeqNo, const time_point& tsNow) const;
+    std::string strFullnessState(bool enable_debug_log, int iFirstUnackSeqNo, const time_point& tsNow) const;
 
 private:
     CTsbpdTime  m_tsbpd;

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -715,19 +715,14 @@ bool srt::CRcvLossList::remove(int32_t seqno)
 
 bool srt::CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
 {
-    if (seqno1 <= seqno2)
+    if (CSeqNo::seqcmp(seqno1, seqno2) > 0)
     {
-        for (int32_t i = seqno1; i <= seqno2; ++i)
-            remove(i);
+        return false;
     }
-    else
+    for (int32_t i = seqno1; CSeqNo::seqcmp(i, seqno2) <= 0; i = CSeqNo::incseq(i))
     {
-        for (int32_t j = seqno1; j < CSeqNo::m_iMaxSeqNo; ++j)
-            remove(j);
-        for (int32_t k = 0; k <= seqno2; ++k)
-            remove(k);
+        remove(i);
     }
-
     return true;
 }
 


### PR DESCRIPTION
It caused the "No room" issue:
```
processData: LOSS DETECTED, %: [ {2147483645 1} ] - RECORDING.
...
20:49:09.916010/SRT:RcvQ:w1!W:SRT.br: CRcvBufferNew::dropUpTo: seqno 3 m_iStartSeqNo 3. Nothing to drop.
20:49:09.916022/SRT:RcvQ:w1 D:SRT.xt: ackDataUpTo: %3 -> %2147483647 (-4 packets)
20:49:09.916031/SRT:RcvQ:w1 D:SRT.xt: ACK: clip %2147483647-%2147483647, REVOKED 0 from RCV buffer
...
20:53:59.603949/SRT:RcvQ:w1!W:SRT.qr: @203486701: No room to store incoming packet seqno 8190, insert offset 2. iFirstUnackSeqNo=2147483647 m_iStartSeqNo=8188 m_iStartPos=6659 m_iMaxPosInc=2. Space avail 2/8192 pkts. (TSBPD ready in -182ms, timespan 0 ms). STDCXX_STEADY drift 0 ms.
```

Previously, the loop of `CRcvLossList::remove()`
```
for (int32_t j = seqno1; j < CSeqNo::m_iMaxSeqNo; ++j) {}
```
excluded `m_iMaxSeqNo`, which caused `m_iRcvLastAck` stuck at `m_iMaxSeqNo`.

Note that if I just modify the `<` to `<=`, `i` will become negative, so I refine it with `CSeqNo`.