### PR TITLE
[build] Upgrade to checkout@v3 GitHub action.

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -18,7 +18,7 @@ jobs:
       with:
         ndk-version: r23
         add-to-path: false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: build
       run: |
         cd ./scripts/build-android/

--- a/.github/workflows/cxx11-macos.yaml
+++ b/.github/workflows/cxx11-macos.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: |
         mkdir _build && cd _build

--- a/.github/workflows/cxx11-ubuntu.yaml
+++ b/.github/workflows/cxx11-ubuntu.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: |
         mkdir _build && cd _build

--- a/.github/workflows/cxx11-win.yaml
+++ b/.github/workflows/cxx11-win.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: |
         md _build && cd _build

--- a/.github/workflows/iOS.yaml
+++ b/.github/workflows/iOS.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: configure
       run: |
         mkdir _build && cd _build


### PR DESCRIPTION
GitHub Actions: All Actions will begin running on Node16 instead of Node12. Link:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/