### PR TITLE
[api] Socket Options: do not allow AES GCM if TSBPD is disabled.

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -204,7 +204,7 @@ The following table lists SRT API socket options in alphabetical order. Option d
 | [`SRTO_BINDTODEVICE`](#SRTO_BINDTODEVICE)               | 1.4.2 | pre-bind | `string`  |         |                   |          | RW  | GSD+  |
 | [`SRTO_CONGESTION`](#SRTO_CONGESTION)                   | 1.3.0 | pre      | `string`  |         | "live"            | \*       | W   | S     |
 | [`SRTO_CONNTIMEO`](#SRTO_CONNTIMEO)                     | 1.1.2 | pre      | `int32_t` | ms      | 3000              | 0..      | W   | GSD+  |
-| [`SRTO_CRYPTOMODE`](#SRTO_CRYPTOMODE)                   | 1.6.0-dev | pre      | `int32_t` |     | 0 (Auto)          | [0, 3]   | W   | GSD   |
+| [`SRTO_CRYPTOMODE`](#SRTO_CRYPTOMODE)                   | 1.6.0-dev | pre      | `int32_t` |     | 0 (Auto)          | [0, 2]   | W   | GSD   |
 | [`SRTO_DRIFTTRACER`](#SRTO_DRIFTTRACER)                 | 1.4.2 | post     | `bool`    |         | true              |          | RW  | GSD   |
 | [`SRTO_ENFORCEDENCRYPTION`](#SRTO_ENFORCEDENCRYPTION)   | 1.3.2 | pre      | `bool`    |         | true              |          | W   | GSD   |
 | [`SRTO_EVENT`](#SRTO_EVENT)                             |       |          | `int32_t` | flags   |                   |          | R   | S     |
@@ -336,6 +336,8 @@ Crypto modes:
 - `0`: auto-select during handshake negotiation (to be implemented; currently similar to AES-CTR).
 - `1`: regular AES-CTR (without message integrity authentication).
 - `2`: AES-GCM mode with message integrity authentication (AEAD).
+
+The AES-GCM mode (2) is only allowed if TSBPD is enabled ([`SRTO_TSBPDMODE`](#SRTO_TSBPDMODE)).
 
 
 [Return to list](#list-of-options)


### PR DESCRIPTION
The AES-GCM mode cannot be used at the moment if TSBPD is disabled.
The main reason is the different handling of the 'timestamp' field of a data packet (see  #2337).
When TSPBD is disabled, the timestamp is set at the time of sending, unique for every retransmission. The timestamp field is included in the associated data for integrity check, while encryption happens only the first time a packet is sent. Using the AES-GCM would fail on a retransmitted packet.

This PR restricts using AES-GCM without TSBPD until a further decision is taken to either exclude the 'timestamp' field from the integrity check when TSBPD is disabled or (preferably) use the same timestamping rule in any mode.

- Do not allow AES GCM if TSBPD is disabled.
- Do not allow disabling TSBPD if GCM is enabled.
