### PR TITLE
Refax: added size cache to the group container

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -336,6 +336,7 @@ void CUDTGroup::GroupContainer::erase(CUDTGroup::gli_t it)
         }
     }
     m_List.erase(it);
+    --m_SizeCache;
 }
 
 void CUDTGroup::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -406,7 +406,9 @@ private:
     SRTSOCKET m_PeerGroupID;
     struct GroupContainer
     {
-        std::list<SocketData>        m_List;
+    private:
+        std::list<SocketData>  m_List;
+        sync::atomic<size_t>   m_SizeCache;
 
         /// This field is used only by some types of groups that need
         /// to keep track as to which link was lately used. Note that
@@ -414,8 +416,11 @@ private:
         /// must be appropriately reset.
         gli_t m_LastActiveLink;
 
+    public:
+
         GroupContainer()
-            : m_LastActiveLink(m_List.end())
+            : m_SizeCache(0)
+            , m_LastActiveLink(m_List.end())
         {
         }
 
@@ -425,13 +430,14 @@ private:
         gli_t        begin() { return m_List.begin(); }
         gli_t        end() { return m_List.end(); }
         bool         empty() { return m_List.empty(); }
-        void         push_back(const SocketData& data) { m_List.push_back(data); }
+        void         push_back(const SocketData& data) { m_List.push_back(data); ++m_SizeCache; }
         void         clear()
         {
             m_LastActiveLink = end();
             m_List.clear();
+            m_SizeCache = 0;
         }
-        size_t size() { return m_List.size(); }
+        size_t size() { return m_SizeCache; }
 
         void erase(gli_t it);
     };


### PR DESCRIPTION
This adds a size cache to the group container.

The group container is `std::list` and as such it doesn't have its own saved cache. There were two reasons to add this:

1. In some future implementations the call to the container's size() can be even very often, while `std::list` original size() is linear time in the number of members.
2. There will be also situations when the size is needed to be taken without locking the group's mutex. With this cache the size can be directly taken from the cache, and as atomic, it doesn't need to be mutex-locked.