### PR TITLE
[API] Crypto mode 'auto' implemented for listener.

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -356,31 +356,19 @@ for connection from this very user. Then AES-GCM (2) can be set on the new socke
 
 There is no way to check the crypto mode being requested by the SRT caller at this point.
 
-| Caller      | Listener    | Negotiated  |
-| ----------- | ----------- | ----------- |
-| 0 (auto)    | 0 (auto)    | AES-CTR (1) |
-| 0 (auto)    | AES-CTR (1) | AES-CTR (1) |
-| 0 (auto)    | AES-GCM (2) | reject      |
-| AES-CTR (1) | 0 (auto)    | AES-CTR (1) |
-| AES-CTR (1) | AES-CTR (1) | AES-CTR (1) |
-| AES-CTR (1) | AES-GCM (2) | reject      |
-| AES-GCM (2) | 0 (auto)    | AES-GCM (2) |
-| AES-GCM (2) | AES-CTR (1) | reject      |
-| AES-GCM (2) | AES-GCM (2) | AES-GCM (2) |
+| Caller      | Listener    | Negotiated  | | Rdv In-tor  | Rdv Res-der | Negotiated  |
+| ----------- | ----------- | ----------- |-| ----------- | ----------- | ----------- |
+| 0 (auto)    | 0 (auto)    | AES-CTR (1) | | 0 (auto)    | 0 (auto)    | AES-CTR (1) |
+| 0 (auto)    | AES-CTR (1) | AES-CTR (1) | | 0 (auto)    | AES-CTR (1) | AES-CTR (1) |
+| 0 (auto)    | AES-GCM (2) | reject      | | 0 (auto)    | AES-GCM (2) | reject      |
+| AES-CTR (1) | 0 (auto)    | AES-CTR (1) | | AES-CTR (1) | 0 (auto)    | AES-CTR (1) |
+| AES-CTR (1) | AES-CTR (1) | AES-CTR (1) | | AES-CTR (1) | AES-CTR (1) | AES-CTR (1) |
+| AES-CTR (1) | AES-GCM (2) | reject      | | AES-CTR (1) | AES-GCM (2) | reject      |
+| AES-GCM (2) | 0 (auto)    | AES-GCM (2) | | AES-GCM (2) | 0 (auto)    | reject      |
+| AES-GCM (2) | AES-CTR (1) | reject      | | AES-GCM (2) | AES-CTR (1) | reject      |
+| AES-GCM (2) | AES-GCM (2) | AES-GCM (2) | | AES-GCM (2) | AES-GCM (2) | AES-GCM (2) |
 
-
-| Rdv In-tor  | Rdv Res-der | Negotiated  |
-| ----------- | ----------- | ----------- |
-| 0 (auto)    | 0 (auto)    | AES-CTR (1) |
-| 0 (auto)    | AES-CTR (1) | AES-CTR (1) |
-| 0 (auto)    | AES-GCM (2) | reject      |
-| AES-CTR (1) | 0 (auto)    | AES-CTR (1) |
-| AES-CTR (1) | AES-CTR (1) | AES-CTR (1) |
-| AES-CTR (1) | AES-GCM (2) | reject      |
-| AES-GCM (2) | 0 (auto)    | reject      |
-| AES-GCM (2) | AES-CTR (1) | reject      |
-| AES-GCM (2) | AES-GCM (2) | AES-GCM (2) |
-
+* Rdv - Rendezvous; In-tor - initiator; Res-der - responder.
 
 [Return to list](#list-of-options)
 

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -338,21 +338,21 @@ Crypto modes:
 - `2`: AES-GCM mode with message integrity authentication (AEAD).
 
 The AES-GCM mode (2) is only allowed if TSBPD is enabled ([`SRTO_TSBPDMODE`](#SRTO_TSBPDMODE)).
-In rendezvous and for a caller Auto (0) is equivalent to AES-CTR (1).
+Auto (0) is equivalent to AES-CTR (1) in Rendezvous and for a Caller.
 
-Once connection is established, reading the `SRTO_CRYPTOMODE` shows the negotiated crypto mode:
+Once a connection is established, reading `SRTO_CRYPTOMODE` shows the negotiated crypto mode:
 AES-CTR (1) or AES-GCM (2).
 
-When the [listener callback](./API-functions.md##srt_listen_callback) is used, the `SRTO_CRYPTOMODE`
-read on the new SRT socket to be accepted is not yet the negotiated but, but the one to negotiate,
-and inherited from the listener SRT socket.
+When [Listener callback](./API-functions.md##srt_listen_callback) is used, the value of
+`SRTO_CRYPTOMODE` read on the new SRT socket to be accepted is not yet the 
+negotiated one. It is the value to be negotiated, and is inherited from the listener SRT socket.
 If a specific behavior for each individual connection request is desired based on
 [the user ID or anything else](../features/access-control.md),
-the indended behavior can be achieved by setting the `SRTO_CRYPTOMODE` on the new SRT socket to a specific value.
+the intended behavior can be achieved by setting the `SRTO_CRYPTOMODE` on the new SRT socket to a specific value.
 
-For example, let's say the initial value set on the listener socket is Auto (0). The listener callback is called
+For example, let's say the initial value set on the listener socket is Auto (0). The listener callback is called,
 signalling the new connection request. The user ID is extracted, and the server wants to force AES-GCM only
-for connection from this very user. Then AES-GCM (2) can be set on the new socket.
+for the connection from this specific user. In this case AES-GCM (2) can be set on the new socket.
 
 There is no way to check the crypto mode being requested by the SRT caller at this point.
 

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -347,7 +347,7 @@ When the [listener callback](./API-functions.md##srt_listen_callback) is used, t
 read on the new SRT socket to be accepted is not yet the negotiated but, but the one to negotiate,
 and inherited from the listener SRT socket.
 If a specific behavior for each individual connection request is desired based on
-[the user ID or anything else](../access-control.md),
+[the user ID or anything else](../features/access-control.md),
 the indended behavior can be achieved by setting the `SRTO_CRYPTOMODE` on the new SRT socket to a specific value.
 
 For example, let's say the initial value set on the listener socket is Auto (0). The listener callback is called

--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -333,7 +333,7 @@ The encryption mode to be used if the [`SRTO_PASSPHRASE`](#SRTO_PASSPHRASE) is s
 
 Crypto modes:
 
-- `0`: auto-select during handshake negotiation (to be implemented; currently similar to AES-CTR).
+- `0`: SRT listener accepts any mode from the caller. SRT Caller or SRT Rendezvous use AES-CTR (1).
 - `1`: regular AES-CTR (without message integrity authentication).
 - `2`: AES-GCM mode with message integrity authentication (AEAD).
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3436,7 +3436,7 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     // handle handshake extension flags.
     m_ConnReq.m_iType = UDT_DGRAM;
 
-    // Auto mode for caller and in rendezvous is equivalent to CIPHER_MODE_AES_CTR.
+    // Auto mode for Caller and in Rendezvous is equivalent to CIPHER_MODE_AES_CTR.
     if (m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AUTO)
         m_config.iCryptoMode = CSrtConfig::CIPHER_MODE_AES_CTR;
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -813,7 +813,10 @@ void srt::CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
         break;
 
     case SRTO_CRYPTOMODE:
-        *(int32_t*)optval = m_config.iCryptoMode;
+        if (m_pCryptoControl)
+            *(int32_t*)optval = m_pCryptoControl->getCryptoMode();
+        else
+            *(int32_t*)optval = m_config.iCryptoMode;
         optlen = sizeof(int32_t);
         break;
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3436,6 +3436,10 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     // handle handshake extension flags.
     m_ConnReq.m_iType = UDT_DGRAM;
 
+    // Auto mode for caller and in rendezvous is equivalent to CIPHER_MODE_AES_CTR.
+    if (m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AUTO)
+        m_config.iCryptoMode = CSrtConfig::CIPHER_MODE_AES_CTR;
+
     // This is my current configuration
     if (m_config.bRendezvous)
     {

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -161,6 +161,10 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
     bool wasb4 SRT_ATR_UNUSED = false;
     size_t sek_len = 0;
 
+    const bool bUseGCM =
+        (m_iCryptoMode == CSrtConfig::CIPHER_MODE_AUTO && kmdata[HCRYPT_MSG_KM_OFS_CIPHER] == HCRYPT_CIPHER_AES_GCM) ||
+        (m_iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM);
+
     // What we have to do:
     // If encryption is on (we know that by having m_KmSecret nonempty), create
     // the crypto context (if bidirectional, create for both sending and receiving).
@@ -208,12 +212,15 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
     }
     wasb4 = m_hRcvCrypto;
 
-    if (!createCryptoCtx((m_hRcvCrypto), m_iRcvKmKeyLen, HAICRYPT_CRYPTO_DIR_RX, m_bUseGCM))
+    if (!createCryptoCtx((m_hRcvCrypto), m_iRcvKmKeyLen, HAICRYPT_CRYPTO_DIR_RX, bUseGCM))
     {
         LOGC(cnlog.Error, log << "processSrtMsg_KMREQ: Can't create RCV CRYPTO CTX - must reject...");
         m_RcvKmState = SRT_KM_S_NOSECRET;
         KMREQ_RESULT_REJECTION();
     }
+
+    // Deduce resulting mode.
+    m_iCryptoMode = bUseGCM ? CSrtConfig::CIPHER_MODE_AES_GCM : CSrtConfig::CIPHER_MODE_AES_CTR;
 
     if (!wasb4)
     {
@@ -573,7 +580,7 @@ srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     , m_RcvKmState(SRT_KM_S_UNSECURED)
     , m_KmRefreshRatePkt(0)
     , m_KmPreAnnouncePkt(0)
-    , m_bUseGCM(false)
+    , m_iCryptoMode(CSrtConfig::CIPHER_MODE_AUTO)
     , m_bErrorReported(false)
 {
     m_KmSecret.len = 0;
@@ -600,10 +607,14 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
 
     // Set UNSECURED state as default
     m_RcvKmState = SRT_KM_S_UNSECURED;
-    m_bUseGCM = cfg.iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM;
+    m_iCryptoMode = cfg.iCryptoMode;
 
 #ifdef SRT_ENABLE_ENCRYPTION
-    if (m_bUseGCM && !isAESGCMSupported())
+    if (!cfg.bTSBPD && m_iCryptoMode == CSrtConfig::CIPHER_MODE_AUTO)
+        m_iCryptoMode = CSrtConfig::CIPHER_MODE_AES_CTR;
+    const bool bUseGCM = m_iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM;
+
+    if (bUseGCM && !isAESGCMSupported())
     {
         LOGC(cnlog.Warn, log << "CCryptoControl: AES GCM is not supported by the crypto service provider.");
         return false;
@@ -616,7 +627,7 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
     m_KmPreAnnouncePkt = cfg.uKmPreAnnouncePkt;
     m_KmRefreshRatePkt = cfg.uKmRefreshRatePkt;
 
-    if ( side == HSD_INITIATOR )
+    if (side == HSD_INITIATOR)
     {
         if (hasPassphrase())
         {
@@ -627,7 +638,7 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
                 m_iSndKmKeyLen = 16;
             }
 
-            bool ok = createCryptoCtx((m_hSndCrypto), m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX, m_bUseGCM);
+            bool ok = createCryptoCtx((m_hSndCrypto), m_iSndKmKeyLen, HAICRYPT_CRYPTO_DIR_TX, bUseGCM);
             HLOGC(cnlog.Debug, log << "CCryptoControl::init: creating SND crypto context: " << ok);
 
             if (ok && bidirectional)
@@ -652,6 +663,8 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
                 NULL, // Do not send the key (the KM msg will be attached to the HSv5 handshake)
                 bidirectional // replicate the key to the receiver context, if bidirectional
             );
+
+            m_iCryptoMode = bUseGCM ? CSrtConfig::CIPHER_MODE_AES_GCM : CSrtConfig::CIPHER_MODE_AES_CTR;
 #else
             // This error would be a consequence of setting the passphrase, while encryption
             // is turned off at compile time. Setting the password itself should be not allowed

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -67,7 +67,7 @@ private:
     // putting the whole HaiCrypt_Cfg object here.
     int m_KmRefreshRatePkt;
     int m_KmPreAnnouncePkt;
-    bool m_bUseGCM; // Use AES GCM crypto mode.
+    int m_iCryptoMode;
 
     HaiCrypt_Secret m_KmSecret;     //Key material shared secret
     // Sender
@@ -109,6 +109,11 @@ public:
     bool hasPassphrase() const
     {
         return m_KmSecret.len > 0;
+    }
+
+    int getCryptoMode() const
+    {
+        return m_iCryptoMode;
     }
 
     /// Regenerate cryptographic key material if needed.


### PR DESCRIPTION
For an SRT listener to accept any crypto mode (AES-GCM or AES-CTR) the `SRTO_CRYPTOMODE=0` (Auto) can be used.

When `SRTO_CRYPTOMODE=0` (Auto) is set on an SRT Caller or SRT Rendezvous the actual mode to be negotiated is AES-CTR.

This change does not require further HS changes on the wire, still allows to let the listener to accept any crypto mode.

Once a connection is established, the actual crypto mode is returned via the `SRTO_CRYPTOMODE`: 1 (AES-CTR) or 2 (AES-GCM).

<img src="https://user-images.githubusercontent.com/12700120/206432704-26ccb63f-a260-4c79-8929-087490f16d9d.png" width="400" />

<img src="https://user-images.githubusercontent.com/12700120/206691297-6da1c7b1-6824-4092-95d7-b75a29459850.png" width="400" />



























































































