### PR TITLE
[MAINT] Fixed wrong null-safety condition check in haicrypt

### DIFF
--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -55,26 +55,20 @@ int HaiCrypt_Tx_GetBuf(HaiCrypt_Handle hhc, size_t data_len, unsigned char **in_
 int HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p[], int maxout)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
-
-	if ((NULL == crypto)
-	||  (NULL == crypto->ctx)
-	||  (NULL == out_p)
-	||  (NULL == out_len_p)) {
-		HCRYPT_LOG(LOG_ERR, "ManageKeys: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-		return(-1);
-	}
-
-	hcrypt_Ctx *ctx = crypto->ctx;
+	hcrypt_Ctx *ctx = NULL;
 	int nbout = 0;
+
+    if ((NULL == crypto)
+            ||  (NULL == (ctx = crypto->ctx))
+            ||  (NULL == out_p)
+            ||  (NULL == out_len_p)) {
+        HCRYPT_LOG(LOG_ERR, "ManageKeys: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+        return(-1);
+    }
 
 	/* Manage Key Material (refresh, announce, decommission) */
 	hcryptCtx_Tx_ManageKM(crypto);
 
-	ctx = crypto->ctx;
-	if (NULL == ctx) {
-		HCRYPT_LOG(LOG_ERR, "%s", "crypto context not defined\n");
-		return(-1);
-	}
 	ASSERT(ctx->status == HCRYPT_CTX_S_ACTIVE);
 
 	nbout = hcryptCtx_Tx_InjectKM(crypto, out_p, out_len_p, maxout);
@@ -84,37 +78,35 @@ int HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p[
 int HaiCrypt_Tx_GetKeyFlags(HaiCrypt_Handle hhc)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
+	hcrypt_Ctx *ctx = NULL;
 
-	if ((NULL == crypto)
-	||  (NULL == crypto->ctx)){
-		HCRYPT_LOG(LOG_ERR, "GetKeyFlags: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-		return(-1);
-	}
+    if ((NULL == crypto)
+            ||  (NULL == (ctx = crypto->ctx))) {
+        HCRYPT_LOG(LOG_ERR, "GetKeyFlags: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+        return(-1);
+    }
 	return(hcryptCtx_GetKeyFlags(crypto->ctx));
 }
 
-int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc, 
-	unsigned char *in_pfx, unsigned char *in_data, size_t in_len) 
+int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
+	unsigned char *in_pfx, unsigned char *in_data, size_t in_len)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
+	hcrypt_Ctx *ctx = NULL;
+	int nbout = 0;
 
-	if ((NULL == crypto)
-	||  (NULL == crypto->ctx)){
-		HCRYPT_LOG(LOG_ERR, "Tx_Data: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-		return(-1);
-	}
-
-	hcrypt_Ctx *ctx = crypto->ctx;
-
+    if ((NULL == crypto)
+            ||  (NULL == (ctx = crypto->ctx))) {
+        HCRYPT_LOG(LOG_ERR, "Tx_Data: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+        return(-1);
+    }
 	/* Get/Set packet index */
-	ctx->msg_info->indexMsg(in_pfx, ctx->MSpfx_cache); 
+	ctx->msg_info->indexMsg(in_pfx, ctx->MSpfx_cache);
 
 	if (hcryptMsg_GetKeyIndex(ctx->msg_info, in_pfx) != hcryptCtx_GetKeyIndex(ctx))
 	{
 		HCRYPT_LOG(LOG_ERR, "Tx_Data: Key mismatch!");
 	}
-
-	int nbout = 0;
 
 	/* Encrypt */
 	{
@@ -133,31 +125,25 @@ int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
 	return(nbout);
 }
 
-int HaiCrypt_Tx_Process(HaiCrypt_Handle hhc, 
-	unsigned char *in_msg, size_t in_len, 
+int HaiCrypt_Tx_Process(HaiCrypt_Handle hhc,
+	unsigned char *in_msg, size_t in_len,
 	void *out_p[], size_t out_len_p[], int maxout)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
-
-	if ((NULL == crypto)
-	||  (NULL == crypto->ctx)
-	||  (NULL == out_p)
-	||  (NULL == out_len_p)) {
-		HCRYPT_LOG(LOG_ERR, "Tx_Process: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-		return(-1);
-	}
-
-	hcrypt_Ctx *ctx = crypto->ctx;
+	hcrypt_Ctx *ctx = NULL;
 	int nb, nbout = 0;
+
+    if ((NULL == crypto)
+            ||  (NULL == (ctx = crypto->ctx))
+            ||  (NULL == out_p)
+            ||  (NULL == out_len_p)) {
+        HCRYPT_LOG(LOG_ERR, "Tx_Process: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+        return(-1);
+    }
 
 	/* Manage Key Material (refresh, announce, decommission) */
 	hcryptCtx_Tx_ManageKM(crypto);
 
-	ctx = crypto->ctx;
-	if (NULL == ctx) {
-		HCRYPT_LOG(LOG_ERR, "%s", "crypto context not defined\n");
-		return(-1);
-	}
 	ASSERT(ctx->status == HCRYPT_CTX_S_ACTIVE);
 
 	nbout += hcryptCtx_Tx_InjectKM(crypto, out_p, out_len_p, maxout);

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -52,19 +52,20 @@ int HaiCrypt_Tx_GetBuf(HaiCrypt_Handle hhc, size_t data_len, unsigned char **in_
 	return(crypto->msg_info->pfx_len);
 }
 
-int HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p[], int maxout) 
+int HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p[], int maxout)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
-	hcrypt_Ctx *ctx = crypto->ctx;
-	int nbout = 0;
 
 	if ((NULL == crypto)
-	||  (NULL == ctx)
+	||  (NULL == crypto->ctx)
 	||  (NULL == out_p)
 	||  (NULL == out_len_p)) {
 		HCRYPT_LOG(LOG_ERR, "ManageKeys: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
 		return(-1);
 	}
+
+	hcrypt_Ctx *ctx = crypto->ctx;
+	int nbout = 0;
 
 	/* Manage Key Material (refresh, announce, decommission) */
 	hcryptCtx_Tx_ManageKM(crypto);
@@ -83,28 +84,28 @@ int HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p[
 int HaiCrypt_Tx_GetKeyFlags(HaiCrypt_Handle hhc)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
-	hcrypt_Ctx *ctx = crypto->ctx;
 
 	if ((NULL == crypto)
-	||  (NULL == ctx)){
+	||  (NULL == crypto->ctx)){
 		HCRYPT_LOG(LOG_ERR, "GetKeyFlags: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
 		return(-1);
 	}
-	return(hcryptCtx_GetKeyFlags(ctx));
+	return(hcryptCtx_GetKeyFlags(crypto->ctx));
 }
 
 int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc, 
 	unsigned char *in_pfx, unsigned char *in_data, size_t in_len) 
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
-	hcrypt_Ctx *ctx = crypto->ctx;
-	int nbout = 0;
 
 	if ((NULL == crypto)
-	||  (NULL == ctx)){
+	||  (NULL == crypto->ctx)){
 		HCRYPT_LOG(LOG_ERR, "Tx_Data: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
 		return(-1);
 	}
+
+	hcrypt_Ctx *ctx = crypto->ctx;
+
 	/* Get/Set packet index */
 	ctx->msg_info->indexMsg(in_pfx, ctx->MSpfx_cache); 
 
@@ -112,6 +113,8 @@ int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
 	{
 		HCRYPT_LOG(LOG_ERR, "Tx_Data: Key mismatch!");
 	}
+
+	int nbout = 0;
 
 	/* Encrypt */
 	{
@@ -135,16 +138,17 @@ int HaiCrypt_Tx_Process(HaiCrypt_Handle hhc,
 	void *out_p[], size_t out_len_p[], int maxout)
 {
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
-	hcrypt_Ctx *ctx = crypto->ctx;
-	int nb, nbout = 0;
 
 	if ((NULL == crypto)
-	||  (NULL == ctx)
+	||  (NULL == crypto->ctx)
 	||  (NULL == out_p)
 	||  (NULL == out_len_p)) {
 		HCRYPT_LOG(LOG_ERR, "Tx_Process: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
 		return(-1);
 	}
+
+	hcrypt_Ctx *ctx = crypto->ctx;
+	int nb, nbout = 0;
 
 	/* Manage Key Material (refresh, announce, decommission) */
 	hcryptCtx_Tx_ManageKM(crypto);

--- a/haicrypt/hcrypt_tx.c
+++ b/haicrypt/hcrypt_tx.c
@@ -58,13 +58,13 @@ int HaiCrypt_Tx_ManageKeys(HaiCrypt_Handle hhc, void *out_p[], size_t out_len_p[
 	hcrypt_Ctx *ctx = NULL;
 	int nbout = 0;
 
-    if ((NULL == crypto)
-            ||  (NULL == (ctx = crypto->ctx))
-            ||  (NULL == out_p)
-            ||  (NULL == out_len_p)) {
-        HCRYPT_LOG(LOG_ERR, "ManageKeys: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-        return(-1);
-    }
+	if ((NULL == crypto)
+	||  (NULL == (ctx = crypto->ctx))
+	||  (NULL == out_p)
+	||  (NULL == out_len_p)) {
+		HCRYPT_LOG(LOG_ERR, "ManageKeys: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+		return(-1);
+	}
 
 	/* Manage Key Material (refresh, announce, decommission) */
 	hcryptCtx_Tx_ManageKM(crypto);
@@ -80,11 +80,11 @@ int HaiCrypt_Tx_GetKeyFlags(HaiCrypt_Handle hhc)
 	hcrypt_Session *crypto = (hcrypt_Session *)hhc;
 	hcrypt_Ctx *ctx = NULL;
 
-    if ((NULL == crypto)
-            ||  (NULL == (ctx = crypto->ctx))) {
-        HCRYPT_LOG(LOG_ERR, "GetKeyFlags: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-        return(-1);
-    }
+	if ((NULL == crypto)
+	||  (NULL == (ctx = crypto->ctx))) {
+		HCRYPT_LOG(LOG_ERR, "GetKeyFlags: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+		return(-1);
+	}
 	return(hcryptCtx_GetKeyFlags(crypto->ctx));
 }
 
@@ -95,11 +95,11 @@ int HaiCrypt_Tx_Data(HaiCrypt_Handle hhc,
 	hcrypt_Ctx *ctx = NULL;
 	int nbout = 0;
 
-    if ((NULL == crypto)
-            ||  (NULL == (ctx = crypto->ctx))) {
-        HCRYPT_LOG(LOG_ERR, "Tx_Data: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-        return(-1);
-    }
+	if ((NULL == crypto)
+	||  (NULL == (ctx = crypto->ctx))) {
+		HCRYPT_LOG(LOG_ERR, "Tx_Data: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+		return(-1);
+	}
 	/* Get/Set packet index */
 	ctx->msg_info->indexMsg(in_pfx, ctx->MSpfx_cache);
 
@@ -133,13 +133,13 @@ int HaiCrypt_Tx_Process(HaiCrypt_Handle hhc,
 	hcrypt_Ctx *ctx = NULL;
 	int nb, nbout = 0;
 
-    if ((NULL == crypto)
-            ||  (NULL == (ctx = crypto->ctx))
-            ||  (NULL == out_p)
-            ||  (NULL == out_len_p)) {
-        HCRYPT_LOG(LOG_ERR, "Tx_Process: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
-        return(-1);
-    }
+	if ((NULL == crypto)
+	||  (NULL == (ctx = crypto->ctx))
+	||  (NULL == out_p)
+	||  (NULL == out_len_p)) {
+		HCRYPT_LOG(LOG_ERR, "Tx_Process: invalid params: crypto=%p crypto->ctx=%p\n", crypto, ctx);
+		return(-1);
+	}
 
 	/* Manage Key Material (refresh, announce, decommission) */
 	hcryptCtx_Tx_ManageKM(crypto);


### PR DESCRIPTION
Fixes #2376 

IMPORTANT: Since this version C99 is the minimum standard required for compiling haicrypt.