### PR TITLE
[build] Run codecov only after success in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ script:
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ./test-srt --gtest_filter="-$TESTS_IPv6";
       fi
+after_success:
     - if (( "$RUN_CODECOV" )); then
         source ./scripts/collect-gcov.sh;
         bash <(curl -s https://codecov.io/bash);


### PR DESCRIPTION
If unit tests fail, the code coverage and sonar scanning are not needed, so just don't run them.