### PR TITLE
[docs] Defined a reason to use C++11 on Windows instead of pthreads port.

### DIFF
--- a/docs/build/build-win.md
+++ b/docs/build/build-win.md
@@ -67,7 +67,8 @@ SRT as of v1.4.2 supports two threading libraries:
 
 The `pthreads` library is provided out-of-the-box on all POSIX-based systems.
 On Windows it can be provided as a 3rd party library (see below).
-However the C++ standard thread library is recommended to be used on Windows.
+However, using pthread wrapper on Windows comes with limitations, e.g. converting time from POSIX-based to Windows-based might loose precision, monotonic clock implementation eventually uses wall clock, etc.  
+**The C++11 standard thread library is recommended to be used on Windows.**
 
 ### 1.3. Package Managers
 


### PR DESCRIPTION
Closes #2109.