### PR TITLE
Reproducing Test Failures after KM fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - os: linux
           env:
           - BUILD_TYPE=Debug
-          - BUILD_OPTS='-DENABLE_CODE_COVERAGE=ON -DENABLE_BONDING=ON -DCMAKE_CXX_FLAGS="-Werror"'
+          - BUILD_OPTS='-DENABLE_CODE_COVERAGE=ON -DENABLE_BONDING=ON -DENABLE_HEAVY_LOGGING=ON -DCMAKE_CXX_FLAGS="-Werror"'
           - RUN_SONARCUBE=1
           - RUN_CODECOV=1
         - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,3 +103,5 @@ after_success:
     - if (( "$RUN_SONARCUBE" )); then
         sonar-scanner -D"sonar.cfamily.gcov.reportPath=.";
       fi
+after_failure:
+    - ls -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ script:
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ./test-srt --gtest_filter="-$TESTS_IPv6";
       fi
+after_success:
     - if (( "$RUN_CODECOV" )); then
         source ./scripts/collect-gcov.sh;
         bash <(curl -s https://codecov.io/bash);

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -38,7 +38,6 @@
    #include <win/wintime.h>
    #endif
 
-   #include <stdint.h>
    #include <inttypes.h>
    #if defined(_MSC_VER)
       #pragma warning(disable: 4251 26812)


### PR DESCRIPTION
Testing if #2553 happens with be1ccf577897965fc3a0d6351678606d8f18cc93 (PR #2541).

```shell
ReuseAddr.SameAddr1
Bind to: 127.0.0.1:5000
Connecting to: 127.0.0.1:5000
Accepted from: 127.0.0.1:46116
Client exit
Server exit
Bind to: 127.0.0.1:5000
Connecting to: 127.0.0.1:5000
Accepted from: 127.0.0.1:41811
Client exit
Server exit
/home/travis/.travis/functions: line 109:  6369 Segmentation fault      ./test-srt --gtest_filter="-$TESTS_IPv6"
```