### PR TITLE
[MAINT] Fixed example buildbreaks. Added examples for message mode transmission

### DIFF
--- a/.github/workflows/cxx11-ubuntu.yaml
+++ b/.github/workflows/cxx11-ubuntu.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: configure
       run: |
         mkdir _build && cd _build
-        cmake ../ -DENABLE_STDCXX_SYNC=ON -DENABLE_UNITTESTS=ON -DENABLE_BONDING=ON
+        cmake ../ -DENABLE_STDCXX_SYNC=ON -DENABLE_UNITTESTS=ON -DENABLE_BONDING=ON -DENABLE_TESTING=ON -DENABLE_EXAMPLES=ON
     - name: build
       run: cd _build && cmake --build ./
     - name: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1339,6 +1339,10 @@ if (ENABLE_EXAMPLES)
 		
 	srt_add_example(recvfile.cpp)
 
+	srt_add_example(sendmsg.cpp)
+		
+	srt_add_example(recvmsg.cpp)
+
 	srt_add_example(test-c-client.c)
 
 	srt_add_example(example-client-nonblock.c)

--- a/examples/recvlive.cpp
+++ b/examples/recvlive.cpp
@@ -53,16 +53,6 @@ int main(int argc, char* argv[])
       return 0;
    }
 
-   // SRT requires that third argument is always SOCK_DGRAM. The Stream API is set by an option,
-   // although there's also lots of other options to be set, for which there's a convenience option,
-   // SRTO_TRANSTYPE.
-   // SRT_TRANSTYPE tt = SRTT_LIVE;
-   // if (SRT_ERROR == srt_setsockopt(sfd, 0, SRTO_TRANSTYPE, &tt, sizeof tt))
-   // {
-   //    cout << "srt_setsockopt: " << srt_getlasterror_str() << endl;
-   //    return 0;
-   // }
-
    bool no = false;
    if (SRT_ERROR == srt_setsockopt(sfd, 0, SRTO_RCVSYN, &no, sizeof no))
    {

--- a/examples/recvmsg.cpp
+++ b/examples/recvmsg.cpp
@@ -1,0 +1,215 @@
+#ifndef WIN32
+   #include <cstdlib>
+   #include <netdb.h>
+#else
+   #include <winsock2.h>
+   #include <ws2tcpip.h>
+#endif
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <cstring>
+#include <cassert>
+
+#include <srt.h>
+#include <netinet_any.h>
+
+using namespace std;
+
+string ShowChar(char in)
+{
+    if (in >= 32 && in < 127)
+        return string(1, in);
+
+    ostringstream os;
+    os << "<" << hex << uppercase << int(in) << ">";
+    return os.str();
+}
+
+string CreateFilename(string fmt, int ord)
+{
+    ostringstream os;
+
+    size_t pos = fmt.find('%');
+    if (pos == string::npos)
+        os << fmt << ord << ".out";
+    else
+    {
+        os << fmt.substr(0, pos) << ord << fmt.substr(pos+1);
+    }
+    return os.str();
+}
+
+int main(int argc, char* argv[])
+{
+   string service("9000");
+   if (argc > 1)
+      service = argv[1];
+
+   if (service == "--help")
+   {
+      cout << "usage: recvmsg [server_port] [filepattern]" << endl;
+      return 0;
+   }
+
+   addrinfo hints;
+   addrinfo* res;
+
+   memset(&hints, 0, sizeof(struct addrinfo));
+   hints.ai_flags = AI_PASSIVE;
+   hints.ai_family = AF_INET;
+   hints.ai_socktype = SOCK_DGRAM;
+
+   if (0 != getaddrinfo(NULL, service.c_str(), &hints, &res))
+   {
+      cout << "illegal port number or port is busy.\n" << endl;
+      return 1;
+   }
+
+   string outfileform;
+   if (argc > 2)
+   {
+       outfileform = argv[2];
+   }
+
+   // use this function to initialize the UDT library
+   srt_startup();
+
+   srt_setloglevel(srt_logging::LogLevel::debug);
+
+   SRTSOCKET sfd = srt_create_socket();
+   if (SRT_INVALID_SOCK == sfd)
+   {
+      cout << "srt_socket: " << srt_getlasterror_str() << endl;
+      return 1;
+   }
+
+   int file_mode = SRTT_FILE;
+   if (SRT_ERROR == srt_setsockflag(sfd, SRTO_TRANSTYPE, &file_mode, sizeof file_mode))
+   {
+      cout << "srt_setsockopt: " << srt_getlasterror_str() << endl;
+      return 1;
+   }
+
+   bool message_mode = true;
+   if (SRT_ERROR == srt_setsockflag(sfd, SRTO_MESSAGEAPI, &message_mode, sizeof message_mode))
+   {
+      cout << "srt_setsockopt: " << srt_getlasterror_str() << endl;
+      return 1;
+   }
+
+   if (SRT_ERROR == srt_bind(sfd, res->ai_addr, res->ai_addrlen))
+   {
+      cout << "srt_bind: " << srt_getlasterror_str() << endl;
+      return 0;
+   }
+
+   freeaddrinfo(res);
+
+   cout << "server is ready at port: " << service << endl;
+
+   if (SRT_ERROR == srt_listen(sfd, 10))
+   {
+      cout << "srt_listen: " << srt_getlasterror_str() << endl;
+      return 1;
+   }
+
+   char data[4096];
+
+   srt::sockaddr_any remote;
+
+   int afd = srt_accept(sfd, remote.get(), &remote.len);
+
+   if (afd == SRT_INVALID_SOCK)
+   {
+       cout << "srt_accept: " << srt_getlasterror_str() << endl;
+       return 1;
+   }
+
+   cout << "Connection from " << remote.str() << " established\n";
+
+   bool save_to_files = true;
+
+   if (outfileform != "")
+       save_to_files = true;
+
+    int ordinal = 1;
+
+   // the event loop
+   while (true)
+   {
+       SRT_SOCKSTATUS status = srt_getsockstate(afd);
+       if ((status == SRTS_BROKEN) ||
+               (status == SRTS_NONEXIST) ||
+               (status == SRTS_CLOSED))
+       {
+           cout << "source disconnected. status=" << status << endl;
+           srt_close(afd);
+           break;
+       }
+
+       int ret = srt_recvmsg(afd, data, sizeof(data));
+       if (ret == SRT_ERROR)
+       {
+           cout << "srt_recvmsg: " << srt_getlasterror_str() << endl;
+           break;
+       }
+       if (ret == 0)
+       {
+           cout << "EOT\n";
+           break;
+       }
+
+       if (ret < 5)
+       {
+           cout << "WRONG MESSAGE SYNTAX\n";
+           break;
+       }
+
+       if (save_to_files)
+       {
+           string fname = CreateFilename(outfileform, ordinal++);
+           ofstream ofile(fname);
+
+           if (!ofile.good())
+           {
+               cout << "ERROR: can't create file: " << fname << " - skipping message\n";
+               continue;
+           }
+
+           ofile.write(data, ret);
+           ofile.close();
+           cout << "Written " << ret << " bytes of message to " << fname << endl;
+       }
+       else
+       {
+           union
+           {
+               char chars[4];
+               int32_t intval;
+           } first4;
+
+           copy(data, data + 4, first4.chars);
+
+           cout << "[" << ret << "B " << ntohl(first4.intval) << "] ";
+           for (int i = 4; i < ret; ++i)
+               cout << ShowChar(data[i]);
+           cout << endl;
+       }
+   }
+
+   srt_close(afd);
+   srt_close(sfd);
+
+   // use this function to release the UDT library
+   srt_cleanup();
+
+   return 0;
+}
+
+// Local Variables:
+// c-file-style: "ellemtel"
+// c-basic-offset: 3
+// compile-command: "g++ -Wall -O2 -std=c++11 -I.. -I../srtcore -o recvlive recvlive.cpp -L.. -lsrt -lpthread -L/usr/local/opt/openssl/lib -lssl -lcrypto"
+// End:

--- a/examples/sendmsg.cpp
+++ b/examples/sendmsg.cpp
@@ -1,0 +1,210 @@
+#ifndef _WIN32
+   #include <arpa/inet.h>
+   #include <netdb.h>
+#else
+   #include <winsock2.h>
+   #include <ws2tcpip.h>
+#endif
+#include <fstream>
+#include <iostream>
+#include <cstdlib>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <iterator>
+#include <algorithm>
+#include <srt.h>
+
+using namespace std;
+
+string ShowChar(char in)
+{
+    if (in >= 32 && in < 127)
+        return string(1, in);
+
+    ostringstream os;
+    os << "<" << hex << uppercase << int(in) << ">";
+    return os.str();
+}
+
+int main(int argc, char* argv[])
+{
+   if ((argc != 4) || (0 == atoi(argv[2])))
+   {
+      cout << "usage: sendmsg server_ip server_port source_filename" << endl;
+      return -1;
+   }
+
+   // Use this function to initialize the UDT library
+   srt_startup();
+
+   srt_setloglevel(srt_logging::LogLevel::debug);
+
+   struct addrinfo hints, *peer;
+
+   memset(&hints, 0, sizeof(struct addrinfo));
+   hints.ai_flags = AI_PASSIVE;
+   hints.ai_family = AF_INET;
+   hints.ai_socktype = SOCK_DGRAM;
+
+   SRTSOCKET fhandle = srt_create_socket();
+   // SRT requires that third argument is always SOCK_DGRAM. The Stream API is set by an option,
+   // although there's also lots of other options to be set, for which there's a convenience option,
+   // SRTO_TRANSTYPE.
+   SRT_TRANSTYPE tt = SRTT_FILE;
+   srt_setsockopt(fhandle, 0, SRTO_TRANSTYPE, &tt, sizeof tt);
+
+   bool message_mode = true;
+   srt_setsockopt(fhandle, 0, SRTO_MESSAGEAPI, &message_mode, sizeof message_mode);
+
+   if (0 != getaddrinfo(argv[1], argv[2], &hints, &peer))
+   {
+      cout << "incorrect server/peer address. " << argv[1] << ":" << argv[2] << endl;
+      return -1;
+   }
+
+   // Connect to the server, implicit bind.
+   if (SRT_ERROR == srt_connect(fhandle, peer->ai_addr, peer->ai_addrlen))
+   {
+       int rej = srt_getrejectreason(fhandle);
+       cout << "connect: " << srt_getlasterror_str() << ":" << srt_rejectreason_str(rej) << endl;
+       return -1;
+   }
+
+   freeaddrinfo(peer);
+
+   string source_fname = argv[3];
+
+   bool use_filelist = false;
+   if (source_fname[0] == '+')
+   {
+       use_filelist = true;
+       source_fname = source_fname.substr(1);
+   }
+
+   istream* pin;
+   ifstream fin;
+   if (source_fname == "-")
+   {
+       pin = &cin;
+   }
+   else
+   {
+       fin.open(source_fname.c_str());
+       pin = &fin;
+   }
+
+   // The syntax is:
+   //
+   // 1. If the first character is +, it's followed by TTL in milliseconds.
+   // 2. Otherwise the first number is the ID, followed by a space, to be filled in first 4 bytes.
+   // 3. Rest of the characters, up to the end of line, should be put into a solid block and sent at once.
+
+   int status = 0;
+
+   int ordinal = 1;
+   int lpos = 0;
+
+   for (;;)
+   {
+       string line;
+       int32_t id = 0;
+       int ttl = -1;
+
+       getline(*pin, (line));
+       if (pin->eof())
+           break;
+
+       // Interpret
+       if (line.size() < 2)
+           continue;
+
+       if (use_filelist)
+       {
+           // The line should contain [+TTL] FILENAME
+           char fname[1024] = "";
+           if (line[0] == '+')
+           {
+               int nparsed = sscanf(line.c_str(), "+%d %n%1000s", &ttl, &lpos, fname);
+               if (nparsed != 2)
+               {
+                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos << ")\n";
+                   status = SRT_ERROR;
+                   break;
+               }
+               line = fname;
+           }
+
+           ifstream ifile (line);
+
+           id = ordinal;
+           ++ordinal;
+
+           if (!ifile.good())
+           {
+               cout << "ERROR: file '" << line << "' cannot be read, skipping\n";
+               continue;
+           }
+
+           line = string(istreambuf_iterator<char>(ifile), istreambuf_iterator<char>());
+       }
+       else
+       {
+           int lpos = 0;
+
+           int nparsed = 0;
+           if (line[0] == '+')
+           {
+               nparsed = sscanf(line.c_str(), "+%d %d %n%*s", &ttl, &id, &lpos);
+               if (nparsed != 2)
+               {
+                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos << ")\n";
+                   status = SRT_ERROR;
+                   break;
+               }
+           }
+           else
+           {
+               nparsed = sscanf(line.c_str(), "%d %n%*s", &id, &lpos);
+               if (nparsed != 1)
+               {
+                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos << ")\n";
+                   status = SRT_ERROR;
+                   break;
+               }
+           }
+       }
+
+       union
+       {
+           char chars[4];
+           int32_t intval;
+       } first4;
+       first4.intval = htonl(id);
+
+       vector<char> input;
+       copy(first4.chars, first4.chars+4, back_inserter(input));
+       copy(line.begin() + lpos, line.end(), back_inserter(input));
+
+       // CHECK CODE
+       // cout << "WILL SEND: TTL=" << ttl << " ";
+       // transform(input.begin(), input.end(),
+       //         ostream_iterator<string>(cout), ShowChar);
+       // cout << endl;
+
+       int nsnd = srt_sendmsg(fhandle, &input[0], input.size(), ttl, false);
+       if (nsnd == SRT_ERROR)
+       {
+           cout << "SRT ERROR: " << srt_getlasterror_str() << endl;
+               status = SRT_ERROR;
+           break;
+       }
+   }
+
+   srt_close(fhandle);
+
+   // Signal to the SRT library to clean up all allocated sockets and resources.
+   srt_cleanup();
+
+   return status;
+}

--- a/examples/test-c-client.c
+++ b/examples/test-c-client.c
@@ -59,7 +59,7 @@ int main(int argc, char** argv)
     }
 
     printf("srt setsockflag\n");
-    if (SRT_ERROR == srt_setsockflag(ss, SRTO_SENDER, &yes, sizeof yes)
+    if (SRT_ERROR == srt_setsockflag(ss, SRTO_SENDER, &yes, sizeof yes))
     {
         fprintf(stderr, "srt_setsockflag: %s\n", srt_getlasterror_str());
         return 1;

--- a/examples/test-c-server.c
+++ b/examples/test-c-server.c
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
     }
 
     printf("srt setsockflag\n");
-    if (SRT_ERROR == srt_setsockflag(ss, SRTO_RCVSYN, &yes, sizeof yes)
+    if (SRT_ERROR == srt_setsockflag(ss, SRTO_RCVSYN, &yes, sizeof yes))
     {
         fprintf(stderr, "srt_setsockflag: %s\n", srt_getlasterror_str());
         return 1;


### PR DESCRIPTION
Changes:
1. Fixed build breaks in the C examples. Broken in #2572.
2. Added building examples and testing (devel apps) to one of the CI builds.
3. Added example files for simple testing the message mode.

The message mode testing can be done the following way:
1. recvmsg hosts a listener and receives messages, then displays them one after another on the screen, or writes them to subsequent files.
2. sendmsg reads messages each one with a single line. Optionally the line can start with + to additionally define a TTL for it. Optionally the input specification can start with + to define the input being a list of lines with filenames. Every line can also contain +N defining a TTL for this message, and the content is read from the given file. First 4 bytes of the message is an identifier, in case of direct line contents it's specified additionally, and for filenames they are ordinal numbers starting from 1.