### PR TITLE
[core] Obtain ConnectionLock while sending crypto keys.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5890,6 +5890,7 @@ void srt::CUDT::checkSndTimers()
 
     // Retransmit KM request after a timeout if there is no response (KM RSP).
     // Or send KM REQ in case of the HSv4.
+    ScopedLock lck(m_ConnectionLock);
     if (m_pCryptoControl)
         m_pCryptoControl->sendKeysToPeer(this, SRTT());
 }

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -665,6 +665,7 @@ private:
     void dropFromLossLists(int32_t from, int32_t to);
     bool getFirstNoncontSequence(int32_t& w_seq, std::string& w_log_reason);
 
+    SRT_ATTR_EXCLUDES(m_ConnectionLock)
     void checkSndTimers();
     
     /// @brief Check and perform KM refresh if needed.

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -676,6 +676,7 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
 void srt::CCryptoControl::close() 
 {
     /* Wipeout secrets */
+    sync::ScopedLock lck(m_mtxLock);
     memset(&m_KmSecret, 0, sizeof(m_KmSecret));
 }
 

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -114,6 +114,7 @@ public:
     /// Regenerate cryptographic key material if needed.
     /// @param[in] sock If not null, the socket will be used to send the KM message to the peer (e.g. KM refresh).
     /// @param[in] bidirectional If true, the key material will be regenerated for both directions (receiver and sender).
+    SRT_ATTR_EXCLUDES(m_mtxLock)
     void regenCryptoKm(CUDT* sock, bool bidirectional);
 
     size_t KeyLen() { return m_iSndKmKeyLen; }
@@ -202,6 +203,7 @@ public:
     std::string FormatKmMessage(std::string hdr, int cmd, size_t srtlen);
 
     bool init(HandshakeSide, const CSrtConfig&, bool);
+    SRT_ATTR_EXCLUDES(m_mtxLock)
     void close();
 
     /// (Re)send KM request to a peer on timeout.
@@ -210,6 +212,7 @@ public:
     /// - The case of key regeneration (KM refresh), when a new key has to be sent again.
     ///   In this case the first sending happens in regenCryptoKm(..). This function
     ///   retransmits the KM request by timeout if not KM response has been received.
+    SRT_ATTR_EXCLUDES(m_mtxLock)
     void sendKeysToPeer(CUDT* sock, int iSRTT);
 
     void setCryptoSecret(const HaiCrypt_Secret& secret)


### PR DESCRIPTION
Fixes #2553 (supposedly).
The issue is only reproducible in Travis. But based on [the stack trace](https://github.com/Haivision/srt/issues/2553#issuecomment-1337628118) after a crash the CryptoControl module is released, while the receiving thread checks the timers and attempts to resend a KM.