### PR TITLE
[core] Fixed CRcvBuffer::dropMessage.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -316,7 +316,8 @@ int CRcvBuffer::dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno, Dro
     {
         // Don't drop messages, if all its packets are already in the buffer.
         // TODO: Don't drop a several-packet message if all packets are in the buffer.
-        if (bKeepExisting && m_entries[i].pUnit && packetAt(i).getMsgBoundary() == PB_SOLO) {
+        if (bKeepExisting && m_entries[i].pUnit && packetAt(i).getMsgBoundary() == PB_SOLO)
+        {
             LOGC(rbuflog.Debug, log << "CRcvBuffer.dropMessage(): Skipped dropping an exising SOLO packet %" << packetAt(i).getSeqNo() << ".");
             continue;
         }

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -151,6 +151,7 @@ public:
     }
 
     /// @brief Checks if the buffer has packets available for reading regardless of the TSBPD.
+    /// A message is available for reading only if all of its packets are present in the buffer.
     /// @return true if there are packets available for reading, false otherwise.
     bool hasAvailablePackets() const;
 

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -79,17 +79,18 @@ public:
         KEEP_EXISTING = 1
     };
 
-    /// @brief Drop the whole message from the buffer.
-    /// If message number is valid, sender has requested to drop the whole message by TTL. In this case it has to provide a valid pkt seqno range.
+    /// @brief Drop a sequence of packets from the buffer.
+    /// If @a msgno is valid, sender has requested to drop the whole message by TTL. In this case it has to also provide a pkt seqno range.
     /// However, if a message has been partially acknowledged and already removed from the SND buffer,
-    /// the seqnolo might specify some position in the middle of the message. In this case the msgno should be used to determine starting packets of the 
-    /// message. If those packet have been acknowledged, they must exist in the receiver buffer unless already read.
-    /// Some packets of the message can be missing on the receiver, therefore the actual drop can only be performed by pkt seqno range.
+    /// the @a seqnolo might specify some position in the middle of the message, not the very first packet.
+    /// If those packets have been acknowledged, they must exist in the receiver buffer unless already read.
+    /// In this case the @a msgno should be used to determine starting packets of the message.
+    /// Some packets of the message can be missing on the receiver, therefore the actual drop should still be performed by pkt seqno range.
     /// If message number is 0 or SRT_MSGNO_NONE, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
-    /// A packedt should be dropped only if it is not a SOLO packet or if it does not exist in the buffer. Set bKeepExisting = true.
-    /// This is done to avoid dropping existing packet due to a sender trying to re-transmit a packet from outdated loss report,
+    /// A SOLO message packet can be kept depending on @a actionOnExisting value.
+    /// TODO: A message in general can be kept if all of its packets are in the buffer, depending on @a actionOnExisting value.
+    /// This is done to avoid dropping existing packet when the sender was asked to re-transmit a packet from an outdated loss report,
     /// which is already not available in the SND buffer.
-    /// When one packet of the message is in the range of dropping, the whole message is to be dropped.
     /// @param seqnolo sequence number of the first packet in the dropping range.
     /// @param seqnohi sequence number of the last packet in the dropping range.
     /// @param msgno message number to drop (0 if unknown)

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -74,14 +74,24 @@ public:
     /// @return the number of dropped packets.
     int dropAll();
 
+    enum DropActionIfExists {
+        DROP_EXISTING = 0,
+        KEEP_EXISTING = 1
+    };
+
     /// @brief Drop the whole message from the buffer.
+    /// If message number is valid, sender has requested to drop the whole message by TTL.
     /// If message number is 0 or SRT_MSGNO_NONE, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
+    /// A packedt should be dropped only if it is not a SOLO packet or if it does not exist in the buffer. Set bKeepExisting = true.
+    /// This is done to avoid dropping existing packet due to a sender trying to re-transmit a packet from outdated loss report,
+    /// which is already not available in the SND buffer.
     /// When one packet of the message is in the range of dropping, the whole message is to be dropped.
     /// @param seqnolo sequence number of the first packet in the dropping range.
     /// @param seqnohi sequence number of the last packet in the dropping range.
     /// @param msgno message number to drop (0 if unknown)
+    /// @param actionOnExisting Should an exising SOLO packet be dropped from the buffer or preserved?
     /// @return the number of packets actually dropped.
-    int dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno);
+    int dropMessage(int32_t seqnolo, int32_t seqnohi, int32_t msgno, DropActionIfExists actionOnExisting);
 
     /// Read the whole message from one or several packets.
     ///

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -80,7 +80,11 @@ public:
     };
 
     /// @brief Drop the whole message from the buffer.
-    /// If message number is valid, sender has requested to drop the whole message by TTL.
+    /// If message number is valid, sender has requested to drop the whole message by TTL. In this case it has to provide a valid pkt seqno range.
+    /// However, if a message has been partially acknowledged and already removed from the SND buffer,
+    /// the seqnolo might specify some position in the middle of the message. In this case the msgno should be used to determine starting packets of the 
+    /// message. If those packet have been acknowledged, they must exist in the receiver buffer unless already read.
+    /// Some packets of the message can be missing on the receiver, therefore the actual drop can only be performed by pkt seqno range.
     /// If message number is 0 or SRT_MSGNO_NONE, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
     /// A packedt should be dropped only if it is not a SOLO packet or if it does not exist in the buffer. Set bKeepExisting = true.
     /// This is done to avoid dropping existing packet due to a sender trying to re-transmit a packet from outdated loss report,

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8797,7 +8797,7 @@ void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
         {
             const bool using_rexmit_flag = m_bPeerRexmitFlag;
             ScopedLock rblock(m_RcvBufferLock);
-            const int iDropCnt = m_pRcvBuffer->dropMessage(dropdata[0], dropdata[1], ctrlpkt.getMsgSeq(using_rexmit_flag));
+            const int iDropCnt = m_pRcvBuffer->dropMessage(dropdata[0], dropdata[1], ctrlpkt.getMsgSeq(using_rexmit_flag), CRcvBuffer::KEEP_EXISTING);
 
             if (iDropCnt > 0)
             {
@@ -9899,7 +9899,7 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
                     // Drop the packet from the receiver buffer.
                     // The packet was added to the buffer based on the sequence number, therefore sequence number should be used to drop it from the buffer.
                     // A drawback is that it would prevent a valid packet with the same sequence number, if it happens to arrive later, to end up in the buffer.
-                    const int iDropCnt = m_pRcvBuffer->dropMessage(u->m_Packet.getSeqNo(), u->m_Packet.getSeqNo(), SRT_MSGNO_NONE);
+                    const int iDropCnt = m_pRcvBuffer->dropMessage(u->m_Packet.getSeqNo(), u->m_Packet.getSeqNo(), SRT_MSGNO_NONE, CRcvBuffer::DROP_EXISTING);
 
                     const steady_clock::time_point tnow = steady_clock::now();
                     ScopedLock lg(m_StatsLock);

--- a/test/test_buffer_rcv.cpp
+++ b/test/test_buffer_rcv.cpp
@@ -268,6 +268,19 @@ TEST_F(CRcvBufferReadMsg, OnePacketGapDrop)
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
 }
 
+TEST_F(CRcvBufferReadMsg, PacketDropBySeqNo)
+{
+    // Add one packet with a gap.
+    EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno)), 0);
+
+    auto& rcv_buffer = *m_rcv_buffer.get();
+    EXPECT_FALSE(hasAvailablePackets());
+    EXPECT_FALSE(rcv_buffer.isRcvDataReady());
+
+    EXPECT_EQ(rcv_buffer.dropMessage(m_init_seqno, m_init_seqno, SRT_MSGNO_NONE, CRcvBuffer::KEEP_EXISTING), 0);
+    EXPECT_EQ(rcv_buffer.dropMessage(m_init_seqno, m_init_seqno, SRT_MSGNO_NONE, CRcvBuffer::DROP_EXISTING), 1);
+}
+
 // Add one packet to the buffer and read it once it is acknowledged.
 // Confirm the data read is valid.
 // Don't allow to add packet with the same sequence number.

--- a/test/test_buffer_rcv.cpp
+++ b/test/test_buffer_rcv.cpp
@@ -48,7 +48,7 @@ public:
     /// Generate and add one packet to the receiver buffer.
     ///
     /// @returns the result of rcv_buffer::insert(..)
-    int addPacket(int seqno, bool pb_first = true, bool pb_last = true, bool out_of_order = false, int ts = 0)
+    int addPacket(int seqno, int msgno, bool pb_first = true, bool pb_last = true, bool out_of_order = false, int ts = 0)
     {
         CUnit* unit = m_unit_queue->getNextAvailUnit();
         EXPECT_NE(unit, nullptr);
@@ -60,7 +60,8 @@ public:
         packet.setLength(m_payload_sz);
         generatePayload(packet.data(), packet.getLength(), packet.m_iSeqNo);
 
-        packet.m_iMsgNo = PacketBoundaryBits(PB_SUBSEQUENT);
+        packet.m_iMsgNo = msgno;
+        packet.m_iMsgNo |= PacketBoundaryBits(PB_SUBSEQUENT);
         if (pb_first)
             packet.m_iMsgNo |= PacketBoundaryBits(PB_FIRST);
         if (pb_last)
@@ -76,13 +77,13 @@ public:
     }
 
     /// @returns 0 on success, the result of rcv_buffer::insert(..) once it failed
-    int addMessage(size_t msg_len_pkts, int start_seqno, bool out_of_order = false, int ts = 0)
+    int addMessage(size_t msg_len_pkts, int msgno, int start_seqno, bool out_of_order = false, int ts = 0)
     {
         for (size_t i = 0; i < msg_len_pkts; ++i)
         {
             const bool pb_first = (i == 0);
             const bool pb_last = (i == (msg_len_pkts - 1));
-            const int res = addPacket(start_seqno + i, pb_first, pb_last, out_of_order, ts);
+            const int res = addPacket(start_seqno + i, msgno, pb_first, pb_last, out_of_order, ts);
 
             if (res != 0)
                 return res;
@@ -151,7 +152,7 @@ TEST_F(CRcvBufferReadMsg, Destroy)
     // Add a number of units (packets) to the buffer
     // equal to the buffer size in packets
     for (int i = 0; i < getAvailBufferSize(); ++i)
-        EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno, i)), 0);
+        EXPECT_EQ(addMessage(1, i + 1, CSeqNo::incseq(m_init_seqno, i)), 0);
 
     m_rcv_buffer.reset();
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
@@ -165,7 +166,7 @@ TEST_F(CRcvBufferReadMsg, FullBuffer)
     // equal to the buffer size in packets
     for (int i = 0; i < getAvailBufferSize(); ++i)
     {
-        EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno, i)), 0);
+        EXPECT_EQ(addMessage(1, i + 1, CSeqNo::incseq(m_init_seqno, i)), 0);
     }
 
     EXPECT_EQ(getAvailBufferSize(), m_buff_size_pkts - 1);   // logic
@@ -174,7 +175,7 @@ TEST_F(CRcvBufferReadMsg, FullBuffer)
     EXPECT_EQ(getAvailBufferSize(), 0);
 
     // Try to add more data than the available size of the buffer
-    EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, getAvailBufferSize())), -1);
+    EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, getAvailBufferSize()), 1), -1);
 
     array<char, m_payload_sz> buff;
     for (int i = 0; i < m_buff_size_pkts - 1; ++i)
@@ -196,7 +197,7 @@ TEST_F(CRcvBufferReadMsg, OnePacketGap)
 {
     // Add one packet message to to the buffer
     // with a gap of one packet.
-    EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno)), 0);
+    EXPECT_EQ(addMessage(1, 1, CSeqNo::incseq(m_init_seqno)), 0);
 
     auto& rcv_buffer = *m_rcv_buffer.get();
     // Before ACK the available buffer size stays the same.
@@ -226,7 +227,7 @@ TEST_F(CRcvBufferReadMsg, OnePacketGap)
     EXPECT_EQ(res, 0);
 
     // Add a missing packet (can't add before an acknowledged position in the old buffer).
-    EXPECT_EQ(addMessage(1, m_init_seqno), 0);
+    EXPECT_EQ(addMessage(1, 1, m_init_seqno), 0);
 
     for (int pktno = 0; pktno < 2; ++pktno)
     {
@@ -254,7 +255,7 @@ TEST_F(CRcvBufferReadMsg, OnePacketGapDrop)
 {
     // Add one packet message to to the buffer
     // with a gap of one packet.
-    EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno)), 0);
+    EXPECT_EQ(addMessage(1, 1, CSeqNo::incseq(m_init_seqno)), 0);
     auto& rcv_buffer = *m_rcv_buffer.get();
     EXPECT_FALSE(hasAvailablePackets());
     EXPECT_FALSE(rcv_buffer.isRcvDataReady());
@@ -271,8 +272,8 @@ TEST_F(CRcvBufferReadMsg, OnePacketGapDrop)
 TEST_F(CRcvBufferReadMsg, PacketDropBySeqNo)
 {
     // Add two packets.
-    EXPECT_EQ(addMessage(1, m_init_seqno), 0);
-    EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno)), 0);
+    EXPECT_EQ(addMessage(1, 1, m_init_seqno), 0);
+    EXPECT_EQ(addMessage(1, 2, CSeqNo::incseq(m_init_seqno)), 0);
 
     auto& rcv_buffer = *m_rcv_buffer.get();
     EXPECT_TRUE(hasAvailablePackets());
@@ -292,6 +293,35 @@ TEST_F(CRcvBufferReadMsg, PacketDropBySeqNo)
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
 }
 
+// Test dropping a message by message number and sequence number.
+TEST_F(CRcvBufferReadMsg, PacketDropByMsgNoSeqNo)
+{
+    const size_t msg_len_pkts = 5;
+    const int msgno = 1;
+    for (size_t i = 0; i < msg_len_pkts; ++i)
+    {
+        if (i == 1 || i == msg_len_pkts - 1)
+            continue; // make a gap in the message
+
+        const bool pb_first = (i == 0);
+        const bool pb_last = false; // Do not put the whole message in the buffer.
+        EXPECT_EQ(addPacket(m_init_seqno + i, msgno, pb_first, pb_last, false), 0);
+    }
+
+    auto& rcv_buffer = *m_rcv_buffer.get();
+    EXPECT_FALSE(hasAvailablePackets()) << "The message in the buffer is not complete";
+    EXPECT_FALSE(rcv_buffer.isRcvDataReady()); // The buffer does not have the whole message.
+
+    // Let's say SND does not have the very first packet of the message,
+    // therefore seqnolo of the msg drop request starts with the second packet of the message.
+    EXPECT_EQ(rcv_buffer.dropMessage(CSeqNo::incseq(m_init_seqno), CSeqNo::incseq(m_init_seqno, msg_len_pkts - 1), msgno, CRcvBuffer::KEEP_EXISTING), msg_len_pkts);
+    EXPECT_FALSE(hasAvailablePackets());
+    EXPECT_FALSE(rcv_buffer.isRcvDataReady());
+
+    EXPECT_EQ(rcv_buffer.getStartSeqNo(), CSeqNo::incseq(m_init_seqno, msg_len_pkts));
+    EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
+}
+
 // Add one packet to the buffer and read it once it is acknowledged.
 // Confirm the data read is valid.
 // Don't allow to add packet with the same sequence number.
@@ -299,9 +329,9 @@ TEST_F(CRcvBufferReadMsg, OnePacket)
 {
     const size_t msg_pkts = 1;
     // Adding one message  without acknowledging
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno, false), 0);
+    EXPECT_EQ(addMessage(msg_pkts, 1, m_init_seqno, false), 0);
     // Adding a packet into the same position must return an error.
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno, false), -1);
+    EXPECT_EQ(addMessage(msg_pkts, 1, m_init_seqno, false), -1);
 
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
@@ -326,7 +356,7 @@ TEST_F(CRcvBufferReadMsg, AddData)
     ASSERT_LT(num_pkts, m_buff_size_pkts);
     for (int i = 0; i < num_pkts; ++i)
     {
-        EXPECT_EQ(addMessage(1, CSeqNo::incseq(m_init_seqno, i)), 0);
+        EXPECT_EQ(addMessage(1, i + 1, CSeqNo::incseq(m_init_seqno, i)), 0);
     }
 
     // The available buffer size remains the same
@@ -352,10 +382,10 @@ TEST_F(CRcvBufferReadMsg, AddData)
     }
 
     // Add packet to the position of oackets already read.
-    EXPECT_EQ(addPacket(m_init_seqno), -2);
+    EXPECT_EQ(addPacket(m_init_seqno, num_pkts + 1), -2);
 
     // Add packet to a non-empty position.
-    EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, ack_pkts)), -1);
+    EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, ack_pkts), num_pkts + 1), -1);
 
     const int num_pkts_left = num_pkts - ack_pkts;
     ackPackets(num_pkts_left);
@@ -374,7 +404,7 @@ TEST_F(CRcvBufferReadMsg, MsgAcked)
 {
     const size_t msg_pkts = 4;
     // Adding one message  without acknowledging
-    addMessage(msg_pkts, m_init_seqno, false);
+    addMessage(msg_pkts, 1, m_init_seqno, false);
 
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
@@ -401,7 +431,7 @@ TEST_F(CRcvBufferReadMsg, SmallReadBuffer)
 {
     const size_t msg_pkts = 4;
     // Adding one message  without acknowledging
-    addMessage(msg_pkts, m_init_seqno, false);
+    addMessage(msg_pkts, 1, m_init_seqno, false);
 
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
@@ -434,7 +464,7 @@ TEST_F(CRcvBufferReadMsg, MsgHalfAck)
 {
     const size_t msg_pkts = 4;
     // Adding one message  without acknowledging
-    addMessage(msg_pkts, m_init_seqno, false);
+    addMessage(msg_pkts, 1, m_init_seqno, false);
     
     // Nothing to read (0 for zero bytes read).
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
@@ -461,7 +491,7 @@ TEST_F(CRcvBufferReadMsg, OutOfOrderMsgNoACK)
 {
     const size_t msg_pkts = 4;
     // Adding one message with the Out-Of-Order flag set, but without acknowledging.
-    addMessage(msg_pkts, m_init_seqno, true);
+    addMessage(msg_pkts, 1, m_init_seqno, true);
 
     EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
     EXPECT_TRUE(hasAvailablePackets());
@@ -488,7 +518,7 @@ TEST_F(CRcvBufferReadMsg, OutOfOrderMsgGap)
 {
     const size_t msg_pkts = 4;
     // Adding one message with the Out-Of-Order flag set, but without acknowledging.
-    addMessage(msg_pkts, CSeqNo::incseq(m_init_seqno, 1), true);
+    addMessage(msg_pkts, 2, CSeqNo::incseq(m_init_seqno, 1), true);
 
     EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
     EXPECT_TRUE(hasAvailablePackets());
@@ -507,10 +537,10 @@ TEST_F(CRcvBufferReadMsg, OutOfOrderMsgGap)
     EXPECT_FALSE(hasAvailablePackets());
     // Adding one message with the Out-Of-Order flag set, but without acknowledging.
     //int seqno, bool pb_first = true, bool pb_last = true, bool out_of_order = false, int ts = 0)
-    const int res2 = addPacket(CSeqNo::incseq(m_init_seqno, 1));
+    const int res2 = addPacket(CSeqNo::incseq(m_init_seqno, 2), 1);
     EXPECT_EQ(res2, -1); // already exists
 
-    EXPECT_EQ(addPacket(m_init_seqno), 0);
+    EXPECT_EQ(addPacket(m_init_seqno, 1), 0);
     ackPackets(msg_pkts + 1);
     EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
     EXPECT_TRUE(hasAvailablePackets());
@@ -526,7 +556,7 @@ TEST_F(CRcvBufferReadMsg, OutOfOrderMsgGap)
 
     // Adding a packet right after the EntryState_Read packets.
     const int seqno = CSeqNo::incseq(m_init_seqno, msg_pkts + 1);
-    EXPECT_EQ(addPacket(seqno), 0);
+    EXPECT_EQ(addPacket(seqno, 3), 0);
     ackPackets(1);
     EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
     EXPECT_TRUE(hasAvailablePackets());
@@ -546,10 +576,11 @@ TEST_F(CRcvBufferReadMsg, LongMsgReadReady)
     array<char, 2 * msg_bytelen> buff;
     for (size_t i = 0; i < msg_pkts; ++i)
     {
+        const int msgno = 1;
         // int addPacket(int seqno, bool pb_first = true, bool pb_last = true, bool out_of_order = false, int ts = 0)
         const bool pb_first = (i == 0);
         const bool pb_last  = (i == (msg_pkts - 1));
-        EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, i), pb_first, pb_last), 0);
+        EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, i), msgno, pb_first, pb_last), 0);
         ackPackets(1);
         if (!pb_last)
         {
@@ -580,7 +611,7 @@ TEST_F(CRcvBufferReadMsg, MsgOutOfOrderDrop)
     const size_t msg_pkts = 4;
     // 1. Add one message (4 packets) without acknowledging
     const int msg_seqno = m_init_seqno + 1; // seqno of the first packet in the message
-    EXPECT_EQ(addMessage(msg_pkts, msg_seqno, true), 0);
+    EXPECT_EQ(addMessage(msg_pkts, 2, msg_seqno, true), 0);
     EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
 
     // 2. Read full message after gap.
@@ -596,7 +627,7 @@ TEST_F(CRcvBufferReadMsg, MsgOutOfOrderDrop)
     EXPECT_FALSE(m_rcv_buffer->isRcvDataReady());
 
     // Can't add to the same message
-    EXPECT_EQ(addMessage(msg_pkts, msg_seqno, true), -1);
+    EXPECT_EQ(addMessage(msg_pkts, 2, msg_seqno, true), -1);
 
     const auto pkt_info = m_rcv_buffer->getFirstValidPacketInfo();
     EXPECT_EQ(pkt_info.seqno, -1); // Nothing to read
@@ -615,9 +646,9 @@ TEST_F(CRcvBufferReadMsg, MsgOutOfOrderAfterInOrder)
 {
     const size_t msg_pkts = 4;
     // 1. Add one packet with inOrder=true and one message (4 packets) with inOrder=false
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno + 2 * msg_pkts, true), 0);
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno, false), 0);
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno + msg_pkts, true), 0);
+    EXPECT_EQ(addMessage(msg_pkts, 3, m_init_seqno + 2 * msg_pkts, true), 0);
+    EXPECT_EQ(addMessage(msg_pkts, 1, m_init_seqno, false), 0);
+    EXPECT_EQ(addMessage(msg_pkts, 2, m_init_seqno + msg_pkts, true), 0);
     EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
 
     // 2. Read messages in order
@@ -655,13 +686,13 @@ TEST_F(CRcvBufferReadMsg, OnePacketTSBPD)
     const int packet_ts = 0;
     // Adding one message. Note that all packets have the out of order flag
     // set to false by default in TSBPD mode, but this flag is ignored.
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno, true, packet_ts), 0);
+    EXPECT_EQ(addMessage(msg_pkts, 1, m_init_seqno, true, packet_ts), 0);
 
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
 
     // Confirm adding to the same location returns an error.
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno, true, packet_ts), -1);
+    EXPECT_EQ(addMessage(msg_pkts, 1, m_init_seqno, true, packet_ts), -1);
 
     // There is one packet in the buffer, but not ready to read after delay/2
     EXPECT_FALSE(m_rcv_buffer->isRcvDataReady(m_tsbpd_base + (m_delay / 2)));
@@ -677,7 +708,7 @@ TEST_F(CRcvBufferReadMsg, OnePacketTSBPD)
 
     // Check the state after a packet was read
     EXPECT_FALSE(m_rcv_buffer->isRcvDataReady(m_tsbpd_base + m_delay));
-    EXPECT_EQ(addMessage(msg_pkts, m_init_seqno, false), -2);
+    EXPECT_EQ(addMessage(msg_pkts, 1, m_init_seqno, false), -2);
 
     EXPECT_FALSE(m_rcv_buffer->isRcvDataReady(m_tsbpd_base + m_delay));
 }
@@ -711,7 +742,7 @@ TEST_F(CRcvBufferReadMsg, TSBPDGapBeforeValid)
     // Add a solo packet to position m_init_seqno + 1 with timestamp 200 us
     const int seqno = m_init_seqno + 1;
     const int32_t pkt_ts = 200;
-    EXPECT_EQ(addMessage(1, seqno, false, pkt_ts), 0);
+    EXPECT_EQ(addMessage(1, 2, seqno, false, pkt_ts), 0);
 
     const auto readready_timestamp = m_tsbpd_base + sync::microseconds_from(pkt_ts) + m_delay;
     // Check that getFirstValidPacketInfo() returns first valid packet.
@@ -760,7 +791,7 @@ TEST_F(CRcvBufferReadStream, ReadSinglePackets)
     ASSERT_LT(num_pkts, m_buff_size_pkts);
     for (int i = 0; i < num_pkts; ++i)
     {
-        EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, i), false, false), 0);
+        EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, i), 0, false, false), 0);
     }
 
     // The available buffer size remains the same
@@ -786,10 +817,10 @@ TEST_F(CRcvBufferReadStream, ReadSinglePackets)
 
     // Add packet to the position of oackets already read.
     // Can't check the old buffer, as it does not handle a negative offset.
-    EXPECT_EQ(addPacket(m_init_seqno), -2);
+    EXPECT_EQ(addPacket(m_init_seqno, 0), -2);
 
     // Add packet to a non-empty position.
-    EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, ack_pkts)), -1);
+    EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, ack_pkts), 0), -1);
 
     const int num_pkts_left = num_pkts - ack_pkts;
     ackPackets(num_pkts_left);
@@ -812,7 +843,7 @@ TEST_F(CRcvBufferReadStream, ReadFractional)
     ASSERT_LT(num_pkts, m_buff_size_pkts);
     for (int i = 0; i < num_pkts; ++i)
     {
-        EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, i), false, false), 0);
+        EXPECT_EQ(addPacket(CSeqNo::incseq(m_init_seqno, i), 0, false, false), 0);
     }
 
     // The available buffer size remains the same


### PR DESCRIPTION
Fixed `CRcvBuffer::dropMessage(..)`.
- Tell what to do with existing packets.
- Fixed pkt seqno dropping loop range.

The function is used in two situations:
1. Incoming message drop request from the sender.
2. Dropping a packet with decryption failure.

If msgno is valid, sender has requested to drop the whole message by TTL. In this case it has to also provide a pkt seqno range.
However, if a message has been partially acknowledged and already removed from the SND buffer,
the seqnolo might specify some position in the middle of the message, not the very first packet.
If those packets have been acknowledged, they must exist in the receiver buffer unless already read.
In this case the msgno should be used to determine starting packets of the message.
Some packets of the message can be missing on the receiver, therefore the actual drop should still be performed by pkt seqno range.
If message number is 0 or SRT_MSGNO_NONE, then use sequence numbers to locate sequence range to drop [seqnolo, seqnohi].
A SOLO message packet can be kept depending on actionOnExisting value.
This is done to avoid dropping existing packet when the sender was asked to re-transmit a packet from an outdated loss report, which is already not available in the SND buffer.

Dropping a packet with decryption failure means the existing packet must be dropped.
Dropping a packet by incoming message drop request means the existing packet must be kept, only missing packets or partially missing messages must be dropped.


### TODO:
- [x] Fix drop by msgno.