### PR TITLE
[core] Improved m_FreshLoss and m_pRcvLossList in processData()

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10052,7 +10052,6 @@ int srt::CUDT::processData(CUnit* in_unit)
     loss_seqs_t                             srt_loss_seqs;
     vector<CUnit *>                         incoming;
     bool                                    was_sent_in_order          = true;
-    bool                                    reorder_prevent_lossreport = false;
 
     // If the peer doesn't understand REXMIT flag, send rexmit request
     // always immediately.
@@ -10367,7 +10366,6 @@ int srt::CUDT::processData(CUnit* in_unit)
                 HLOGC(qrlog.Debug,
                       log << CONID() << "FreshLoss: added sequences: " << Printable(srt_loss_seqs)
                           << " tolerance: " << initial_loss_ttl);
-                reorder_prevent_lossreport = true;
             }
         }
 
@@ -10416,7 +10414,7 @@ int srt::CUDT::processData(CUnit* in_unit)
     if (!srt_loss_seqs.empty())
     {
         const bool report_recorded_loss = !m_PacketFilter || m_PktFilterRexmitLevel == SRT_ARQ_ALWAYS;
-        if (!reorder_prevent_lossreport && report_recorded_loss)
+        if (!initial_loss_ttl && report_recorded_loss)
         {
             HLOGC(qrlog.Debug, log << CONID() << "WILL REPORT LOSSES (SRT): " << Printable(srt_loss_seqs));
             sendLossReport(srt_loss_seqs);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10348,24 +10348,17 @@ int srt::CUDT::processData(CUnit* in_unit)
             ScopedLock lock(m_RcvLossLock);
 
             HLOGC(qrlog.Debug,
-                  log << CONID() << "processData: LOSS DETECTED, %: " << Printable(srt_loss_seqs) << " - RECORDING.");
+                  log << CONID() << "processData: RECORDING LOSS: " << Printable(srt_loss_seqs)
+                      << " tolerance=" << initial_loss_ttl);
+
             for (loss_seqs_t::iterator i = srt_loss_seqs.begin(); i != srt_loss_seqs.end(); ++i)
             {
-                // If loss found, insert them to the receiver loss list.
                 m_pRcvLossList->insert(i->first, i->second);
-            }
-
-            if (initial_loss_ttl)
-            {
-                // pack loss list for (possibly belated) NAK
-                // The LOSSREPORT will be sent in a while.
-                for (loss_seqs_t::iterator i = srt_loss_seqs.begin(); i != srt_loss_seqs.end(); ++i)
+                if (initial_loss_ttl)
                 {
+                    // The LOSSREPORT will be sent after initial_loss_ttl.
                     m_FreshLoss.push_back(CRcvFreshLoss(i->first, i->second, initial_loss_ttl));
                 }
-                HLOGC(qrlog.Debug,
-                      log << CONID() << "FreshLoss: added sequences: " << Printable(srt_loss_seqs)
-                          << " tolerance: " << initial_loss_ttl);
             }
         }
 


### PR DESCRIPTION
This PR consists two commits:
* [Moved m_FreshLoss.push_back() out of the incoming loop.](https://github.com/Haivision/srt/commit/f8869021c369b40ab8eb66b5906b69d38d2c5ae6)
  Previously, `m_FreshLoss.push_back()` happened inside
  ```
  for (vector<CUnit *>::iterator unitIt = incoming.begin(); unitIt != incoming.end(); ++unitIt)
  ```
  result that `srt_loss_seqs` will be added and logged repeatedly.

* [Also protected m_pRcvLossList->insert() with m_RcvBufferLock.](https://github.com/Haivision/srt/commit/2b014ad099ddd39bd59435ff96d9a42f6955c38f)
  * Update `m_FreshLoss` and `m_pRcvLossList` at the same time to improve their consistency and reduce one `m_RcvLossLock`.
  * Fix the synchronous issue between `processData()` and `tsbpd()`, related PR https://github.com/Haivision/srt/pull/2195, I found that the error logs of that PR happened frequently when the workload is high.