### PR TITLE
Refax: improve logging and code readability around specific logging

### DIFF
--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -172,8 +172,10 @@ extern Logger inlog;
 }
 using namespace srt_logging;
 
+namespace srt {
+
 // Set up the aliases in the constructure
-srt::CPacket::CPacket()
+CPacket::CPacket()
     : m_extra_pad()
     , m_data_owned(false)
     , m_iSeqNo((int32_t&)(m_nHeader[SRT_PH_SEQNO]))
@@ -194,12 +196,12 @@ srt::CPacket::CPacket()
     m_PacketVector[PV_DATA].set(NULL, 0);
 }
 
-char* srt::CPacket::getData()
+char* CPacket::getData()
 {
     return (char*)m_PacketVector[PV_DATA].dataRef();
 }
 
-void srt::CPacket::allocate(size_t alloc_buffer_size)
+void CPacket::allocate(size_t alloc_buffer_size)
 {
     if (m_data_owned)
     {
@@ -213,14 +215,14 @@ void srt::CPacket::allocate(size_t alloc_buffer_size)
     m_data_owned = true;
 }
 
-void srt::CPacket::deallocate()
+void CPacket::deallocate()
 {
     if (m_data_owned)
         delete[](char*) m_PacketVector[PV_DATA].data();
     m_PacketVector[PV_DATA].set(NULL, 0);
 }
 
-char* srt::CPacket::release()
+char* CPacket::release()
 {
     // When not owned, release returns NULL.
     char* buffer = NULL;
@@ -234,7 +236,7 @@ char* srt::CPacket::release()
     return buffer;
 }
 
-srt::CPacket::~CPacket()
+CPacket::~CPacket()
 {
     // PV_HEADER is always owned, PV_DATA may use a "borrowed" buffer.
     // Delete the internal buffer only if it was declared as owned.
@@ -242,30 +244,78 @@ srt::CPacket::~CPacket()
         delete[](char*) m_PacketVector[PV_DATA].data();
 }
 
-size_t srt::CPacket::getLength() const
+size_t CPacket::getLength() const
 {
     return m_PacketVector[PV_DATA].size();
 }
 
-void srt::CPacket::setLength(size_t len)
+void CPacket::setLength(size_t len)
 {
     m_PacketVector[PV_DATA].setLength(len);
 }
 
-void srt::CPacket::setLength(size_t len, size_t cap)
+void CPacket::setLength(size_t len, size_t cap)
 {
    SRT_ASSERT(len <= cap);
    setLength(len);
    m_zCapacity = cap;
 }
 
-void srt::CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
+#if ENABLE_HEAVY_LOGGING
+// Debug only
+static std::string FormatNumbers(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
+{
+    // This may be changed over time, so use special interpretation
+    // only for certain types, and still display all data, no matter
+    // if it is expected to provide anything or not.
+    std::ostringstream out;
+
+    out << "ARG=";
+    if (lparam)
+        out << *lparam;
+    else
+        out << "none";
+
+    if (size == 0)
+    {
+        out << " [no data]";
+        return out.str();
+    }
+    else if (!rparam)
+    {
+        out << " [ {" << size << "} ]";
+        return out.str();
+    }
+
+    bool interp_as_seq = (pkttype == UMSG_LOSSREPORT || pkttype == UMSG_DROPREQ);
+
+    out << " [ ";
+    for (size_t i = 0; i < size; ++i)
+    {
+        int32_t val = ((int32_t*)rparam)[i];
+        if (interp_as_seq)
+        {
+            if (val & LOSSDATA_SEQNO_RANGE_FIRST)
+                out << "<" << (val & (~LOSSDATA_SEQNO_RANGE_FIRST)) << ">";
+            else
+                out << val;
+        }
+        else
+        {
+            out << std::showpos << std::hex << val << "/" << std::dec << val;
+        }
+    }
+
+    out << "]";
+    return out.str();
+}
+#endif
+
+void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, size_t size)
 {
     // Set (bit-0 = 1) and (bit-1~15 = type)
     setControl(pkttype);
-    HLOGC(inlog.Debug,
-          log << "pack: type=" << MessageTypeStr(pkttype) << " ARG=" << (lparam ? Sprint(*lparam) : std::string("NULL"))
-              << " [ " << (rparam ? Sprint(*(int32_t*)rparam) : std::string()) << " ]");
+    HLOGC(inlog.Debug, log << "pack: type=" << MessageTypeStr(pkttype) << FormatNumbers(pkttype, lparam, rparam, size));
 
     // Set additional information and control information field
     switch (pkttype)
@@ -371,7 +421,7 @@ void srt::CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rpa
     }
 }
 
-void srt::CPacket::toNL()
+void CPacket::toNL()
 {
     // XXX USE HtoNLA!
     if (isControl())
@@ -389,7 +439,7 @@ void srt::CPacket::toNL()
     }
 }
 
-void srt::CPacket::toHL()
+void CPacket::toHL()
 {
     // convert back into local host order
     uint32_t* p = m_nHeader;
@@ -406,22 +456,22 @@ void srt::CPacket::toHL()
     }
 }
 
-srt::IOVector* srt::CPacket::getPacketVector()
+IOVector* CPacket::getPacketVector()
 {
     return m_PacketVector;
 }
 
-srt::UDTMessageType srt::CPacket::getType() const
+UDTMessageType CPacket::getType() const
 {
     return UDTMessageType(SEQNO_MSGTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]));
 }
 
-int srt::CPacket::getExtendedType() const
+int CPacket::getExtendedType() const
 {
     return SEQNO_EXTTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]);
 }
 
-int32_t srt::CPacket::getAckSeqNo() const
+int32_t CPacket::getAckSeqNo() const
 {
     // read additional information field
     // This field is used only in UMSG_ACK and UMSG_ACKACK,
@@ -430,7 +480,7 @@ int32_t srt::CPacket::getAckSeqNo() const
     return m_nHeader[SRT_PH_MSGNO];
 }
 
-uint16_t srt::CPacket::getControlFlags() const
+uint16_t CPacket::getControlFlags() const
 {
     // This returns exactly the "extended type" value,
     // which is not used at all in case when the standard
@@ -439,17 +489,17 @@ uint16_t srt::CPacket::getControlFlags() const
     return SEQNO_EXTTYPE::unwrap(m_nHeader[SRT_PH_SEQNO]);
 }
 
-srt::PacketBoundary srt::CPacket::getMsgBoundary() const
+PacketBoundary CPacket::getMsgBoundary() const
 {
     return PacketBoundary(MSGNO_PACKET_BOUNDARY::unwrap(m_nHeader[SRT_PH_MSGNO]));
 }
 
-bool srt::CPacket::getMsgOrderFlag() const
+bool CPacket::getMsgOrderFlag() const
 {
     return 0 != MSGNO_PACKET_INORDER::unwrap(m_nHeader[SRT_PH_MSGNO]);
 }
 
-int32_t srt::CPacket::getMsgSeq(bool has_rexmit) const
+int32_t CPacket::getMsgSeq(bool has_rexmit) const
 {
     if (has_rexmit)
     {
@@ -461,18 +511,18 @@ int32_t srt::CPacket::getMsgSeq(bool has_rexmit) const
     }
 }
 
-bool srt::CPacket::getRexmitFlag() const
+bool CPacket::getRexmitFlag() const
 {
     return 0 != MSGNO_REXMIT::unwrap(m_nHeader[SRT_PH_MSGNO]);
 }
 
-void srt::CPacket::setRexmitFlag(bool bRexmit)
+void CPacket::setRexmitFlag(bool bRexmit)
 {
     const int32_t clr_msgno = m_nHeader[SRT_PH_MSGNO] & ~MSGNO_REXMIT::mask;
     m_nHeader[SRT_PH_MSGNO] = clr_msgno | MSGNO_REXMIT::wrap(bRexmit? 1 : 0);
 }
 
-srt::EncryptionKeySpec srt::CPacket::getMsgCryptoFlags() const
+EncryptionKeySpec CPacket::getMsgCryptoFlags() const
 {
     return EncryptionKeySpec(MSGNO_ENCKEYSPEC::unwrap(m_nHeader[SRT_PH_MSGNO]));
 }
@@ -480,19 +530,19 @@ srt::EncryptionKeySpec srt::CPacket::getMsgCryptoFlags() const
 // This is required as the encryption/decryption happens in place.
 // This is required to clear off the flags after decryption or set
 // crypto flags after encrypting a packet.
-void srt::CPacket::setMsgCryptoFlags(EncryptionKeySpec spec)
+void CPacket::setMsgCryptoFlags(EncryptionKeySpec spec)
 {
     int32_t clr_msgno       = m_nHeader[SRT_PH_MSGNO] & ~MSGNO_ENCKEYSPEC::mask;
     m_nHeader[SRT_PH_MSGNO] = clr_msgno | EncryptionKeyBits(spec);
 }
 
-uint32_t srt::CPacket::getMsgTimeStamp() const
+uint32_t CPacket::getMsgTimeStamp() const
 {
     // SRT_DEBUG_TSBPD_WRAP may enable smaller timestamp for faster wraparoud handling tests
     return (uint32_t)m_nHeader[SRT_PH_TIMESTAMP] & TIMESTAMP_MASK;
 }
 
-srt::CPacket* srt::CPacket::clone() const
+CPacket* CPacket::clone() const
 {
     CPacket* pkt = new CPacket;
     memcpy((pkt->m_nHeader), m_nHeader, HDR_SIZE);
@@ -502,9 +552,6 @@ srt::CPacket* srt::CPacket::clone() const
 
     return pkt;
 }
-
-namespace srt
-{
 
 // Useful for debugging
 std::string PacketMessageFlagStr(uint32_t msgno_field)
@@ -534,10 +581,8 @@ inline void SprintSpecialWord(std::ostream& os, int32_t val)
         os << val;
 }
 
-} // namespace srt
-
 #if ENABLE_LOGGING
-std::string srt::CPacket::Info()
+std::string CPacket::Info()
 {
     std::ostringstream os;
     os << "TARGET=@" << m_iID << " ";
@@ -592,3 +637,5 @@ std::string srt::CPacket::Info()
     return os.str();
 }
 #endif
+
+} // end namespace srt

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -481,6 +481,25 @@ bool srt::CSndQueue::getBind(char* dst, size_t len) const
 }
 #endif
 
+#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
+static void CSndQueueDebugHighratePrint(const CSndQueue* self, const steady_clock::time_point currtime)
+{
+    if (self->m_ullDbgTime <= currtime)
+    {
+        fprintf(stdout,
+                "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",
+                self->m_WorkerStats.lIteration,
+                self->m_WorkerStats.lSleepTo,
+                self->m_WorkerStats.lNotReadyPop,
+                self->m_WorkerStats.lSendTo,
+                self->m_WorkerStats.lNotReadyTs,
+                self->m_WorkerStats.lCondWait);
+        memset(&self->m_WorkerStats, 0, sizeof(self->m_WorkerStats));
+        self->m_ullDbgTime = currtime + self->m_ullDbgPeriod;
+    }
+}
+#endif
+
 void* srt::CSndQueue::worker(void* param)
 {
     CSndQueue* self = (CSndQueue*)param;
@@ -492,34 +511,30 @@ void* srt::CSndQueue::worker(void* param)
 #endif
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
+#define IF_DEBUG_HIGHRATE(statement) statement
     CTimer::rdtsc(self->m_ullDbgTime);
     self->m_ullDbgPeriod = uint64_t(5000000) * CTimer::getCPUFrequency();
     self->m_ullDbgTime += self->m_ullDbgPeriod;
+#else
+#define IF_DEBUG_HIGHRATE(statement) (void)0
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
 
     while (!self->m_bClosing)
     {
         const steady_clock::time_point next_time = self->m_pSndUList->getNextProcTime();
 
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-        self->m_WorkerStats.lIteration++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+        IF_DEBUG_HIGHRATE(self->m_WorkerStats.lIteration++);
 
         if (is_zero(next_time))
         {
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-            self->m_WorkerStats.lNotReadyTs++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+            IF_DEBUG_HIGHRATE(self->m_WorkerStats.lNotReadyTs++);
 
             // wait here if there is no sockets with data to be sent
             THREAD_PAUSED();
             if (!self->m_bClosing)
             {
                 self->m_pSndUList->waitNonEmpty();
-
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-                self->m_WorkerStats.lCondWait++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+                IF_DEBUG_HIGHRATE(self->m_WorkerStats.lCondWait++);
             }
             THREAD_RESUMED();
 
@@ -529,43 +544,23 @@ void* srt::CSndQueue::worker(void* param)
         // wait until next processing time of the first socket on the list
         const steady_clock::time_point currtime = steady_clock::now();
 
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-        if (self->m_ullDbgTime <= currtime)
-        {
-            fprintf(stdout,
-                    "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",
-                    self->m_WorkerStats.lIteration,
-                    self->m_WorkerStats.lSleepTo,
-                    self->m_WorkerStats.lNotReadyPop,
-                    self->m_WorkerStats.lSendTo,
-                    self->m_WorkerStats.lNotReadyTs,
-                    self->m_WorkerStats.lCondWait);
-            memset(&self->m_WorkerStats, 0, sizeof(self->m_WorkerStats));
-            self->m_ullDbgTime = currtime + self->m_ullDbgPeriod;
-        }
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
-
-        THREAD_PAUSED();
+        IF_DEBUG_HIGHRATE(CSndQueueDebugHighratePrint(self, currtime));
         if (currtime < next_time)
         {
+            THREAD_PAUSED();
             self->m_pTimer->sleep_until(next_time);
-
-#if defined(HAI_DEBUG_SNDQ_HIGHRATE)
-            self->m_WorkerStats.lSleepTo++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+            THREAD_RESUMED();
+            IF_DEBUG_HIGHRATE(self->m_WorkerStats.lSleepTo++);
         }
-        THREAD_RESUMED();
 
         // Get a socket with a send request if any.
         CUDT* u = self->m_pSndUList->pop();
         if (u == NULL)
         {
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-            self->m_WorkerStats.lNotReadyPop++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+            IF_DEBUG_HIGHRATE(self->m_WorkerStats.lNotReadyPop++);
             continue;
         }
-        
+
 #define UST(field) ((u->m_b##field) ? "+" : "-") << #field << " "
         HLOGC(qslog.Debug,
             log << "CSndQueue: requesting packet from @" << u->socketID() << " STATUS: " << UST(Listening)
@@ -575,9 +570,7 @@ void* srt::CSndQueue::worker(void* param)
 
         if (!u->m_bConnected || u->m_bBroken)
         {
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-            self->m_WorkerStats.lNotReadyPop++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+            IF_DEBUG_HIGHRATE(self->m_WorkerStats.lNotReadyPop++);
             continue;
         }
 
@@ -588,9 +581,7 @@ void* srt::CSndQueue::worker(void* param)
         // Check if payload size is invalid.
         if (res_time.first == false)
         {
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-            self->m_WorkerStats.lNotReadyPop++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+            IF_DEBUG_HIGHRATE(self->m_WorkerStats.lNotReadyPop++);
             continue;
         }
 
@@ -602,9 +593,7 @@ void* srt::CSndQueue::worker(void* param)
         HLOGC(qslog.Debug, log << self->CONID() << "chn:SENDING: " << pkt.Info());
         self->m_pChannel->sendto(addr, pkt);
 
-#if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-        self->m_WorkerStats.lSendTo++;
-#endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+        IF_DEBUG_HIGHRATE(self->m_WorkerStats.lSendTo++);
     }
 
     THREAD_EXIT();

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -482,9 +482,9 @@ bool srt::CSndQueue::getBind(char* dst, size_t len) const
 #endif
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-static void CSndQueueDebugHighratePrint(const CSndQueue* self, const steady_clock::time_point currtime)
+static void CSndQueueDebugHighratePrint(const srt::CSndQueue* self, const steady_clock::time_point currtime)
 {
-    if (self->m_ullDbgTime <= currtime)
+    if (self->m_DbgTime <= currtime)
     {
         fprintf(stdout,
                 "SndQueue %lu slt:%lu nrp:%lu snt:%lu nrt:%lu ctw:%lu\n",
@@ -495,7 +495,7 @@ static void CSndQueueDebugHighratePrint(const CSndQueue* self, const steady_cloc
                 self->m_WorkerStats.lNotReadyTs,
                 self->m_WorkerStats.lCondWait);
         memset(&self->m_WorkerStats, 0, sizeof(self->m_WorkerStats));
-        self->m_ullDbgTime = currtime + self->m_ullDbgPeriod;
+        self->m_DbgTime = currtime + self->m_DbgPeriod;
     }
 }
 #endif
@@ -512,9 +512,9 @@ void* srt::CSndQueue::worker(void* param)
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
 #define IF_DEBUG_HIGHRATE(statement) statement
-    CTimer::rdtsc(self->m_ullDbgTime);
-    self->m_ullDbgPeriod = uint64_t(5000000) * CTimer::getCPUFrequency();
-    self->m_ullDbgTime += self->m_ullDbgPeriod;
+    self->m_DbgTime = sync::steady_clock::now();
+    self->m_DbgPeriod = sync::microseconds_from(5000000);
+    self->m_DbgTime += self->m_DbgPeriod;
 #else
 #define IF_DEBUG_HIGHRATE(statement) (void)0
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -451,9 +451,10 @@ private:
 
     sync::atomic<bool> m_bClosing;            // closing the worker
 
+public:
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE) //>>debug high freq worker
-    uint64_t m_ullDbgPeriod;
-    uint64_t m_ullDbgTime;
+    sync::steady_clock::duration m_DbgPeriod;
+    mutable sync::steady_clock::time_point m_DbgTime;
     struct
     {
         unsigned long lIteration;   //
@@ -462,14 +463,15 @@ private:
         unsigned long lSendTo;
         unsigned long lNotReadyTs;
         unsigned long lCondWait; // block on m_WindowCond
-    } m_WorkerStats;
+    } mutable m_WorkerStats;
 #endif /* SRT_DEBUG_SNDQ_HIGHRATE */
+
+private:
 
 #if ENABLE_LOGGING
     static int m_counter;
 #endif
 
-private:
     CSndQueue(const CSndQueue&);
     CSndQueue& operator=(const CSndQueue&);
 };


### PR DESCRIPTION
Changes:
1. Added formatting function for numbers used in `CPacket::pack` logging to make log information clearer.
2. Put whole contents (previously too finegrained) of packet.cpp file under `srt` namespace
3. In queue.cpp, shipped off the highrate logging facility to a separate function and simplified macro in order to improve readability of the `CSndQueue::worker` function.