### PR TITLE
[MAINT] Added setting CLOSING state when closing a socket

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2120,6 +2120,7 @@ int srt::CUDTUnited::close(CUDTSocket* s)
     ...
     }
     */
+    CSync::notify_one_relaxed(m_GCStopCond);
 
     return 0;
 }

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1990,12 +1990,14 @@ int srt::CUDTUnited::close(CUDTSocket* s)
 
         HLOGC(smlog.Debug, log << s->core().CONID() << "CLOSING (removing listener immediately)");
         s->core().notListening();
+        s->m_Status = SRTS_CLOSING;
 
         // broadcast all "accept" waiting
         CSync::lock_notify_all(s->m_AcceptCond, s->m_AcceptLock);
     }
     else
     {
+        s->m_Status = SRTS_CLOSING;
         // Note: this call may be done on a socket that hasn't finished
         // sending all packets scheduled for sending, which means, this call
         // may block INDEFINITELY. As long as it's acceptable to block the


### PR DESCRIPTION
1. setting SRTS_CLOSING state on a socket that was requested to be closed.
2. Added time tracking when closing a socket with tracked wiping to track the time taken for wiping out a socket.