### PR TITLE
[core] Utilize all insert results of the new recv buffer.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -148,11 +148,12 @@ CRcvBuffer::~CRcvBuffer()
     }
 }
 
-int CRcvBuffer::insert(CUnit* unit)
+int CRcvBuffer::insert(CUnit* unit, int32_t& w_offset)
 {
     SRT_ASSERT(unit != NULL);
     const int32_t seqno  = unit->m_Packet.getSeqNo();
     const int     offset = CSeqNo::seqoff(m_iStartSeqNo, seqno);
+    w_offset             = offset;
 
     IF_RCVBUF_DEBUG(ScopedLog scoped_log);
     IF_RCVBUF_DEBUG(scoped_log.ss << "CRcvBuffer::insert: seqno " << seqno);
@@ -1048,17 +1049,15 @@ void CRcvBuffer::updateTsbPdTimeBase(uint32_t usPktTimestamp)
     m_tsbpd.updateTsbPdTimeBase(usPktTimestamp);
 }
 
-string CRcvBuffer::strFullnessState(bool enable_debug_log, int iFirstUnackSeqNo, const time_point& tsNow) const
+string CRcvBuffer::strFullnessState(bool enable_debug_log, const time_point& tsNow) const
 {
     stringstream ss;
 
     if (enable_debug_log)
     {
-        ss << "iFirstUnackSeqNo=" << iFirstUnackSeqNo << " m_iStartSeqNo=" << m_iStartSeqNo
-           << " m_iStartPos=" << m_iStartPos << " m_iMaxPosInc=" << m_iMaxPosInc << ". ";
+        ss << "m_iStartSeqNo=" << m_iStartSeqNo << " m_iStartPos=" << m_iStartPos << " m_iMaxPosInc=" << m_iMaxPosInc
+           << ". ";
     }
-
-    ss << "Space avail " << getAvailSize(iFirstUnackSeqNo) << "/" << m_szSize << " pkts. ";
 
     if (m_tsbpd.isEnabled() && m_iMaxPosInc > 0)
     {

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -148,12 +148,11 @@ CRcvBuffer::~CRcvBuffer()
     }
 }
 
-int CRcvBuffer::insert(CUnit* unit, int32_t& w_offset)
+int CRcvBuffer::insert(CUnit* unit)
 {
     SRT_ASSERT(unit != NULL);
     const int32_t seqno  = unit->m_Packet.getSeqNo();
     const int     offset = CSeqNo::seqoff(m_iStartSeqNo, seqno);
-    w_offset             = offset;
 
     IF_RCVBUF_DEBUG(ScopedLog scoped_log);
     IF_RCVBUF_DEBUG(scoped_log.ss << "CRcvBuffer::insert: seqno " << seqno);

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -58,12 +58,11 @@ public:
     /// Similar to CRcvBuffer::addData(CUnit* unit, int offset)
     ///
     /// @param [in] unit pointer to a data unit containing new packet
-    /// @param [out] w_offset insert offset from the start pos.
     ///
     /// @return  0 on success, -1 if packet is already in buffer, -2 if packet is before m_iStartSeqNo.
     /// -3 if a packet is offset is ahead the buffer capacity.
     // TODO: Previously '-2' also meant 'already acknowledged'. Check usage of this value.
-    int insert(CUnit* unit, int32_t& w_offset);
+    int insert(CUnit* unit);
 
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -58,12 +58,12 @@ public:
     /// Similar to CRcvBuffer::addData(CUnit* unit, int offset)
     ///
     /// @param [in] unit pointer to a data unit containing new packet
-    /// @param [in] offset offset from last ACK point.
+    /// @param [out] w_offset insert offset from the start pos.
     ///
     /// @return  0 on success, -1 if packet is already in buffer, -2 if packet is before m_iStartSeqNo.
     /// -3 if a packet is offset is ahead the buffer capacity.
     // TODO: Previously '-2' also meant 'already acknowledged'. Check usage of this value.
-    int insert(CUnit* unit);
+    int insert(CUnit* unit, int32_t& w_offset);
 
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number
@@ -343,7 +343,7 @@ public: // TSBPD public functions
 
     /// Form a string of the current buffer fullness state.
     /// number of packets acknowledged, TSBPD readiness, etc.
-    std::string strFullnessState(bool enable_debug_log, int iFirstUnackSeqNo, const time_point& tsNow) const;
+    std::string strFullnessState(bool enable_debug_log, const time_point& tsNow) const;
 
 private:
     CTsbpdTime  m_tsbpd;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9851,16 +9851,19 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
 
         if (m_pRcvBuffer)
         {
-            bufinfo << " avail=" << getAvailRcvBufferSizeNoLock() << " buffer=(" << m_iRcvLastSkipAck << ":"
-                    << m_iRcvCurrSeqNo // -1 = size to last index
-                    << "+" << CSeqNo::incseq(m_iRcvLastSkipAck, m_pRcvBuffer->capacity() - 1) << ")";
+            bufinfo << " avail=" << getAvailRcvBufferSizeNoLock()
+                << " buffer=(" << m_iRcvLastSkipAck
+                << ":" << m_iRcvCurrSeqNo                   // -1 = size to last index
+                << "+" << CSeqNo::incseq(m_iRcvLastSkipAck, m_pRcvBuffer->capacity()-1)
+                << ")";
         }
 
         // Empty buffer info in case of groupwise receiver.
         // There's no way to obtain this information here.
 
         LOGC(qrlog.Debug, log << CONID() << "RECEIVED: seq=" << rpkt.m_iSeqNo
-                << " offset=" << insert_offset
+                << " insert_offset=" << insert_offset
+                << " ack_offset=" << ack_offset
                 << bufinfo.str()
                 << " RSL=" << expectspec.str()
                 << " SN=" << s_rexmitstat_str[pktrexmitflag]

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9732,8 +9732,9 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
             time_point pts = getPktTsbPdTime(NULL, rpkt);
 
             enterCS(m_StatsLock);
-            const double bltime = (double)CountIIR<uint64_t>(
-                uint64_t(m_stats.traceBelatedTime) * 1000, count_microseconds(steady_clock::now() - pts), 0.2);
+            const double bltime = (double) CountIIR<uint64_t>(
+                    uint64_t(m_stats.traceBelatedTime) * 1000,
+                    count_microseconds(steady_clock::now() - pts), 0.2);
             m_stats.traceBelatedTime = bltime / 1000.0;
             m_stats.rcvr.recvdBelated.count(rpkt.getLength());
             leaveCS(m_StatsLock);

--- a/test/test_buffer_rcv.cpp
+++ b/test/test_buffer_rcv.cpp
@@ -72,8 +72,7 @@ public:
             EXPECT_TRUE(packet.getMsgOrderFlag());
         }
 
-        int offset = 0;
-        return m_rcv_buffer->insert(unit, offset);
+        return m_rcv_buffer->insert(unit);
     }
 
     /// @returns 0 on success, the result of rcv_buffer::insert(..) once it failed

--- a/test/test_buffer_rcv.cpp
+++ b/test/test_buffer_rcv.cpp
@@ -72,7 +72,8 @@ public:
             EXPECT_TRUE(packet.getMsgOrderFlag());
         }
 
-        return m_rcv_buffer->insert(unit);
+        int offset = 0;
+        return m_rcv_buffer->insert(unit, offset);
     }
 
     /// @returns 0 on success, the result of rcv_buffer::insert(..) once it failed


### PR DESCRIPTION
As https://github.com/Haivision/srt/pull/2530/files#r1020280948 said.
This PR decouples `handleSocketPacketReception()` from `getAvailRcvBufferSizeNoLock()`.
The "no room" condition now only relies on the recv buffer itself.