### PR TITLE
Use overlapped WSASendTo to avoid UDP sending losses.

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -773,7 +773,7 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
     SecureZeroMemory((PVOID)&overlapped, sizeof(WSAOVERLAPPED));
     int   res = ::WSASendTo(m_iSocket, (LPWSABUF)packet.m_PacketVector, 2, &size, 0, addr.get(), addrsize, &overlapped, NULL);
 
-    if (res == SOCKET_ERROR && WSA_IO_PENDING == NET_ERROR)
+    if (res == SOCKET_ERROR && NET_ERROR == WSA_IO_PENDING)
     {
         DWORD dwFlags = 0;
         const bool bCompleted = WSAGetOverlappedResult(m_iSocket, &overlapped, &size, true, &dwFlags);

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -769,8 +769,19 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
 #else
     DWORD size     = (DWORD)(CPacket::HDR_SIZE + packet.getLength());
     int   addrsize = addr.size();
-    int   res = ::WSASendTo(m_iSocket, (LPWSABUF)packet.m_PacketVector, 2, &size, 0, addr.get(), addrsize, NULL, NULL);
-    res       = (0 == res) ? size : -1;
+    WSAOVERLAPPED overlapped;
+    SecureZeroMemory((PVOID)&overlapped, sizeof(WSAOVERLAPPED));
+    int   res = ::WSASendTo(m_iSocket, (LPWSABUF)packet.m_PacketVector, 2, &size, 0, addr.get(), addrsize, &overlapped, NULL);
+
+    if (res == SOCKET_ERROR && WSA_IO_PENDING == NET_ERROR)
+    {
+        DWORD dwFlags = 0;
+        const bool bCompleted = WSAGetOverlappedResult(m_iSocket, &overlapped, &size, true, &dwFlags);
+        WSACloseEvent(overlapped.hEvent);
+        res = bCompleted ? 0 : -1;
+    }
+
+    res = (0 == res) ? size : -1;
 #endif
 
     packet.toHL();


### PR DESCRIPTION
Added check of the `WSASend` result, as reported in #973.
Given that `::send(...)` wan not observed to fail on Linux, adding a common `::select(...)` call for both Windows and Linux might decrease the performance.
This PR uses Windows OverlappedIO API to wait for `WSASend` to succeed.

Fixes #973.
Closes #974 (replaces).

### TODO

- [x] Retest.