### PR TITLE
[core] Pass std::string by const ref where possible.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -4475,7 +4475,7 @@ void dellogfa(LogFA fa)
     srt_logger_config.enabled_fa.set(fa, false);
 }
 
-void resetlogfa(set<LogFA> fas)
+void resetlogfa(const set<LogFA>& fas)
 {
     ScopedLock gg(srt_logger_config.mutex);
     for (int i = 0; i <= SRT_LOGFA_LASTNONE; ++i)

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -457,7 +457,7 @@ std::string TransmissionEventStr(ETransmissionEvent ev)
     return vals[ev];
 }
 
-bool SrtParseConfig(string s, SrtConfig& w_config)
+bool SrtParseConfig(const string& s, SrtConfig& w_config)
 {
     using namespace std;
 

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -1414,7 +1414,7 @@ inline std::string SrtVersionString(int version)
     return buf;
 }
 
-bool SrtParseConfig(std::string s, SrtConfig& w_config);
+bool SrtParseConfig(const std::string& s, SrtConfig& w_config);
 
 } // namespace srt
 

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -52,8 +52,8 @@ public:
 
     struct IsName
     {
-        std::string n;
-        IsName(std::string nn): n(nn) {}
+        const std::string n;
+        IsName(const std::string& nn): n(nn) {}
         bool operator()(NamePtr np) { return n == np.first; }
     };
 

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -26,7 +26,7 @@ using namespace std;
 using namespace srt_logging;
 using namespace srt::sync;
 
-bool srt::ParseFilterConfig(string s, SrtFilterConfig& w_config, PacketFilter::Factory** ppf)
+bool srt::ParseFilterConfig(const string& s, SrtFilterConfig& w_config, PacketFilter::Factory** ppf)
 {
     if (!SrtParseConfig(s, (w_config)))
         return false;
@@ -43,7 +43,7 @@ bool srt::ParseFilterConfig(string s, SrtFilterConfig& w_config, PacketFilter::F
     return true;
 }
 
-bool srt::ParseFilterConfig(string s, SrtFilterConfig& w_config)
+bool srt::ParseFilterConfig(const string& s, SrtFilterConfig& w_config)
 {
     return ParseFilterConfig(s, (w_config), NULL);
 }

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -51,7 +51,7 @@ public:
         virtual ~Factory();
     };
 private:
-    friend bool ParseFilterConfig(std::string s, SrtFilterConfig& out, PacketFilter::Factory** ppf);
+    friend bool ParseFilterConfig(const std::string& s, SrtFilterConfig& out, PacketFilter::Factory** ppf);
 
     template <class Target>
     class Creator: public Factory
@@ -212,7 +212,7 @@ bool CheckFilterCompat(SrtFilterConfig& w_agent, SrtFilterConfig peer);
 inline void PacketFilter::feedSource(CPacket& w_packet) { SRT_ASSERT(m_filter); return m_filter->feedSource((w_packet)); }
 inline SRT_ARQLevel PacketFilter::arqLevel() { SRT_ASSERT(m_filter); return m_filter->arqLevel(); }
 
-bool ParseFilterConfig(std::string s, SrtFilterConfig& out, PacketFilter::Factory** ppf);
+bool ParseFilterConfig(const std::string& s, SrtFilterConfig& out, PacketFilter::Factory** ppf);
 
 } // namespace srt
 

--- a/srtcore/packetfilter_api.h
+++ b/srtcore/packetfilter_api.h
@@ -81,7 +81,7 @@ struct SrtPacket
 };
 
 
-bool ParseFilterConfig(std::string s, SrtFilterConfig& w_config);
+bool ParseFilterConfig(const std::string& s, SrtFilterConfig& w_config);
 
 
 class SrtPacketFilterBase

--- a/srtcore/udt.h
+++ b/srtcore/udt.h
@@ -235,7 +235,7 @@ namespace srt
 SRT_API void setloglevel(srt_logging::LogLevel::type ll);
 SRT_API void addlogfa(srt_logging::LogFA fa);
 SRT_API void dellogfa(srt_logging::LogFA fa);
-SRT_API void resetlogfa(std::set<srt_logging::LogFA> fas);
+SRT_API void resetlogfa(const std::set<srt_logging::LogFA>& fas);
 SRT_API void resetlogfa(const int* fara, size_t fara_size);
 SRT_API void setlogstream(std::ostream& stream);
 SRT_API void setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler);


### PR DESCRIPTION
Touches `udt.h`. It is not the official SRT API though.
Fixes #2379.