### PR TITLE
[build] Identify parameters with a prepended -l in CMAKE_CXX_IMPLICIT_ LINK_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1113,7 +1113,7 @@ endif()
 # obtained by `pkg-config --libs`.
 if(ENABLE_CXX_DEPS)
 	foreach(LIB ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
-		if(IS_ABSOLUTE ${LIB} AND EXISTS ${LIB})
+		if((IS_ABSOLUTE ${LIB} AND EXISTS ${LIB}) OR (${LIB} MATCHES "^-l"))
 			set(SRT_LIBS_PRIVATE ${SRT_LIBS_PRIVATE} ${LIB})
 		else()
 			set(SRT_LIBS_PRIVATE ${SRT_LIBS_PRIVATE} "-l${LIB}")


### PR DESCRIPTION
Normally, the libraries listed in CMAKE_CXX_IMPLICIT_LINK_LIBRARIES are of the form of either an absolute file name (which is already handled) or a plain library base name without prefixes or suffixes.

In some cases, it may also be a literal linker option in the form -l<value>. This seems to happen when the compiler driver specifies -l:<literalfilename>.

This avoids creating bogus pkg-config entries when building with llvm-mingw, with -DCMAKE_CXX_FLAGS=-static-libgcc, which makes CMAKE_CXX_IMPLICIT_LINK_LIBRARIES end up with one entry being "-l:libunwind.a".