### PR TITLE
[core] Fixed missing DROPREQ for LOSSREPORT that partially predates ACK.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8492,80 +8492,75 @@ void srt::CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
         ScopedLock ack_lock(m_RecvAckLock);
 
         // decode loss list message and insert loss into the sender loss list
-        for (int i = 0, n = (int)(ctrlpkt.getLength() / 4); i < n; ++i)
+        for (int i = 0, n = (int)losslist_len; i < n; ++i)
         {
             if (IsSet(losslist[i], LOSSDATA_SEQNO_RANGE_FIRST))
             {
-                // Then it's this is a <lo, hi> specification with HI in a consecutive cell.
+                // Then it's this is a <LO, HI> specification with HI in a consecutive cell.
                 const int32_t losslist_lo = SEQNO_VALUE::unwrap(losslist[i]);
                 const int32_t losslist_hi = losslist[i + 1];
-                // <lo, hi> specification means that the consecutive cell has been already interpreted.
+                // <LO, HI> specification means that the consecutive cell has been already interpreted.
                 ++i;
-
                 HLOGF(inlog.Debug,
                     "%sreceived UMSG_LOSSREPORT: %d-%d (%d packets)...", CONID().c_str(),
                     losslist_lo,
                     losslist_hi,
-                    CSeqNo::seqoff(losslist_lo, losslist_hi) + 1);
+                    CSeqNo::seqlen(losslist_lo, losslist_hi));
 
                 if ((CSeqNo::seqcmp(losslist_lo, losslist_hi) > 0) ||
                     (CSeqNo::seqcmp(losslist_hi, m_iSndCurrSeqNo) > 0))
                 {
+                    // LO must not be greater than HI.
+                    // HI must not be greater than the most recent sent seq.
                     LOGC(inlog.Warn, log << CONID() << "rcv LOSSREPORT rng " << losslist_lo << " - " << losslist_hi
                         << " with last sent " << m_iSndCurrSeqNo << " - DISCARDING");
-                    // seq_a must not be greater than seq_b; seq_b must not be greater than the most recent sent seq
                     secure = false;
                     wrong_loss = losslist_hi;
                     break;
                 }
 
                 int num = 0;
-                //   IF losslist_lo %>= m_iSndLastAck
                 if (CSeqNo::seqcmp(losslist_lo, m_iSndLastAck) >= 0)
                 {
                     HLOGC(inlog.Debug, log << CONID() << "LOSSREPORT: adding "
                         << losslist_lo << " - " << losslist_hi << " to loss list");
                     num = m_pSndLossList->insert(losslist_lo, losslist_hi);
                 }
-                // ELSE IF losslist_hi %>= m_iSndLastAck
-                else if (CSeqNo::seqcmp(losslist_hi, m_iSndLastAck) >= 0)
-                {
-                    // This should be theoretically impossible because this would mean
-                    // that the received packet loss report informs about the loss that predates
-                    // the ACK sequence.
-                    // However, this can happen if the packet reordering has caused the earlier sent
-                    // LOSSREPORT will be delivered after later sent ACK. Whatever, ACK should be
-                    // more important, so simply drop the part that predates ACK.
-                    HLOGC(inlog.Debug, log << CONID() << "LOSSREPORT: adding "
-                        << m_iSndLastAck << "[ACK] - " << losslist_hi << " to loss list");
-                    num = m_pSndLossList->insert(m_iSndLastAck, losslist_hi);
-                }
                 else
                 {
-                    // This should be treated as IPE, but this may happen in one situtation:
+                    // This should be theoretically impossible because this would mean that
+                    // the received packet loss report informs about the loss that predates
+                    // the ACK sequence.
+                    // However, this can happen in these situations:
+                    // - if the packet reordering has caused the earlier sent LOSSREPORT will be
+                    // delivered after later sent ACK. Whatever, ACK should be more important,
+                    // so simply drop the part that predates ACK.
                     // - redundancy second link (ISN was screwed up initially, but late towards last sent)
                     // - initial DROPREQ was lost
                     // This just causes repeating DROPREQ, as when the receiver continues sending
                     // LOSSREPORT, it's probably UNAWARE OF THE SITUATION.
-                    //
+                    int32_t dropreq_hi = losslist_hi;
+
+                    if (CSeqNo::seqcmp(losslist_hi, m_iSndLastAck) >= 0)
+                    {
+                        HLOGC(inlog.Debug, log << CONID() << "LOSSREPORT: adding "
+                                << m_iSndLastAck << "[ACK] - " << losslist_hi << " to loss list");
+                        num = m_pSndLossList->insert(m_iSndLastAck, losslist_hi);
+                        dropreq_hi = CSeqNo::decseq(m_iSndLastAck);
+                    }
+
+                    // In distinction to losslist, DROPREQ has always just one range,
+                    // and the data are <LO, HI>, with no range bit.
+                    int32_t seqpair[2] = { losslist_lo, dropreq_hi };
+                    const int32_t no_msgno = 0; // We don't know.
+
                     // When this DROPREQ gets lost in UDP again, the receiver will do one of these:
                     // - repeatedly send LOSSREPORT (as per NAKREPORT), so this will happen again
                     // - finally give up rexmit request as per TLPKTDROP (DROPREQ should make
                     //   TSBPD wake up should it still wait for new packets to get ACK-ed)
-
-                    HLOGC(inlog.Debug, log << CONID() << "LOSSREPORT: IGNORED with SndLastAck=%"
-                        << m_iSndLastAck << ": %" << losslist_lo << "-" << losslist_hi
-                        << " - sending DROPREQ (IPE or DROPREQ lost with ISN screw)");
-
-                    // This means that the loss touches upon a range that wasn't ever sent.
-                    // Normally this should never happen, but this might be a case when the
-                    // ISN FIX for redundant connection was missed.
-
-                    // In distinction to losslist, DROPREQ has always a range
-                    // always just one range, and the data are <LO, HI>, with no range bit.
-                    int32_t seqpair[2] = { losslist_lo, losslist_hi };
-                    const int32_t no_msgno = 0; // We don't know - this wasn't ever sent
-
+                    HLOGC(inlog.Debug,
+                          log << CONID() << "LOSSREPORT: IGNORED with SndLastAck=%" << m_iSndLastAck << ": %"
+                              << losslist_lo << "-" << dropreq_hi << " - sending DROPREQ");
                     sendCtrl(UMSG_DROPREQ, &no_msgno, seqpair, sizeof(seqpair));
                 }
 
@@ -8585,13 +8580,24 @@ void srt::CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
                     break;
                 }
 
-                HLOGC(inlog.Debug, log << CONID() << "rcv LOSSREPORT: %"
-                    << losslist[i] << " (1 packet)");
+                HLOGC(inlog.Debug,
+                      log << CONID() << "LOSSREPORT: adding %" << losslist[i] << " (1 packet) to loss list");
                 const int num = m_pSndLossList->insert(losslist[i], losslist[i]);
 
                 enterCS(m_StatsLock);
                 m_stats.sndr.lost.count(num);
                 leaveCS(m_StatsLock);
+            }
+            else
+            {
+                // In distinction to losslist, DROPREQ has always just one range,
+                // and the data are <LO, HI>, with no range bit.
+                int32_t seqpair[2] = { losslist[i], losslist[i] };
+                const int32_t no_msgno = 0; // We don't know.
+                HLOGC(inlog.Debug,
+                      log << CONID() << "LOSSREPORT: IGNORED with SndLastAck=%" << m_iSndLastAck << ": %" << losslist[i]
+                          << " - sending DROPREQ");
+                sendCtrl(UMSG_DROPREQ, &no_msgno, seqpair, sizeof(seqpair));
             }
         }
     }


### PR DESCRIPTION
Fixed a bug occurred in group in-order message mode.
I only enabled few heavy logs in production env:
```
13:16:28.613875/SRT:RcvQ:w3 D:SRT.sm: generateSocketID: : @540801042
13:16:28.614177/SRT:RcvQ:w3 D:SRT.gm: @540801042:synchronizeWithGroup: ST=13:14:17.945509367 [STDY] -> 13:05:18.457541056 [STDY] PST=13:14:17.856090360 [STDY] -> 13:05:18.429949816 [STDY]
13:16:28.614211/SRT:RcvQ:w3 D:SRT.gm: @540801042:AFTER HS: (GROUP, but no TSBPD set)
13:16:28.614251/SRT:RcvQ:w3 D:SRT.gm: applyGroupSequences: @540801042 gets seq from @540801166 rcv %1030134429 snd %1030134390 as GROUPWISE snd-seq
13:16:28.614268/SRT:RcvQ:w3 D:SRT.gm: @540801042:synchronizeWithGroup: DERIVED ISN: RCV=%1030134430 -> %1030134429 (shift by -1) SND=%1030134430 -> %1030134390 (shift by -40)
13:18:55.824817/SRT:RcvQ:w3 D:SRT.gm: applyGroupSequences: @540800754 gets seq from @540801042 rcv %1030134429 snd %1030134390 as GROUPWISE snd-seq
13:25:55.170386/SRT:RcvQ:w3 D:SRT.gm: applyGroupSequences: @540800180 gets seq from @540801042 rcv %1030134429 snd %1030134390 as GROUPWISE snd-seq
```
Note `@540801042:synchronizeWithGroup: DERIVED ISN: RCV=%1030134430 -> %1030134429 (shift by -1)`.
-> sender sent `1030134428`, receiver member A received `1030134428`, acked `1030134429`
-> sender sent `1030134429`, receiver member A not yet received `1030134429`
-> receiver member B was added into the group,  `rcv_isn` was set to `1030134430` from the sender handshake, then immediately set to `1030134429` by `synchronizeWithGroup()`
-> receiver member A received `1030134429`, acked `1030134430`
-> receiver member A was removed from the group
branch 1:
-> sender sent `1030134430`, receiver member B received, reported lossreport `[1030134429]`
-> sender received lossreport, but `1030134429` was predated `m_iSndLastAck (1030134430)`, ignored
-> receiver member B was stuck at `1030134429` forever (no TLPKTDROP)
branch 2:
-> sender sent `1030134430-1030134431`, receiver member B received `1030134431`, reported lossreport `[1030134429-1030134430]`
-> sender received lossreport, but only `1030134430` was added into the send loss list
-> receiver member B was stuck at `1030134429` forever (no TLPKTDROP)

Previously, only if `LO < HI < m_iSndLastAck`, a DROPREQ will be sent.
This PR fixed these cases: `LO < m_iSndLastAck <= HI` or `LO == HI < m_iSndLastAck`.