### PR TITLE
Reduce frequency of the decryption failure log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,16 @@ else()
 	message(STATUS "USE_BUSY_WAITING: OFF (default)")
 endif()
 
+# Reduce the frequency of some frequent logs, milliseconds
+set(SRT_LOG_SLOWDOWN_FREQ_MS_DEFAULT 1000) # 1s
+if (NOT DEFINED SRT_LOG_SLOWDOWN_FREQ_MS)
+	if (ENABLE_HEAVY_LOGGING)
+		set(SRT_LOG_SLOWDOWN_FREQ_MS 0) # Just show every log message.
+	else()
+		set(SRT_LOG_SLOWDOWN_FREQ_MS ${SRT_LOG_SLOWDOWN_FREQ_MS_DEFAULT})
+	endif()
+endif()
+
 if ( CYGWIN AND NOT CYGWIN_USE_POSIX )
 	set(WIN32 1)
 	set(CMAKE_LEGACY_CYGWIN_WIN32 1)
@@ -1066,6 +1076,8 @@ target_compile_definitions(srt_virtual PRIVATE -DSRT_EXPORTS )
 if (ENABLE_SHARED)
 	target_compile_definitions(srt_virtual PUBLIC -DSRT_DYNAMIC)
 endif()
+
+target_compile_definitions(srt_virtual PRIVATE -DSRT_LOG_SLOWDOWN_FREQ_MS=${SRT_LOG_SLOWDOWN_FREQ_MS})
 
 if (srt_libspec_shared)
 	if (MICROSOFT)

--- a/docs/build/build-options.md
+++ b/docs/build/build-options.md
@@ -40,7 +40,7 @@ Option details are given further below.
 | [`ENABLE_HEAVY_LOGGING`](#enable_heavy_logging)              | 1.3.0 | `BOOL`    | OFF        | Enables heavy logging instructions in the code that occur often and cover many detailed aspects of library behavior. Default: OFF in release mode.   |
 | [`ENABLE_INET_PTON`](#enable_inet_pton)                      | 1.3.2 | `BOOL`    | ON         | Enables usage of the `inet_pton` function used to resolve the network endpoint name into an IP address.                                              |
 | [`ENABLE_LOGGING`](#enable_logging)                          | 1.2.0 | `BOOL`    | ON         | Enables normal logging, including errors.                                                                                                            |
-| [`ENABLE_MONOTONIC_CLOCK`](#enable_monotonic_clock)          | 1.4.0 | `BOOL`    | ON\*        | Enforces the use of `clock_gettime` with a monotonic clock that is independent of the currently set time in the system.                              |
+| [`ENABLE_MONOTONIC_CLOCK`](#enable_monotonic_clock)          | 1.4.0 | `BOOL`    | ON\*       | Enforces the use of `clock_gettime` with a monotonic clock that is independent of the currently set time in the system.                              |
 | [`ENABLE_PROFILE`](#enable_profile)                          | 1.2.0 | `BOOL`    | OFF        | Enables code instrumentation for profiling (only for GNU-compatible compilers).                                                                      |
 | [`ENABLE_RELATIVE_LIBPATH`](#enable_relative_libpath)        | 1.3.2 | `BOOL`    | OFF        | Enables adding a relative path to a library for linking against a shared SRT library by reaching out to a sibling directory.                         |
 | [`ENABLE_SHARED`](#enable_shared--enable_static)             | 1.2.0 | `BOOL`    | ON         | Enables building SRT as a shared library.                                                                                                            |
@@ -57,6 +57,7 @@ Option details are given further below.
 | [`PKG_CONFIG_EXECUTABLE`](#pkg_config_executable)            | 1.3.0 | `BOOL`    | OFF        | Configures the path to the `pkg-config` tool.                                                                                                        |
 | [`PTHREAD_INCLUDE_DIR`](#pthread_include_dir)                | 1.3.0 | `STRING`  | OFF        | Configures the path to include files for a `pthread` library.                                                                                        |
 | [`PTHREAD_LIBRARY`](#pthread_library)                        | 1.3.0 | `STRING`  | OFF        | Configures the path to a `pthread` library.                                                                                                          |
+| [`SRT_LOG_SLOWDOWN_FREQ_MS`](#SRT_LOG_SLOWDOWN_FREQ_MS)      | 1.5.2 | `INT`     | 1000\*     | Reduce the frequency of some frequent logs, milliseconds.                                                                                            |
 | [`USE_BUSY_WAITING`](#use_busy_waiting)                      | 1.3.3 | `BOOL`    | OFF        | Enables more accurate sending times at the cost of potentially higher CPU load.                                                                      |
 | [`USE_CXX_STD`](#use_cxx_std)                                | 1.4.2 | `STRING`  | OFF        | Enforces using a particular C++ standard (11, 14, 17, etc.) when compiling.                                                                          |
 | [`USE_ENCLIB`](#use_enclib)                                  | 1.3.3 | `STRING`  | openssl    | Encryption library to be used (`openssl`, `openssl-evp` (since 1.5.1), `gnutls`, `mbedtls`).                                                         |
@@ -545,6 +546,14 @@ in the system.
 **`--pthread-library=<filepath>`**
 
 Used to configure the path to a `pthread` library.
+
+
+#### SRT_LOG_SLOWDOWN_FREQ_MS
+**`--srt-log-slowdown-freq-ms=<ms>`** (DEFAULT 1000 ms; or 0 ms if `ENABLE_HEAVY_LOGGING`)
+
+Reduce the frequency of some frequent logs, milliseconds.
+
+- Decryption failure warning message (`SRT_LOGFA_QUE_RECV`).
 
 
 #### USE_BUSY_WAITING

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9893,7 +9893,9 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
                     const int iDropCnt = m_pRcvBuffer->dropMessage(u->m_Packet.getSeqNo(), u->m_Packet.getSeqNo(), SRT_MSGNO_NONE);
 
                     const steady_clock::time_point tnow = steady_clock::now();
+                    ScopedLock lg(m_StatsLock);
                     m_stats.rcvr.dropped.count(stats::BytesPackets(iDropCnt * rpkt.getLength(), iDropCnt));
+                    m_stats.rcvr.undecrypted.count(stats::BytesPackets(rpkt.getLength(), 1));
                     if (m_tsLogSlowDown + milliseconds_from(SRT_LOG_SLOWDOWN_FREQ_MS) <= tnow)
                     {
                         LOGC(qrlog.Warn, log << CONID() << "Decryption failed (seqno %" << u->m_Packet.getSeqNo() << "), dropped "

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9892,6 +9892,10 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
                     // A drawback is that it would prevent a valid packet with the same sequence number, if it happens to arrive later, to end up in the buffer.
                     const int iDropCnt = m_pRcvBuffer->dropMessage(u->m_Packet.getSeqNo(), u->m_Packet.getSeqNo(), SRT_MSGNO_NONE);
 
+#ifndef SRT_LOG_SLOWDOWN_FREQ_MS
+#define SRT_LOG_SLOWDOWN_FREQ_MS 1000
+#endif
+
                     const steady_clock::time_point tnow = steady_clock::now();
                     ScopedLock lg(m_StatsLock);
                     m_stats.rcvr.dropped.count(stats::BytesPackets(iDropCnt * rpkt.getLength(), iDropCnt));

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9902,8 +9902,8 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
                     if (!m_stats.rcvr.undecrypted.trace.count())
                     {
                         // Reduce log frequency.
-                        LOGC(qrlog.Warn, log << CONID() << "Decryption failed, in total " << 1 + m_stats.rcvr.undecrypted.total.count()
-                            << " pkts undecrypted.");
+                        LOGC(qrlog.Error, log << CONID() << "Packet decryption failure, in total " << 1 + m_stats.rcvr.undecrypted.total.count()
+                            << " pkts undecrypted. Silencing the log.");
                     }
 #endif
                     m_stats.rcvr.dropped.count(stats::BytesPackets(iDropCnt * rpkt.getLength(), iDropCnt));

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -901,6 +901,11 @@ private: // Timers
                                                  // The "slow down" group of logs are those that can be printed too often otherwise, but can't be turned off (warnings and errors).
                                                  // Currently only used by decryption failure message, therefore no mutex protection needed.
 
+    /// @brief Check if a frequent log can be shown.
+    /// @param tnow current time
+    /// @return true if it is ok to print a frequent log message.
+    bool frequentLogAllowed(const time_point& tnow) const;
+
 private: // Receiving related data
     CRcvBuffer* m_pRcvBuffer;                    //< Receiver buffer
     SRT_ATTR_GUARDED_BY(m_RcvLossLock)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -846,6 +846,8 @@ private: // Timers
 
     time_point m_tsNextSendTime;                 // Scheduled time of next packet sending
 
+    time_point m_tsLogSlowDown;                  // Reduce the frequency of some frequent logs. Currently only decryption failure log is slown down. No mutex needed.
+
     sync::atomic<int32_t> m_iSndLastFullAck;     // Last full ACK received
     SRT_ATTR_GUARDED_BY(m_RecvAckLock)
     sync::atomic<int32_t> m_iSndLastAck;         // Last ACK received

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -846,8 +846,6 @@ private: // Timers
 
     time_point m_tsNextSendTime;                 // Scheduled time of next packet sending
 
-    time_point m_tsLogSlowDown;                  // Reduce the frequency of some frequent logs. Currently only decryption failure log is slown down. No mutex needed.
-
     sync::atomic<int32_t> m_iSndLastFullAck;     // Last full ACK received
     SRT_ATTR_GUARDED_BY(m_RecvAckLock)
     sync::atomic<int32_t> m_iSndLastAck;         // Last ACK received

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -897,6 +897,10 @@ private: // Timers
     SRT_ATTR_GUARDED_BY(m_RecvAckLock)
     int32_t m_iReXmitCount;                      // Re-Transmit Count since last ACK
 
+    time_point m_tsLogSlowDown;                  // The last time a log message from the "slow down" group was shown.
+                                                 // The "slow down" group of logs are those that can be printed too often otherwise, but can't be turned off (warnings and errors).
+                                                 // Currently only used by decryption failure message, therefore no mutex protection needed.
+
 private: // Receiving related data
     CRcvBuffer* m_pRcvBuffer;                    //< Receiver buffer
     SRT_ATTR_GUARDED_BY(m_RcvLossLock)

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -870,7 +870,7 @@ srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNU
     const int rc = HaiCrypt_Rx_Data(m_hRcvCrypto, ((uint8_t *)w_packet.getHeader()), ((uint8_t *)w_packet.m_pcData), w_packet.getLength());
     if (rc <= 0)
     {
-        LOGC(cnlog.Note, log << "decrypt ERROR (IPE): HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
+        LOGC(cnlog.Note, log << "decrypt ERROR: HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
         // -1: decryption failure
         // 0: key not received yet
         return ENCS_FAILED;

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -867,10 +867,10 @@ srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNU
         return ENCS_FAILED;
     }
 
-    int rc = HaiCrypt_Rx_Data(m_hRcvCrypto, ((uint8_t *)w_packet.getHeader()), ((uint8_t *)w_packet.m_pcData), w_packet.getLength());
-    if ( rc <= 0 )
+    const int rc = HaiCrypt_Rx_Data(m_hRcvCrypto, ((uint8_t *)w_packet.getHeader()), ((uint8_t *)w_packet.m_pcData), w_packet.getLength());
+    if (rc <= 0)
     {
-        LOGC(cnlog.Warn, log << "decrypt ERROR (IPE): HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
+        LOGC(cnlog.Note, log << "decrypt ERROR (IPE): HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
         // -1: decryption failure
         // 0: key not received yet
         return ENCS_FAILED;

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -870,7 +870,7 @@ srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNU
     int rc = HaiCrypt_Rx_Data(m_hRcvCrypto, ((uint8_t *)w_packet.getHeader()), ((uint8_t *)w_packet.m_pcData), w_packet.getLength());
     if ( rc <= 0 )
     {
-        LOGC(cnlog.Error, log << "decrypt ERROR (IPE): HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
+        LOGC(cnlog.Warn, log << "decrypt ERROR (IPE): HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
         // -1: decryption failure
         // 0: key not received yet
         return ENCS_FAILED;


### PR DESCRIPTION
### Current Behavior

If SRT fails to decrypt a packet, one error message is printed from `CCryptoControl::decrypt(..)` :
```shell
W:SRT.cn: decrypt ERROR (IPE): HaiCrypt_Rx_Data failure=-1 - returning failed decryption
```
and one warning is reported from `CUDT::handleSocketPacketReception(..)`:
```shell
Decryption failed. Seqno %...
```

Thus two warnings are printed per single decryption failure. In case of an attack in AES-GCM mode, a lot of data packets may be corrupted, and decryption is expected to fail. That would result in too many warning messages.

### The Proposal

This PR introduces a new variable `m_tsLogSlowDown` to reduce the frequency of some potentially frequent warnings. Currently, only decryption failure warning uses this mechanism.

By default, the following warning will be shown not more often than once per 1 s:
```shell
W:SRT.qr: @879501775: Decryption failed (seqno %1229888030), dropped 1. pktRcvUndecryptTotal=5.
```

The frequency can be set via the `SRT_LOG_SLOWDOWN_FREQ_MS` definition (available in CMake).

### TODO

```c++
#ifndef SRT_LOG_SLOWDOWN_FREQ_MS
#define SRT_LOG_SLOWDOWN_FREQ_MS 1000
#endif
```
