### PR TITLE
Add AES GCM to the SRT API.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1355,10 +1355,11 @@ if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 	set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 	# Version ranges are only supported with CMake 3.19 or later.
+	# Need GTest v1.10 or higher to support GTEST_SKIP.
 	if (${CMAKE_VERSION} VERSION_LESS "3.19.0")
-		find_package(GTest 1.8)
+		find_package(GTest 1.10)
 	else()
-		find_package(GTest 1.8...1.12)
+		find_package(GTest 1.10...1.12)
 	endif()
 	if (NOT GTEST_FOUND)
 		message(STATUS "GTEST not found! Fetching from git.")

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -254,7 +254,8 @@ const SocketOption srt_options [] {
 #ifdef SRT_ENABLE_BINDTODEVICE
     { "bindtodevice", 0, SRTO_BINDTODEVICE, SocketOption::PRE, SocketOption::STRING, nullptr},
 #endif
-    { "retransmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
+    { "retransmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr },
+    { "cryptomode", 0, SRTO_CRYPTOMODE, SocketOption::PRE, SocketOption::INT, nullptr }
 };
 }
 

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -153,25 +153,26 @@ Since SRT v1.5.0.
 
 <h4 id="rejection-reasons">Rejection Reasons</h4>
 
-| *Rejection Reason*                                | *Description*                                                                                                  |
-|:------------------------------------------------- |:-------------------------------------------------------------------------------------------------------------- |
-| [SRT_REJ_UNKNOWN](#SRT_REJ_UNKNOWN)               | A fallback value for cases when there was no connection rejected                                               |
-| [SRT_REJ_SYSTEM](#SRT_REJ_SYSTEM)                 | A system function reported a failure                                                                           |
-| [SRT_REJ_PEER](#SRT_REJ_PEER)                     | The connection has been rejected by peer, but no further details are available                                 |
-| [SRT_REJ_RESOURCE](#SRT_REJ_RESOURCE)             | A problem with resource allocation (usually memory)                                                            |
-| [SRT_REJ_ROGUE](#SRT_REJ_ROGUE)                   | The data sent by one party to another cannot be properly interpreted                                           |
-| [SRT_REJ_BACKLOG](#SRT_REJ_BACKLOG)               | The listener's backlog has exceeded                                                                            |
-| [SRT_REJ_IPE](#SRT_REJ_IPE)                       | Internal Program Error                                                                                         |
-| [SRT_REJ_CLOSE](#SRT_REJ_CLOSE)                   | The listener socket received a request as it is being closed                                                   |
-| [SRT_REJ_VERSION](#SRT_REJ_VERSION)               | A party did not satisfy the minimum version requirement that had been set up for a connection                  |
-| [SRT_REJ_RDVCOOKIE](#SRT_REJ_RDVCOOKIE)           | Rendezvous cookie collision                                                                                    |
-| [SRT_REJ_BADSECRET](#SRT_REJ_BADSECRET)           | Both parties have defined a passprhase for connection and they differ                                          |
-| [SRT_REJ_UNSECURE](#SRT_REJ_UNSECURE)             | Only one connection party has set up a password                                                                |
-| [SRT_REJ_MESSAGEAPI](#SRT_REJ_MESSAGEAPI)         | The value for [`SRTO_MESSAGEAPI`](API-socket-options.md#SRTO_MESSAGEAPI) flag is different on both connection parties  |
-| [SRT_REJ_FILTER](#SRT_REJ_FILTER)                 | The [`SRTO_PACKETFILTER`](API-socket-options.md#SRTO_PACKETFILTER) option has been set differently on both connection parties  |
-| [SRT_REJ_GROUP](#SRT_REJ_GROUP)                   | The group type or some group settings are incompatible for both connection parties                             |
-| [SRT_REJ_TIMEOUT](#SRT_REJ_TIMEOUT)               | The connection wasn't rejected, but it timed out                                                               |
-| <img width=290px height=1px/>                     | <img width=720px height=1px/>                                                                                  |
+| *Rejection Reason*                           | *Since*   | *Description*                                                                                                  |
+|:-------------------------------------------- |:--------- |:-------------------------------------------------------------------------------------------------------------- |
+| [SRT_REJ_UNKNOWN](#SRT_REJ_UNKNOWN)          | 1.3.4     | A fallback value for cases when there was no connection rejected                                               |
+| [SRT_REJ_SYSTEM](#SRT_REJ_SYSTEM)            | 1.3.4     | A system function reported a failure                                                                           |
+| [SRT_REJ_PEER](#SRT_REJ_PEER)                | 1.3.4     | The connection has been rejected by peer, but no further details are available                                 |
+| [SRT_REJ_RESOURCE](#SRT_REJ_RESOURCE)        | 1.3.4     | A problem with resource allocation (usually memory)                                                            |
+| [SRT_REJ_ROGUE](#SRT_REJ_ROGUE)              | 1.3.4     | The data sent by one party to another cannot be properly interpreted                                           |
+| [SRT_REJ_BACKLOG](#SRT_REJ_BACKLOG)          | 1.3.4     | The listener's backlog has exceeded                                                                            |
+| [SRT_REJ_IPE](#SRT_REJ_IPE)                  | 1.3.4     | Internal Program Error                                                                                         |
+| [SRT_REJ_CLOSE](#SRT_REJ_CLOSE)              | 1.3.4     | The listener socket received a request as it is being closed                                                   |
+| [SRT_REJ_VERSION](#SRT_REJ_VERSION)          | 1.3.4     | A party did not satisfy the minimum version requirement that had been set up for a connection                  |
+| [SRT_REJ_RDVCOOKIE](#SRT_REJ_RDVCOOKIE)      | 1.3.4     | Rendezvous cookie collision                                                                                    |
+| [SRT_REJ_BADSECRET](#SRT_REJ_BADSECRET)      | 1.3.4     | Both parties have defined a passprhase for connection and they differ                                          |
+| [SRT_REJ_UNSECURE](#SRT_REJ_UNSECURE)        | 1.3.4     | Only one connection party has set up a password                                                                |
+| [SRT_REJ_MESSAGEAPI](#SRT_REJ_MESSAGEAPI)    | 1.3.4     | The value for [`SRTO_MESSAGEAPI`](API-socket-options.md#SRTO_MESSAGEAPI) flag is different on both connection parties  |
+| [SRT_REJ_FILTER](#SRT_REJ_FILTER)            | 1.3.4     | The [`SRTO_PACKETFILTER`](API-socket-options.md#SRTO_PACKETFILTER) option has been set differently on both connection parties  |
+| [SRT_REJ_GROUP](#SRT_REJ_GROUP)              | 1.4.2     | The group type or some group settings are incompatible for both connection parties                             |
+| [SRT_REJ_TIMEOUT](#SRT_REJ_TIMEOUT)          | 1.4.2     | The connection wasn't rejected, but it timed out                                                               |
+| [SRT_REJ_CRYPTO](#SRT_REJ_CRYPTO)            | 1.6.0-dev | The connection was rejected due to an unsupported or mismatching encryption mode                               |
+| <img width=290px height=1px/>                |           |                                                                                                                |
 
 <h4 id="error-codes">Error Codes</h4>
   

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -48,26 +48,30 @@ See [Transmission Types](API.md#transmission-types) for details.
 The defined encryption state as performed by the Key Material Exchange, used
 by `SRTO_RCVKMSTATE`, `SRTO_SNDKMSTATE` and `SRTO_KMSTATE` options:
 
-- `SRT_KM_S_UNSECURED`: no encryption/decryption. If this state is only on
+- `SRT_KM_S_UNSECURED` (`0`): no encryption/decryption. If this state is only on
 the receiver, received encrypted packets will be dropped.
 
-- `SRT_KM_S_SECURING`: pending security (HSv4 only). This is a temporary state
+- `SRT_KM_S_SECURING`(`1`): pending security (HSv4 only). This is a temporary state
 used only if the connection uses HSv4 and the Key Material Exchange is
 not finished yet. On HSv5 this is not possible because the Key Material
 Exchange for the initial key is done in the handshake.
 
-- `SRT_KM_S_SECURED`: KM exchange was successful and the data will be sent
+- `SRT_KM_S_SECURED` (`2`): KM exchange was successful and the data will be sent
 encrypted and will be decrypted by the receiver. This state is only possible on
 both sides in both directions simultaneously.
 
-- `SRT_KM_S_NOSECRET`: If this state is in the sending direction (`SRTO_SNDKMSTATE`), 
+- `SRT_KM_S_NOSECRET` (`3`): If this state is in the sending direction (`SRTO_SNDKMSTATE`), 
 then it means that the sending party has set a passphrase, but the peer did not. 
 In this case the sending party can receive unencrypted packets from the peer, but 
 packets it sends to the peer will be encrypted and the peer will not be able to 
 decrypt them. This state is only possible in HSv5.
 
-- `SRT_KM_S_BADSECRET`: The password is wrong (set differently on each party);
+- `SRT_KM_S_BADSECRET` (`4`): The password is wrong (set differently on each party);
 encrypted payloads won't be decrypted in either direction.
+
+- `SRT_KM_S_BADCRYPTOMODE` (`5`): The crypto mode mode configuration is either not supported
+or mismatches the configuration of the peer.
+
 
 Note that with the default value of `SRTO_ENFORCEDENCRYPTION` option (true),
 the state is equal on both sides in both directions, and it can be only
@@ -200,12 +204,13 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_BINDTODEVICE`](#SRTO_BINDTODEVICE)               | 1.4.2 | pre-bind | `string`  |         |                   |          | RW  | GSD+  |
 | [`SRTO_CONGESTION`](#SRTO_CONGESTION)                   | 1.3.0 | pre      | `string`  |         | "live"            | \*       | W   | S     |
 | [`SRTO_CONNTIMEO`](#SRTO_CONNTIMEO)                     | 1.1.2 | pre      | `int32_t` | ms      | 3000              | 0..      | W   | GSD+  |
+| [`SRTO_CRYPTOMODE`](#SRTO_CRYPTOMODE)                   | 1.6.0-dev | pre      | `int32_t` |     | 0 (Auto)          | [0, 3]   | W   | GSD   |
 | [`SRTO_DRIFTTRACER`](#SRTO_DRIFTTRACER)                 | 1.4.2 | post     | `bool`    |         | true              |          | RW  | GSD   |
 | [`SRTO_ENFORCEDENCRYPTION`](#SRTO_ENFORCEDENCRYPTION)   | 1.3.2 | pre      | `bool`    |         | true              |          | W   | GSD   |
 | [`SRTO_EVENT`](#SRTO_EVENT)                             |       |          | `int32_t` | flags   |                   |          | R   | S     |
 | [`SRTO_FC`](#SRTO_FC)                                   |       | pre      | `int32_t` | pkts    | 25600             | 32..     | RW  | GSD   |
 | [`SRTO_GROUPCONNECT`](#SRTO_GROUPCONNECT)               | 1.5.0 | pre      | `int32_t` |         | 0                 | 0...1    | W   | S     |
-| [`SRTO_GROUPMINSTABLETIMEO`](#SRTO_GROUPMINSTABLETIMEO) | 1.5.0 | pre     | `int32_t` | ms      | 60                | 60-...   | W   | GDI+  |
+| [`SRTO_GROUPMINSTABLETIMEO`](#SRTO_GROUPMINSTABLETIMEO) | 1.5.0 | pre      | `int32_t` | ms      | 60                | 60-...   | W   | GDI+  |
 | [`SRTO_GROUPTYPE`](#SRTO_GROUPTYPE)                     | 1.5.0 |          | `int32_t` | enum    |                   |          | R   | S     |
 | [`SRTO_INPUTBW`](#SRTO_INPUTBW)                         | 1.0.5 | post     | `int64_t` | B/s     | 0                 | 0..      | RW  | GSD   |
 | [`SRTO_IPTOS`](#SRTO_IPTOS)                             | 1.0.5 | pre-bind | `int32_t` |         | (system)          | 0..255   | RW  | GSD   |
@@ -313,6 +318,25 @@ rather change the whole set of options using the [`SRTO_TRANSTYPE`](#SRTO_TRANST
 Connect timeout. This option applies to the caller and rendezvous connection
 modes. For the rendezvous mode (see `SRTO_RENDEZVOUS`) the effective connection timeout
 will be 10 times the value set with `SRTO_CONNTIMEO`.
+
+[Return to list](#list-of-options)
+
+---
+
+#### SRTO_CRYPTOMODE
+
+| OptName            | Since     | Restrict |   Type    | Units  | Default  | Range  | Dir | Entity |
+| ------------------ | --------- | -------- | --------- | ------ | -------- | ------ | --- | ------ |
+| `SRTO_CRYPTOMODE`  | 1.6.0-dev | pre      | `int32_t` |        | 0 (Auto) | [0, 2] | RW  | GSD   |
+
+The encryption mode to be used if the [`SRTO_PASSPHRASE`](#SRTO_PASSPHRASE) is set.
+
+Crypto modes:
+
+- `0`: auto-select during handshake negotiation (to be implemented; currently similar to AES-CTR).
+- `1`: regular AES-CTR (without message integrity authentication).
+- `2`: AES-GCM mode with message integrity authentication (AEAD).
+
 
 [Return to list](#list-of-options)
 

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -336,6 +336,7 @@ following type specification:
 | -------------------- | ---------------- | ------------------------- | ----------- |
 | `congestion`         | {`live`, `file`} | `SRTO_CONGESTION`         | Type of congestion control. |
 | `conntimeo`          | `ms`             | `SRTO_CONNTIMEO`          | Connection timeout. |
+| `cryptomode`         | 0..2             | `SRTO_CRYPTOMODE`         | Cryptographic mode. |
 | `drifttracer`        | `bool`           | `SRTO_DRIFTTRACER`        | Enable drift tracer. |
 | `enforcedencryption` | `bool`           | `SRTO_ENFORCEDENCRYPTION` | Reject connection if parties set different passphrase. |
 | `fc`                 | `bytes`          | `SRTO_FC`                 | Flow control window size. |

--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -122,7 +122,7 @@ int hcryptCtx_Rx_ParseKM(hcrypt_Session *crypto, unsigned char *km_msg, size_t m
 			return(-1);
 		}
 
-		if (HCRYPT_CIPHER_AES_CTR != km_msg[HCRYPT_MSG_KM_OFS_CIPHER]
+		if (HCRYPT_CIPHER_AES_CTR == km_msg[HCRYPT_MSG_KM_OFS_CIPHER]
 			&& HCRYPT_AUTH_NONE != km_msg[HCRYPT_MSG_KM_OFS_AUTH]) {
 			HCRYPT_LOG(LOG_WARNING, "%s", "KMmsg unsupported auth method\n");
 			return(-1);

--- a/scripts/googletest-download.cmake
+++ b/scripts/googletest-download.cmake
@@ -11,7 +11,7 @@ ExternalProject_Add(
 	BINARY_DIR "@GOOGLETEST_DOWNLOAD_ROOT@/googletest-build"
 	GIT_REPOSITORY
 	https://github.com/google/googletest.git
-	GIT_TAG release-1.8.1
+	GIT_TAG release-1.10.0
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND ""
 	INSTALL_COMMAND ""

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -260,7 +260,7 @@ int CRcvBuffer::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno)
     IF_RCVBUF_DEBUG(scoped_log.ss << "CRcvBuffer::dropMessage: seqnolo " << seqnolo << " seqnohi " << seqnohi << " m_iStartSeqNo " << m_iStartSeqNo);
     // TODO: count bytes as removed?
     const int end_pos = incPos(m_iStartPos, m_iMaxPosInc);
-    if (msgno != 0)
+    if (msgno > 0) // including SRT_MSGNO_NONE and SRT_MSGNO_CONTROL
     {
         IF_RCVBUF_DEBUG(scoped_log.ss << " msgno " << msgno);
         int minDroppedOffset = -1;

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -76,7 +76,7 @@ public:
     int dropAll();
 
     /// @brief Drop the whole message from the buffer.
-    /// If message number is 0, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
+    /// If message number is 0 or SRT_MSGNO_NONE, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
     /// When one packet of the message is in the range of dropping, the whole message is to be dropped.
     /// @param seqnolo sequence number of the first packet in the dropping range.
     /// @param seqnohi sequence number of the last packet in the dropping range.

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -140,7 +140,8 @@ const char* srt_rejectreason_name [] = {
     "CONGESTION",
     "FILTER",
     "GROUP",
-    "TIMEOUT"
+    "TIMEOUT",
+    "CRYPTO"
 };
 }
 

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -883,6 +883,28 @@ struct CSrtConfigSetter<SRTO_RETRANSMITALGO>
     }
 };
 
+template<>
+struct CSrtConfigSetter<SRTO_CRYPTOMODE>
+{
+    static void set(CSrtConfig& co, const void* optval, int optlen)
+    {
+        const int val = cast_optval<int>(optval, optlen);
+        if (val < CSrtConfig::CIPHER_MODE_AUTO || val > CSrtConfig::CIPHER_MODE_AES_GCM)
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+
+#ifdef SRT_ENABLE_ENCRYPTION
+        if (val == CSrtConfig::CIPHER_MODE_AES_GCM && !HaiCrypt_IsAESGCM_Supported())
+        {
+            using namespace srt_logging;
+            LOGC(aclog.Error, log << "AES GCM is not supported by the crypto provider.");
+            throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
+        }
+#endif
+
+        co.iCryptoMode = val;
+    }
+};
+
 int dispatchSet(SRT_SOCKOPT optName, CSrtConfig& co, const void* optval, int optlen)
 {
     switch (optName)
@@ -940,6 +962,7 @@ int dispatchSet(SRT_SOCKOPT optName, CSrtConfig& co, const void* optval, int opt
         DISPATCH(SRTO_IPV6ONLY);
         DISPATCH(SRTO_PACKETFILTER);
         DISPATCH(SRTO_RETRANSMITALGO);
+        DISPATCH(SRTO_CRYPTOMODE);
 
 #undef DISPATCH
     default:

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -176,6 +176,13 @@ struct CSrtConfig: CSrtMuxerConfig
         DEF_LINGER_S = 3*60,    // 3 minutes
         DEF_CONNTIMEO_S = 3;    // 3 seconds
 
+    enum
+    {
+        CIPHER_MODE_AUTO = 0,
+        CIPHER_MODE_AES_CTR = 1,
+        CIPHER_MODE_AES_GCM = 2
+    };
+
     static const int      COMM_RESPONSE_TIMEOUT_MS      = 5 * 1000; // 5 seconds
     static const uint32_t COMM_DEF_MIN_STABILITY_TIMEOUT_MS = 60;   // 60 ms
 
@@ -224,6 +231,7 @@ struct CSrtConfig: CSrtMuxerConfig
     int      iPeerIdleTimeout_ms; // Timeout for hearing anything from the peer (ms).
     uint32_t uMinStabilityTimeout_ms;
     int      iRetransmitAlgo;
+    int      iCryptoMode; // SRTO_CRYPTOMODE
 
     int64_t llInputBW;         // Input stream rate (bytes/sec). 0: use internally estimated input bandwidth
     int64_t llMinInputBW;      // Minimum input stream rate estimate (bytes/sec)
@@ -275,6 +283,7 @@ struct CSrtConfig: CSrtMuxerConfig
         , iPeerIdleTimeout_ms(COMM_RESPONSE_TIMEOUT_MS)
         , uMinStabilityTimeout_ms(COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
         , iRetransmitAlgo(1)
+        , iCryptoMode(CIPHER_MODE_AUTO)
         , llInputBW(0)
         , llMinInputBW(0)
         , iOverheadBW(25)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -239,6 +239,7 @@ typedef enum SRT_SOCKOPT {
    SRTO_GROUPTYPE,           // Group type to which an accepted socket is about to be added, available in the handshake (ENABLE_BONDING)
    SRTO_PACKETFILTER = 60,   // Add and configure a packet filter
    SRTO_RETRANSMITALGO = 61, // An option to select packet retransmission algorithm
+   SRTO_CRYPTOMODE = 62,     // Encryption cipher mode (AES-CTR, AES-GCM, ...).
 
    SRTO_E_SIZE // Always last element, not a valid option.
 } SRT_SOCKOPT;
@@ -553,6 +554,7 @@ enum SRT_REJECT_REASON
     SRT_REJ_FILTER,      // incompatible packet filter
     SRT_REJ_GROUP,       // incompatible group
     SRT_REJ_TIMEOUT,     // connection timeout
+    SRT_REJ_CRYPTO,      // conflicting cryptographic configurations
 
     SRT_REJ_E_SIZE,
 };
@@ -634,11 +636,12 @@ enum SRT_REJECT_REASON
 
 enum SRT_KM_STATE
 {
-    SRT_KM_S_UNSECURED = 0,      //No encryption
-    SRT_KM_S_SECURING  = 1,      //Stream encrypted, exchanging Keying Material
-    SRT_KM_S_SECURED   = 2,      //Stream encrypted, keying Material exchanged, decrypting ok.
-    SRT_KM_S_NOSECRET  = 3,      //Stream encrypted and no secret to decrypt Keying Material
-    SRT_KM_S_BADSECRET = 4       //Stream encrypted and wrong secret, cannot decrypt Keying Material
+    SRT_KM_S_UNSECURED     = 0, // No encryption
+    SRT_KM_S_SECURING      = 1, // Stream encrypted, exchanging Keying Material
+    SRT_KM_S_SECURED       = 2, // Stream encrypted, keying Material exchanged, decrypting ok.
+    SRT_KM_S_NOSECRET      = 3, // Stream encrypted and no secret to decrypt Keying Material
+    SRT_KM_S_BADSECRET     = 4, // Stream encrypted and wrong secret is used, cannot decrypt Keying Material
+    SRT_KM_S_BADCRYPTOMODE = 5  // Stream encrypted but wrong ccryptographic mode is used, cannot decrypt. Since v1.6.0.
 };
 
 enum SRT_EPOLL_OPT

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -438,7 +438,8 @@ const char* const srt_rejection_reason_msg [] = {
     "Congestion controller type collision",
     "Packet Filter settings error",
     "Group settings collision",
-    "Connection timeout"
+    "Connection timeout",
+    "Crypto mode"
 };
 
 // Deprecated, available in SRT API.
@@ -459,7 +460,8 @@ extern const char* const srt_rejectreason_msg[] = {
     srt_rejection_reason_msg[13],
     srt_rejection_reason_msg[14],
     srt_rejection_reason_msg[15],
-    srt_rejection_reason_msg[16]
+    srt_rejection_reason_msg[16],
+    srt_rejection_reason_msg[17]
 };
 
 const char* srt_rejectreason_str(int id)

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -6,7 +6,7 @@ test_buffer_rcv.cpp
 test_bonding.cpp
 test_common.cpp
 test_connection_timeout.cpp
-test_many_connections.cpp
+test_crypto.cpp
 test_cryspr.cpp
 test_enforced_encryption.cpp
 test_epoll.cpp
@@ -16,6 +16,7 @@ test_ipv6.cpp
 test_listen_callback.cpp
 test_losslist_rcv.cpp
 test_losslist_snd.cpp
+test_many_connections.cpp
 test_muxer.cpp
 test_seqno.cpp
 test_socket_options.cpp

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,0 +1,112 @@
+#include <array>
+#include <numeric>
+
+#include "gtest/gtest.h"
+
+#ifdef SRT_ENABLE_ENCRYPTION
+#include "crypto.h"
+#include "hcrypt.h" // Imports the CRYSPR_HAS_AESGCM definition.
+#include "socketconfig.h"
+
+
+namespace srt
+{
+
+    class Crypto
+        : public ::testing::Test
+    {
+    protected:
+        Crypto()
+            : m_crypt(0)
+        {
+            // initialization code here
+        }
+
+        virtual ~Crypto()
+        {
+            // cleanup any pending stuff, but no exceptions allowed
+        }
+
+    protected:
+        // SetUp() is run immediately before a test starts.
+        void SetUp() override
+        {
+            CSrtConfig cfg;
+
+            memset(&cfg.CryptoSecret, 0, sizeof(cfg.CryptoSecret));
+            cfg.CryptoSecret.typ = HAICRYPT_SECTYP_PASSPHRASE;
+            cfg.CryptoSecret.len = (m_pwd.size() <= (int)sizeof(cfg.CryptoSecret.str) ? m_pwd.size() : (int)sizeof(cfg.CryptoSecret.str));
+            memcpy((cfg.CryptoSecret.str), m_pwd.c_str(), m_pwd.size());
+
+            m_crypt.setCryptoSecret(cfg.CryptoSecret);
+
+            // 2 = 128, 3 = 192, 4 = 256
+            cfg.iSndCryptoKeyLen = SrtHSRequest::SRT_PBKEYLEN_BITS::wrap(4);
+            m_crypt.setCryptoKeylen(cfg.iSndCryptoKeyLen);
+
+            cfg.iCryptoMode = CSrtConfig::CIPHER_MODE_AES_GCM;
+            EXPECT_EQ(m_crypt.init(HSD_INITIATOR, cfg, true), HaiCrypt_IsAESGCM_Supported() != 0);
+
+            const unsigned char* kmmsg = m_crypt.getKmMsg_data(0);
+            const size_t km_len = m_crypt.getKmMsg_size(0);
+            uint32_t kmout[72];
+            size_t kmout_len = 72;
+
+            std::array<uint32_t, 72> km_nworder;
+            NtoHLA(km_nworder.data(), reinterpret_cast<const uint32_t*>(kmmsg), km_len);
+            m_crypt.processSrtMsg_KMREQ(km_nworder.data(), km_len, 5, kmout, kmout_len);
+        }
+
+        void TearDown() override
+        {
+        }
+
+    protected:
+
+        srt::CCryptoControl m_crypt;
+        const std::string m_pwd = "abcdefghijk";
+    };
+
+
+    // Check that destroying the buffer also frees memory units.
+    TEST_F(Crypto, GCM)
+    {
+        if (HaiCrypt_IsAESGCM_Supported() == 0)
+            GTEST_SKIP() << "The crypto service provider does not support AES GCM.";
+
+        const size_t mtu_size = 1500;
+        const size_t pld_size = 1316;
+        const size_t tag_len  = 16;
+
+        CPacket pkt;
+        pkt.allocate(mtu_size);
+
+        const int seqno = 1;
+        const int msgno = 1;
+        const int inorder = 1;
+        const int kflg = m_crypt.getSndCryptoFlags();
+
+        pkt.m_iSeqNo = seqno;
+        pkt.m_iMsgNo = msgno | inorder | PacketBoundaryBits(PB_SOLO) | MSGNO_ENCKEYSPEC::wrap(kflg);;
+        pkt.m_iTimeStamp = 356;
+
+        std::iota(pkt.data(), pkt.data() + pld_size, '0');
+        pkt.setLength(pld_size);
+
+        EXPECT_EQ(m_crypt.encrypt(pkt), ENCS_CLEAR);
+        EXPECT_EQ(pkt.getLength(), pld_size + tag_len);
+
+        auto pkt_enc = std::unique_ptr<CPacket>(pkt.clone());
+
+        EXPECT_EQ(m_crypt.decrypt(pkt), ENCS_CLEAR);
+        EXPECT_EQ(pkt.getLength(), pld_size);
+
+        // Modify the payload and expect auth to fail.
+        pkt_enc->data()[10] = '5';
+        EXPECT_EQ(m_crypt.decrypt(*pkt_enc.get()), ENCS_FAILED);
+        
+    }
+
+} // namespace srt
+
+#endif //SRT_ENABLE_ENCRYPTION


### PR DESCRIPTION
### API Changes

- [x] Socket option `SRTO_CRYPTOMODE` where `0` means the standard AES-CTR; `1` enables AES GCM.
- [x] `SRT_KM_S_BADCRYPTOMODE` to signal rejection due to crypto mode mismatch.
- [x] New rejection reason `SRT_REJ_CRYPTO`.

### Functional Changes

- [x] Encrypt/decrypt using the AES GCM mode.
- [x] ~~When TSBPD is disabled, exclude the timestamp field from the encryption (Receiver, Sender).~~
- [x] Exclude the retransmission flag from decryption (Receiver).
- [x] ~~Maybe temporarily disable AEAD if TSBPD is disabled.~~
- [x] Break the connection if AEAD decryption has failed.

### Documentation Updates

- [x] Socket option `SRTO_CRYPTOMODE`.
- [x]  `SRT_KM_S_BADCRYPTOMODE` rejection reason.

### Sample Applications

- [x] Add URI query option `cryptomode`.

### Unit Tests

- [x] Test AES GCM via the `CCryptoControl`.

### To Consider

- [x] ~~Maybe `SRTO_CIPHERSUITE` instead of `SRTO_CRYPTOMODE`?~~