### PR TITLE
[core] Fixed usages of m_iRcvLastAck.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6688,7 +6688,7 @@ size_t srt::CUDT::getAvailRcvBufferSizeLock() const
 
 size_t srt::CUDT::getAvailRcvBufferSizeNoLock() const
 {
-    return m_pRcvBuffer->getAvailSize(m_iRcvLastAck);
+    return m_pRcvBuffer->getAvailSize(m_iRcvLastSkipAck);
 }
 
 bool srt::CUDT::isRcvBufferReady() const
@@ -9782,7 +9782,7 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
             {
                 LOGC(qrlog.Warn, log << CONID() << "No room to store incoming packet seqno " << rpkt.m_iSeqNo
                         << ", insert offset " << offset << ". "
-                        << m_pRcvBuffer->strFullnessState(qrlog.Warn.CheckEnabled(), m_iRcvLastAck, steady_clock::now())
+                        << m_pRcvBuffer->strFullnessState(qrlog.Warn.CheckEnabled(), m_iRcvLastSkipAck, steady_clock::now())
                     );
 
                 return -1;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -907,11 +907,11 @@ private: // Receiving related data
     CACKWindow<ACK_WND_SIZE> m_ACKWindow;        // ACK history window
     CPktTimeWindow<16, 64> m_RcvTimeWindow;      // Packet arrival time window
 
-    int32_t m_iRcvLastAck;                       // First unacknowledged packet seqno sent in the latest ACK.
+    int32_t m_iRcvLastAck;                       // First unacknowledged packet seqno sent in the latest ACK. Should only be used in sendCtrlAck().
 #ifdef ENABLE_LOGGING
     int32_t m_iDebugPrevLastAck;
 #endif
-    int32_t m_iRcvLastSkipAck;                   // Last dropped sequence ACK
+    int32_t m_iRcvLastSkipAck;                   // Last dropped sequence ACK. Should be used as the base seq of recv buffer.
     int32_t m_iRcvLastAckAck;                    // (RCV) Latest packet seqno in a sent ACK acknowledged by ACKACK. RcvQTh (sendCtrlAck {r}, processCtrlAckAck {r}, processCtrlAck {r}, connection {w}).
     int32_t m_iAckSeqNo;                         // Last ACK sequence number
     sync::atomic<int32_t> m_iRcvCurrSeqNo;       // (RCV) Largest received sequence number. RcvQTh, TSBPDTh.


### PR DESCRIPTION
As discussed in https://github.com/Haivision/srt/pull/2500#discussion_r1019280623.