### PR TITLE
[core] Fixed cloning the RX crypto context (AEAD)

### DIFF
--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -196,6 +196,9 @@ int HaiCrypt_ExtractConfig(HaiCrypt_Handle hhcSrc, HaiCrypt_Cfg* pcfg)
     pcfg->flags = HAICRYPT_CFG_F_CRYPTO;
     if ((ctx->flags & HCRYPT_CTX_F_ENCRYPT) == HCRYPT_CTX_F_ENCRYPT)
         pcfg->flags |= HAICRYPT_CFG_F_TX;
+   
+    if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
+        pcfg->flags |= HAICRYPT_CFG_F_GCM;
 
     /* Set this explicitly - this use of this library is SRT only. */
     pcfg->xport = HAICRYPT_XPT_SRT;


### PR DESCRIPTION
When cloning the RX crypto context to the TX crypto context there was an error in not setting the AES-GCM flag.
The bug resulted in the listener being unable to send a message to the caller with AES GCM mode.

Fixes #2534.
Issue after #2476. Affected SRT version v1.6.0-dev.