### PR TITLE
drifttracer: add cumulativeOverdrift and expose via stats

### DIFF
--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -196,6 +196,8 @@ public:
     }
 
     int64_t getDrift() const { return m_tsbpd.drift(); }
+    int64_t getOverdrift() const { return m_tsbpd.overdrift(); }
+    int64_t getCumulativeOverdrift() const { return m_tsbpd.cumulativeoverdrift(); }
 
     // TODO: make thread safe?
     int debugGetSize() const

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7348,6 +7348,7 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
             {
                 perf->pktRcvBuf = m_pRcvBuffer->getRcvAvgDataSize(perf->byteRcvBuf, perf->msRcvBuf);
             }
+            perf->usRcvCumulativeOverdrift = m_pRcvBuffer->getCumulativeOverdrift();
         }
         else
         {
@@ -7355,6 +7356,7 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
             perf->pktRcvBuf  = 0;
             perf->byteRcvBuf = 0;
             perf->msRcvBuf   = 0;
+            perf->usRcvCumulativeOverdrift = 0;
         }
 
         leaveCS(m_ConnectionLock);
@@ -7368,6 +7370,7 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
         perf->msSndBuf   = 0;
         perf->byteRcvBuf = 0;
         perf->msRcvBuf   = 0;
+        perf->usRcvCumulativeOverdrift = 0;
     }
 }
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -381,6 +381,7 @@ struct CBytePerfMon
    int      byteRcvBuf;                 // Undelivered bytes of UDT receiver
    int      msRcvBuf;                   // Undelivered timespan (msec) of UDT receiver
    int      msRcvTsbPdDelay;            // Timestamp-based Packet Delivery Delay
+   int64_t  usRcvCumulativeOverdrift;   // Cumulative overdrift, in microseconds
 
    int      pktSndFilterExtraTotal;     // number of control packets supplied by packet filter
    int      pktRcvFilterExtraTotal;     // number of control packets received and not supplied back

--- a/srtcore/tsbpd_time.cpp
+++ b/srtcore/tsbpd_time.cpp
@@ -38,6 +38,7 @@ public:
                int64_t                                    drift_sample,
                int64_t                                    drift,
                int64_t                                    overdrift,
+               int64_t                                    cumulativeoverdrift,
                const srt::sync::steady_clock::time_point& pkt_base,
                const srt::sync::steady_clock::time_point& tsbpd_base)
     {
@@ -61,6 +62,7 @@ public:
         m_fout << drift_sample << ",";
         m_fout << drift << ",";
         m_fout << overdrift << ",";
+        m_fout << cumulativeoverdrift << ",";
         m_fout << str_pkt_base << ",";
         m_fout << str_tbase << "\n";
         m_fout.flush();
@@ -70,7 +72,7 @@ private:
     void print_header()
     {
         m_fout << "usElapsedStd,usAckAckTimestampStd,";
-        m_fout << "usRTTStd,usDriftSampleStd,usDriftStd,usOverdriftStd,tsPktBase,TSBPDBase\n";
+        m_fout << "usRTTStd,usDriftSampleStd,usDriftStd,usOverdriftStd,usCumulativeOverdriftStd,tsPktBase,TSBPDBase\n";
     }
 
     void create_file()
@@ -150,6 +152,7 @@ bool CTsbpdTime::addDriftSample(uint32_t usPktTimestamp, const time_point& tsPkt
                          count_microseconds(tdDrift),
                          m_DriftTracer.drift(),
                          m_DriftTracer.overdrift(),
+                         m_DriftTracer.cumulativeoverdrift(),
                          tsPktBaseTime,
                          m_tsTsbPdTimeBase);
 #endif

--- a/srtcore/tsbpd_time.h
+++ b/srtcore/tsbpd_time.h
@@ -110,6 +110,10 @@ public:
     /// @return current overdrift value.
     int64_t    overdrift() const { return m_DriftTracer.overdrift(); }
 
+    /// @brief Get current cumulative overdrift value.
+    /// @return current cumulative overdrift value.
+    int64_t    cumulativeoverdrift() const { return m_DriftTracer.cumulativeoverdrift(); }
+
     /// @brief Get internal state to apply to another member of a socket group.
     /// @param w_tb TsbPd base time.
     /// @param w_udrift drift value.

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -824,6 +824,7 @@ class DriftTracer
 {
     int64_t  m_qDrift;
     int64_t  m_qOverdrift;
+    int64_t  m_qCumulativeOverdrift;
 
     int64_t  m_qDriftSum;
     unsigned m_uDriftSpan;
@@ -832,6 +833,7 @@ public:
     DriftTracer()
         : m_qDrift(0)
         , m_qOverdrift(0)
+        , m_qCumulativeOverdrift(0)
         , m_qDriftSum(0)
         , m_uDriftSpan(0)
     {}
@@ -865,6 +867,7 @@ public:
         {
             m_qOverdrift = m_qDrift < 0 ? -MAX_DRIFT : MAX_DRIFT;
             m_qDrift -= m_qOverdrift;
+            m_qCumulativeOverdrift += m_qOverdrift;
         }
 
         // printDriftOffset(m_qOverdrift, m_qDrift);
@@ -904,6 +907,7 @@ public:
     // overdrift.
     int64_t drift() const { return m_qDrift; }
     int64_t overdrift() const { return m_qOverdrift; }
+    int64_t cumulativeoverdrift() const { return m_qCumulativeOverdrift; }
 };
 
 template <class KeyType, class ValueType>


### PR DESCRIPTION
The cumulative overdraft represents the clock drift since the start of the stream. Exposing this information via the stats system allowed my video player to adjust its playback speed to accommodate the clock drift and keep everything sweet.