### PR TITLE
[core] Reject if SRT_MAGIC_CODE is not set in the HS induction response.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4520,12 +4520,14 @@ EConnectStatus srt::CUDT::processConnectResponse(const CPacket& response, CUDTEx
             // it means that it is HSv5 capable. It can still accept the HSv4 handshake.
             if (m_ConnRes.m_iVersion > HS_VERSION_UDT4)
             {
-                int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
+                const int hs_flags = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
 
                 if (hs_flags != SrtHSRequest::SRT_MAGIC_CODE)
                 {
                     LOGC(cnlog.Warn,
-                         log << CONID() << "processConnectResponse: Listener HSv5 did not set the SRT_MAGIC_CODE");
+                         log << CONID() << "processConnectResponse: Listener HSv5 did not set the SRT_MAGIC_CODE.");
+                    m_RejectReason = SRT_REJ_ROGUE;
+                    return CONN_REJECT;
                 }
 
                 checkUpdateCryptoKeyLen("processConnectResponse", m_ConnRes.m_iType);


### PR DESCRIPTION
According to the [SRT Internet-Draft](https://datatracker.ietf.org/doc/html/draft-sharabayko-srt-01#section-4.3.1.1), if the Extension Flags field does not contain the magic value 0x4A17 the connection is rejected. This is a contingency for the case where someone who, in an attempt to extend UDT independently, increases the Version value to 5  and tries to test it against SRT.

Fixes #2494.