### PR TITLE
Refax: safety improvements

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -193,6 +193,15 @@ public:
     /// to finish sending the data that were scheduled for sending so far.
     void setClosed();
 
+    // This is necessary to be called from the group before the group clears
+    // the connection with the socket. As for managed groups (and there are
+    // currently no other group types), a socket disconnected from the group
+    // is no longer usable.
+    void setClosing()
+    {
+        core().m_bClosing = true;
+    }
+
     /// This does the same as setClosed, plus sets the m_bBroken to true.
     /// Such a socket can still be read from so that remaining data from
     /// the receiver buffer can be read, but no longer sends anything.

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11019,7 +11019,10 @@ int srt::CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
      * not knowing what to retransmit when the only NAK sent by receiver is lost,
      * all packets past last ACK are retransmitted (rexmitMethod() == SRM_FASTREXMIT).
      */
+    enterCS(m_RcvLossLock);
     const int loss_len = m_pRcvLossList->getLossLength();
+    leaveCS(m_RcvLossLock);
+
     SRT_ASSERT(loss_len >= 0);
     int debug_decision = BECAUSE_NO_REASON;
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -893,9 +893,13 @@ void CUDTGroup::close()
                 continue;
             }
 
-            // XXX This is not true in case of non-managed groups, which
+            // Make the socket closing BEFORE withdrawing its group membership
+            // because a socket created as a group member cannot be valid
+            // without the group.
+            // This is not true in case of non-managed groups, which
             // only collect sockets, but also non-managed groups should not
-            // use common group buffering and tsbpd.
+            // use common group buffering and tsbpd. Also currently there are
+            // no other groups than managed one.
             s->setClosing();
 
             s->m_GroupOf = NULL;

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -892,6 +892,12 @@ void CUDTGroup::close()
                 HLOGC(smlog.Debug, log << "group/close: IPE(NF): group member @" << ig->id << " already deleted");
                 continue;
             }
+
+            // XXX This is not true in case of non-managed groups, which
+            // only collect sockets, but also non-managed groups should not
+            // use common group buffering and tsbpd.
+            s->setClosing();
+
             s->m_GroupOf = NULL;
             s->m_GroupMemberData = NULL;
             HLOGC(smlog.Debug, log << "group/close: CUTTING OFF @" << ig->id << " (found as @" << s->m_SocketID << ") from the group");


### PR DESCRIPTION
1. The call to `m_pRcvLossList->getLossLength()` (affinity: `CRcvQueue::worker`) added a mutex lock because this container may be also modified in the `CUDT::dropFromLossList` that is among others also called from `CUDT::rcvDropTooLateUpTo` (affinity: `CUDT::tsbpd`). Of course, the list can be also modified before sending the lossreport could be done, but this will then recheck the losses anyway.
2. The socket is set closing state before its ties to the group are severed. This prevents the socket from any processing that should involve working socket, while access to some vital resources may be already denied for this socket, as they are dependent on the group.