### PR TITLE
[build] Disable ConnectionTimeout test (blocking), Win GitHub Action.

### DIFF
--- a/.github/workflows/cxx11-win.yaml
+++ b/.github/workflows/cxx11-win.yaml
@@ -21,4 +21,4 @@ jobs:
     - name: build
       run: cd _build && cmake --build ./ --config Release
     - name: test
-      run: cd _build && ctest -E "TestIPv6.v6_calls_v4" --gtest_filter="-TestConnectionTimeout.BlockingLoop" --extra-verbose -C Release
+      run: cd _build && ctest -E "TestIPv6.v6_calls_v4|TestConnectionTimeout.BlockingLoop" --extra-verbose -C Release


### PR DESCRIPTION
The test `TestConnectionTimeout.BlockingLoop` keeps failing in GitHub Action Windows.
It seems related to VM changes, because re-running the test for v1.4.4 in GitHub Action Win also led to the test failure, while previously it was passing.
The test is also passing on a local Windows machine.

I find nothing more clever to do except disable the test in Windows GitHub Action.