### PR TITLE
RCV erase undecrypted packet instead of dropping.

### DIFF
--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -64,6 +64,12 @@ public:
     // TODO: Previously '-2' also meant 'already acknowledged'. Check usage of this value.
     int insert(CUnit* unit);
 
+    /// Erase a packet from the buffer based on the packet sequence number.
+    /// The entry is marked EntryState_Empty. The CUnit is marked free.
+    /// @param seqno packet sequence number.
+    /// @return the number of packets erased.
+    int erase(int32_t seqno);
+
     /// Drop packets in the receiver buffer from the current position up to the seqno (excluding seqno).
     /// @param [in] seqno drop units up to this sequence number
     /// @return  number of dropped packets.

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -646,7 +646,7 @@ enum SRT_KM_STATE
     SRT_KM_S_NOSECRET      = 3, // Stream encrypted and no secret to decrypt Keying Material
     SRT_KM_S_BADSECRET     = 4 // Stream encrypted and wrong secret is used, cannot decrypt Keying Material
 #ifdef ENABLE_AEAD_API_PREVIEW
-    ,SRT_KM_S_BADCRYPTOMODE = 5  // Stream encrypted but wrong ccryptographic mode is used, cannot decrypt. Since v1.6.0.
+    ,SRT_KM_S_BADCRYPTOMODE = 5  // Stream encrypted but wrong cryptographic mode is used, cannot decrypt. Since v1.6.0.
 #endif
 };
 


### PR DESCRIPTION
Erase the packet from the RCV buffer on decryption failure. However, this also requires re-adding the packet to the loss list.

### TODO

- [ ] Erasing the packet means it has to be added back to the loss list.

Addresses #2626