### PR TITLE
[core] Tune logs of group members adding and removing.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1458,7 +1458,7 @@ int srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, i
                 ns->m_GroupMemberData    = f;
                 ns->m_GroupOf            = &g;
                 f->weight                = targets[tii].weight;
-                LOGC(aclog.Note, log << "srt_connect_group: socket @" << sid << " added to group $" << g.m_GroupID);
+                HLOGC(aclog.Debug, log << "srt_connect_group: socket @" << sid << " added to group $" << g.m_GroupID);
             }
             else
             {
@@ -2611,7 +2611,7 @@ void srt::CUDTUnited::checkBrokenSockets()
 #if ENABLE_BONDING
         if (s->m_GroupOf)
         {
-            LOGC(smlog.Note,
+            HLOGC(smlog.Debug,
                  log << "@" << s->m_SocketID << " IS MEMBER OF $" << s->m_GroupOf->id() << " - REMOVING FROM GROUP");
             s->removeFromGroup(true);
         }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -226,7 +226,7 @@ CUDTGroup::SocketData* CUDTGroup::add(SocketData data)
     data.sndstate = SRT_GST_PENDING;
     data.rcvstate = SRT_GST_PENDING;
 
-    HLOGC(gmlog.Debug, log << "CUDTGroup::add: adding new member @" << data.id);
+    LOGC(gmlog.Note, log << "group/add: adding member @" << data.id << " into group $" << id());
     m_Group.push_back(data);
     gli_t end = m_Group.end();
     if (m_iMaxPayloadSize == -1)

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -155,7 +155,7 @@ public:
         srt::sync::ScopedLock g(m_GroupLock);
 
         bool empty = false;
-        HLOGC(gmlog.Debug, log << "group/remove: going to remove @" << id << " from $" << m_GroupID);
+        LOGC(gmlog.Note, log << "group/remove: removing member @" << id << " from group $" << m_GroupID);
 
         gli_t f = std::find_if(m_Group.begin(), m_Group.end(), HaveID(id));
         if (f != m_Group.end())


### PR DESCRIPTION
Currently there is no log for `group xxx add member yyy` in listener side if the heavy logging is disabled.