### PR TITLE
[core] Fixed TARGET_OS_MAC not defined.

### DIFF
--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -14,7 +14,6 @@
 #include "buffer_tools.h" // AvgBufSize
 #include "common.h"
 #include "queue.h"
-#include "sync.h"
 #include "tsbpd_time.h"
 
 namespace srt

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -54,7 +54,6 @@ modified by
 #include "buffer_tools.h"
 #include "packet.h"
 #include "logger_defs.h"
-#include "sync.h"
 #include "utilities.h"
 
 namespace srt {

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -53,7 +53,6 @@ modified by
 #ifndef INC_SRT_BUFFER_TOOLS_H
 #define INC_SRT_BUFFER_TOOLS_H
 
-#include "sync.h"
 #include "common.h"
 
 namespace srt {

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -11,6 +11,8 @@
 #ifndef INC_SRT_SYNC_H
 #define INC_SRT_SYNC_H
 
+#include "platform_sys.h"
+
 #include <cstdlib>
 #include <limits>
 #ifdef ENABLE_STDCXX_SYNC


### PR DESCRIPTION
The issue was introduced in #2499 (v1.6.0-dev).
The header `sync.h` requires `platform_sys.h`. The file `buffer_tools.h` included `sync.h` first, leading to the undefined `TARGET_OS_MAC`.
Also removed some excessive `sync.h` includes, as `common.h` already includes `sync.h`, no need to include twice.

When building on MacOS CLANG 13.0.0.13000029
```shell
[  3%] Building CXX object CMakeFiles/srt_virtual.dir/srtcore/buffer_rcv.cpp.o
srtcore/buffer_rcv.cpp:48:
srtcore/buffer_rcv.h:14:
srtcore/buffer_tools.h:56:
srtcore/sync.h:40:7: warning: 'TARGET_OS_MAC' is not defined, evaluates to 0 [-Wundef-prefix=TARGET_OS_]
#elif TARGET_OS_MAC
      ^
```