### PR TITLE
[AEAD] Set AES-GCM auth in the KM message.

### DIFF
--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -109,6 +109,10 @@ int  HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p
 int  HaiCrypt_Tx_Data(HaiCrypt_Handle hhc, unsigned char *pfx, unsigned char *data, size_t data_len);
 int  HaiCrypt_Rx_Data(HaiCrypt_Handle hhc, unsigned char *pfx, unsigned char *data, size_t data_len);
 
+/// @brief Check if the crypto service provider supports AES GCM.
+/// @return returns 1 if AES GCM is supported, 0 otherwise.
+int  HaiCrypt_IsAESGCM_Supported();
+
 /* Status values */
 
 #define HAICRYPT_ERROR -1

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -335,3 +335,12 @@ int HaiCrypt_Close(HaiCrypt_Handle hhc)
     HCRYPT_LOG_EXIT();
     return rc;
 }
+
+int  HaiCrypt_IsAESGCM_Supported()
+{
+#if CRYSPR_HAS_AESGCM
+    return 1;
+#else
+    return 0;
+#endif
+}

--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -116,7 +116,14 @@ int hcryptCtx_Rx_ParseKM(hcrypt_Session *crypto, unsigned char *km_msg, size_t m
 		}
 #endif
 
-		if (HCRYPT_AUTH_NONE != km_msg[HCRYPT_MSG_KM_OFS_AUTH]) {
+		if (HCRYPT_CIPHER_AES_GCM == km_msg[HCRYPT_MSG_KM_OFS_CIPHER]
+			&& HCRYPT_AUTH_AES_GCM != km_msg[HCRYPT_MSG_KM_OFS_AUTH]) {
+			HCRYPT_LOG(LOG_WARNING, "%s", "KMmsg GCM auth method was expected.\n");
+			return(-1);
+		}
+
+		if (HCRYPT_CIPHER_AES_CTR != km_msg[HCRYPT_MSG_KM_OFS_CIPHER]
+			&& HCRYPT_AUTH_NONE != km_msg[HCRYPT_MSG_KM_OFS_AUTH]) {
 			HCRYPT_LOG(LOG_WARNING, "%s", "KMmsg unsupported auth method\n");
 			return(-1);
 		}

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -300,7 +300,7 @@ int hcryptCtx_Tx_AsmKM(hcrypt_Session *crypto, hcrypt_Ctx *ctx, unsigned char *a
 
 	/* crypto->KMmsg_cache[4..7]: KEKI=0 */
 	km_msg[HCRYPT_MSG_KM_OFS_CIPHER] = (ctx->mode == HCRYPT_CTX_MODE_AESGCM) ? HCRYPT_CIPHER_AES_GCM : HCRYPT_CIPHER_AES_CTR;
-	km_msg[HCRYPT_MSG_KM_OFS_AUTH] = HCRYPT_AUTH_NONE;
+	km_msg[HCRYPT_MSG_KM_OFS_AUTH] = (ctx->mode == HCRYPT_CTX_MODE_AESGCM) ? HCRYPT_AUTH_AES_GCM : HCRYPT_AUTH_NONE;
 	km_msg[HCRYPT_MSG_KM_OFS_SE] = (char) crypto->se;
 	hcryptMsg_KM_SetSaltLen(km_msg, ctx->salt_len);
 	hcryptMsg_KM_SetSekLen(km_msg, ctx->sek_len);

--- a/haicrypt/hcrypt_msg.h
+++ b/haicrypt/hcrypt_msg.h
@@ -125,6 +125,7 @@ typedef struct {
 #define HCRYPT_CIPHER_AES_GCM   4
 
 #define HCRYPT_AUTH_NONE        0
+#define HCRYPT_AUTH_AES_GCM     1
 
 #define HCRYPT_SE_TSUDP         1
         hcrypt_MsgInfo *        hcryptMsg_STA_MsgInfo(void);

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -81,10 +81,8 @@ void srt::CCryptoControl::globalInit()
 
 bool srt::CCryptoControl::isAESGCMSupported()
 {
-#if defined(SRT_ENABLE_ENCRYPTION) && CRYSPR_HAS_AESGCM
-    // We need to force the Cryspr to be initialized during startup to avoid the
-    // possibility of multiple threads initialzing the same static data later on.
-    return true;
+#ifdef SRT_ENABLE_ENCRYPTION
+    return HaiCrypt_IsAESGCM_Supported() != 0;
 #else
     return false;
 #endif


### PR DESCRIPTION
```
    0                   1                   2                   3
    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |S|  V  |   PT  |              Sign             |   Resv1   | KK|
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                              KEKI                             |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |     Cipher    |      Auth     |       SE      |     Resv2     |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |             Resv3             |     SLen/4    |     KLen/4    |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                              Salt                             |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |                                                               |
   +                          Wrapped Key                          +
   |                                                               |
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

The Auth field in the case of GCM must contain not the HCRYPT_AUTH_NONE, but HCRYPT_AUTH_GCM.
According to [RFC 5647](https://www.rfc-editor.org/rfc/rfc5647.html#section-5.1), "If AES-GCM is selected as the encryption algorithm for a given tunnel, AES-GCM MUST also be selected as the Message Authentication Code (MAC) algorithm. Conversely, if AES-GCM is selected as the MAC algorithm, it MUST also be selected as the encryption algorithm".

### Fields Affected

**Legend**
❌ - no changes.
❗ - changes needed.


| Field | Meaning | To Be Changed? |
| --- | --- | --- |
| Version (V) = 1 | Related to SRT v1... | ❌ ❓  |
| Cipher | 2: AES-CTR <br> 4: AES-GCM ➕  | ❗ |
| Authentication (Auth) | Specifies a message authentication code algorithm: <br/> 0: None or KEKI indexed crypto context. <br/> 1: AES-GCM. | ❗ |
|  |  |  |

Related issue #2339.
Related SRT Internet Draft updates: https://github.com/Haivision/srt-rfc/pull/115.