### PR TITLE
Fixed warnings and removed redundant includes

### DIFF
--- a/haicrypt/cryspr-mbedtls.c
+++ b/haicrypt/cryspr-mbedtls.c
@@ -19,8 +19,6 @@ written by
         GnuTLS/Nettle CRYSPR/4SRT (CRYypto Service PRovider for SRT)
 *****************************************************************************/
 
-#include "platform_sys.h"
-
 #include "hcrypt.h"
 
 #include <string.h>

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -17,8 +17,6 @@ written by
 		CRYSPR/4SRT Initial implementation.
 *****************************************************************************/
 
-#include "platform_sys.h"
-
 #include "hcrypt.h"
 #include "cryspr.h"
 
@@ -561,7 +559,7 @@ static int crysprFallback_MsEncrypt(
 			memcpy(in_data[0].payload, &out_msg[pfx_len], out_len);
 			if (ctx->mode == HCRYPT_CTX_MODE_AESGCM) {
 				// Encoding produced more payload (auth tag).
-				return out_len;
+				return (int)out_len;
 			}
 #endif /* CRYSPR_HAS_AESCTR */
 	} else {

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -111,7 +111,7 @@ int  HaiCrypt_Rx_Data(HaiCrypt_Handle hhc, unsigned char *pfx, unsigned char *da
 
 /// @brief Check if the crypto service provider supports AES GCM.
 /// @return returns 1 if AES GCM is supported, 0 otherwise.
-int  HaiCrypt_IsAESGCM_Supported();
+int  HaiCrypt_IsAESGCM_Supported(void);
 
 /* Status values */
 

--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -19,8 +19,6 @@ written by
 		Adaptation for SRT.
 *****************************************************************************/
 
-#include "platform_sys.h"
-
 #include <string.h>				/* memcpy */
 #include "hcrypt.h"
 

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -19,8 +19,6 @@ written by
 		Adaptation for SRT.
 *****************************************************************************/
 
-#include "platform_sys.h"
-
 #include <string.h>		/* memcpy */
 #ifdef _WIN32
 	#include <winsock2.h>

--- a/haicrypt/hcrypt_rx.c
+++ b/haicrypt/hcrypt_rx.c
@@ -19,8 +19,6 @@ written by
         Adaptation for SRT.
 *****************************************************************************/
 
-#include "platform_sys.h"
-
 #include <stdlib.h>				/* NULL */
 #include <string.h>				/* memcmp */
 #include "hcrypt.h"


### PR DESCRIPTION
The includes were necessary when platform_sys.h included pragmas to disable some warnings. These aren't needed now the warnings have been fixed properly.

This commit also includes a couple of warning fixes which seem to have slipped through the net.