### PR TITLE
Repurposed the pktRcvAvgBelatedTime to trace the unique packet delay.

### DIFF
--- a/apps/statswriter.cpp
+++ b/apps/statswriter.cpp
@@ -300,8 +300,8 @@ public:
         output << "DROP PKT    SENT: " << setw(11) << mon.pktSndDrop         << "  RECEIVED:   " << setw(11) << mon.pktRcvDrop           << endl;
         output << "FILTER EXTRA  TX: " << setw(11) << mon.pktSndFilterExtra  << "        RX:   " << setw(11) << mon.pktRcvFilterExtra    << endl;
         output << "FILTER RX  SUPPL: " << setw(11) << mon.pktRcvFilterSupply << "  RX  LOSS:   " << setw(11) << mon.pktRcvFilterLoss     << endl;
-        output << "RATE     SENDING: " << setw(11) << mon.mbpsSendRate       << "  RECEIVING:  " << setw(11) << mon.mbpsRecvRate         << endl;
-        output << "BELATED RECEIVED: " << setw(11) << mon.pktRcvBelated      << "  AVG TIME:   " << setw(11) << mon.pktRcvAvgBelatedTime << endl;
+        output << "RATE     SENDING: " << setw(11) << mon.mbpsSendRate       << " RECEIVING:   " << setw(11) << mon.mbpsRecvRate         << endl;
+        output << "BELATED RECEIVED: " << setw(11) << mon.pktRcvBelated      << " AVG DELAY:   " << setw(11) << mon.pktRcvAvgBelatedTime << endl;
         output << "REORDER DISTANCE: " << setw(11) << mon.pktReorderDistance << endl;
         output << "WINDOW      FLOW: " << setw(11) << mon.pktFlowWindow      << "  CONGESTION: " << setw(11) << mon.pktCongestionWindow  << "  FLIGHT: " << setw(11) << mon.pktFlightSize << endl;
         output << "LINK         RTT: " << setw(9)  << mon.msRTT            << "ms  BANDWIDTH:  " << setw(7)  << mon.mbpsBandwidth    << "Mb/s " << endl;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10132,6 +10132,8 @@ int srt::CUDT::processData(CUnit* in_unit)
         // Prevent TsbPd thread from modifying Ack position while adding data
         // offset from RcvLastAck in RcvBuffer must remain valid between seqoff() and addData()
         UniqueLock recvbuf_acklock(m_RcvBufferLock);
+        // Needed for possibly check for needsQuickACK.
+        bool incoming_belated = (CSeqNo::seqcmp(in_unit->m_Packet.m_iSeqNo, m_iRcvLastSkipAck) < 0);
 
         const int res = handleSocketPacketReception(incoming,
                 (new_inserted),
@@ -10173,8 +10175,6 @@ int srt::CUDT::processData(CUnit* in_unit)
                 }
             }
         }
-
-        const bool incoming_belated = (CSeqNo::seqcmp(packet.m_iSeqNo, m_iRcvLastSkipAck) < 0);
 
         // This is moved earlier after introducing filter because it shouldn't
         // be executed in case when the packet was rejected by the receiver buffer.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -78,17 +78,6 @@ modified by
 #include <haicrypt.h>
 
 
-// TODO: Utility function - to be moved to utilities.h?
-template <class T>
-inline T CountIIR(T base, T newval, double factor)
-{
-    if ( base == 0.0 )
-        return newval;
-
-    T diff = newval - base;
-    return base+T(diff*factor);
-}
-
 // TODO: Probably a better rework for that can be done - this can be
 // turned into a serializable structure, just like it's done for CHandShake.
 enum AckDataItem


### PR DESCRIPTION
Fixed statistics related to `pktRcvAvgBelatedTime` and `pktRcvBelated`.

1. The `pktRcvAvgBelated` has changed the purpose, as previous one was useless and meaningless, while the new meaining partially matches the name. This means now: the average distance between ETS and arrival time. ETS is the expected arrival time which is identical to arrival time for the very first data packet and as the calculation of the TsbPdTime currently involves the latency setting, this time is calculated basing on the TsbPdTime by decreasing it by latency, that is, it's the time when particular packet, stating by its timestamp, would arrive if the network traveling time was identical to the one of the very first data packet. This value can be used in trial transmissions to have idea how much on average the packet could be delayed in the network more than expected, as this value eats up time reserved by latency. This will be helpful in better shaping the latency settings to avoid dropped packets due to too little time reserved for retransmission. Note that this stat doesn't trace the extra time eaten up by retransmitted packets (for that purpose additional stats can be added).
2. The stat `pktRcvBelated` that calculates packets that were rejected due to being received too late, was doing it a bit incorrectly. This is now calculated for every packet that has a sequence number in the past for the buffer. This still doesn't state whether a packet was received useful (that is, if this isn't a duplicated packet that was retransmitted uselessly).