### PR TITLE
[core] Fix CRcvBuffer last position in getTimespan_ms().

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -591,14 +591,24 @@ int CRcvBuffer::getTimespan_ms() const
     if (m_iMaxPosInc == 0)
         return 0;
 
-    const int lastpos = incPos(m_iStartPos, m_iMaxPosInc - 1);
-    // Should not happen if TSBPD is enabled (reading out of order is not allowed).
-    SRT_ASSERT(m_entries[lastpos].pUnit != NULL);
+    int lastpos = incPos(m_iStartPos, m_iMaxPosInc - 1);
+    // Normally the last position should always be non empty
+    // if TSBPD is enabled (reading out of order is not allowed).
+    // However if decryption of the last packet fails, it may be dropped
+    // from the buffer (AES-GCM), and the position will be empty.
+    SRT_ASSERT(m_entries[lastpos].pUnit != NULL || m_entries[lastpos].status == EntryState_Drop);
+    while (m_entries[lastpos].pUnit == NULL)
+    {
+        if (lastpos == m_iStartPos)
+            break;
+
+        lastpos = decPos(lastpos);
+    }
+    
     if (m_entries[lastpos].pUnit == NULL)
         return 0;
 
     int startpos = m_iStartPos;
-
     while (m_entries[startpos].pUnit == NULL)
     {
         if (startpos == lastpos)


### PR DESCRIPTION
With the introduction of the AES-GCM encryption mode, the last position in the receiver buffer can be dropped.
The assertion, placed in the `CRcvBuffer::getTimespan_ms()`, is updated to reflect the new behavior.
Furthermore, the search for the last position is improved. 
The `CRcvBuffer::getTimespan_ms()` is used to estimate the average packet size. On decryption failure, the connection will get broken, so there is probably not much sense in searching for the last valid position. However, it is more correct from the logic of the receiver buffer, because it does not control the connection state.