### PR TITLE
[BUG] Fixed PKTINFO case that was failing for IPv4+IPv6 bound sockets

### DIFF
--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -177,21 +177,24 @@ private:
     // This structure is exclusively used to determine the required size for
     // CMSG buffer so that it can be allocated in a solid block with CChannel.
     // NOT TO BE USED to access any data inside the CMSG message.
-    struct CMSGNodeAlike
+    struct CMSGNodeIPv4
     {
-        union
-        {
-            in_pktinfo in4;
-            in6_pktinfo in6;
-        };
+        in_pktinfo in4;
+        size_t extrafill;
+        cmsghdr hdr;
+    };
+
+    struct CMSGNodeIPv6
+    {
+        in6_pktinfo in6;
         size_t extrafill;
         cmsghdr hdr;
     };
 
     // This is 'mutable' because it's a utility buffer defined here
     // to avoid unnecessary re-allocations.
-    mutable char m_acCmsgRecvBuffer [sizeof (CMSGNodeAlike)]; // Reserved space for ancillary data with pktinfo
-    mutable char m_acCmsgSendBuffer [sizeof (CMSGNodeAlike)]; // Reserved space for ancillary data with pktinfo
+    mutable char m_acCmsgRecvBuffer [sizeof (CMSGNodeIPv4) + sizeof (CMSGNodeIPv6)]; // Reserved space for ancillary data with pktinfo
+    mutable char m_acCmsgSendBuffer [sizeof (CMSGNodeIPv4) + sizeof (CMSGNodeIPv6)]; // Reserved space for ancillary data with pktinfo
 
     // IMPORTANT!!! This function shall be called EXCLUSIVELY just after
     // calling ::recvmsg function. It uses a static buffer to supply data


### PR DESCRIPTION
The problem detected while fixing #2608 and handling of the dual-IP address binding cases.

The problem:

The CMSG should be provided only per requested information, however in case of dual-bound sockets (IPv4 + IPv6), which would be used in case when the listener has bound to "::" with IPV6_V6ONLY option 0 (which means binding to both IPv4 and IPv6 wildcards) will effectively have set both IPPROTO_IP/IP_PKTINFO and IPPROTO_IPV6/IPV6_RECVPKTINFO flags set and in consequence both IPv4 and IPv6 pktinfo message will be provided with `recvmsg` call. The problem was that the space reserved for filling in this message was set as the one for only IPv4 or IPv6. The fix reserved enough space to fill BOTH IPv4 and IPv6 pktinfo cmsg at once.

Besides, there is added also an enhanced diagnostics where the problem has been detected: the flags set back on the returned data are parsed. This happens only for POSIX systems because Windows uses `WSARecvFrom`, which doesn't report these flags.