### PR TITLE
Implementation of SWIG with C# bindings

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,29 +3,29 @@ configuration:
   - Debug
 
 image:
+  - Ubuntu
   - Visual Studio 2019
   - Visual Studio 2015
-  - Visual Studio 2013
 
 platform:
   - x64
   - x86
 
 build_script:
-  - ps: $VSIMG = $Env:APPVEYOR_BUILD_WORKER_IMAGE; $CNFG = $Env:CONFIGURATION
+  - ps: $VSIMG = $Env:APPVEYOR_BUILD_WORKER_IMAGE; $CNFG = $Env:CONFIGURATION  
   # use a few differing arguments depending on VS version to exercise different options during builds
-  - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON -BONDING ON }
-  - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON }
+  - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON -BONDING ON -ENABLE_SWIG ON}
+  - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -ENABLE_SWIG ON}
   - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON -BONDING ON}
   - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS OFF }
-  - ps: if ($VSIMG -match '2013' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -CXX11 OFF -BUILD_APPS ON }
-  - ps: if ($VSIMG -match '2013' -and $CNFG -eq "Debug")   { Exit-AppveyorBuild } # just skip 2013 debug build for speed
+  - sh: ./scripts/build-lin-docker.ps1
 
 test_script:
   - ps: if ( $Env:RUN_UNIT_TESTS ) { cd ./_build; ctest -E "TestIPv6.v6_calls_v4" --extra-verbose -C $Env:CONFIGURATION; cd ../ }
-  
+        
 after_build:
-- cmd: >-
-    scripts/gather-package.bat
-        7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-Win%PLATFORM%-%VS_VERSION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\package\*
-        appveyor PushArtifact SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-Win%PLATFORM%-%VS_VERSION%-%APPVEYOR_BUILD_VERSION%.zip
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%
+  - cmd: scripts/gather-package.bat
+  - cmd: scripts/create-win64-nuget.bat
+  - cmd: 7z a SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-Win%PLATFORM%-%VS_VERSION%-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\package\*
+  - cmd: appveyor PushArtifact SRT-%APPVEYOR_REPO_BRANCH%-%CONFIGURATION%-Win%PLATFORM%-%VS_VERSION%-%APPVEYOR_BUILD_VERSION%.zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - ps: if ($VSIMG -match '2019' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -ENABLE_SWIG ON}
   - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Release") { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS ON -UNIT_TESTS ON -BONDING ON}
   - ps: if ($VSIMG -match '2015' -and $CNFG -eq "Debug")   { .\scripts\build-windows.ps1 -STATIC_LINK_SSL ON -BUILD_APPS OFF }
-  - sh: ./scripts/build-lin-docker.ps1
+  - sh: ./scripts/build-lin-docker.ps1 -ENABLE_SWIG ON
 
 test_script:
   - ps: if ( $Env:RUN_UNIT_TESTS ) { cd ./_build; ctest -E "TestIPv6.v6_calls_v4" --extra-verbose -C $Env:CONFIGURATION; cd ../ }

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ vcpkg/
 
 # LSP
 compile_commands.json
+
+# Nuget packages
+packages/
+package/
+*.nupkg
+
+# Swig bindings
+/srtcore/swig_bindings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1351,7 +1351,6 @@ if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.21)
 	cmake_policy(SET CMP0122 NEW)
 endif()
 
-
 #experimental SWIG support for csharp
 if(ENABLE_SWIG)
 	#on windows, there is no swig just in the path - nuget / scripted downloads must be pointed at (linux it just works)
@@ -1364,6 +1363,10 @@ if(ENABLE_SWIG)
 	
 	FIND_PACKAGE(SWIG REQUIRED)
 	INCLUDE(${SWIG_USE_FILE})
+	
+	if(UNIX AND NOT APPLE)
+		list(APPEND CMAKE_SWIG_FLAGS "-DSWIGWORDSIZE64")
+	endif()
 
 	if(ENABLE_SWIG_CSHARP)
 		swig_add_library(srt_swig_csharp LANGUAGE csharp SOURCES srtcore/srt.i OUTPUT_DIR ${CMAKE_BINARY_DIR}/swig_bindings/csharp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1352,8 +1352,9 @@ if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.21)
 endif()
 
 
-#experimental SWIG support for csharp - only enabled for Windows currently
+#experimental SWIG support for csharp
 if(ENABLE_SWIG)
+	#on windows, there is no swig just in the path - nuget / scripted downloads must be pointed at (linux it just works)
 	if(MICROSOFT)
 		#if nuget has been used to install swig in the project packages, bind to that
 		if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/packages/swig/swigwin-4.1.1/swig.exe")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,8 @@ option(USE_BUSY_WAITING "Enable more accurate sending times at a cost of potenti
 option(USE_GNUSTL "Get c++ library/headers from the gnustl.pc" OFF)
 option(ENABLE_SOCK_CLOEXEC "Enable setting SOCK_CLOEXEC on a socket" ON)
 option(ENABLE_SHOW_PROJECT_CONFIG "Enable show Project Configuration" OFF)
+option(ENABLE_SWIG "Enable SWIG, used to generate alternative language bindings" OFF)
+option(ENABLE_SWIG_CSHARP "Enable SWIG binding generation for CSharp language (only effective if ENABLE_SWIG is ON)" ON)
 
 option(ENABLE_CLANG_TSA "Enable Clang Thread Safety Analysis" OFF)
 
@@ -1340,6 +1342,34 @@ endif()
 	srt_add_example(testcapi-connect.c)
 endif()
 
+#SWIG support - adding bindings for other languages into a new library that statically include the main SRT lib
+cmake_policy(SET CMP0078 NEW)
+cmake_policy(SET CMP0086 NEW)
+
+#older cmakes do not understand this policy, so filter (VS2015 AppVeyor cmake is too old)
+if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.21)
+	cmake_policy(SET CMP0122 NEW)
+endif()
+
+
+#experimental SWIG support for csharp - only enabled for Windows currently
+if(ENABLE_SWIG)
+	if(MICROSOFT)
+		#if nuget has been used to install swig in the project packages, bind to that
+		if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/packages/swig/swigwin-4.1.1/swig.exe")
+			set(SWIG_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/packages/swig/swigwin-4.1.1/swig.exe")
+		endif()
+	endif()
+	
+	FIND_PACKAGE(SWIG REQUIRED)
+	INCLUDE(${SWIG_USE_FILE})
+
+	if(ENABLE_SWIG_CSHARP)
+		swig_add_library(srt_swig_csharp LANGUAGE csharp SOURCES srtcore/srt.i OUTPUT_DIR ${CMAKE_BINARY_DIR}/swig_bindings/csharp)
+		swig_link_libraries(srt_swig_csharp ${srt_link_library} ${DEPENDS_srt})
+		set_property(TARGET srt_swig_csharp PROPERTY SWIG_COMPILE_OPTIONS -namespace SrtSharp)
+	endif()
+endif()
 
 if (ENABLE_UNITTESTS AND ENABLE_CXX11)
 

--- a/scripts/Dockerfile.linux
+++ b/scripts/Dockerfile.linux
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="Lewis Kirkaldie <lewis@cinegy.com>"
+
+ENV TZ=Europe/Berlin
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+#base dev packages and OS tools, including mono and boost other library dependencies
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+        build-essential git nano gnupg apt-utils unzip sudo bzip2 \
+        apt-transport-https curl wget ca-certificates cpio \
+        libssl-dev software-properties-common \
+        p7zip-full p7zip-rar swig && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/*
+
+#add powershell core & dotnet 6.0
+RUN cd /tmp && \
+  curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -sS && \
+  dpkg -i packages-microsoft-prod.deb && \
+  rm packages-microsoft-prod.deb && \
+  apt-get update && \
+  apt-get install -y powershell && \
+  apt-get install -y dotnet-sdk-6.0 && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+#add cmake 3.24.1
+RUN mkdir -p /usr/src/cmake \
+&& curl -L https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-linux-x86_64.tar.gz -o /usr/src/cmake/cmake.tar.gz -sS \
+&& tar -C /usr/src/cmake -xzf /usr/src/cmake/cmake.tar.gz \
+&& ln -s /usr/src/cmake/cmake-3.24.1-linux-x86_64/bin/cmake /usr/bin/cmake \
+&& rm /usr/src/cmake/cmake.tar.gz

--- a/scripts/Dockerfile.linux
+++ b/scripts/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Lewis Kirkaldie <lewis@cinegy.com>"
 
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 
 #add powershell core & dotnet 6.0
 RUN cd /tmp && \
-  curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -sS && \
+  curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -sS && \
   dpkg -i packages-microsoft-prod.deb && \
   rm packages-microsoft-prod.deb && \
   apt-get update && \

--- a/scripts/Dockerfile.linux
+++ b/scripts/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM debian:bullseye
 
 LABEL maintainer="Lewis Kirkaldie <lewis@cinegy.com>"
 
@@ -15,20 +15,17 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
         build-essential git nano gnupg apt-utils unzip sudo bzip2 \
         apt-transport-https curl wget ca-certificates cpio \
         libssl-dev software-properties-common \
-        p7zip-full p7zip-rar swig && \
+        p7zip-full swig && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/*
 
-#add powershell core & dotnet 6.0
-RUN cd /tmp && \
-  curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -sS && \
-  dpkg -i packages-microsoft-prod.deb && \
-  rm packages-microsoft-prod.deb && \
-  apt-get update && \
-  apt-get install -y powershell && \
-  apt-get install -y dotnet-sdk-6.0 && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/*
+# add powershell core & dotnet 6.0
+# RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+#   sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list' && \
+#   apt update && sudo apt install -y powershell && \
+#   apt-get install -y dotnet-sdk-6.0 && \
+#   apt-get clean && \
+#   rm -rf /var/lib/apt/lists/*
 
 #add cmake 3.24.1
 RUN mkdir -p /usr/src/cmake \

--- a/scripts/build-lin-docker.bat
+++ b/scripts/build-lin-docker.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\PowerShell.exe -Command "& '%~dpn0.ps1'"
+pause

--- a/scripts/build-lin-docker.ps1
+++ b/scripts/build-lin-docker.ps1
@@ -1,0 +1,55 @@
+#! /usr/bin/pwsh
+
+################################################################################
+# Linux SRT Build Script
+#============================
+# Usable on a Linux machine (or container), or called by CI systems like AppVeyor
+#
+# By default produces a 64-bit Release binary using C++11 threads, without
+# encryption or unit tests enabled, but including test apps.
+################################################################################
+
+param (
+    [Parameter()][String]$CONFIGURATION = "Release",
+    [Parameter()][String]$DEVENV_PLATFORM = "x64",
+    [Parameter()][String]$ENABLE_ENCRYPTION = "OFF",
+    [Parameter()][String]$STATIC_LINK_SSL = "OFF",
+    [Parameter()][String]$CXX11 = "ON",
+    [Parameter()][String]$BUILD_APPS = "ON",
+    [Parameter()][String]$UNIT_TESTS = "OFF",
+    [Parameter()][String]$BUILD_DIR = "_build-linux",
+    [Parameter()][String]$ENABLE_SWIG = "OFF",
+    [Parameter()][String]$ENABLE_SWIG_CSHARP = "ON"
+)
+
+$projectRoot = Join-Path $PSScriptRoot "/.." -Resolve
+
+# generate command to make sure an up-to-date docker container (for compiling within) is built
+$execVar = "docker build -t srtbuildcontainer:latest -f $($projectRoot)/scripts/Dockerfile.linux ."
+Write-Output $execVar
+Invoke-Expression "& $execVar"
+
+# clear any previous build and create & enter the build directory
+$buildDir = Join-Path "$projectRoot" "$BUILD_DIR"
+Write-Output "Creating (or cleaning if already existing) the folder $buildDir for project files and outputs"
+Remove-Item -Path $buildDir -Recurse -Force -ErrorAction SilentlyContinue | Out-Null
+New-Item -ItemType Directory -Path $buildDir -ErrorAction SilentlyContinue | Out-Null
+
+# build the cmake command flags from arguments
+$cmakeFlags = "-DCMAKE_BUILD_TYPE=$CONFIGURATION " + 
+                "-DENABLE_STDCXX_SYNC=$CXX11 " + 
+                "-DENABLE_APPS=$BUILD_APPS " + 
+                "-DENABLE_ENCRYPTION=$ENABLE_ENCRYPTION " +
+                "-DENABLE_UNITTESTS=$UNIT_TESTS " +
+                "-DENABLE_SWIG=$ENABLE_SWIG " +
+                "-DENABLE_SWIG_CSHARP=$ENABLE_SWIG_CSHARP"
+
+# generate command for docker run of cmake generation step
+$execVar = "docker run --rm -v $($projectRoot):/srt -w /srt/$BUILD_DIR srtbuildcontainer:latest cmake -S ../ $cmakeFlags"
+Write-Output $execVar
+Invoke-Expression "& $execVar"
+
+# generate command for docker run of cmake build
+$execVar = "docker run --rm -v $($projectRoot):/srt -w /srt/$BUILD_DIR srtbuildcontainer:latest cmake --build ./"
+Write-Output $execVar
+Invoke-Expression "& $execVar"

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/bash
+
+set -e
+set -o pipefail
+
+if [ -d Release.linux ]; then
+	rm -rf ./Release.linux
+fi
+
+printf "\nBuilding Release\n"
+mkdir Release.linux
+cd Release.linux
+cmake -S ../ -DENABLE_STDCXX_SYNC=ON -DENABLE_UNITTESTS=ON -DENABLE_EXPERIMENTAL_BONDING=ON -DENABLE_SWIG=ON
+cmake --build ./

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -21,7 +21,7 @@ param (
     [Parameter()][String]$BUILD_DIR = "_build",
     [Parameter()][String]$VCPKG_OPENSSL = "OFF",
     [Parameter()][String]$BONDING = "OFF",
-    [Parameter()][String]$ENABLE_SWIG = "ON",
+    [Parameter()][String]$ENABLE_SWIG = "OFF",
     [Parameter()][String]$ENABLE_SWIG_CSHARP = "ON"
 )
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -56,6 +56,13 @@ if ( $Env:APPVEYOR ) {
     Copy-Item -Path "C:\OpenSSL-v111-Win64" "C:\OpenSSL-Win64" -Recurse | Out-Null
 }
 
+# if running within TeamCity, force SWIG and BONDING to ON (to avoid changing default behaviour on pre-existing CI systems)
+# this should be removable ones master branch is merged to always have these params available (so CI can set them reliably itself)
+if($Env:TEAMCITY_VERSION){
+    $ENABLE_SWIG = "ON"
+    $BONDING = "ON"
+}
+
 # persist VS_VERSION so it can be used in an artifact name later
 $Env:VS_VERSION = $VS_VERSION
 
@@ -243,7 +250,7 @@ if ( $null -eq $msBuildPath ) {
 & $msBuildPath SRT.sln -m /p:Configuration=$CONFIGURATION /p:Platform=$DEVENV_PLATFORM
 
 # if CSharp SWIG is on, now trigger compilation of these elements (cmake for dotnet is very new, and not available in older versions)
-if($ENABLE_SWIG_CSHARP){
+if(($ENABLE_SWIG -eq "ON") -and ($ENABLE_SWIG_CSHARP -eq "ON")){
     Push-Location "$buildDir/swig_bindings/csharp"
     Copy-Item "$projectRoot/srtcore/swig_bindings/csharp/*.csproj" .
     & dotnet build -c $CONFIGURATION

--- a/scripts/create-nuget.ps1
+++ b/scripts/create-nuget.ps1
@@ -1,0 +1,28 @@
+################################################################################
+# Windows SRT NuGet Package Creation Script
+#============================
+# Usable on a Windows PC with Powershell and nuget available, 
+# or called by CI systems like AppVeyor
+#
+################################################################################
+
+param (
+    [Parameter()][String]$PACKAGEFOLDER = "package",
+    [Parameter()][String]$VERSION = "1.5.1.0"
+)
+
+# make all errors trigger a script stop, rather than just carry on
+$ErrorActionPreference = "Stop"
+
+$packageDir = Join-Path $PSScriptRoot "../" $PACKAGEFOLDER -Resolve
+
+Get-ChildItem $packageDir -Filter *.zip | Foreach-Object {
+   Expand-Archive -Force -Path $_.FullName -DestinationPath $(Join-Path $packageDir "extracted")
+}
+
+nuget pack .\nuget\SrtSharp\SrtSharp.nuspec -version $VERSION
+
+# if antyhing returned non-zero, throw to cause failure in CI
+if( $LASTEXITCODE -ne 0 ) {
+    throw
+}

--- a/scripts/create-win64-nuget.bat
+++ b/scripts/create-win64-nuget.bat
@@ -1,0 +1,29 @@
+rem Bundle CI NuGet package for VS2015 Win64 Release only build (true package should contain multi-arch composite output)
+@echo off
+
+rem If running in AppVeyor, only create a NuGet package on VS2015 x64 Release
+IF DEFINED APPVEYOR_BUILD_VERSION (
+    IF "%PLATFORM%"=="x64" (
+        IF "%VS_VERSION%"=="2015" (
+            IF "%CONFIGURATION%"=="Release" (
+                echo "Building NuPkg for this build (VS2015, x64 Release)"
+                nuget pack .\scripts\nuget\SrtSharp\SrtSharp.nuspec -version %APPVEYOR_BUILD_VERSION%-2015-beta
+                appveyor PushArtifact SrtSharp.%APPVEYOR_BUILD_VERSION%-2015-beta.nupkg
+                exit 0
+            )
+        )        
+        IF "%VS_VERSION%"=="2019" (
+            IF "%CONFIGURATION%"=="Release" (
+                echo "Building NuPkg for this build (VS2019, x64 Release)"
+                nuget pack .\scripts\nuget\SrtSharp\SrtSharp.nuspec -version %APPVEYOR_BUILD_VERSION%-beta
+                appveyor PushArtifact SrtSharp.%APPVEYOR_BUILD_VERSION%-beta.nupkg
+                exit 0
+            )
+        )
+    )
+    echo "Skipping NuPkg build (not VS2015/2019, x64 Release)"
+    exit 0
+) ELSE (
+    rem probably running on a local workstation, so use the first given argument parameter as the version number and don't push or exit
+    nuget pack .\scripts\nuget\SrtSharp\SrtSharp.nuspec -version %1
+)

--- a/scripts/gather-package.bat
+++ b/scripts/gather-package.bat
@@ -18,9 +18,10 @@ md %APPVEYOR_BUILD_FOLDER%\package\lib
 IF "%GATHER_SSL_INTO_PACKAGE%"=="True" (
     md %APPVEYOR_BUILD_FOLDER%\package\openssl-win%FOLDER_PLATFORM%
 )
+md %APPVEYOR_BUILD_FOLDER%\package\swig_bindings
 
 rem Gather SRT includes, binaries and libs
-copy %APPVEYOR_BUILD_FOLDER%\version.h %APPVEYOR_BUILD_FOLDER%\package\include\
+copy %APPVEYOR_BUILD_FOLDER%\_build\version.h %APPVEYOR_BUILD_FOLDER%\package\include\
 copy %APPVEYOR_BUILD_FOLDER%\srtcore\*.h %APPVEYOR_BUILD_FOLDER%\package\include\
 copy %APPVEYOR_BUILD_FOLDER%\haicrypt\*.h %APPVEYOR_BUILD_FOLDER%\package\include\
 copy %APPVEYOR_BUILD_FOLDER%\common\*.h %APPVEYOR_BUILD_FOLDER%\package\include\
@@ -28,10 +29,16 @@ copy %APPVEYOR_BUILD_FOLDER%\common\win\*.h %APPVEYOR_BUILD_FOLDER%\package\incl
 copy %APPVEYOR_BUILD_FOLDER%\_build\%CONFIGURATION%\*.exe %APPVEYOR_BUILD_FOLDER%\package\bin\
 copy %APPVEYOR_BUILD_FOLDER%\_build\%CONFIGURATION%\*.dll %APPVEYOR_BUILD_FOLDER%\package\bin\
 copy %APPVEYOR_BUILD_FOLDER%\_build\%CONFIGURATION%\*.lib %APPVEYOR_BUILD_FOLDER%\package\lib\
-copy %APPVEYOR_BUILD_FOLDER%\_build\%CONFIGURATION%\*.pdb %APPVEYOR_BUILD_FOLDER%\package\bin\
 
 rem Gather 3rd party openssl elements
 IF "%GATHER_SSL_INTO_PACKAGE%"=="True" (
     (robocopy c:\openssl-win%FOLDER_PLATFORM%\ %APPVEYOR_BUILD_FOLDER%\package\openssl-win%FOLDER_PLATFORM% /s /e /np) ^& IF %ERRORLEVEL% GTR 1 exit %ERRORLEVEL%
 )
+IF "%CONFIGURATION%"=="Debug" (
+    copy %APPVEYOR_BUILD_FOLDER%\_build\%CONFIGURATION%\*.pdb %APPVEYOR_BUILD_FOLDER%\package\bin\
+)
+
+rem gather any generated bindings for languages
+(robocopy %APPVEYOR_BUILD_FOLDER%\srtcore\swig_bindings\ %APPVEYOR_BUILD_FOLDER%\package\swig_bindings /s /e /np) ^& IF %ERRORLEVEL% GTR 1 exit %ERRORLEVEL%
+
 exit 0

--- a/scripts/get-windows-build-packages.bat
+++ b/scripts/get-windows-build-packages.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+PowerShell.exe -ExecutionPolicy Bypass -Command "& '%~dpn0.ps1'"

--- a/scripts/get-windows-build-packages.ps1
+++ b/scripts/get-windows-build-packages.ps1
@@ -1,0 +1,6 @@
+#Script to grab external libraries for building these samples
+
+# prep shared variables
+$DEVENV_PLATFORM = 'x64' # alternative is x86
+$FOLDER_PLATFORM = 'win64' # alternative is win32
+nuget install swigwintools -version 4.0.0

--- a/scripts/nuget/SrtSharp/SrtSharp.nuspec
+++ b/scripts/nuget/SrtSharp/SrtSharp.nuspec
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package >
+	<metadata>
+		<id>SrtSharp</id>
+		<title>SRT Library wrapped for C#</title>
+		<version>$version$-beta</version>
+		<authors>Cinegy GmbH</authors>
+		<owners>Cinegy GmbH</owners>
+		<license type="expression">MPL-2.0</license>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>Secure, Reliable Transport Library with C# bindings, published by Cinegy GmbH</description>
+		<copyright>2019 SRT Haivision Systems Inc (packaged by Cinegy GmbH). All rights reserved.</copyright>  
+		<dependencies>
+      		<group targetFramework="netstandard2.0" />
+    	</dependencies>
+	</metadata>
+
+	<files>
+		<file src="..\..\..\package\bin\srt_swig_csharp.dll" target="runtimes\win-x64\native\release"/>
+		
+		<file src="..\..\..\package\swig_bindings\csharp\bin\Release\netstandard2.0\srtsharp.dll" target="lib\netstandard2.0" /> 
+
+		<file src="..\..\..\package\include\**\*.*" target="sources"/>
+
+		<file src="..\..\..\package\swig_bindings\**\*.*" target="bindings" exclude="**\*.dll"/>
+
+		<file src="build\*" target="build" />
+	</files>
+</package>

--- a/scripts/nuget/SrtSharp/SrtSharp.nuspec
+++ b/scripts/nuget/SrtSharp/SrtSharp.nuspec
@@ -16,13 +16,14 @@
 	</metadata>
 
 	<files>
-		<file src="..\..\..\package\bin\srt_swig_csharp.dll" target="runtimes\win-x64\native\release"/>
+		<file src="..\..\..\package\extracted\bin\srt_swig_csharp.dll" target="runtimes\win-x64\native\release"/>
+		<file src="..\..\..\package\extracted\Release.linux\libsrt_swig_csharp.so" target="runtimes\linux-x64\native\release"/>
 		
-		<file src="..\..\..\package\swig_bindings\csharp\bin\Release\netstandard2.0\srtsharp.dll" target="lib\netstandard2.0" /> 
+		<file src="..\..\..\package\extracted\bin\srtsharp.dll" target="lib\netstandard2.0" /> 
+ 
+		<file src="..\..\..\package\extracted\include\**\*.h" target="sources"/>
 
-		<file src="..\..\..\package\include\**\*.*" target="sources"/>
-
-		<file src="..\..\..\package\swig_bindings\**\*.*" target="bindings" exclude="**\*.dll"/>
+		<!-- <file src="..\..\..\_build\swig_bindings\**\*.*" target="bindings" exclude="**\*.dll"/>  -->
 
 		<file src="build\*" target="build" />
 	</files>

--- a/scripts/nuget/SrtSharp/build/SrtSharp.props
+++ b/scripts/nuget/SrtSharp/build/SrtSharp.props
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\..\sources\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+		</ClCompile>
+		<Link>
+			<AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)\..\runtimes\win-$(PlatformTarget)\native\release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+			<AdditionalDependencies>cinecoder.lib;%(AdditionalDependencies)</AdditionalDependencies>
+		</Link>
+		<Midl>
+			<AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)\..\sources\interfaces;$(MSBuildThisFileDirectory)\..\sources\interfaces\Systems;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+		</Midl>
+	</ItemDefinitionGroup>
+	
+	<Target Name="Copy native SRT references" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <SourceFiles Include="$(MSBuildThisFileDirectory)\..\runtimes\win-$(PlatformTarget)\native\**\*.dll"/>
+      <SourceFiles Include="$(MSBuildThisFileDirectory)\..\runtimes\win-$(PlatformTarget)\native\**\*.pdb"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(SourceFiles)" DestinationFiles="@(SourceFiles->'$(TargetDir)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/scripts/nuget/SrtSharp/build/SrtSharp.targets
+++ b/scripts/nuget/SrtSharp/build/SrtSharp.targets
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <IncludeSrtInterop Condition="'$(IncludeSrtInterop)'==''">True</IncludeSrtInterop>
+    <EmbedSrtInterop Condition="'$(EmbedSrtInterop)'==''">False</EmbedSrtInterop>
+  </PropertyGroup>
+  
+  <!--
+  <ItemGroup>
+    <Reference Include="srt_swig_netcore" Condition="'$(IncludeSrtInterop)'=='True'">
+      <HintPath>$(MSBuildThisFileDirectory)\..\runtimes\any\netstandard2.0\srt_swig_netcore.dll</HintPath>
+      <EmbedInteropTypes Condition="'$(EmbedSrtInterop)'=='True'">True</EmbedInteropTypes>
+    </Reference>
+  </ItemGroup>
+  -->
+
+  <Target Name="Copy Native SRT references" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <SourceFiles Include="$(MSBuildThisFileDirectory)\..\runtimes\win-$(PlatformTarget)\native\release\**\*.dll"/>
+      <SourceFiles Include="$(MSBuildThisFileDirectory)\..\runtimes\win-$(PlatformTarget)\native\release\**\*.pdb"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(SourceFiles)" DestinationFiles="@(SourceFiles->'$(TargetDir)%(RecursiveDir)%(Filename)%(Extension)')" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/scripts/set-version-metadata.ps1
+++ b/scripts/set-version-metadata.ps1
@@ -40,7 +40,7 @@ if($Env:TEAMCITY_VERSION){
 #find C++ resource files and update file description with branch / commit details
 $FileDescriptionStringRegex = '(\bVALUE\s+\"FileDescription\"\s*\,\s*\")([^\"]*\\\")*[^\"]*(\")'
 
-Get-ChildItem -Path "../srtcore/srt_shared.rc" | ForEach-Object {
+Get-ChildItem -Path "$PSScriptRoot/../srtcore/srt_shared.rc" | ForEach-Object {
     $fileName = $_
     Write-Output "Processing metadata changes for file: $fileName"
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -60,6 +60,11 @@ written by
    #define SRT_API __attribute__ ((visibility("default")))
 #endif
 
+#ifdef SWIG
+   // Remove SRT_API definition when using SWIG
+   #undef SRT_API
+   #define SRT_API
+#endif
 
 // For feature tests if you need.
 // You can use these constants with SRTO_MINVERSION option.

--- a/srtcore/srt.i
+++ b/srtcore/srt.i
@@ -16,7 +16,7 @@ written by
 /*
 Automatic generatation of bindings via SWIG (http://www.swig.org)
 Install swig via the following (or use instructions from the link above):
-   sudo apt install swig / nuget install swigwintools    
+   sudo apt install swig / nuget install swigwintools / download latest from swig.org   
 Generate the bindings using:
    mkdir srtcore/bindings/csharp -p
    swig -v -csharp -namespace SrtSharp -outdir ./srtcore/bindings/csharp/ ./srtcore/srt.i
@@ -29,12 +29,33 @@ You can now reference the SrtSharp lib in your .Net Core projects.  Ensure the s
 %}
 
 %include <arrays_csharp.i>
+%include "stdint.i"
+%include "typemaps.i"
 
+
+#if defined(SWIGCSHARP)
 //push anything with an argument name 'buf' back to being an array (e.g. csharp defaults this type to string, which is not ideal here)
 %apply unsigned char INOUT[]  { char* buf}
 
+#if defined(SWIGWORDSIZE64)
+%define PRIMITIVE_TYPEMAP(NEW_TYPE, TYPE)
+%clear NEW_TYPE;
+%clear NEW_TYPE *;
+%clear NEW_TYPE &;
+%clear const NEW_TYPE &;
+%apply TYPE { NEW_TYPE };
+%apply TYPE * { NEW_TYPE * };
+%apply TYPE & { NEW_TYPE & };
+%apply const TYPE & { const NEW_TYPE & };
+%enddef // PRIMITIVE_TYPEMAP
+PRIMITIVE_TYPEMAP(long int, long long);
+PRIMITIVE_TYPEMAP(unsigned long int, unsigned long long);
+#undef PRIMITIVE_TYPEMAP
+#endif // defined(SWIGWORDSIZE64)
+#endif // defined(SWIGCSHARP)
+
 /// 
-/// C# related configration section, customizing binding for this language  
+/// C# related configuration section, customizing binding for this language  
 /// 
 
 // add top-level code to module file, which allows C# bindings of specific objects to be injected for easier use in C# 

--- a/srtcore/srt.i
+++ b/srtcore/srt.i
@@ -1,0 +1,107 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2018 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+/*****************************************************************************
+written by
+   Lewis Kirkaldie - Cinegy GmbH
+ *****************************************************************************/
+
+/*
+Automatic generatation of bindings via SWIG (http://www.swig.org)
+Install swig via the following (or use instructions from the link above):
+   sudo apt install swig / nuget install swigwintools    
+Generate the bindings using:
+   mkdir srtcore/bindings/csharp -p
+   swig -v -csharp -namespace SrtSharp -outdir ./srtcore/bindings/csharp/ ./srtcore/srt.i
+You can now reference the SrtSharp lib in your .Net Core projects.  Ensure the srtlib.so (or srt.dll / srt_swig_csharp.dll) is in the binary path of your .NetCore project.
+*/
+
+%module srt
+%{
+   #include "srt.h"
+%}
+
+%include <arrays_csharp.i>
+
+//push anything with an argument name 'buf' back to being an array (e.g. csharp defaults this type to string, which is not ideal here)
+%apply unsigned char INOUT[]  { char* buf}
+
+/// 
+/// C# related configration section, customizing binding for this language  
+/// 
+
+// add top-level code to module file, which allows C# bindings of specific objects to be injected for easier use in C# 
+
+%pragma(csharp) moduleimports=%{ 
+using System;
+using System.Net;
+using System.Runtime.InteropServices;
+
+// sockaddr_in layout in C# - for easier creation of socket object from C# code
+[StructLayout(LayoutKind.Sequential)]
+public struct sockaddr_in
+{
+   public short sin_family;
+   public ushort sin_port;
+   public uint sin_addr;
+   public long sin_zero;
+};
+
+public static class SocketHelper{
+   public static SWIGTYPE_p_sockaddr CreateSocketAddress(string address, int port){
+            var destination = IPAddress.Parse(address);
+            
+      var sin = new sockaddr_in()
+      {
+         sin_family = srt.AF_INET,
+         sin_port = (ushort)IPAddress.HostToNetworkOrder((short)port),
+#pragma warning disable 618
+         sin_addr = (uint)destination.Address,
+#pragma warning restore 618
+         sin_zero = 0
+      };
+
+      var hnd = GCHandle.Alloc(sin, GCHandleType.Pinned);
+      
+      var socketAddress = new SWIGTYPE_p_sockaddr(hnd.AddrOfPinnedObject(), false);
+      
+      hnd.Free();
+
+      return socketAddress;
+   }
+}
+%}
+
+/// Rebind objects from the default mappings for types and objects that are optimized for C#
+
+//enums in C# are int by default, this override pushes this enum to the require uint format
+%typemap(csbase) SRT_EPOLL_OPT "uint"
+
+//the SRT_ERRNO enum references itself another enum - we must import this other enum into the class file for resolution
+%typemap(csimports) SRT_ERRNO %{
+
+   using static CodeMajor;
+   using static CodeMinor;
+
+%}
+
+SWIG_CSBODY_PROXY(public, public, SWIGTYPE)
+SWIG_CSBODY_TYPEWRAPPER(public, public, public, SWIGTYPE)
+
+%typemap(ctype) SWIGTYPE "const struct sockaddr*"
+%typemap(imtype, out="global::System.IntPtr") SWIGTYPE "global::System.Runtime.InteropServices.HandleRef"
+%typemap(cstype) const struct sockaddr* "SWIGTYPE_p_sockaddr"
+
+// General interface definition of wrapper - due to above typemaps and code, we can now just reference the main srt.h file
+
+const short AF_INET = 2;
+
+
+%include "srt.h";

--- a/srtcore/swig_bindings/csharp/srtsharp.csproj
+++ b/srtcore/swig_bindings/csharp/srtsharp.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Platform>AnyCPU</Platform>    
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This PR shows SWIG inclusion for C#, with clearer type mapping for easy managed code consumption.

Included to permit easier testing is a Linux 'build container' Dockerfile that is used to make it easy to get a consistent build across different CI systems (we use TeamCity in Cinegy).

The required 'nuget' files are left for reference in the scripts folder, that is used by me to push the 'SrtSharp' nuget package to public repos.

VS2013 support on the AppVeyor system is dropped within this PR, since it's nearly 10 years old now and I already added more to it - it's slow enough already :)

Everything SWIG is disabled by default in CMake, and just the tiniest #define is twiddle is added to the srt.h file (most other changes are new files or just scripting stuff for CI code)