### PR TITLE
CRYSPR AES GCM follow up adjustments.

### DIFF
--- a/haicrypt/cryspr-openssl-evp.c
+++ b/haicrypt/cryspr-openssl-evp.c
@@ -295,7 +295,7 @@ int crysprOpenSSL_EVP_AES_GCMCipher(bool                 bEncrypt, /* true:encry
         return -1;
     }
 
-    if (!bEncrypt && !EVP_CIPHER_CTX_ctrl(aes_key, EVP_CTRL_GCM_SET_TAG, 16, out_tag)) {
+    if (!bEncrypt && !EVP_CIPHER_CTX_ctrl(aes_key, EVP_CTRL_GCM_SET_TAG, HAICRYPT_AUTHTAG_MAX, out_tag)) {
         ERR_print_errors_fp(stderr);
         HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_EncryptUpdate failed");
         return -1;
@@ -318,7 +318,7 @@ int crysprOpenSSL_EVP_AES_GCMCipher(bool                 bEncrypt, /* true:encry
     }
 
     /* Get the tag if we are encrypting */
-    if (bEncrypt && !EVP_CIPHER_CTX_ctrl(aes_key, EVP_CTRL_GCM_GET_TAG, 16, out_tag))
+    if (bEncrypt && !EVP_CIPHER_CTX_ctrl(aes_key, EVP_CTRL_GCM_GET_TAG, HAICRYPT_AUTHTAG_MAX, out_tag))
     {
         ERR_print_errors_fp(stderr);
         HCRYPT_LOG(LOG_ERR, "%s\n", "EVP_CIPHER_CTX_ctrl(EVP_CTRL_GCM_GET_TAG) failed");

--- a/haicrypt/cryspr.h
+++ b/haicrypt/cryspr.h
@@ -63,7 +63,6 @@ typedef struct tag_CRYSPR_cb {
 #endif /* !CRYSPR_HAS_AESCTR */
 
 #define	CRYSPR_OUTMSGMAX		6
-#define	CRYSPR_AUTHTAGMAX		16  /* maximum length of the auth tag (e.g. GCM) */
     uint8_t *       outbuf; 		/* output circle buffer */
     size_t          outbuf_ofs;		/* write offset in circle buffer */
     size_t          outbuf_siz;		/* circle buffer size */
@@ -105,7 +104,7 @@ typedef struct tag_CRYSPR_methods {
             bool bEncrypt,          /* true:encrypt false:decrypt (don't care with CTR) */
             CRYSPR_AESCTX* aes_key, /* ctx */
             unsigned char* iv,      /* iv */
-            unsigned char* aad,     /* associated data */
+            const unsigned char* aad, /* associated data */
             size_t aadlen,
             const unsigned char* indata,  /* src (clear text) */
             size_t inlen,           /* src length */

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -36,7 +36,7 @@ HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance (void);     /* Return a default crys
 #define HAICRYPT_PWD_MAX_SZ         80  /* MAX password (for Password-based Key Derivation) */
 #define HAICRYPT_KEY_MAX_SZ         32  /* MAX key */
 #define HAICRYPT_SECRET_MAX_SZ      (HAICRYPT_PWD_MAX_SZ > HAICRYPT_KEY_MAX_SZ ? HAICRYPT_PWD_MAX_SZ : HAICRYPT_KEY_MAX_SZ)
-
+#define	HAICRYPT_AUTHTAG_MAX        16  /* maximum length of the auth tag (e.g. GCM) */
 
 #define HAICRYPT_SALT_SZ            16
 

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -303,8 +303,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
             return(-1);
         }
 
-
-        /* Configure contexts */
+        /* Configure contexts. Note that GCM mode has been already copied from the source context. */
         if (hcryptCtx_Rx_Init(cryptoClone, &cryptoClone->ctx_pair[0], NULL)
                 ||  hcryptCtx_Rx_Init(cryptoClone, &cryptoClone->ctx_pair[1], NULL)) {
             free(cryptoClone);


### PR DESCRIPTION
- Fixed usage of the `aes_gcm_cipher(..)` prototype. `crysprStub_AES_GCMCipher` was not matching.
- Renamed CRYSPR_AUTHTAGMAX to HAICRYPT_AUTHTAG_MAX and relocated.