### PR TITLE
[core] Add auth tag to the sender buffer.

### DIFF
--- a/srtcore/buffer_snd.h
+++ b/srtcore/buffer_snd.h
@@ -157,8 +157,9 @@ public:
 
     /// @brief CSndBuffer constructor.
     /// @param size initial number of blocks (each block to store one packet payload).
-    /// @param maxpld maximum packet payload.
-    CSndBuffer(int size = 32, int maxpld = 1500);
+    /// @param maxpld maximum packet payload (including auth tag).
+    /// @param authtag auth tag length in bytes (16 for GCM, 0 otherwise).
+    CSndBuffer(int size = 32, int maxpld = 1500, int authtag = 0);
     ~CSndBuffer();
 
 public:
@@ -259,7 +260,7 @@ private:
     struct Block
     {
         char* m_pcData;  // pointer to the data block
-        int   m_iLength; // payload length of the block.
+        int   m_iLength; // payload length of the block (excluding auth tag).
 
         int32_t    m_iMsgNoBitset; // message number
         int32_t    m_iSeqNo;       // sequence number for scheduling
@@ -295,7 +296,8 @@ private:
     int32_t m_iNextMsgNo; // next message number
 
     int m_iSize; // buffer size (number of packets)
-    const int m_iBlockLen;  // maximum length of a block holding packet payload (excluding packet header).
+    const int m_iBlockLen;  // maximum length of a block holding packet payload and AUTH tag (excluding packet header).
+    const int m_iAuthTagSize; // Authentication tag size (if GCM is enabled).
     int m_iCount; // number of used blocks
 
     int        m_iBytesCount; // number of payload bytes in queue

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -252,6 +252,13 @@ void srt::CPacket::setLength(size_t len)
     m_PacketVector[PV_DATA].setLength(len);
 }
 
+void srt::CPacket::setLength(size_t len, size_t cap)
+{
+   SRT_ASSERT(len <= cap);
+   setLength(len);
+   m_zCapacity = cap;
+}
+
 void srt::CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
 {
     // Set (bit-0 = 1) and (bit-1~15 = type)
@@ -456,8 +463,13 @@ int32_t srt::CPacket::getMsgSeq(bool has_rexmit) const
 
 bool srt::CPacket::getRexmitFlag() const
 {
-    // return false; //
     return 0 != MSGNO_REXMIT::unwrap(m_nHeader[SRT_PH_MSGNO]);
+}
+
+void srt::CPacket::setRexmitFlag(bool bRexmit)
+{
+    const int32_t clr_msgno = m_nHeader[SRT_PH_MSGNO] & ~MSGNO_REXMIT::mask;
+    m_nHeader[SRT_PH_MSGNO] = clr_msgno | MSGNO_REXMIT::wrap(bRexmit? 1 : 0);
 }
 
 srt::EncryptionKeySpec srt::CPacket::getMsgCryptoFlags() const

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -236,6 +236,11 @@ public:
     /// @param len [in] the payload or the control information field length.
     void setLength(size_t len);
 
+    /// Set the payload or the control information field length.
+    /// @param len [in] the payload or the control information field length.
+    /// @param cap [in] capacity (if known).
+    void setLength(size_t len, size_t cap);
+
     /// Pack a Control packet.
     /// @param pkttype [in] packet type filed.
     /// @param lparam [in] pointer to the first data structure, explained by the packet type.
@@ -286,6 +291,8 @@ public:
     /// (because the peer will understand this bit as a part of MSGNO field).
     bool getRexmitFlag() const;
 
+    void setRexmitFlag(bool bRexmit);
+
     /// Read the message sequence number.
     /// @return packet header field [1]
     int32_t getMsgSeq(bool has_rexmit = true) const;
@@ -335,6 +342,7 @@ protected:
 
     int32_t m_extra_pad;
     bool    m_data_owned;
+    size_t  m_zCapacity;
 
 protected:
     CPacket& operator=(const CPacket&);
@@ -368,6 +376,8 @@ public:
     char*       data() { return m_pcData; }
     const char* data() const { return m_pcData; }
     size_t      size() const { return getLength(); }
+    size_t      capacity() const { return m_zCapacity; }
+    void        setCapacity(size_t cap) { m_zCapacity = cap; }
     uint32_t    header(SrtPktHeaderFields field) const { return m_nHeader[field]; }
 
 #if ENABLE_LOGGING


### PR DESCRIPTION
The additional space is to be used to store the auth tag in GCM AEAD mode.
The SND buffer (unfortunately) has to know if AUTH tag is to be used or not because it splits a message into several packets when `addBuffer(..)` is called. Every packet needs to have additional space in the end for the AUTH tag if AES GCM is enabled.

The `CPacket` class has to possess a 'capacity' property to distinguish between the payload size and the capacity to hold more data (auth tag).

The structure of the data packet is the following (with the auth tag in the end):
```
    0                   1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+- SRT Header +-+-+-+-+-+-+-+-+-+-+-+-+-+
   |0|                    Packet Sequence Number                   |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |P P|O|K K|R|                   Message Number                  |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                           Timestamp                           |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                     Destination Socket ID                     |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                                                               |
   +                             Payload                           +
   |                                                               |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                        Authentication Tag                     |   <----- !!!
   |                 (GCM: 16 bytes / CCM: 14 bytes)               |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

Related FR #2336.