### PR TITLE
[core] CodeQL: operation requires 22 bytes.

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -1409,7 +1409,7 @@ inline std::string SrtVersionString(int version)
     int minor = (version/0x100)%0x100;
     int major = version/0x10000;
 
-    char buf[20];
+    char buf[22];
     sprintf(buf, "%d.%d.%d", major, minor, patch);
     return buf;
 }


### PR DESCRIPTION
CodeQL reports (#2578):
> This 'call to sprintf' operation requires 22 bytes but the destination is only 20 bytes.

Not sure where 22 bytes come from though.
I assume the longest would be `SrtVersionString(-2147483647) = -32767.-255.-255` which is 17 characters.

```c++
// int version max 2147483647, min -2147483648.
int patch = version % 0x100; // max 255   min -255
int minor = (version/0x100)%0x100; // max 255, min -255.
int major = version/0x10000; // max 127.  min -32767
```