### PR TITLE
[apps] Fix ENABLE_AEAD_API_PREVIEW in apps.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
-set (SRT_VERSION 1.5.1)
+set (SRT_VERSION 1.5.2)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil) # needed for set_version_variables
@@ -428,7 +428,7 @@ if (ENABLE_ENCRYPTION)
 			add_definitions(-DENABLE_AEAD_API_PREVIEW)
 			message(STATUS "ENCRYPTION AEAD API: ENABLED")
 		else()
-			message(FATAL_ERROR "ENABLE_AEAD_API_PREVIEW is only available with USE_ENC_LIB=openssl-evp!")
+			message(FATAL_ERROR "ENABLE_AEAD_API_PREVIEW is only available with USE_ENCLIB=openssl-evp!")
 		endif()
 	else()
 		message(STATUS "ENCRYPTION AEAD API: DISABLED")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
-set (SRT_VERSION 1.5.2)
+set (SRT_VERSION 1.5.1)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil) # needed for set_version_variables

--- a/apps/socketoptions.hpp
+++ b/apps/socketoptions.hpp
@@ -255,7 +255,7 @@ const SocketOption srt_options [] {
     { "bindtodevice", 0, SRTO_BINDTODEVICE, SocketOption::PRE, SocketOption::STRING, nullptr},
 #endif
     { "retransmitalgo", 0, SRTO_RETRANSMITALGO, SocketOption::PRE, SocketOption::INT, nullptr }
-#ifdef ENABLE_AEAD_PREVIEW
+#ifdef ENABLE_AEAD_API_PREVIEW
     ,{ "cryptomode", 0, SRTO_CRYPTOMODE, SocketOption::PRE, SocketOption::INT, nullptr }
 #endif
 };


### PR DESCRIPTION
The PR contains some follow-up fixes after #2586.
- CMake error message hint to use `USE_ENCLIB` (was `USE_ENC_LIB`).
- Apps URI option 'cryptomode' enabled if `ENABLE_AEAD_API_PREVIEW` (was `ENABLE_AEAD_PREVIEW`).