### PR TITLE
drifttracer: include msRcvBuf in debug trace drift

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -968,11 +968,17 @@ int CRcvBuffer::scanNotInOrderMessageLeft(const int startPos, int msgNo) const
     return -1;
 }
 
+#if SRT_DEBUG_TRACE_DRIFT
+bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t usTimestamp, const time_point& tsPktArrival, int usRTTSample, int msRcvBuf)
+{
+    return m_tsbpd.addDriftSample(usTimestamp, tsPktArrival, usRTTSample, msRcvBuf);
+}
+#else
 bool CRcvBuffer::addRcvTsbPdDriftSample(uint32_t usTimestamp, const time_point& tsPktArrival, int usRTTSample)
 {
     return m_tsbpd.addDriftSample(usTimestamp, tsPktArrival, usRTTSample);
 }
-
+#endif
 void CRcvBuffer::setTsbPdMode(const steady_clock::time_point& timebase, bool wrap, duration delay)
 {
     m_tsbpd.setTsbPdMode(timebase, wrap, delay);

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -335,8 +335,11 @@ public: // TSBPD public functions
 
     void applyGroupDrift(const time_point& timebase, bool wrp, const duration& udrift);
 
+#if SRT_DEBUG_TRACE_DRIFT
+    bool addRcvTsbPdDriftSample(uint32_t usTimestamp, const time_point& tsPktArrival, int usRTTSample, int msRcvBuf);
+#else
     bool addRcvTsbPdDriftSample(uint32_t usTimestamp, const time_point& tsPktArrival, int usRTTSample);
-
+#endif
     time_point getPktTsbPdTime(uint32_t usPktTimestamp) const;
 
     time_point getTsbPdTimeBase(uint32_t usPktTimestamp) const;

--- a/srtcore/tsbpd_time.cpp
+++ b/srtcore/tsbpd_time.cpp
@@ -39,7 +39,8 @@ public:
                int64_t                                    drift,
                int64_t                                    overdrift,
                const srt::sync::steady_clock::time_point& pkt_base,
-               const srt::sync::steady_clock::time_point& tsbpd_base)
+               const srt::sync::steady_clock::time_point& tsbpd_base,
+               int                                        timespan_ms)
     {
         using namespace srt::sync;
         ScopedLock lck(m_mtx);
@@ -62,7 +63,8 @@ public:
         m_fout << drift << ",";
         m_fout << overdrift << ",";
         m_fout << str_pkt_base << ",";
-        m_fout << str_tbase << "\n";
+        m_fout << str_tbase << ",";
+        m_fout << timespan_ms << "\n";
         m_fout.flush();
     }
 
@@ -70,7 +72,7 @@ private:
     void print_header()
     {
         m_fout << "usElapsedStd,usAckAckTimestampStd,";
-        m_fout << "usRTTStd,usDriftSampleStd,usDriftStd,usOverdriftStd,tsPktBase,TSBPDBase\n";
+        m_fout << "usRTTStd,usDriftSampleStd,usDriftStd,usOverdriftStd,tsPktBase,TSBPDBase,msRcvBuf\n";
     }
 
     void create_file()
@@ -103,7 +105,11 @@ drift_logger g_drift_logger;
 
 #endif // SRT_DEBUG_TRACE_DRIFT
 
+#if SRT_DEBUG_TRACE_DRIFT
+bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, const time_point& tsPktArrival, int usRTTSample, int msRcvBuf)
+#else
 bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, const time_point& tsPktArrival, int usRTTSample)
+#endif
 {
     if (!m_bTsbPdMode)
         return false;
@@ -151,7 +157,8 @@ bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, const time_point& tsPkt
                          m_DriftTracer.drift(),
                          m_DriftTracer.overdrift(),
                          tsPktBaseTime,
-                         m_tsTsbPdTimeBase);
+                         m_tsTsbPdTimeBase,
+                         msRcvBuf);
 #endif
     return updated;
 }

--- a/srtcore/tsbpd_time.h
+++ b/srtcore/tsbpd_time.h
@@ -68,10 +68,14 @@ public:
     /// @param [in] pktTimestamp Timestamp of the arrived ACKACK packet.
     /// @param [in] tsPktArrival packet arrival time.
     /// @param [in] usRTTSample RTT sample from an ACK-ACKACK pair. If no sample, pass '-1'.
-    /// 
+    /// @param [in] msRcvBuf Undelivered timespan (msec) of UDT receiver
+    ///
     /// @return true if TSBPD base time has changed, false otherwise.
+#if SRT_DEBUG_TRACE_DRIFT
+    bool addDriftSample(uint32_t pktTimestamp, const time_point& tsPktArrival, int usRTTSample, int msRcvBuf);
+#else
     bool addDriftSample(uint32_t pktTimestamp, const time_point& tsPktArrival, int usRTTSample);
-
+#endif
     /// @brief Handle timestamp of data packet when 32-bit integer carryover is about to happen.
     /// When packet timestamp approaches CPacket::MAX_TIMESTAMP, the TSBPD base time should be
     /// shifted accordingly to correctly handle new packets with timestamps starting from zero.


### PR DESCRIPTION
I found it useful to be able to view the current msRcvBuf along with the other information relating to the drift samples in order to confirm that the drift calculation was correctly keeping the receive buffer the right size.