### PR TITLE
CRYSPR: Add AES GCM mode with OpenSSL EVP.

### DIFF
--- a/haicrypt/cryspr-openssl-evp.c
+++ b/haicrypt/cryspr-openssl-evp.c
@@ -34,9 +34,11 @@ int crysprOpenSSL_EVP_Prng(unsigned char* rn, int len)
 const EVP_CIPHER* (*Xcipher_fnptr)(void) = EVP_aes_128_ecb;
 
 const EVP_CIPHER* (*_crysprOpenSSL_EVP_cipher_fnptr[][3])(void) = {
-    {NULL, NULL, NULL},
-    {EVP_aes_128_ecb, EVP_aes_192_ecb, EVP_aes_256_ecb},
-    {EVP_aes_128_ctr, EVP_aes_192_ctr, EVP_aes_256_ctr},
+    {NULL, NULL, NULL}, // HCRYPT_CTX_MODE_CLRTXT
+    {EVP_aes_128_ecb, EVP_aes_192_ecb, EVP_aes_256_ecb}, // HCRYPT_CTX_MODE_AESECB
+    {EVP_aes_128_ctr, EVP_aes_192_ctr, EVP_aes_256_ctr}, // HCRYPT_CTX_MODE_AESCTR
+    {NULL, NULL, NULL}, // HCRYPT_CTX_MODE_AESCBC
+    {EVP_aes_128_gcm, EVP_aes_192_gcm, EVP_aes_256_gcm}, // HCRYPT_CTX_MODE_AESGCM
 };
 
 int crysprOpenSSL_EVP_AES_SetKey(
@@ -60,6 +62,8 @@ int crysprOpenSSL_EVP_AES_SetKey(
         /* internal implementation of AES-CTR using crypto lib's AES-ECB */
         cipher_type = HCRYPT_CTX_MODE_AESECB;
 #endif
+        break;
+    case HCRYPT_CTX_MODE_AESGCM:
         break;
     default:
         HCRYPT_LOG(LOG_ERR,
@@ -156,7 +160,7 @@ int crysprOpenSSL_EVP_AES_EcbCipher(bool                 bEncrypt, /* true:encry
         return (-1); /* output buf size must have room for PKCS7 padding */
     }
     /* allows reusing of 'e' for multiple encryption cycles */
-    if (!EVP_CipherInit_ex(aes_key, NULL, NULL, NULL, NULL, -1))
+    if (!EVP_CipherInit_ex(aes_key, NULL, NULL, NULL, NULL, bEncrypt))
     {
         HCRYPT_LOG(LOG_ERR, "EVP_CipherInit_ex(%p,NULL,...,-1) failed\n", aes_key);
         return -1;
@@ -247,6 +251,83 @@ int crysprOpenSSL_EVP_AES_CtrCipher(bool                 bEncrypt, /* true:encry
     return 0;
 }
 
+int crysprOpenSSL_EVP_AES_GCMCipher(bool                 bEncrypt, /* true:encrypt, false:decrypt */
+                                    CRYSPR_AESCTX*       aes_key,  /* CRYpto Service PRovider AES Key context */
+                                    unsigned char*       iv,       /* iv */
+                                    const unsigned char* aad,      /* associated data */
+                                    size_t               aadlen,
+                                    const unsigned char* indata,   /* src */
+                                    size_t               inlen,    /* length */
+                                    unsigned char*       out_txt,
+                                    unsigned char*       out_tag)  /* auth tag */
+{
+    int c_len, f_len;
+
+    /* allows reusing of 'e' for multiple encryption cycles */
+    if (!EVP_CipherInit_ex(aes_key, NULL, NULL, NULL, iv, -1))
+    {
+        HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_CipherInit_ex() failed");
+        return -1;
+    }
+    if (!EVP_CIPHER_CTX_set_padding(aes_key, 0))
+    {
+        HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_CIPHER_CTX_set_padding() failed");
+        return -1;
+    }
+
+    /*
+     * Provide any AAD data. This can be called zero or more times as
+     * required
+     */
+    if (1 != EVP_CipherUpdate(aes_key, NULL, &c_len, aad, (int) aadlen))
+    {
+        ERR_print_errors_fp(stderr);
+        HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_EncryptUpdate failed");
+        return -1;
+    }
+
+    /* update ciphertext, c_len is filled with the length of ciphertext generated,
+     * cryptoPtr->cipher_in_len is the size of plain/cipher text in bytes
+     */
+    if (!EVP_CipherUpdate(aes_key, out_txt, &c_len, indata, (int) inlen))
+    {
+        HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_CipherUpdate() failed");
+        return -1;
+    }
+
+    if (!bEncrypt && !EVP_CIPHER_CTX_ctrl(aes_key, EVP_CTRL_GCM_SET_TAG, 16, out_tag)) {
+        ERR_print_errors_fp(stderr);
+        HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_EncryptUpdate failed");
+        return -1;
+    }
+
+    /* update ciphertext with the final remaining bytes */
+    /* Useless with pre-padding */
+    f_len = 0;
+    if (0 == EVP_CipherFinal_ex(aes_key, &out_txt[c_len], &f_len))
+    {
+#if ENABLE_HAICRYPT_LOGGING
+        char szErrBuf[256];
+        HCRYPT_LOG(LOG_ERR,
+                   "EVP_CipherFinal_ex(ctx,&out[%d],%d)) failed: %s\n",
+                   c_len,
+                   f_len,
+                   ERR_error_string(ERR_get_error(), szErrBuf));
+#endif /*ENABLE_HAICRYPT_LOGGING*/
+        return -1;
+    }
+
+    /* Get the tag if we are encrypting */
+    if (bEncrypt && !EVP_CIPHER_CTX_ctrl(aes_key, EVP_CTRL_GCM_GET_TAG, 16, out_tag))
+    {
+        ERR_print_errors_fp(stderr);
+        HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_CIPHER_CTX_ctrl(EVP_CTRL_GCM_GET_TAG) failed");
+        return -1;
+    }
+
+    return 0;
+}
+
 /*
  * Password-based Key Derivation Function
  */
@@ -300,6 +381,7 @@ CRYSPR_methods* crysprOpenSSL_EVP(void)
 #if CRYSPR_HAS_AESCTR
         crysprOpenSSL_EVP_methods.aes_ctr_cipher = crysprOpenSSL_EVP_AES_CtrCipher;
 #endif
+        crysprOpenSSL_EVP_methods.aes_gcm_cipher = crysprOpenSSL_EVP_AES_GCMCipher;
 #if !(CRYSPR_HAS_AESCTR && CRYSPR_HAS_AESKWRAP)
         /* AES-ECB only required if cryspr has no AES-CTR and no AES KeyWrap */
         /* OpenSSL has both AESCTR and AESKWRP and the AESECB wrapper is only used

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -14,7 +14,7 @@ written by
    Haivision Systems Inc.
 
    2019-06-28 (jdube)
-        CRYSPR/4SRT Initial implementation.
+		CRYSPR/4SRT Initial implementation.
 *****************************************************************************/
 
 #include "hcrypt.h"
@@ -25,111 +25,131 @@ written by
 
 int crysprStub_Prng(unsigned char *rn, int len)
 {
-    (void)rn;
-    (void)len;
-    return(0);
+	(void)rn;
+	(void)len;
+	return(0);
 }
 
 int crysprStub_AES_SetKey(
-    int cipher_type,            /* One of HCRYPT_CTX_MODE_[CLRTXT|AESECB|AESCTR|AESGDM] */
-    bool bEncrypt,              /* true Enxcrypt key, false: decrypt */
-    const unsigned char *kstr,  /* key sttring*/
-    size_t kstr_len,            /* kstr len in  bytes (16, 24, or 32 bytes (for AES128,AES192, or AES256) */
-    CRYSPR_AESCTX *aes_key)     /* Cryptolib Specific AES key context */
+	int cipher_type,            /* One of HCRYPT_CTX_MODE_[CLRTXT|AESECB|AESCTR|AESGDM] */
+	bool bEncrypt,              /* true Enxcrypt key, false: decrypt */
+	const unsigned char *kstr,  /* key sttring*/
+	size_t kstr_len,            /* kstr len in  bytes (16, 24, or 32 bytes (for AES128,AES192, or AES256) */
+	CRYSPR_AESCTX *aes_key)     /* Cryptolib Specific AES key context */
 {
-    (void)cipher_type;
-    (void)bEncrypt;
-    (void)kstr;
-    (void)kstr_len;
-    (void)aes_key;
+	(void)cipher_type;
+	(void)bEncrypt;
+	(void)kstr;
+	(void)kstr_len;
+	(void)aes_key;
 
-    return(0);
+	return(0);
 }
 
 int crysprStub_AES_EcbCipher(
-    bool bEncrypt,              /* true:encrypt, false:decrypt */
-    CRYSPR_AESCTX *aes_key,     /* AES context */
-    const unsigned char *indata,/* src (clear text)*/
-    size_t inlen,               /* length */
-    unsigned char *out_txt,     /* dst (cipher text) */
-    size_t *outlen)             /* dst len */
+	bool bEncrypt,              /* true:encrypt, false:decrypt */
+	CRYSPR_AESCTX *aes_key,     /* AES context */
+	const unsigned char *indata,/* src (clear text)*/
+	size_t inlen,               /* length */
+	unsigned char *out_txt,     /* dst (cipher text) */
+	size_t *outlen)             /* dst len */
 {
-    (void)bEncrypt;
-    (void)aes_key;
-    (void)indata;
-    (void)inlen;
-    (void)out_txt;
-    (void)outlen;
+	(void)bEncrypt;
+	(void)aes_key;
+	(void)indata;
+	(void)inlen;
+	(void)out_txt;
+	(void)outlen;
 
-    return -1;
+	return -1;
 }
 
 int crysprStub_AES_CtrCipher(
-    bool bEncrypt,              /* true:encrypt, false:decrypt */
-    CRYSPR_AESCTX *aes_key,     /* AES context */
-    unsigned char *iv,          /* iv */
-    const unsigned char *indata,/* src */
-    size_t inlen,               /* length */
-    unsigned char *out_txt)     /* dest */
+	bool bEncrypt,              /* true:encrypt, false:decrypt */
+	CRYSPR_AESCTX *aes_key,     /* AES context */
+	unsigned char *iv,          /* iv */
+	const unsigned char *indata,/* src */
+	size_t inlen,               /* length */
+	unsigned char *out_txt)     /* dest */
 {
-    (void)bEncrypt;
-    (void)aes_key;
-    (void)iv;
-    (void)indata;
-    (void)inlen;
-    (void)out_txt;
+	(void)bEncrypt;
+	(void)aes_key;
+	(void)iv;
+	(void)indata;
+	(void)inlen;
+	(void)out_txt;
 
-    return(-1);
+	return(-1);
+}
+
+int crysprStub_AES_GCMCipher(
+	bool bEncrypt,              /* true:encrypt, false:decrypt */
+	CRYSPR_AESCTX *aes_key,     /* AES context */
+	unsigned char *iv,          /* iv */
+	const unsigned char *tag,   /* auth tag */
+	const unsigned char *indata,/* src */
+	size_t inlen,               /* length */
+	unsigned char *out_txt)     /* dest */
+{
+	(void)bEncrypt;
+	(void)aes_key;
+	(void)iv;
+	(void)tag;
+	(void)indata;
+	(void)inlen;
+	(void)out_txt;
+
+	return(-1);
 }
 
 unsigned char *crysprStub_SHA1_MsgDigest(
-    const unsigned char *m, /* in: message */
-    size_t m_len,           /* message length */
-    unsigned char *md)      /* out: message digest buffer *160 bytes */
+	const unsigned char *m, /* in: message */
+	size_t m_len,           /* message length */
+	unsigned char *md)      /* out: message digest buffer *160 bytes */
 {
-    (void)m;
-    (void)m_len;
-    (void)md;
+	(void)m;
+	(void)m_len;
+	(void)md;
 
-    return(NULL);//return md;
+	return(NULL);//return md;
 }
 
 /*
 * Password-based Key Derivation Function
 */
 int crysprStub_KmPbkdf2(
-    CRYSPR_cb *cryspr_cb,
-    char *passwd,           /* passphrase */
-    size_t passwd_len,      /* passphrase len */
-    unsigned char *salt,    /* salt */
-    size_t salt_len,        /* salt_len */
-    int itr,                /* iterations */
-    size_t key_len,         /* key_len */
-    unsigned char *out)     /* derived key */
+	CRYSPR_cb *cryspr_cb,
+	char *passwd,           /* passphrase */
+	size_t passwd_len,      /* passphrase len */
+	unsigned char *salt,    /* salt */
+	size_t salt_len,        /* salt_len */
+	int itr,                /* iterations */
+	size_t key_len,         /* key_len */
+	unsigned char *out)     /* derived key */
 {
-    (void)cryspr_cb;
-    (void)passwd;
-    (void)passwd_len;
-    (void)salt;
-    (void)salt_len;
-    (void)itr;
-    (void)key_len;
-    (void)out;
+	(void)cryspr_cb;
+	(void)passwd;
+	(void)passwd_len;
+	(void)salt;
+	(void)salt_len;
+	(void)itr;
+	(void)key_len;
+	(void)out;
 
-    /* >>Todo:
-     * develop PBKDF2 using SHA1 primitive cryspr_cb->cryspr->sha1_msg_digest() for cryptolibs not providing it
-     */
-    return(-1);
+	/* >>Todo:
+	 * develop PBKDF2 using SHA1 primitive cryspr_cb->cryspr->sha1_msg_digest() for cryptolibs not providing it
+	 */
+	return(-1);
 }
 
 static int crysprFallback_KmSetKey(CRYSPR_cb *cryspr_cb, bool bWrap, const unsigned char *kek, size_t kek_len)
 {
-    CRYSPR_AESCTX *aes_kek = CRYSPR_GETKEK(cryspr_cb);
+	CRYSPR_AESCTX *aes_kek = CRYSPR_GETKEK(cryspr_cb);
 
-    if (cryspr_cb->cryspr->aes_set_key(HCRYPT_CTX_MODE_AESECB, bWrap, kek, kek_len, aes_kek)) {
-        HCRYPT_LOG(LOG_ERR, "aes_set_%s_key(kek) failed\n", bWrap? "encrypt": "decrypt");
-        return(-1);
-    }
+	if (cryspr_cb->cryspr->aes_set_key(HCRYPT_CTX_MODE_AESECB, bWrap, kek, kek_len, aes_kek)) {
+		HCRYPT_LOG(LOG_ERR, "aes_set_%s_key(kek) failed\n", bWrap? "encrypt": "decrypt");
+		return(-1);
+	}
 	return(0);
 }
 
@@ -144,7 +164,7 @@ static const unsigned char default_iv[] = {
 int crysprFallback_AES_WrapKey(CRYSPR_cb *cryspr_cb,
 		unsigned char *out,
 		const unsigned char *in,
-        unsigned int inlen)
+		unsigned int inlen)
 {
 	unsigned char *A, B[16], *R;
 	const unsigned char *iv = default_iv;
@@ -180,13 +200,13 @@ int crysprFallback_AES_WrapKey(CRYSPR_cb *cryspr_cb,
 		}
 	}
 	memcpy(out, A, 8);
-    return 0;
+	return 0;
 }
 
 int crysprFallback_AES_UnwrapKey(CRYSPR_cb *cryspr_cb,
 		unsigned char *out,
 		const unsigned char *in,
-        unsigned int inlen)
+		unsigned int inlen)
 {
 	unsigned char *A, B[16], *R;
 	const unsigned char *iv = default_iv;
@@ -225,9 +245,9 @@ int crysprFallback_AES_UnwrapKey(CRYSPR_cb *cryspr_cb,
 	if (memcmp(A, iv, 8))
 	{
 		memset(out, 0, inlen);
-        return -1;
+		return -1;
 	}
-    return 0;
+	return 0;
 }
 
 static unsigned char *_crysprFallback_GetOutbuf(CRYSPR_cb *cryspr_cb, size_t pfx_len, size_t out_len)
@@ -249,12 +269,12 @@ CRYSPR_cb *crysprHelper_Open(CRYSPR_methods *cryspr, size_t cb_len, size_t max_l
 	unsigned char *membuf;
 	size_t memsiz, padded_len = hcryptMsg_PaddedLen(max_len, 128/8);
 
-    if(cb_len < sizeof(*cryspr_cb)) {
-        HCRYPT_LOG(LOG_ERR, "crysprHelper_Open() cb_len too small (%zd < %zd)n",
-                   cb_len, sizeof(*cryspr_cb));
-        return(NULL);
-    }
-    memsiz = cb_len + (CRYSPR_OUTMSGMAX * padded_len);
+	if(cb_len < sizeof(*cryspr_cb)) {
+		HCRYPT_LOG(LOG_ERR, "crysprHelper_Open() cb_len too small (%zd < %zd)n",
+				   cb_len, sizeof(*cryspr_cb));
+		return(NULL);
+	}
+	memsiz = cb_len + (CRYSPR_OUTMSGMAX * padded_len);
 #if !CRYSPR_HAS_AESCTR
 	memsiz += HCRYPT_CTR_STREAM_SZ;
 #endif /* !CRYSPR_HAS_AESCTR */
@@ -267,8 +287,8 @@ CRYSPR_cb *crysprHelper_Open(CRYSPR_methods *cryspr, size_t cb_len, size_t max_l
 	membuf = (unsigned char *)cryspr_cb;
 	membuf += sizeof(*cryspr_cb);
 
-    /*reserve cryspr's private data that caller will initialize */
-    membuf += (cb_len-sizeof(CRYSPR_cb));
+	/*reserve cryspr's private data that caller will initialize */
+	membuf += (cb_len-sizeof(CRYSPR_cb));
 
 #if !CRYSPR_HAS_AESCTR
 	cryspr_cb->ctr_stream = membuf;
@@ -289,28 +309,33 @@ CRYSPR_cb *crysprHelper_Open(CRYSPR_methods *cryspr, size_t cb_len, size_t max_l
 
 int crysprHelper_Close(CRYSPR_cb *cryspr_cb)
 {
-    free(cryspr_cb);
-    return(0);
+	free(cryspr_cb);
+	return(0);
 }
 
 static CRYSPR_cb *crysprFallback_Open(CRYSPR_methods *cryspr, size_t max_len)
 {
-    CRYSPR_cb *cryspr_cb;
+	CRYSPR_cb *cryspr_cb;
 
-    cryspr_cb = crysprHelper_Open(cryspr, sizeof(CRYSPR_cb), max_len);
-    return(cryspr_cb);
+	cryspr_cb = crysprHelper_Open(cryspr, sizeof(CRYSPR_cb), max_len);
+	return(cryspr_cb);
 }
 
 static int crysprFallback_Close(CRYSPR_cb *cryspr_cb)
 {
-    return(crysprHelper_Close(cryspr_cb));
+	return(crysprHelper_Close(cryspr_cb));
 }
 
 static int crysprFallback_MsSetKey(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx, const unsigned char *key, size_t key_len)
 {
 	CRYSPR_AESCTX *aes_sek = CRYSPR_GETSEK(cryspr_cb, hcryptCtx_GetKeyIndex(ctx)); /* Ctx tells if it's for odd or even key */
 
-	if ((ctx->flags & HCRYPT_CTX_F_ENCRYPT)        /* Encrypt key */
+	if (ctx->mode == HCRYPT_CTX_MODE_AESGCM) {   /* AES GCM mode */
+		if (cryspr_cb->cryspr->aes_set_key(HCRYPT_CTX_MODE_AESGCM, (ctx->flags & HCRYPT_CTX_F_ENCRYPT) != 0, key, key_len, aes_sek)) {
+			HCRYPT_LOG(LOG_ERR, "%s", "CRYSPR->set_encrypt_key(sek) failed\n");
+			return(-1);
+		}
+	} else if ((ctx->flags & HCRYPT_CTX_F_ENCRYPT)        /* Encrypt key */
 	||  (ctx->mode == HCRYPT_CTX_MODE_AESCTR)) {   /* CTR mode decrypts using encryption methods */
 		if (cryspr_cb->cryspr->aes_set_key(HCRYPT_CTX_MODE_AESCTR, true, key, key_len, aes_sek)) {
 			HCRYPT_LOG(LOG_ERR, "%s", "CRYSPR->set_encrypt_key(sek) failed\n");
@@ -395,9 +420,19 @@ static int crysprFallback_MsEncrypt(
 	 * to reserve room for unencrypted message header in output buffer
 	 */
 	pfx_len = ctx->msg_info->pfx_len;
+	// Extra 16 bytes are needed for an authentication tag in GCM.
+	const int aux_len = (ctx->mode == HCRYPT_CTX_MODE_AESGCM) ? 16 : 0;
+
+	// Auth tag produced by AES GCM.
+	unsigned char tag[16];
 
 	/* Get buffer room from the internal circular output buffer */
-	out_msg = _crysprFallback_GetOutbuf(cryspr_cb, pfx_len, in_data[0].len);
+	// TODO: Reserve additional 16 bytes for auth tag in AES GCM mode.
+	out_msg = _crysprFallback_GetOutbuf(cryspr_cb, pfx_len, in_data[0].len + aux_len);
+	if (NULL == out_msg) {
+		/* input data too big */
+		return(-1);
+	}
 
 	if (NULL == out_msg) {
 		/* input data too big */
@@ -406,6 +441,7 @@ static int crysprFallback_MsEncrypt(
 
 	switch(ctx->mode) {
 		case HCRYPT_CTX_MODE_AESCTR: /* Counter mode */
+		case HCRYPT_CTX_MODE_AESGCM:
 		{
 			/* Get current key (odd|even) from context */
 			CRYSPR_AESCTX *aes_key = CRYSPR_GETSEK(cryspr_cb, hcryptCtx_GetKeyIndex(ctx)); /* Ctx tells if it's for odd or even key */
@@ -416,48 +452,64 @@ static int crysprFallback_MsEncrypt(
 			hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
 
 			/*
-				* Compute the Initial Vector
-				* IV (128-bit):
-				*    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
-				* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				* |                   0s                  |      pki      |  ctr  |
-				* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				*                            XOR
-				* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				* |                         nonce                         +
-				* +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				*
-				* pki    (32-bit): packet index
-				* ctr    (16-bit): block counter
-				* nonce (112-bit): number used once (salt)
-				*/
+			 * Compute the Initial Vector
+			 * IV (128-bit):
+			 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			 * |                   0s                  |      pki      |  ctr  |
+			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			 *                            XOR
+			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			 * |                         nonce                         +
+			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+			 *
+			 * pki    (32-bit): packet index
+			 * ctr    (16-bit): block counter
+			 * nonce (112-bit): number used once (salt)
+			*/
 			hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
 
+			if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
+			{
+				const int iret = cryspr_cb->cryspr->aes_gcm_cipher(true, aes_key, iv, in_data[0].pfx, pfx_len, in_data[0].payload, in_data[0].len,
+						&out_msg[pfx_len], tag);
+				if (iret) {
+					return(iret);
+				}
+			}
+			else {
 #if CRYSPR_HAS_AESCTR
-			cryspr_cb->cryspr->aes_ctr_cipher(true, aes_key, iv, in_data[0].payload, in_data[0].len,
-					&out_msg[pfx_len]);
+				cryspr_cb->cryspr->aes_ctr_cipher(true, aes_key, iv, in_data[0].payload, in_data[0].len,
+						&out_msg[pfx_len]);
 #else /*CRYSPR_HAS_AESCTR*/
-			/* Create CtrStream. May be longer than in_len (next cryspr block size boundary) */
-			int iret = _crysprFallback_AES_SetCtrStream(cryspr_cb, ctx, in_data[0].len, iv);
-			if (iret) {
-				return(iret);
-			}
-			/* Reserve output buffer for cryspr */
-			out_msg = _crysprFallback_GetOutbuf(cryspr_cb, pfx_len, cryspr_cb->ctr_stream_len);
 
-			/* Create KeyStream (encrypt CtrStream) */
-			iret = cryspr_cb->cryspr->aes_ecb_cipher(true, aes_key,
-					cryspr_cb->ctr_stream, cryspr_cb->ctr_stream_len,
-					&out_msg[pfx_len], &out_len);
-			if (iret) {
-				HCRYPT_LOG(LOG_ERR, "%s", "hcOpenSSL_AES_ecb_cipher(encrypt, failed\n");
-				return(iret);
-			}
+				/* Create CtrStream. May be longer than in_len (next cryspr block size boundary) */
+				int iret = _crysprFallback_AES_SetCtrStream(cryspr_cb, ctx, in_data[0].len, iv);
+				if (iret) {
+					return(iret);
+				}
+				/* Reserve output buffer for cryspr */
+				out_msg = _crysprFallback_GetOutbuf(cryspr_cb, pfx_len, cryspr_cb->ctr_stream_len);
+
+				/* Create KeyStream (encrypt CtrStream) */
+				iret = cryspr_cb->cryspr->aes_ecb_cipher(true, aes_key,
+						cryspr_cb->ctr_stream, cryspr_cb->ctr_stream_len,
+						&out_msg[pfx_len], &out_len);
+				if (iret) {
+					HCRYPT_LOG(LOG_ERR, "%s", "hcOpenSSL_AES_ecb_cipher(encrypt, failed\n");
+					return(iret);
+				}
 #endif/*CRYSPR_HAS_AESCTR*/
+			}
 			/* Prepend packet prefix (clear text) in output buffer */
 			memcpy(out_msg, in_data[0].pfx, pfx_len);
 			/* CTR mode output length is same as input, no padding */
 			out_len = in_data[0].len;
+			if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
+			{
+				memcpy(out_msg + pfx_len + out_len, tag, sizeof(tag));
+				out_len += sizeof(tag);
+			}
 			break;
 		}
 		case HCRYPT_CTX_MODE_CLRTXT:    /* Clear text mode (transparent mode for tests) */
@@ -497,8 +549,12 @@ static int crysprFallback_MsEncrypt(
 			memcpy(in_data[0].payload, &out_msg[pfx_len], out_len);
 		}
 #else /* CRYSPR_HAS_AESCTR */
-		/* Copy output data back in input buffer */
-		memcpy(in_data[0].payload, &out_msg[pfx_len], out_len);
+			/* Copy output data back in input buffer */
+			memcpy(in_data[0].payload, &out_msg[pfx_len], out_len);
+			if (ctx->mode == HCRYPT_CTX_MODE_AESGCM) {
+				// Encoding produced more payload (auth tag).
+				return out_len;
+			}
 #endif /* CRYSPR_HAS_AESCTR */
 	} else {
 		/* Copy header in output buffer if needed */
@@ -533,8 +589,8 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 	if (NULL != out_txt) {
 		switch(ctx->mode) {
 			case HCRYPT_CTX_MODE_AESCTR:
+			case HCRYPT_CTX_MODE_AESGCM:
 			{
-#if CRYSPR_HAS_AESCTR
 				/* Get current key (odd|even) from context */
 				CRYSPR_AESCTX *aes_key = CRYSPR_GETSEK(cryspr_cb, hcryptCtx_GetKeyIndex(ctx));
 				unsigned char iv[CRYSPR_AESBLKSZ];
@@ -560,54 +616,63 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 				 */
 				hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
 
-				cryspr_cb->cryspr->aes_ctr_cipher(false, aes_key, iv, in_data[0].payload, in_data[0].len,
-						out_txt);
-				out_len = in_data[0].len;
-#else  /*CRYSPR_HAS_AESCTR*/
-				/* Get current key (odd|even) from context */
-				CRYSPR_AESCTX *aes_key = CRYSPR_GETSEK(cryspr_cb, hcryptCtx_GetKeyIndex(ctx));
-				unsigned char iv[CRYSPR_AESBLKSZ];
-				int iret = 0;
-
-				/* Get input packet index (in network order) */
-				hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
-
-				/*
-				 * Compute the Initial Vector
-				 * IV (128-bit):
-				 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 * |                   0s                  |      pki      |  ctr  |
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 *                            XOR
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 * |                         nonce                         +
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 *
-				 * pki    (32-bit): packet index
-				 * ctr    (16-bit): block counter
-				 * nonce (112-bit): number used once (salt)
-				 */
-				hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
-
-				/* Create CtrStream. May be longer than in_len (next cipher block size boundary) */
-				iret = _crysprFallback_AES_SetCtrStream(cryspr_cb, ctx, in_data[0].len, iv);
-				if (iret) {
-					return(iret);
+				if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
+				{
+					unsigned char* tag = in_data[0].payload + in_data[0].len - 16;
+					int liret = cryspr_cb->cryspr->aes_gcm_cipher(false, aes_key, iv, in_data[0].pfx, ctx->msg_info->pfx_len, in_data[0].payload, in_data[0].len - 16,
+						out_txt, tag);
+					if (liret) {
+						return(liret);
+					}
+					out_len = in_data[0].len - 16;
 				}
-				/* Reserve output buffer for cryspr */
-				out_txt = _crysprFallback_GetOutbuf(cryspr_cb, 0, cryspr_cb->ctr_stream_len);
+				else {
+#if CRYSPR_HAS_AESCTR
+					cryspr_cb->cryspr->aes_ctr_cipher(false, aes_key, iv, in_data[0].payload, in_data[0].len,
+						out_txt);
+					out_len = in_data[0].len;
+#else  /*CRYSPR_HAS_AESCTR*/
 
-				/* Create KeyStream (encrypt CtrStream) */
-				iret = cryspr_cb->cryspr->aes_ecb_cipher(true, aes_key,
+					/* Get input packet index (in network order) */
+					hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
+
+					/*
+					 * Compute the Initial Vector
+					 * IV (128-bit):
+					 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
+					 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+					 * |                   0s                  |      pki      |  ctr  |
+					 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+					 *                            XOR
+					 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+					 * |                         nonce                         +
+					 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+					 *
+					 * pki    (32-bit): packet index
+					 * ctr    (16-bit): block counter
+					 * nonce (112-bit): number used once (salt)
+					 */
+					hcrypt_SetCtrIV((unsigned char*)&pki, ctx->salt, iv);
+
+					/* Create CtrStream. May be longer than in_len (next cipher block size boundary) */
+					int liret = _crysprFallback_AES_SetCtrStream(cryspr_cb, ctx, in_data[0].len, iv);
+					if (liret) {
+						return(liret);
+					}
+					/* Reserve output buffer for cryspr */
+					out_txt = _crysprFallback_GetOutbuf(cryspr_cb, 0, cryspr_cb->ctr_stream_len);
+
+					/* Create KeyStream (encrypt CtrStream) */
+					liret = cryspr_cb->cryspr->aes_ecb_cipher(true, aes_key,
 						cryspr_cb->ctr_stream, cryspr_cb->ctr_stream_len,
 						out_txt, &out_len);
-				if (iret) {
-					HCRYPT_LOG(LOG_ERR, "%s", "crysprNatural_AES_ecb_cipher(encrypt failed\n");
-					return(iret);
-				}
+					if (liret) {
+						HCRYPT_LOG(LOG_ERR, "%s", "crysprNatural_AES_ecb_cipher(encrypt failed\n");
+						return(liret);
+					}
 
 #endif /*CRYSPR_HAS_AESCTR*/
+				}
 				break;
 			}
 			case HCRYPT_CTX_MODE_CLRTXT:
@@ -638,6 +703,7 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 #else /* CRYSPR_HAS_AESCTR */
 			/* Copy output data back in input buffer */
 			memcpy(in_data[0].payload, out_txt, out_len);
+			in_data->len = out_len;
 #endif /* CRYSPR_HAS_AESCTR */
 		} else {
 			/* Copy header in output buffer if needed */
@@ -683,8 +749,8 @@ CRYSPR_methods *crysprInit(CRYSPR_methods *cryspr)
 	cryspr->aes_set_key     = crysprStub_AES_SetKey;
 	cryspr->aes_ecb_cipher  = crysprStub_AES_EcbCipher;
 	cryspr->aes_ctr_cipher  = crysprStub_AES_CtrCipher;
+	cryspr->aes_gcm_cipher  = crysprStub_AES_GCMCipher;
 	cryspr->sha1_msg_digest = crysprStub_SHA1_MsgDigest;
-
 
 	/* Crypto Session API */
 	cryspr->open       = crysprFallback_Open;
@@ -704,5 +770,11 @@ CRYSPR_methods *crysprInit(CRYSPR_methods *cryspr)
 
 HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance(void)
 {
-    return((HaiCrypt_Cryspr)cryspr4SRT());
+	return((HaiCrypt_Cryspr)cryspr4SRT());
 }
+
+int HaiCryptCryspr_Is_AES_GCM_Supported(void)
+{
+	return (cryspr4SRT()->aes_gcm_cipher != crysprStub_AES_GCMCipher) ? 1 : 0;
+}
+

--- a/haicrypt/cryspr.h
+++ b/haicrypt/cryspr.h
@@ -40,32 +40,32 @@ extern "C" {
 
 typedef struct tag_CRYSPR_cb {
 #ifdef CRYSPR2
-	CRYSPR_AESCTX  *aes_kek;		/* Key Encrypting Key (KEK) */
-	CRYSPR_AESCTX  *aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
+    CRYSPR_AESCTX  *aes_kek;		/* Key Encrypting Key (KEK) */
+    CRYSPR_AESCTX  *aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
 #define CRYSPR_GETKEK(cb)       ((cb)->aes_kek)
 #define CRYSPR_GETSEK(cb,kk)    ((cb)->aes_sek[kk])
 #else /*CRYSPR2*/
-	CRYSPR_AESCTX   aes_kek;		/* Key Encrypting Key (KEK) */
-	CRYSPR_AESCTX   aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
+    CRYSPR_AESCTX   aes_kek;		/* Key Encrypting Key (KEK) */
+    CRYSPR_AESCTX   aes_sek[2];		/* even/odd Stream Encrypting Key (SEK) */
 #define CRYSPR_GETKEK(cb)       (&((cb)->aes_kek))
 #define CRYSPR_GETSEK(cb,kk)    (&((cb)->aes_sek[kk]))
 #endif /*CRYSPR2*/
 
-	struct tag_CRYSPR_methods *cryspr;
+    struct tag_CRYSPR_methods *cryspr;
 
 #if !CRYSPR_HAS_AESCTR
                                         /* Reserve room to build the counter stream ourself */
 #define HCRYPT_CTR_BLK_SZ       CRYSPR_AESBLKSZ
 #define HCRYPT_CTR_STREAM_SZ	2048
-	unsigned char * ctr_stream;
-	size_t          ctr_stream_len; /* Content size */
-	size_t          ctr_stream_siz; /* Allocated length */
+    unsigned char * ctr_stream;
+    size_t          ctr_stream_len; /* Content size */
+    size_t          ctr_stream_siz; /* Allocated length */
 #endif /* !CRYSPR_HAS_AESCTR */
 
 #define	CRYSPR_OUTMSGMAX		6
-	uint8_t *       outbuf; 		/* output circle buffer */
-	size_t          outbuf_ofs;		/* write offset in circle buffer */
-	size_t          outbuf_siz;		/* circle buffer size */
+    uint8_t *       outbuf; 		/* output circle buffer */
+    size_t          outbuf_ofs;		/* write offset in circle buffer */
+    size_t          outbuf_siz;		/* circle buffer size */
 } CRYSPR_cb;
 
 typedef struct tag_CRYSPR_methods {
@@ -99,6 +99,17 @@ typedef struct tag_CRYSPR_methods {
             const unsigned char *indata,  /* src (clear text) */
             size_t inlen,           /* src length */
             unsigned char *out_txt);/* dest */
+
+        int (*aes_gcm_cipher)(
+            bool bEncrypt,          /* true:encrypt false:decrypt (don't care with CTR) */
+            CRYSPR_AESCTX* aes_key, /* ctx */
+            unsigned char* iv,      /* iv */
+            unsigned char* aad,     /* associated data */
+            size_t aadlen,
+            const unsigned char* indata,  /* src (clear text) */
+            size_t inlen,           /* src length */
+            unsigned char* out_txt, /* dest */
+            unsigned char* out_tag);
 
         unsigned char *(*sha1_msg_digest)(
             const unsigned char *m, /* in: message */

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -31,6 +31,10 @@ typedef void *HaiCrypt_Cryspr;
 
 HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance (void);     /* Return a default cryspr instance */
 
+/// @brief Check if AES GCM is supported.
+/// @return 1 if AES GCM is supported, 0 otherwise
+int HaiCryptCryspr_Is_AES_GCM_Supported(void);
+
 #define HAICRYPT_CIPHER_BLK_SZ      16  /* AES Block Size */
 
 #define HAICRYPT_PWD_MAX_SZ         80  /* MAX password (for Password-based Key Derivation) */
@@ -60,6 +64,7 @@ typedef struct {
 #define HAICRYPT_CFG_F_TX       0x01        /* !TX -> RX */
 #define HAICRYPT_CFG_F_CRYPTO   0x02        /* Perform crypto Tx:Encrypt Rx:Decrypt */
 #define HAICRYPT_CFG_F_FEC      0x04        /* Do Forward Error Correction */
+#define HAICRYPT_CFG_F_GCM      0x08        /* Use AES-GCM */
         unsigned        flags;
 
         HaiCrypt_Secret secret;             /* Security Association */
@@ -112,6 +117,7 @@ int  HaiCrypt_Rx_Data(HaiCrypt_Handle hhc, unsigned char *pfx, unsigned char *da
 
 #define HAICRYPT_ERROR -1
 #define HAICRYPT_ERROR_WRONG_SECRET -2
+#define HAICRYPT_ERROR_CIPHER -3
 #define HAICRYPT_OK 0
 
 

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -156,7 +156,7 @@ int HaiCrypt_Create(const HaiCrypt_Cfg *cfg, HaiCrypt_Handle *phhc)
                 ||  hcryptCtx_Tx_Init(crypto, &crypto->ctx_pair[1], cfg)) {
             free(crypto);
             return(-1);
-        }			
+        }
         /* Generate keys for first (default) context */
         if (hcryptCtx_Tx_Rekey(crypto, &crypto->ctx_pair[0])) {
             free(crypto);

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -163,7 +163,18 @@ int hcryptCtx_Tx_AsmKM(hcrypt_Session *crypto, hcrypt_Ctx *ctx, unsigned char *a
 int hcryptCtx_Tx_ManageKM(hcrypt_Session *crypto);
 int hcryptCtx_Tx_InjectKM(hcrypt_Session *crypto, void *out_p[], size_t out_len_p[], int maxout);
 
+/// @brief Initialize receiving crypto context.
+/// @param crypto library instance handle.
+/// @param ctx additional crypto context.
+/// @param cfg crypto configuration.
+/// @return -1 on error, 0 otherwise.
 int hcryptCtx_Rx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cfg *cfg);
+
+/// @brief Parse an incoming message related to cryptography module.
+/// @param crypto library instance handle.
+/// @param msg a message to parse.
+/// @param msg_len length of the message in bytes.
+/// @return 0 on success; -3 on cipher mode mismatch; -2 on unmatched shared secret; -1 on other failures.
 int hcryptCtx_Rx_ParseKM(hcrypt_Session *crypto, unsigned char *msg, size_t msg_len);
 
 #endif /* HCRYPT_H */

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -68,6 +68,7 @@ typedef struct tag_hcrypt_Ctx {
 #define HCRYPT_CTX_MODE_AESECB  1   /* Electronic Code Book mode */
 #define HCRYPT_CTX_MODE_AESCTR  2   /* Counter mode */
 #define HCRYPT_CTX_MODE_AESCBC  3   /* Cipher-block chaining mode */
+#define HCRYPT_CTX_MODE_AESGCM  4   /* AES GCM authenticated encryption */
         unsigned         mode;
 
         struct {

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -14,18 +14,18 @@ written by
    Haivision Systems Inc.
 
    2011-06-23 (jdube)
-        HaiCrypt initial implementation.
+		HaiCrypt initial implementation.
    2014-03-11 (jdube)
-        Adaptation for SRT.
+		Adaptation for SRT.
 *****************************************************************************/
 
 #include <string.h>		/* memcpy */
 #ifdef _WIN32
-    #include <winsock2.h>
-    #include <ws2tcpip.h>
-    #include <win/wintime.h>
+	#include <winsock2.h>
+	#include <ws2tcpip.h>
+	#include <win/wintime.h>
 #else
-    #include <sys/time.h>
+	#include <sys/time.h>
 #endif
 #include "hcrypt.h"
 
@@ -33,7 +33,7 @@ int hcryptCtx_Tx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 {
 	ctx->cfg.key_len = cfg->key_len;
 
-	ctx->mode = HCRYPT_CTX_MODE_AESCTR;
+	ctx->mode = (cfg->flags & HAICRYPT_CFG_F_GCM) ? HCRYPT_CTX_MODE_AESGCM : HCRYPT_CTX_MODE_AESCTR;
 	ctx->status = HCRYPT_CTX_S_INIT;
 
 	ctx->msg_info = crypto->msg_info;
@@ -299,9 +299,9 @@ int hcryptCtx_Tx_AsmKM(hcrypt_Session *crypto, hcrypt_Ctx *ctx, unsigned char *a
 		2 == sek_cnt ? HCRYPT_MSG_F_xSEK : (ctx->flags & HCRYPT_MSG_F_xSEK));
 
 	/* crypto->KMmsg_cache[4..7]: KEKI=0 */
-	km_msg[HCRYPT_MSG_KM_OFS_CIPHER] = HCRYPT_CIPHER_AES_CTR;
+	km_msg[HCRYPT_MSG_KM_OFS_CIPHER] = (ctx->mode == HCRYPT_CTX_MODE_AESGCM) ? HCRYPT_CIPHER_AES_GCM : HCRYPT_CIPHER_AES_CTR;
 	km_msg[HCRYPT_MSG_KM_OFS_AUTH] = HCRYPT_AUTH_NONE;
-	km_msg[HCRYPT_MSG_KM_OFS_SE] = crypto->se;
+	km_msg[HCRYPT_MSG_KM_OFS_SE] = (char) crypto->se;
 	hcryptMsg_KM_SetSaltLen(km_msg, ctx->salt_len);
 	hcryptMsg_KM_SetSekLen(km_msg, ctx->sek_len);
 

--- a/haicrypt/hcrypt_msg.h
+++ b/haicrypt/hcrypt_msg.h
@@ -122,6 +122,7 @@ typedef struct {
 #define HCRYPT_CIPHER_AES_ECB   1
 #define HCRYPT_CIPHER_AES_CTR   2
 #define HCRYPT_CIPHER_AES_CBC   3
+#define HCRYPT_CIPHER_AES_GCM   4
 
 #define HCRYPT_AUTH_NONE        0
 

--- a/haicrypt/hcrypt_rx.c
+++ b/haicrypt/hcrypt_rx.c
@@ -124,9 +124,6 @@ int HaiCrypt_Rx_Process(HaiCrypt_Handle hhc,
 		||  (0 != memcmp(ctx->KMmsg_cache, in_msg, in_len))) { /* or different */
 
 			nbout = hcryptCtx_Rx_ParseKM(crypto, in_msg, in_len);
-			//-2: unmatched shared secret
-			//-1: other failures
-			//0: success
 		} else {
 			nbout = 0;
 		}

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -14,20 +14,20 @@ written by
    Haivision Systems Inc.
 
    2011-06-23 (jdube)
-        HaiCrypt initial implementation.
+		HaiCrypt initial implementation.
    2014-03-11 (jdube)
-        Adaptation for SRT.
+		Adaptation for SRT.
 *****************************************************************************/
 
 #include <sys/types.h>
 #include <stdlib.h>     /* NULL */
 #include <string.h>     /* memcpy */
 #ifdef _WIN32
-    #include <winsock2.h>
-    #include <ws2tcpip.h>
-    #include <stdint.h>
+	#include <winsock2.h>
+	#include <ws2tcpip.h>
+	#include <stdint.h>
 #else
-    #include <arpa/inet.h>  /* htonl */
+	#include <arpa/inet.h>  /* htonl */
 #endif
 #include "hcrypt.h"
 

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -79,6 +79,17 @@ void srt::CCryptoControl::globalInit()
 #endif
 }
 
+bool srt::CCryptoControl::isAESGCMSupported()
+{
+#ifdef SRT_ENABLE_ENCRYPTION
+    // We need to force the Cryspr to be initialized during startup to avoid the
+    // possibility of multiple threads initialzing the same static data later on.
+    return HaiCryptCryspr_Is_AES_GCM_Supported() != 0;
+#else
+    return false;
+#endif
+}
+
 #if ENABLE_LOGGING
 std::string srt::CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srtlen)
 {
@@ -112,7 +123,7 @@ void srt::CCryptoControl::createFakeSndContext()
     if (!m_iSndKmKeyLen)
         m_iSndKmKeyLen = 16;
 
-    if (!createCryptoCtx(m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX, (m_hSndCrypto)))
+    if (!createCryptoCtx((m_hSndCrypto), m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX, false))
     {
         HLOGC(cnlog.Debug, log << "Error: Can't create fake crypto context for sending - sending will return ERROR!");
         m_hSndCrypto = 0;
@@ -199,7 +210,7 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
     }
     wasb4 = m_hRcvCrypto;
 
-    if (!createCryptoCtx(m_iRcvKmKeyLen, HAICRYPT_CRYPTO_DIR_RX, (m_hRcvCrypto)))
+    if (!createCryptoCtx((m_hRcvCrypto), m_iRcvKmKeyLen, HAICRYPT_CRYPTO_DIR_RX, m_bUseGCM))
     {
         LOGC(cnlog.Error, log << "processSrtMsg_KMREQ: Can't create RCV CRYPTO CTX - must reject...");
         m_RcvKmState = SRT_KM_S_NOSECRET;
@@ -230,6 +241,11 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
         w_srtlen = 1;
         LOGC(cnlog.Warn, log << "KMREQ/rcv: (snd) Rx process failure - BADSECRET");
         break;
+    case HAICRYPT_ERROR_CIPHER:
+        m_RcvKmState = m_SndKmState = SRT_KM_S_BADSECRET; // TODO: Use a different, dedicated state.
+        w_srtlen = 1;
+        LOGC(cnlog.Warn, log << "KMREQ/rcv: (snd) Rx process failure - BADCRYPTOMODE");
+        break;
     case HAICRYPT_ERROR: //Other errors
     default:
         m_RcvKmState = m_SndKmState = SRT_KM_S_NOSECRET;
@@ -243,7 +259,6 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
     // Since now, when CCryptoControl::decrypt() encounters an error, it will print it, ONCE,
     // until the next KMREQ is received as a key regeneration.
     m_bErrorReported = false;
-
 
     if (w_srtlen == 1)
         goto HSv4_ErrorReport;
@@ -560,6 +575,7 @@ srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     , m_RcvKmState(SRT_KM_S_UNSECURED)
     , m_KmRefreshRatePkt(0)
     , m_KmPreAnnouncePkt(0)
+    , m_bUseGCM(false)
     , m_bErrorReported(false)
 {
 
@@ -605,13 +621,13 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
                 m_iSndKmKeyLen = 16;
             }
 
-            bool ok = createCryptoCtx(m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX, (m_hSndCrypto));
+            bool ok = createCryptoCtx((m_hSndCrypto), m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX, m_bUseGCM);
             HLOGC(cnlog.Debug, log << "CCryptoControl::init: creating SND crypto context: " << ok);
 
             if (ok && bidirectional)
             {
                 m_iRcvKmKeyLen = m_iSndKmKeyLen;
-                int st = HaiCrypt_Clone(m_hSndCrypto, HAICRYPT_CRYPTO_DIR_RX, &m_hRcvCrypto);
+                const int st = HaiCrypt_Clone(m_hSndCrypto, HAICRYPT_CRYPTO_DIR_RX, &m_hRcvCrypto);
                 HLOGC(cnlog.Debug, log << "CCryptoControl::init: creating CLONED RCV crypto context: status=" << st);
                 ok = st == 0;
             }
@@ -691,9 +707,8 @@ static std::string CryptoFlags(int flg)
 } // namespace srt
 #endif // ENABLE_HEAVY_LOGGING
 
-bool srt::CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir, HaiCrypt_Handle& w_hCrypto)
+bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t keylen, HaiCrypt_CryptoDir cdir, bool bAESGCM)
 {
-
     if (w_hCrypto)
     {
         // XXX You can check here if the existing handle represents
@@ -715,7 +730,7 @@ bool srt::CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir
     m_KmRefreshRatePkt = 2000;
     m_KmPreAnnouncePkt = 500;
 #endif
-    crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (cdir == HAICRYPT_CRYPTO_DIR_TX ? HAICRYPT_CFG_F_TX : 0);
+    crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (cdir == HAICRYPT_CRYPTO_DIR_TX ? HAICRYPT_CFG_F_TX : 0) | (bAESGCM ? HAICRYPT_CFG_F_GCM : 0);
     crypto_cfg.xport = HAICRYPT_XPT_SRT;
     crypto_cfg.cryspr = HaiCryptCryspr_Get_Instance();
     crypto_cfg.key_len = (size_t)keylen;
@@ -724,7 +739,6 @@ bool srt::CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir
     crypto_cfg.km_refresh_rate_pkt = m_KmRefreshRatePkt == 0 ? HAICRYPT_DEF_KM_REFRESH_RATE : m_KmRefreshRatePkt;
     crypto_cfg.km_pre_announce_pkt = m_KmPreAnnouncePkt == 0 ? SRT_CRYPT_KM_PRE_ANNOUNCE : m_KmPreAnnouncePkt;
     crypto_cfg.secret = m_KmSecret;
-    //memcpy(&crypto_cfg.secret, &m_KmSecret, sizeof(crypto_cfg.secret));
 
     HLOGC(cnlog.Debug, log << "CRYPTO CFG: flags=" << CryptoFlags(crypto_cfg.flags) << " xport=" << crypto_cfg.xport << " cryspr=" << crypto_cfg.cryspr
         << " keylen=" << crypto_cfg.key_len << " passphrase_length=" << crypto_cfg.secret.len);
@@ -740,7 +754,7 @@ bool srt::CCryptoControl::createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir cdir
     return true;
 }
 #else
-bool srt::CCryptoControl::createCryptoCtx(size_t, HaiCrypt_CryptoDir, HaiCrypt_Handle&)
+bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle&, size_t, HaiCrypt_CryptoDir, bool)
 {
     return false;
 }
@@ -754,6 +768,8 @@ srt::EncryptionStatus srt::CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNU
     if ( getSndCryptoFlags() == EK_NOENC )
         return ENCS_CLEAR;
 
+    // Note that in case of GCM the header has to zero Retransmitted Packet Flag (R).
+    // If TSBPD is disabled, timestamp also has to be zeroed.
     int rc = HaiCrypt_Tx_Data(m_hSndCrypto, ((uint8_t*)w_packet.getHeader()), ((uint8_t*)w_packet.m_pcData), w_packet.getLength());
     if (rc < 0)
     {

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -69,6 +69,7 @@ private:
     // putting the whole HaiCrypt_Cfg object here.
     int m_KmRefreshRatePkt;
     int m_KmPreAnnouncePkt;
+    bool m_bUseGCM; // Use AES GCM crypto mode.
 
     HaiCrypt_Secret m_KmSecret;     //Key material shared secret
     // Sender
@@ -86,6 +87,8 @@ private:
 
 public:
     static void globalInit();
+
+    static bool isAESGCMSupported();
 
     bool sendingAllowed()
     {
@@ -224,7 +227,7 @@ public:
         m_iRcvKmKeyLen = keylen;
     }
 
-    bool createCryptoCtx(size_t keylen, HaiCrypt_CryptoDir tx, HaiCrypt_Handle& rh);
+    bool createCryptoCtx(HaiCrypt_Handle& rh, size_t keylen, HaiCrypt_CryptoDir tx, bool bAESGCM);
 
     int getSndCryptoFlags() const
     {

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -238,7 +238,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_GROUPMINSTABLETIMEO, // Minimum Link Stability timeout (backup mode) in milliseconds (ENABLE_BONDING)
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake (ENABLE_BONDING)
    SRTO_PACKETFILTER = 60,   // Add and configure a packet filter
-   SRTO_RETRANSMITALGO = 61,  // An option to select packet retransmission algorithm
+   SRTO_RETRANSMITALGO = 61, // An option to select packet retransmission algorithm
 
    SRTO_E_SIZE // Always last element, not a valid option.
 } SRT_SOCKOPT;


### PR DESCRIPTION
Add AES GCM crypto mode support into the CRYSPR library if built with OpenSSL EVP (`-DUSE_ENCLIB=openssl-evp`).

### List of Changes

- `HCRYPT_CTX_MODE_AESGCM` to the `hcrypt_Ctx`.
- `aes_gcm_cipher` function pointer is added to the `CRYSPR_methods`.
  - `crysprOpenSSL_EVP_AES_GCMCipher` function added in `cryspr-openssl-evp.c`; it uses `EVP_aes_<128/192/256>_gcm` functions in case EVP API is enabled.
  - `crysprStub_AES_GCMCipher` function (noop) is used otherwise.
- ...


Related FR #2336.