### PR TITLE
[TEST] Added check for read-ready for decryption failure case

### DIFF
--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -345,10 +345,16 @@ public:
         ASSERT_EQ(SetPassword(PEER_CALLER, test.password[PEER_CALLER]), SRT_SUCCESS);
         ASSERT_EQ(SetPassword(PEER_LISTENER, test.password[PEER_LISTENER]), SRT_SUCCESS);
 
+        // Determine the subcase for the KLUDGE (check the behavior of the decryption failure)
+        bool case_pw_failure = test.password[PEER_CALLER] != test.password[PEER_LISTENER];
+        bool case_both_relaxed = !test.enforcedenc[PEER_LISTENER] && !test.enforcedenc[PEER_CALLER];
+        bool case_sender_enc = test.password[PEER_CALLER] != "";
+
         const TResult &expect = test.expected_result;
 
         // Start testing
         srt::sync::atomic<bool> caller_done;
+        //volatile bool caller_done = false; // 1.4.3
         sockaddr_in sa;
         memset(&sa, 0, sizeof sa);
         sa.sin_family = AF_INET;
@@ -358,6 +364,8 @@ public:
         ASSERT_NE(srt_bind(m_listener_socket, psa, sizeof sa), SRT_ERROR);
         ASSERT_NE(srt_listen(m_listener_socket, 4), SRT_ERROR);
 
+        SRTSOCKET accepted_socket = -1;
+
         auto accepting_thread = std::thread([&] {
             const int epoll_event = WaitOnEpoll(expect);
 
@@ -366,7 +374,7 @@ public:
             // otherwise SRT_INVALID_SOCKET after the listening socket is closed.
             sockaddr_in client_address;
             int length = sizeof(sockaddr_in);
-            SRTSOCKET accepted_socket = -1;
+            //SRTSOCKET accepted_socket = -1;
             if (epoll_event == SRT_EPOLL_IN)
             {
                 accepted_socket = srt_accept(m_listener_socket, (sockaddr*)&client_address, &length);
@@ -483,6 +491,53 @@ public:
 
         EXPECT_EQ(srt_getsockstate(m_listener_socket), SRTS_LISTENING);
         EXPECT_EQ(GetKMState(m_listener_socket), SRT_KM_S_UNSECURED);
+
+        if (!is_blocking && case_both_relaxed && case_pw_failure && case_sender_enc)
+        {
+            //// ! KLUDGE !
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            EXPECT_FALSE(accepting_thread.joinable());
+
+            int const epollRead = srt_epoll_create();
+            int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+            srt_epoll_add_usock(epollRead, accepted_socket, &events);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            {
+                int const epollWrite = srt_epoll_create();
+                events = SRT_EPOLL_OUT | SRT_EPOLL_ERR;
+                srt_epoll_add_usock(epollWrite, m_caller_socket, &events);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+                SRTSOCKET   srtSocket  = SRT_INVALID_SOCK;
+                int         socketNum  = 1;
+                const int epoll_res_w = srt_epoll_wait(epollWrite,
+                        nullptr, nullptr, // read
+                        &srtSocket, &socketNum, // write
+                        500,
+                        nullptr, nullptr, nullptr, nullptr); // R/W system sockets
+                std::cout << "W: " << epoll_res_w << std::endl;
+
+                char buffer[1316] = {1, 2, 3, 4};
+                ASSERT_NE(srt_sendmsg2(m_caller_socket, buffer, sizeof buffer, nullptr), SRT_ERROR);
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+
+            SRTSOCKET   srtSocket  = SRT_INVALID_SOCK;
+            int         socketNum  = 1;
+            int epoll_res_r = srt_epoll_wait(epollRead, &srtSocket, &socketNum, nullptr, nullptr, 500, nullptr, nullptr, nullptr, nullptr);
+            std::cout << "R: " << epoll_res_r << std::endl;
+            EXPECT_LE(epoll_res_r, 0) << "It's wrongly reported, so let's take a look...";
+            char buffer[1316] = {};
+            EXPECT_EQ(srt_recvmsg2(accepted_socket, buffer, sizeof buffer, nullptr), -1);
+
+            epoll_res_r = srt_epoll_wait(epollRead, &srtSocket, &socketNum, nullptr, nullptr, 500, nullptr, nullptr, nullptr, nullptr);
+            EXPECT_LE(epoll_res_r, 0) << "Another?!";
+            //// ! /KLUDGE !
+
+            srt_epoll_release(epollRead);
+        }
 
         if (is_blocking)
         {

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -346,15 +346,14 @@ public:
         ASSERT_EQ(SetPassword(PEER_LISTENER, test.password[PEER_LISTENER]), SRT_SUCCESS);
 
         // Determine the subcase for the KLUDGE (check the behavior of the decryption failure)
-        bool case_pw_failure = test.password[PEER_CALLER] != test.password[PEER_LISTENER];
-        bool case_both_relaxed = !test.enforcedenc[PEER_LISTENER] && !test.enforcedenc[PEER_CALLER];
-        bool case_sender_enc = test.password[PEER_CALLER] != "";
+        const bool case_pw_failure = test.password[PEER_CALLER] != test.password[PEER_LISTENER];
+        const bool case_both_relaxed = !test.enforcedenc[PEER_LISTENER] && !test.enforcedenc[PEER_CALLER];
+        const bool case_sender_enc = test.password[PEER_CALLER] != "";
 
         const TResult &expect = test.expected_result;
 
         // Start testing
         srt::sync::atomic<bool> caller_done;
-        //volatile bool caller_done = false; // 1.4.3
         sockaddr_in sa;
         memset(&sa, 0, sizeof sa);
         sa.sin_family = AF_INET;
@@ -374,7 +373,6 @@ public:
             // otherwise SRT_INVALID_SOCKET after the listening socket is closed.
             sockaddr_in client_address;
             int length = sizeof(sockaddr_in);
-            //SRTSOCKET accepted_socket = -1;
             if (epoll_event == SRT_EPOLL_IN)
             {
                 accepted_socket = srt_accept(m_listener_socket, (sockaddr*)&client_address, &length);
@@ -494,7 +492,7 @@ public:
 
         if (!is_blocking && case_both_relaxed && case_pw_failure && case_sender_enc)
         {
-            //// ! KLUDGE !
+            // Additionally check decryption failure does not trigger read-readiness (see issue #2503).
 
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
             EXPECT_FALSE(accepting_thread.joinable());


### PR DESCRIPTION
Related to #2503 although this problem was not confirmed in the latest version.

This adds the check if in the non-blocking mode the read-ready epoll flag has NOT been set in case of decryption failure.

Decryption failure is expected with both sides set "relaxed encryption", both have different password settings, and the sender is set a passphrase. In all other cases this should either result in rejected connection or successful reception, and these latter cases read-readiness should be expected (this is checked though through an attempt for reading).