### PR TITLE
[core] Fixed the inconsistency between getFirstLostSeq() and ackDataUpTo()

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7807,7 +7807,8 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
     dropToGroupRecvBase();
 #endif
 
-    /* tsbpd thread may also call ackData when skipping packet so protect code */
+    // The TSBPD thread may change the first lost sequence record (TLPKTDROP).
+    // To avoid it the m_RcvBufferLock has to be acquired.
     UniqueLock bufflock(m_RcvBufferLock);
 
     {


### PR DESCRIPTION
I found the `ackDataUpTo: IPE` logs from https://github.com/Haivision/srt/pull/2463 happened frequently, e.g.
```
11:05:45.433712/SRT:TsbPd!W:SRT.br: @965985327:RCV-DROPPED 53 packet(s). Packet seqno %1675849901 delayed for 234.185 ms
11:05:45.433777/SRT:RcvQ:w1*E:SRT.xt: @965985327: ackDataUpTo: IPE: invalid ACK from %1675849901 to %1675849848 (-53 packets)
```
It may caused by the inconsistency between `getFirstLostSeq()` and `ackDataUpTo()`:
```
[RcvQ] m_pRcvLossList->getFirstLostSeq() -> 1675849848
[TsbPd] rcvDropTooLateUpTo() -> 1675849901
[RcvQ] ackDataUpTo() -> 1675849848 < 1675849901!
```
So `getFirstLostSeq()` should be protected by `m_RcvBufferLock` together with `ackDataUpTo()`.