### PR TITLE
[core]: Fixed validation of input parameters in srt_connect

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1224,6 +1224,12 @@ int srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockadd
 
 int srt::CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
+    if (!name || size_t(namelen) < sizeof(sockaddr_in))
+    {
+        LOGC(aclog.Error, log << "connect(): invalid call: name=" << name << " namelen=" << namelen);
+        throw CUDTException(MJ_NOTSUP, MN_INVAL);
+    }
+
     sockaddr_any target_addr(name, namelen);
     if (target_addr.len == 0)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1179,7 +1179,7 @@ SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int
 int srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int namelen)
 {
     // Here both srcname and tarname must be specified
-    if (!srcname || !tarname || size_t(namelen) < sizeof(sockaddr_in))
+    if (!srcname || !tarname || namelen < int(sizeof(sockaddr_in)))
     {
         LOGC(aclog.Error,
              log << "connect(with source): invalid call: srcname=" << srcname << " tarname=" << tarname
@@ -1224,7 +1224,7 @@ int srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockadd
 
 int srt::CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
-    if (!name || size_t(namelen) < sizeof(sockaddr_in))
+    if (!name || namelen < int(sizeof(sockaddr_in)))
     {
         LOGC(aclog.Error, log << "connect(): invalid call: name=" << name << " namelen=" << namelen);
         throw CUDTException(MJ_NOTSUP, MN_INVAL);


### PR DESCRIPTION
Hi,

As discussed here https://srtalliance.slack.com/archives/C7MP1DJ20/p1667339255259169, in `srt_connect()` the input parameters are not validated before their usage whereas all other functions validate their input parameters.

I guess the validation was missing, the PR adds it.
