### PR TITLE
[core] Moved KM refresh in packUniqueData()

### DIFF
--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -360,7 +360,7 @@ int hcryptCtx_Tx_ManageKM(hcrypt_Session *crypto)
 		 * prepare next SEK for announcement
 		 */
 		hcryptCtx_Tx_Refresh(crypto);
-
+		
 		HCRYPT_LOG(LOG_INFO, "KM[%d] Pre-announced\n",
 			(ctx->alt->flags & HCRYPT_CTX_F_xSEK)/2);
 

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -108,6 +108,12 @@ int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
 	/* Get/Set packet index */
 	ctx->msg_info->indexMsg(in_pfx, ctx->MSpfx_cache); 
 
+	// TODO: Consider network order. Make nicer.
+	if (((in_pfx[7] >> 3) & 0x3) != 1 + hcryptCtx_GetKeyIndex(ctx))
+	{
+		HCRYPT_LOG(LOG_ERR, "Tx_Data: Key mismatch: pkt=%d ctx=%d, hdr=0x%X\n", ((in_pfx[7] >> 3) & 0x3), 1+hcryptCtx_GetKeyIndex(ctx), in_pfx[7]);
+	}
+
 	/* Encrypt */
 	{
 		hcrypt_DataDesc indata;

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -108,10 +108,9 @@ int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
 	/* Get/Set packet index */
 	ctx->msg_info->indexMsg(in_pfx, ctx->MSpfx_cache); 
 
-	// TODO: Consider network order. Make nicer.
-	if (((in_pfx[7] >> 3) & 0x3) != 1 + hcryptCtx_GetKeyIndex(ctx))
+	if (hcryptMsg_GetKeyIndex(ctx->msg_info, in_pfx) != hcryptCtx_GetKeyIndex(ctx))
 	{
-		HCRYPT_LOG(LOG_ERR, "Tx_Data: Key mismatch: pkt=%d ctx=%d, hdr=0x%X\n", ((in_pfx[7] >> 3) & 0x3), 1+hcryptCtx_GetKeyIndex(ctx), in_pfx[7]);
+		HCRYPT_LOG(LOG_ERR, "Tx_Data: Key mismatch!");
 	}
 
 	/* Encrypt */

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5901,7 +5901,7 @@ void srt::CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timeb
     sendSrtMsg(SRT_CMD_HSREQ);
 }
 
-void srt::CUDT::checkSndTimers(Whether2RegenKm regen)
+void srt::CUDT::checkSndTimers()
 {
     if (m_SrtHsSide == HSD_INITIATOR)
     {
@@ -5918,17 +5918,18 @@ void srt::CUDT::checkSndTimers(Whether2RegenKm regen)
                   << " - not considering legacy handshake");
     }
 
-    // This must be done always on sender, regardless of HS side.
-    // When regen == DONT_REGEN_KM, it's a handshake call, so do
-    // it only for initiator.
-    if (regen || m_SrtHsSide == HSD_INITIATOR)
-    {
-        // Don't call this function in "non-regen mode" (sending only),
-        // if this side is RESPONDER. This shall be called only with
-        // regeneration request, which is required by the sender.
-        if (m_pCryptoControl)
-            m_pCryptoControl->sendKeysToPeer(this, SRTT(), regen);
-    }
+    // Retransmit KM request after a timeout if there is no response (KM RSP).
+    // Or send KM REQ in case of the HSv4.
+    if (m_pCryptoControl)
+        m_pCryptoControl->sendKeysToPeer(this, SRTT());
+}
+
+void srt::CUDT::checkSndKMRefresh()
+{
+    // Do not apply the regenerated key to the to the receiver context.
+    const bool bidir = false;
+    if (m_pCryptoControl)
+        m_pCryptoControl->regenCryptoKm(this, bidir);
 }
 
 void srt::CUDT::addressAndSend(CPacket& w_pkt)
@@ -8385,7 +8386,6 @@ void srt::CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_
         // cudt->deliveryRate() instead.
     }
 
-    checkSndTimers(REGEN_KM);
     updateCC(TEV_ACK, EventVariant(ackdata_seqno));
 
     enterCS(m_StatsLock);
@@ -9548,6 +9548,8 @@ bool srt::CUDT::packUniqueData(CPacket& w_packet)
             LOGC(qslog.Warn, log << CONID() << "ENCRYPT FAILED - packet won't be sent, size=" << pld_size);
             return false;
         }
+
+        checkSndKMRefresh();
     }
 
 #if SRT_DEBUG_TRACE_SND
@@ -11147,6 +11149,9 @@ bool srt::CUDT::checkExpTimer(const steady_clock::time_point& currtime, int chec
 
 void srt::CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
 {
+    // Check if HSv4 should be retransmitted, and if KM_REQ should be resent if the side is INITIATOR.
+    checkSndTimers();
+
     // There are two algorithms of blind packet retransmission: LATEREXMIT and FASTREXMIT.
     //
     // LATEREXMIT is only used with FileCC.
@@ -11210,7 +11215,6 @@ void srt::CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
 
     ++m_iReXmitCount;
 
-    checkSndTimers(DONT_REGEN_KM);
     const ECheckTimerStage stage = is_fastrexmit ? TEV_CHT_FASTREXMIT : TEV_CHT_REXMIT;
     updateCC(TEV_CHECKTIMER, EventVariant(stage));
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -664,7 +664,11 @@ private:
     void unlose(const CPacket& oldpacket);
     void dropFromLossLists(int32_t from, int32_t to);
 
-    void checkSndTimers(Whether2RegenKm regen = DONT_REGEN_KM);
+    void checkSndTimers();
+    
+    /// @brief Check and perform KM refresh if needed.
+    void checkSndKMRefresh();
+
     void handshakeDone()
     {
         m_iSndHsRetryCnt = 0;

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -148,7 +148,7 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
     // what has called this function. The HSv5 handshake only enforces bidirectional
     // connection.
 
-    bool bidirectional = hsv > CUDT::HS_VERSION_UDT4;
+    const bool bidirectional = hsv > CUDT::HS_VERSION_UDT4;
 
     // Local macro to return rejection appropriately.
     // CHANGED. The first version made HSv5 reject the connection.
@@ -447,8 +447,9 @@ int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len
     return retstatus;
 }
 
-void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SRT_ATR_UNUSED, Whether2RegenKm regen SRT_ATR_UNUSED)
+void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SRT_ATR_UNUSED)
 {
+    sync::ScopedLock lck(m_mtxLock);
     if (!m_hSndCrypto || m_SndKmState == SRT_KM_S_UNSECURED)
     {
         HLOGC(cnlog.Debug, log << "sendKeysToPeer: NOT sending/regenerating keys: "
@@ -481,21 +482,13 @@ void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SR
             }
         }
     }
-
-
-    if (regen)
-    {
-        regenCryptoKm(
-            sock, // send UMSG_EXT + SRT_CMD_KMREQ to the peer using this socket
-            false // Do not apply the regenerated key to the to the receiver context
-        ); // regenerate and send
-    }
 #endif
 }
 
-#ifdef SRT_ENABLE_ENCRYPTION
-void srt::CCryptoControl::regenCryptoKm(CUDT* sock, bool bidirectional)
+void srt::CCryptoControl::regenCryptoKm(CUDT* sock SRT_ATR_UNUSED, bool bidirectional SRT_ATR_UNUSED)
 {
+#ifdef SRT_ENABLE_ENCRYPTION
+    sync::ScopedLock lck(m_mtxLock);
     if (!m_hSndCrypto)
         return;
 
@@ -569,8 +562,8 @@ void srt::CCryptoControl::regenCryptoKm(CUDT* sock, bool bidirectional)
 
     if (sent)
         m_SndKmLastTime = srt::sync::steady_clock::now();
-}
 #endif
+}
 
 srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     : m_SocketID(id)
@@ -583,7 +576,6 @@ srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     , m_bUseGCM(false)
     , m_bErrorReported(false)
 {
-
     m_KmSecret.len = 0;
     //send
     m_SndKmMsg[0].MsgLen = 0;


### PR DESCRIPTION
## Problem Statement

The issue is described in #2502: it is possible to get a corrupted packet on the receiving side when encryption is enabled.
The reason is that a data packet may be encrypted with a key different from the one indicated in the `KK` flied of the data packet header.

The active key (odd/even) switch happens in the RcvQ thread:
```c++
CUDT::processCtrlAck(..)
⋅ ⋅ CUDT::checkSndTimers(..)
⋅ ⋅ ⋅ ⋅ CCryptoControl::sendKeysToPeer(..) // Key refresh
```

The SndQ Thread first sets the KK frags of a data packet, then encrypts the packet, **potentially with a different key if KM refresh has happened**.
```c++
CUDT::packUniqueData(..)
⋅ ⋅ CCryptoControl::encrypt(..)
```

## Steps to Reporoduce

https://github.com/Haivision/srt/issues/2502#issuecomment-1311631552

## Proposed Solution

**Statement 1.** KM refresh is performed by the payload sender for the TX context. Thus it should be done in the sending queue, in particular, right after (or just before) encoding the next unique data packet.

**Statement 2.** KM_REQ retransmission has to be performed from the RcvQ thread, when checking retransmission timers. The same for HS_REQ retransmission. There is no need to do this operation in the processing of an incoming ACK packet.

**Proposed Solution.** Perform key refresh in the same thread where encryption happens, in particular, right after the encryption of a unique data packet.

Fixes #2502.

