### PR TITLE
Refax: remove usage of LOGF/HLOGF

### DIFF
--- a/haicrypt/haicrypt_log.cpp
+++ b/haicrypt/haicrypt_log.cpp
@@ -44,10 +44,10 @@ int HaiCrypt_SetLogLevel(int level, int logfa)
 #define HAICRYPT_DEFINE_LOG_DISPATCHER(LOGLEVEL, dispatcher) \
     int HaiCrypt_LogF_##LOGLEVEL ( const char* file, int line, const char* function, const char* format, ...) \
 { \
-    va_list ap; \
-    va_start(ap, format); \
     srt_logging::LogDispatcher& lg = hclog.dispatcher; \
     if (!lg.CheckEnabled()) return -1; \
+    va_list ap; \
+    va_start(ap, format); \
     lg().setloc(file, line, function).vform(format, ap); \
     va_end(ap); \
     return 0; \

--- a/haicrypt/haicrypt_log.h
+++ b/haicrypt/haicrypt_log.h
@@ -21,7 +21,7 @@ HAICRYPT_DECLARE_LOG_DISPATCHER(LOG_EMERG);
 
 #define HCRYPT_LOG_INIT()
 #define HCRYPT_LOG_EXIT()
-#define HCRYPT_LOG(lvl, fmt, ...) HaiCrypt_LogF_##lvl (__FILE__, __LINE__, __FUNCTION__, fmt, __VA_ARGS__)
+#define HCRYPT_LOG(lvl, ...) HaiCrypt_LogF_##lvl (__FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
 
 #if ENABLE_HAICRYPT_LOGGING == 2
 #define HCRYPT_DEV 1

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -563,7 +563,7 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
     }
     catch (const CUDTException&)
     {
-        LOGF(cnlog.Fatal, "newConnection: IPE: all sockets occupied? Last gen=%d", m_SocketIDGenerator);
+        LOGC(cnlog.Fatal, log << "newConnection: IPE: all sockets occupied? Last gen=" << m_SocketIDGenerator);
         // generateSocketID throws exception, which can be naturally handled
         // when the call is derived from the API call, but here it's called
         // internally in response to receiving a handshake. It must be handled
@@ -600,7 +600,8 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
         // this call causes sending the SRT Handshake through this socket.
         // Without this mapping the socket cannot be found and therefore
         // the SRT Handshake message would fail.
-        HLOGF(cnlog.Debug, "newConnection: incoming %s, mapping socket %d", peer.str().c_str(), ns->m_SocketID);
+        HLOGC(cnlog.Debug, log <<
+                "newConnection: incoming " << peer.str() << ", mapping socket " << ns->m_SocketID);
         {
             ScopedLock cg(m_GlobControlLock);
             m_Sockets[ns->m_SocketID] = ns;
@@ -647,7 +648,8 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
         ScopedLock glock(m_GlobControlLock);
         try
         {
-            HLOGF(cnlog.Debug, "newConnection: mapping peer %d to that socket (%d)\n", ns->m_PeerID, ns->m_SocketID);
+            HLOGC(cnlog.Debug, log << "newConnection: mapping peer " << ns->m_PeerID
+                    << " to that socket (" << ns->m_SocketID << ")");
             m_PeerRec[ns->getPeerSpec()].insert(ns->m_SocketID);
         }
         catch (...)
@@ -2640,7 +2642,7 @@ void srt::CUDTUnited::checkBrokenSockets()
 
     for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
     {
-        // HLOGF(smlog.Debug, "checking CLOSED socket: %d\n", j->first);
+        // HLOGC(smlog.Debug, log << "checking CLOSED socket: " << j->first);
         if (!is_zero(j->second->core().m_tsLingerExpiration))
         {
             // asynchronous close:
@@ -2667,7 +2669,7 @@ void srt::CUDTUnited::checkBrokenSockets()
                       log << "checkBrokenSockets: @" << j->second->m_SocketID << " closed "
                           << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
 
-                // HLOGF(smlog.Debug, "will unref socket: %d\n", j->first);
+                // HLOGC(smlog.Debug, log << "will unref socket: " << j->first);
                 tbr.push_back(j->first);
             }
         }

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -60,6 +60,7 @@ written by
 
 // LOGF uses printf-like style formatting.
 // Usage: LOGF(gglog.Debug, "%s: %d", param1.c_str(), int(param2));
+// NOTE: LOGF is deprecated and should not be used
 #define LOGF(logdes, ...) if (logdes.CheckEnabled()) logdes().setloc(__FILE__, __LINE__, __FUNCTION__).form(__VA_ARGS__)
 
 // LOGP is C++11 only OR with only one string argument.
@@ -242,7 +243,9 @@ public:
             return *this;
         }
 
-        DummyProxy& form(const char*, ...)
+        // DEPRECATED: DO NOT use LOGF/HLOGF macros anymore.
+        // Use iostream-style formatting with LOGC or a direct argument with LOGP.
+        SRT_ATR_DEPRECATED_PX DummyProxy& form(const char*, ...) SRT_ATR_DEPRECATED
         {
             return *this;
         }


### PR DESCRIPTION
Requested by #2126.

The LOGF/HLOGF macros haven't been removed, just in case, but their usage will be now deprecated. The `form` method of the log dispatcher, which is being used in this macro, has been marked deprecated in order to make it loud. All uses of LOGF macros have been replaced with LOGC or LOGP.

Note that this has no influence on the logging in haicrypt, as it uses `vform`, not `form` method through the wrapper functions.