### PR TITLE
[core] Fixed some wrong usages of m_iMaxSeqNo.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8652,7 +8652,7 @@ void srt::CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
 
     // This variable is used in "normal" logs, so it may cause a warning
     // when logging is forcefully off.
-    int32_t wrong_loss SRT_ATR_UNUSED = CSeqNo::m_iMaxSeqNo;
+    int32_t wrong_loss SRT_ATR_UNUSED = SRT_SEQNO_NONE;
 
     // protect packet retransmission
     {

--- a/srtcore/fec.h
+++ b/srtcore/fec.h
@@ -47,7 +47,7 @@ public:
         size_t drop;      //< by how much the sequence should increase to get to the next series
         size_t collected; //< how many packets were taken to collect the clip
 
-        Group(): base(CSeqNo::m_iMaxSeqNo), step(0), drop(0), collected(0)
+        Group(): base(SRT_SEQNO_NONE), step(0), drop(0), collected(0)
         {
         }
 
@@ -87,7 +87,7 @@ public:
 #if ENABLE_HEAVY_LOGGING
         std::string DisplayStats()
         {
-            if (base == CSeqNo::m_iMaxSeqNo)
+            if (base == SRT_SEQNO_NONE)
                 return "UNINITIALIZED!!!";
 
             std::ostringstream os;


### PR DESCRIPTION
Because of https://github.com/Haivision/srt/pull/2463, I searched all usages of `m_iMaxSeqNo`.
 it is a valid seqno, so I replaced some `m_iMaxSeqNo` with `SRT_SEQNO_NONE`.