### PR TITLE
[core] CodeQL warning: checking NULL after new.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -459,10 +459,8 @@ SRTSOCKET srt::CUDTUnited::newSocket(CUDTSocket** pps)
         // failure and rollback
         delete ns;
         ns = NULL;
-    }
-
-    if (!ns)
         throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
+    }
 
     if (pps)
         *pps = ns;


### PR DESCRIPTION
Different overloads of the `new` operator handle allocation failures in different ways. If `new T` fails for some type `T`, it throws a `std::bad_alloc` exception, but `new(std::nothrow) T` returns a null pointer. If the programmer does not use the corresponding method of error handling, allocation failure may go unhandled and could cause the program to behave in unexpected ways.

As reported in PR #2578.