### PR TITLE
[BUG] Fixed usage of the right rejection reason depending on the encryption error also when rejected on the caller level.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2659,7 +2659,14 @@ bool srt::CUDT::interpretSrtHandshake(const CHandShake& hs,
                 int res = m_pCryptoControl->processSrtMsg_KMRSP(begin + 1, bytelen, HS_VERSION_SRT1);
                 if (m_config.bEnforcedEnc && res == -1)
                 {
-                    m_RejectReason = SRT_REJ_UNSECURE;
+                    if (m_pCryptoControl->m_SndKmState == SRT_KM_S_BADSECRET)
+                        m_RejectReason = SRT_REJ_BADSECRET;
+#ifdef ENABLE_AEAD_API_PREVIEW
+                    else if (m_pCryptoControl->m_SndKmState == SRT_KM_S_BADCRYPTOMODE)
+                        m_RejectReason = SRT_REJ_CRYPTO;
+#endif
+                    else
+                        m_RejectReason = SRT_REJ_UNSECURE;
                     LOGC(cnlog.Error,
                          log << CONID() << "KMRSP failed - rejecting connection as per enforced encryption.");
                     return false;


### PR DESCRIPTION
Fixes #2620 

The problem: the caller may reject the connection that was accepted by the listener because the listener is set relaxed encryption and the caller - enforced encryption. In this case the caller was reporting `SRT_REJ_UNSECURE` regardless of the real rejection reason, which is determined during the KMRSP processing on the caller side.