### PR TITLE
Refax: Cleanup for bonding conditionals and unused code

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -312,8 +312,10 @@ public: // internal API
     int32_t     schedSeqNo()                    const { return m_iSndNextSeqNo; }
     bool        overrideSndSeqNo(int32_t seq);
 
+#if ENABLE_BONDING
     sync::steady_clock::time_point   lastRspTime()          const { return m_tsLastRspTime.load(); }
     sync::steady_clock::time_point   freshActivationStart() const { return m_tsFreshActivation; }
+#endif
 
     int32_t     rcvSeqNo()          const { return m_iRcvCurrSeqNo; }
     int         flowWindowSize()    const { return m_iFlowWindowSize; }
@@ -1134,10 +1136,12 @@ public:
     static const int PACKETPAIR_MASK = 0xF;
 
 private: // Timers functions
+#if ENABLE_BONDING
     time_point m_tsFreshActivation; // GROUPS: time of fresh activation of the link, or 0 if past the activation phase or idle
     time_point m_tsUnstableSince;   // GROUPS: time since unexpected ACK delay experienced, or 0 if link seems healthy
     time_point m_tsWarySince;       // GROUPS: time since an unstable link has first some response
-    
+#endif
+
     static const int BECAUSE_NO_REASON = 0, // NO BITS
                      BECAUSE_ACK       = 1 << 0,
                      BECAUSE_LITEACK   = 1 << 1,

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -3,7 +3,6 @@ any.hpp
 
 SOURCES
 test_buffer_rcv.cpp
-test_bonding.cpp
 test_common.cpp
 test_connection_timeout.cpp
 test_crypto.cpp
@@ -30,3 +29,4 @@ test_reuseaddr.cpp
 # Tests for bonding only - put here!
 
 SOURCES - ENABLE_BONDING
+test_bonding.cpp

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -1,18 +1,8 @@
-
-#include <stdio.h>
-#include <stdlib.h>
 #include <future>
 #include <thread>
 #include <chrono>
 #include <vector>
 #include <functional>
-#ifdef _WIN32
-#define usleep(x) Sleep(x / 1000)
-#else
-#include <unistd.h>
-#endif
-
-#if ENABLE_BONDING
 
 #include "gtest/gtest.h"
 
@@ -344,4 +334,3 @@ TEST(Bonding, CloseGroupAndSocket)
     srt_cleanup();
 }
 
-#endif // ENABLE_BONDING


### PR DESCRIPTION
1. Added exclusion for non-bonding for fields in `CUDT` that are not in use when bonding is off
2. Changed bonding test conditional from "masking whole file" to conditional in the filelist
3. Removed unused `CUDT::defaultPacketArrival`. This function was planned to be an alternative loss handling for the case of common-buffer groups, but things have changed largely in the meantime and this function is no longer necessary, and not used in the new group code.
4. In `test_bonding.cpp` deleted lines with unused includes and defines.