### PR TITLE
Refax: removed m_RcvLastSkipAck and its dependencies

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -1050,13 +1050,13 @@ void CRcvBuffer::updateTsbPdTimeBase(uint32_t usPktTimestamp)
 
 string CRcvBuffer::strFullnessState(bool enable_debug_log, int iFirstUnackSeqNo, const time_point& tsNow) const
 {
+    if (!enable_debug_log)
+        return string();
+
     stringstream ss;
 
-    if (enable_debug_log)
-    {
-        ss << "iFirstUnackSeqNo=" << iFirstUnackSeqNo << " m_iStartSeqNo=" << m_iStartSeqNo
-           << " m_iStartPos=" << m_iStartPos << " m_iMaxPosInc=" << m_iMaxPosInc << ". ";
-    }
+    ss << "iFirstUnackSeqNo=" << iFirstUnackSeqNo << " m_iStartSeqNo=" << m_iStartSeqNo
+        << " m_iStartPos=" << m_iStartPos << " m_iMaxPosInc=" << m_iMaxPosInc << ". ";
 
     ss << "Space avail " << getAvailSize(iFirstUnackSeqNo) << "/" << m_szSize << " pkts. ";
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5415,17 +5415,13 @@ int srt::CUDT::rcvDropTooLateUpTo(int seqno)
 {
     // Make sure that it would not drop over m_iRcvCurrSeqNo, which may break senders.
     if (CSeqNo::seqcmp(seqno, CSeqNo::incseq(m_iRcvCurrSeqNo)) > 0)
-        seqno = CSeqNo::incseq(m_iRcvCurrSeqNo);
-
-    const int seq_gap_len = CSeqNo::seqoff(m_iRcvLastSkipAck, seqno);
-
-    // seq_gap_len can be <= 0 if a packet has been dropped by the sender.
-    if (seq_gap_len > 0)
     {
-        // Remove [from,to-inclusive]
-        dropFromLossLists(m_iRcvLastSkipAck, CSeqNo::decseq(seqno));
-        m_iRcvLastSkipAck = seqno;
+        LOGC(tslog.Error, log << CONID() << "IPE: drop request up to %" << seqno << " while last received is %"
+                << m_iRcvCurrSeqNo << " - fixing");
+        seqno = CSeqNo::incseq(m_iRcvCurrSeqNo);
     }
+
+    dropFromLossLists(CSeqNo::decseq(seqno));
 
     const int iDropCnt = m_pRcvBuffer->dropUpTo(seqno);
     if (iDropCnt > 0)
@@ -5443,9 +5439,8 @@ void srt::CUDT::setInitialRcvSeq(int32_t isn)
 {
     m_iRcvLastAck = isn;
 #ifdef ENABLE_LOGGING
-    m_iDebugPrevLastAck = m_iRcvLastAck;
+    m_iDebugPrevLastAck = isn;
 #endif
-    m_iRcvLastSkipAck = m_iRcvLastAck;
     m_iRcvLastAckAck = isn;
     m_iRcvCurrSeqNo = CSeqNo::decseq(isn);
 
@@ -5461,11 +5456,11 @@ void srt::CUDT::setInitialRcvSeq(int32_t isn)
             m_stats.rcvr.dropped.count(stats::BytesPackets(iDropCnt * avgpayloadsz, (uint32_t) iDropCnt));
         }
 
-        m_pRcvBuffer->setStartSeqNo(m_iRcvLastSkipAck);
+        m_pRcvBuffer->setStartSeqNo(isn);
     }
 }
 
-void srt::CUDT::updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno)
+void srt::CUDT::updateForgotten(int seqlen, int32_t skiptoseqno)
 {
     enterCS(m_StatsLock);
     // Estimate dropped bytes from average payload size.
@@ -5473,7 +5468,7 @@ void srt::CUDT::updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno
     m_stats.rcvr.dropped.count(stats::BytesPackets(seqlen * avgpayloadsz, (uint32_t) seqlen));
     leaveCS(m_StatsLock);
 
-    dropFromLossLists(lastack, CSeqNo::decseq(skiptoseqno)); //remove(from,to-inclusive)
+    dropFromLossLists(CSeqNo::decseq(skiptoseqno)); //remove(from,to-inclusive)
 }
 
 bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout)
@@ -5509,8 +5504,7 @@ bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd
 
     try
     {
-        const int authtag = m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM ? HAICRYPT_AUTHTAG_MAX : 0;
-        m_pSndBuffer = new CSndBuffer(32, m_iMaxSRTPayloadSize, authtag);
+        m_pSndBuffer = new CSndBuffer(32, m_iMaxSRTPayloadSize);
         SRT_ASSERT(m_iISN != -1);
         m_pRcvBuffer = new srt::CRcvBuffer(m_iISN, m_config.iRcvBufSize, m_pRcvQueue->m_pUnitQueue, m_config.bMessageAPI);
         // after introducing lite ACK, the sndlosslist may not be cleared in time, so it requires twice space.
@@ -7563,26 +7557,10 @@ void srt::CUDT::releaseSynch()
     leaveCS(m_RecvLock);
 }
 
-// [[using locked(m_RcvBufferLock)]];
-void srt::CUDT::ackDataUpTo(int32_t ack)
-{
-    const int acksize SRT_ATR_UNUSED = CSeqNo::seqoff(m_iRcvLastSkipAck, ack);
-    if (acksize < 0)
-    {
-        LOGC(xtlog.Error,
-             log << CONID() << "ackDataUpTo: IPE: invalid ACK from %" << m_iRcvLastSkipAck << " to %" << ack << " ("
-                 << acksize << " packets)");
-        return;
-    }
-    HLOGC(xtlog.Debug,
-          log << CONID() << "ackDataUpTo: %" << m_iRcvLastSkipAck << " -> %" << ack << " (" << acksize << " packets)");
-
-    m_iRcvLastAck = ack;
-    m_iRcvLastSkipAck = ack;
-}
 
 #if ENABLE_BONDING
-void srt::CUDT::dropToGroupRecvBase() {
+void srt::CUDT::dropToGroupRecvBase()
+{
     int32_t group_recv_base = SRT_SEQNO_NONE;
     if (m_parent->m_GroupOf)
     {
@@ -7607,7 +7585,7 @@ void srt::CUDT::dropToGroupRecvBase() {
     {
         HLOGC(grlog.Debug,
               log << CONID() << "dropToGroupRecvBase: dropped " << cnt << " packets before ACK: group_recv_base="
-                  << group_recv_base << " m_iRcvLastSkipAck=" << m_iRcvLastSkipAck
+                  << group_recv_base << " m_iRcvLastAck=" << m_iRcvLastAck
                   << " m_iRcvCurrSeqNo=" << m_iRcvCurrSeqNo << " m_bTsbPd=" << m_bTsbPd);
     }
 }
@@ -7785,10 +7763,29 @@ void srt::CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rp
         m_tsLastSndTime.store(steady_clock::now());
 }
 
+bool srt::CUDT::getFirstNoncontSequence(int32_t& w_seq, string& w_log_reason)
+{
+    {
+        ScopedLock losslock (m_RcvLossLock);
+        int32_t seq = m_pRcvLossList->getFirstLostSeq();
+        if (seq != SRT_SEQNO_NONE)
+        {
+            w_seq = seq;
+            w_log_reason = "first lost";
+            return true;
+        }
+    }
+
+    w_seq = CSeqNo::incseq(m_iRcvCurrSeqNo);
+    w_log_reason = "expected next";
+
+    return true;
+}
+
+
 int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 {
     SRT_ASSERT(ctrlpkt.getMsgTimeStamp() != 0);
-    int32_t ack;    // First unacknowledged packet seqnuence number (acknowledge up to ack).
     int nbsent = 0;
     int local_prevack = 0;
 
@@ -7804,8 +7801,8 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 
     local_prevack = m_iDebugPrevLastAck;
 
-    string reason = "first lost"; // just for "a reason" of giving particular % for ACK
 #endif
+    string reason; // just for "a reason" of giving particular % for ACK
 
 #if ENABLE_BONDING
     dropToGroupRecvBase();
@@ -7815,22 +7812,9 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
     // To avoid it the m_RcvBufferLock has to be acquired.
     UniqueLock bufflock(m_RcvBufferLock);
 
-    {
-        // If there is no loss, the ACK is the current largest sequence number plus 1;
-        // Otherwise it is the smallest sequence number in the receiver loss list.
-        ScopedLock lock(m_RcvLossLock);
-        // TODO: Consider the Fresh Loss list as well!!!
-        ack = m_pRcvLossList->getFirstLostSeq();
-    }
-
-    // We don't need to check the length prematurely,
-    // if length is 0, this will return SRT_SEQNO_NONE.
-    // If so happened, simply use the latest received pkt + 1.
-    if (ack == SRT_SEQNO_NONE)
-    {
-        ack = CSeqNo::incseq(m_iRcvCurrSeqNo);
-        IF_HEAVY_LOGGING(reason = "expected next");
-    }
+    int32_t ack;    // First unacknowledged packet sequence number (acknowledge up to ack).
+    if (!getFirstNoncontSequence((ack), (reason)))
+        return nbsent;
 
     if (m_iRcvLastAckAck == ack)
     {
@@ -7855,7 +7839,27 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
     // There are new received packets to acknowledge, update related information.
     if (CSeqNo::seqcmp(ack, m_iRcvLastAck) > 0)
     {
-        ackDataUpTo(ack);
+        // Sanity check if the "selected ACK" points to a sequence
+        // in the past for the buffer. This SHOULD NEVER HAPPEN because
+        // on drop the loss records should have been removed, and the last received
+        // sequence also can't be in the past towards the buffer.
+        if (CSeqNo::seqcmp(ack, m_pRcvBuffer->getStartSeqNo()) < 0)
+        {
+            // Log and DO NOT UPDATE. Count on that next time
+            // the found out ack will be better.
+
+            LOGC(xtlog.Error,
+                    log << CONID() << "ack: IPE: invalid ACK from %" << m_iRcvLastAck << " to %" << ack << " ("
+                    << CSeqNo::seqoff(m_iRcvLastAck, ack) << " packets)");
+        }
+        else
+        {
+            HLOGC(xtlog.Debug,
+                    log << CONID() << "ack: %" << m_iRcvLastAck << " -> %" << ack << " ("
+                    << CSeqNo::seqoff(m_iRcvLastAck, ack) << " packets)");
+
+            m_iRcvLastAck = ack;
+        }
 
 #if ENABLE_BONDING
         const int32_t group_read_seq = m_pRcvBuffer->getFirstReadablePacketInfo(steady_clock::now()).seqno;
@@ -7895,7 +7899,7 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
             }
         }
 #endif
-        IF_HEAVY_LOGGING(int32_t oldack = m_iRcvLastSkipAck);
+        IF_HEAVY_LOGGING(int32_t oldack = m_iRcvLastAck);
 
         // If TSBPD is enabled, then INSTEAD OF signaling m_RecvDataCond,
         // signal m_RcvTsbPdCond. This will kick in the tsbpd thread, which
@@ -7996,8 +8000,6 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
         data[ACKD_RCVLASTACK] = m_iRcvLastAck;
         data[ACKD_RTT] = m_iSRTT;
         data[ACKD_RTTVAR] = m_iRTTVar;
-        // The ackDataUpTo() above ensures this condition.
-        SRT_ASSERT(m_iRcvLastSkipAck == m_iRcvLastAck);
         data[ACKD_BUFFERLEFT] = (int) getAvailRcvBufferSizeNoLock();
         // a minimum flow window of 2 is used, even if buffer is full, to break potential deadlock
         if (data[ACKD_BUFFERLEFT] < 2)
@@ -8773,7 +8775,7 @@ void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
         }
     }
 
-    dropFromLossLists(dropdata[0], dropdata[1]);
+    dropFromLossLists(dropdata[1]);
 
     // If dropping ahead of the current largest sequence number,
     // move the recv seq number forward.
@@ -9724,12 +9726,7 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
 
         bool adding_successful = true;
 
-        // m_iRcvLastSkipAck is the base sequence number for the receiver buffer.
-        // This is the offset in the buffer; if this is negative, it means that
-        // this sequence is already in the past and the buffer is not interested.
-        // Meaning, this packet will be rejected, even if it could potentially be
-        // one of missing packets in the transmission.
-        int32_t offset = CSeqNo::seqoff(m_iRcvLastSkipAck, rpkt.m_iSeqNo);
+        int32_t offset = CSeqNo::seqoff(m_iRcvLastAck, rpkt.m_iSeqNo);
 
         IF_HEAVY_LOGGING(const char *exc_type = "EXPECTED");
 
@@ -9771,9 +9768,9 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
                 LOGC(qrlog.Error, log << CONID() <<
                         "SEQUENCE DISCREPANCY. BREAKING CONNECTION."
                         " seq=" << rpkt.m_iSeqNo
-                        << " buffer=(" << m_iRcvLastSkipAck
+                        << " buffer=(" << m_pRcvBuffer->getStartSeqNo()
                         << ":" << m_iRcvCurrSeqNo                   // -1 = size to last index
-                        << "+" << CSeqNo::incseq(m_iRcvLastSkipAck, int(m_pRcvBuffer->capacity()) - 1)
+                        << "+" << CSeqNo::incseq(m_pRcvBuffer->getStartSeqNo(), int(m_pRcvBuffer->capacity()) - 1)
                         << "), " << (offset-avail_bufsize+1)
                         << " past max. Reception no longer possible. REQUESTING TO CLOSE.");
 
@@ -9860,9 +9857,9 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
         {
             bufinfo << " BUFr=" << avail_bufsize
                 << " avail=" << getAvailRcvBufferSizeNoLock()
-                << " buffer=(" << m_iRcvLastSkipAck
+                << " buffer=(" << m_pRcvBuffer->getStartSeqNo()
                 << ":" << m_iRcvCurrSeqNo                   // -1 = size to last index
-                << "+" << CSeqNo::incseq(m_iRcvLastSkipAck, m_pRcvBuffer->capacity()-1)
+                << "+" << CSeqNo::incseq(m_pRcvBuffer->getStartSeqNo(), m_pRcvBuffer->capacity()-1)
                 << ")";
         }
 
@@ -10105,7 +10102,7 @@ int srt::CUDT::processData(CUnit* in_unit)
         // offset from RcvLastAck in RcvBuffer must remain valid between seqoff() and addData()
         UniqueLock recvbuf_acklock(m_RcvBufferLock);
         // Needed for possibly check for needsQuickACK.
-        bool incoming_belated = (CSeqNo::seqcmp(in_unit->m_Packet.m_iSeqNo, m_iRcvLastSkipAck) < 0);
+        bool incoming_belated = (CSeqNo::seqcmp(in_unit->m_Packet.m_iSeqNo, m_pRcvBuffer->getStartSeqNo()) < 0);
 
         const int res = handleSocketPacketReception(incoming,
                 (new_inserted),
@@ -10328,8 +10325,22 @@ int srt::CUDT::processData(CUnit* in_unit)
 }
 
 #if ENABLE_BONDING
+
+// XXX NOTE: this is updated from the value of m_iRcvLastAck,
+// which might be past the buffer and potentially cause setting
+// the value to the last received and re-requiring retransmission.
+// Worst case is that there could be a few packets to tear the transmission
+// even more (as there will be likely no time to recover them), but
+// if the transmission was already torn in the previously active link
+// this shouldn't be a problem that these packets won't be recovered
+// after activating the second link, although will be retried this way.
 void srt::CUDT::updateIdleLinkFrom(CUDT* source)
 {
+    int bufseq;
+    {
+        ScopedLock lg (m_RcvBufferLock);
+        bufseq = source->m_pRcvBuffer->getStartSeqNo();
+    }
     ScopedLock lg (m_RecvLock);
 
     if (!m_pRcvBuffer->empty())
@@ -10338,14 +10349,19 @@ void srt::CUDT::updateIdleLinkFrom(CUDT* source)
         return;
     }
 
-    // XXX Try to optimize this. Note that here happens:
-    // - decseq just to have a value to compare directly
-    // - seqcmp with that value
-    // - if passed, in setInitialRcvSeq there's the same decseq again
-    int32_t new_last_rcv = CSeqNo::decseq(source->m_iRcvLastSkipAck);
+    int32_t new_last_rcv = source->m_iRcvLastAck;
 
-    // if (new_last_rcv <% m_iRcvCurrSeqNo)
-    if (CSeqNo::seqcmp(new_last_rcv, m_iRcvCurrSeqNo) < 0)
+    if (CSeqNo::seqcmp(new_last_rcv, bufseq) < 0)
+    {
+        // Emergency check whether the last ACK was behind the
+        // buffer. This may happen when TSBPD dropped empty cells.
+        // This may cause that the newly activated link may derive
+        // these empty cells which will never be recovered.
+        new_last_rcv = bufseq;
+    }
+
+    // if (new_last_rcv <=% m_iRcvCurrSeqNo)
+    if (CSeqNo::seqcmp(new_last_rcv, m_iRcvCurrSeqNo) <= 0)
     {
         // Reject the change because that would shift the reception pointer backwards.
         HLOGC(grlog.Debug, log << "grp: NOT updating rcv-seq in @" << m_SocketID
@@ -10355,8 +10371,8 @@ void srt::CUDT::updateIdleLinkFrom(CUDT* source)
     }
 
     HLOGC(grlog.Debug, log << "grp: updating rcv-seq in @" << m_SocketID
-            << " from @" << source->m_SocketID << ": %" << source->m_iRcvLastSkipAck);
-    setInitialRcvSeq(source->m_iRcvLastSkipAck);
+            << " from @" << source->m_SocketID << ": %" << new_last_rcv);
+    setInitialRcvSeq(new_last_rcv);
 }
 
 #endif
@@ -10521,12 +10537,13 @@ breakbreak:;
     }
 }
 
-void srt::CUDT::dropFromLossLists(int32_t from, int32_t to)
+void srt::CUDT::dropFromLossLists(int32_t to)
 {
     ScopedLock lg(m_RcvLossLock);
-    m_pRcvLossList->remove(from, to);
+    int32_t from SRT_ATR_UNUSED = m_pRcvLossList->removeUpTo(to);
 
-    HLOGF(qrlog.Debug, "%sTLPKTDROP seq %d-%d (%d packets)", CONID().c_str(), from, to, CSeqNo::seqlen(from, to));
+    HLOGC(qrlog.Debug, log << CONID() << "TLPKTDROP %(" << from << ", " << to << " ("
+            << CSeqNo::seqlen(from, to) << " packets)");
 
     if (m_bPeerRexmitFlag == 0 || m_iReorderTolerance == 0)
         return;
@@ -10542,7 +10559,7 @@ void srt::CUDT::dropFromLossLists(int32_t from, int32_t to)
     size_t delete_index = 0;
     for (size_t i = 0; i < m_FreshLoss.size(); ++i)
     {
-        CRcvFreshLoss::Emod result = m_FreshLoss[i].revoke(from, to);
+        CRcvFreshLoss::Emod result = m_FreshLoss[i].revoke(SRT_SEQNO_NONE, to);
         switch (result)
         {
         case CRcvFreshLoss::DELETE:

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1099,9 +1099,6 @@ private: // Generation and processing of packets
 
     void processKeepalive(const CPacket& ctrlpkt, const time_point& tsArrival);
 
-    /// Locks m_RcvBufferLock and retrieves the available size of the receiver buffer.
-    SRT_ATTR_EXCLUDES(m_RcvBufferLock)
-    size_t getAvailRcvBufferSizeLock() const;
 
     /// Retrieves the available size of the receiver buffer.
     /// Expects that m_RcvBufferLock is locked.

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -662,7 +662,8 @@ private:
     /// removes the loss record from both current receiver loss list and
     /// the receiver fresh loss list.
     void unlose(const CPacket& oldpacket);
-    void dropFromLossLists(int32_t from, int32_t to);
+    void dropFromLossLists(int32_t to);
+    bool getFirstNoncontSequence(int32_t& w_seq, std::string& w_log_reason);
 
     void checkSndTimers(Whether2RegenKm regen = DONT_REGEN_KM);
     void handshakeDone()
@@ -718,7 +719,7 @@ private:
     /// @return The number of packets dropped.
     int rcvDropTooLateUpTo(int seqno);
 
-    void updateForgotten(int seqlen, int32_t lastack, int32_t skiptoseqno);
+    void updateForgotten(int seqlen, int32_t skiptoseqno);
 
     static loss_seqs_t defaultPacketArrival(void* vself, CPacket& pkt);
     static loss_seqs_t groupPacketArrival(void* vself, CPacket& pkt);
@@ -911,7 +912,6 @@ private: // Receiving related data
 #ifdef ENABLE_LOGGING
     int32_t m_iDebugPrevLastAck;
 #endif
-    int32_t m_iRcvLastSkipAck;                   // Last dropped sequence ACK
     int32_t m_iRcvLastAckAck;                    // (RCV) Latest packet seqno in a sent ACK acknowledged by ACKACK. RcvQTh (sendCtrlAck {r}, processCtrlAckAck {r}, processCtrlAck {r}, connection {w}).
     int32_t m_iAckSeqNo;                         // Last ACK sequence number
     sync::atomic<int32_t> m_iRcvCurrSeqNo;       // (RCV) Largest received sequence number. RcvQTh, TSBPDTh.
@@ -1090,11 +1090,6 @@ private: // Generation and processing of packets
     int processConnectRequest(const sockaddr_any& addr, CPacket& packet);
     static void addLossRecord(std::vector<int32_t>& lossrecord, int32_t lo, int32_t hi);
     int32_t bake(const sockaddr_any& addr, int32_t previous_cookie = 0, int correction = 0);
-
-    /// @brief Acknowledge reading position up to the @p seq.
-    /// Updates m_iRcvLastAck and m_iRcvLastSkipAck to @p seq.
-    /// @param seq first unacknowledged packet sequence number.
-    void ackDataUpTo(int32_t seq);
 
 #if ENABLE_BONDING
     /// @brief Drop packets in the recv buffer behind group_recv_base.

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -4000,7 +4000,7 @@ void CUDTGroup::updateLatestRcv(CUDTSocket* s)
 
     HLOGC(grlog.Debug,
           log << "updateLatestRcv: BACKUP group, updating from active link @" << s->m_SocketID << " with %"
-              << s->core().m_iRcvLastSkipAck);
+              << s->core().m_iRcvLastAck);
 
     CUDT*         source = &s->core();
     vector<CUDT*> targets;

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -728,6 +728,25 @@ bool srt::CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
     return true;
 }
 
+int32_t srt::CRcvLossList::removeUpTo(int32_t seqno)
+{
+    int32_t first = getFirstLostSeq();
+    if (first == SRT_SEQNO_NONE)
+        return first; // empty, so nothing to remove
+
+    if (CSeqNo::seqcmp(seqno, first) <= 0)
+        return first; // seqno older than first - nothing to remove
+
+    // NOTE: seqno is past-the-end here. Removed are only seqs
+    // that are earlier than this.
+    for (int32_t i = first; CSeqNo::seqcmp(i, seqno) <= 0; i = CSeqNo::incseq(i))
+    {
+        remove(i);
+    }
+
+    return first;
+}
+
 bool srt::CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
 {
     if (0 == m_iLength)
@@ -836,8 +855,10 @@ srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t lo, int32_t hi)
     // ITEM:  <lo, hi>                      <--- delete
     // If the sequence range is older than the range to be revoked,
     // delete it anyway.
-    if (CSeqNo::seqcmp(lo, seq[1]) > 0)
+    if (lo != SRT_SEQNO_NONE && CSeqNo::seqcmp(lo, seq[1]) > 0)
         return DELETE;
+    // IF <lo> is NONE, then rely simply on that item.hi <% arg.hi,
+    // which is a condition at the end.
 
     // LOHI:  <lo, hi>
     // ITEM:             <lo, hi>  <-- NOTFOUND

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -150,6 +150,12 @@ public:
 
     bool remove(int32_t seqno1, int32_t seqno2);
 
+
+    /// Remove all numbers that precede the given sequence number.
+    /// @param [in] seqno sequence number.
+    /// @return the first removed sequence number
+    int32_t removeUpTo(int32_t seqno);
+
     /// Find if there is any lost packets whose sequence number falling seqno1 and seqno2.
     /// @param [in] seqno1 start sequence number.
     /// @param [in] seqno2 end sequence number.


### PR DESCRIPTION
Removed the `m_iRcvLastSkipAck` field. This field was different to `m_iRcvLastAck` in case when a drop was done and was used as a base sequence pinned in the old receiver buffer to the "end pointer" that was pointing to the end of the initial contiguous region. With the defined sequence number of the first cell in the new receiver buffer this field was only duplicating the information as well as the convention where the acknowledgement signs off packets for retrieval in live mode as well has been dismissed (this is still valid in file mode, but relies on only signaling the CV and setting read ready; both these things are being done by the TSBPD thread in live mode). The value of this field can be determined from `m_iRcvLastAck` and `m_pRcvBuffer->getStartSeqNo()`, whichever is later, however the way how this value was used in comparisons had to be changed as well, as the check if a sequence is within the buffer can be now done more straighforward way.