### PR TITLE
Update inconsistent header size calculation

### DIFF
--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -29,9 +29,9 @@ The following function returns the buffer size in packets:
 ```c++
 int getRbufSizePkts(int SRTO_RCVBUF, int SRTO_MSS, int SRTO_FC)
 {
-    // UDP header size is assumed to be 28 bytes
-    // 20 bytes IPv4 + 8 bytes of UDP
-    const int UDPHDR_SIZE = 28;
+    // UDP header size is assumed to be 44 bytes
+    // 20 bytes IPv4 + 8 bytes of UDP + 16 bytes SRT
+    const int UDPHDR_SIZE = 44;
     const int pkts = (rbuf_size / (SRTO_MSS - UDPHDR_SIZE));
 
     return min(pkts, SRTO_FC);

--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -32,7 +32,7 @@ int getRbufSizePkts(int SRTO_RCVBUF, int SRTO_MSS, int SRTO_FC)
     // UDP header size is assumed to be 44 bytes
     // 20 bytes IPv4 + 8 bytes of UDP + 16 bytes SRT
     const int UDPHDR_SIZE = 44;
-    const int pkts = (rbuf_size / (SRTO_MSS - UDPHDR_SIZE));
+    const int pkts = (rbuf_size / (SRTO_MSS - UDPHDR_SIZE - SRTHDR_SIZE));
 
     return min(pkts, SRTO_FC);
 }

--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -30,8 +30,9 @@ The following function returns the buffer size in packets:
 int getRbufSizePkts(int SRTO_RCVBUF, int SRTO_MSS, int SRTO_FC)
 {
     // UDP header size is assumed to be 28 bytes
-    // 20 bytes IPv4 + 8 bytes of UDP + 16 bytes SRT
+    // 20 bytes IPv4 + 8 bytes of UDP
     const int UDPHDR_SIZE = 28;
+    // SRT Header is 16 bytes
     const int SRTHDR_SIZE = 16;
     const int pkts = (rbuf_size / (SRTO_MSS - UDPHDR_SIZE - SRTHDR_SIZE));
 

--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -29,9 +29,10 @@ The following function returns the buffer size in packets:
 ```c++
 int getRbufSizePkts(int SRTO_RCVBUF, int SRTO_MSS, int SRTO_FC)
 {
-    // UDP header size is assumed to be 44 bytes
+    // UDP header size is assumed to be 28 bytes
     // 20 bytes IPv4 + 8 bytes of UDP + 16 bytes SRT
-    const int UDPHDR_SIZE = 44;
+    const int UDPHDR_SIZE = 28;
+    const int SRTHDR_SIZE = 16;
     const int pkts = (rbuf_size / (SRTO_MSS - UDPHDR_SIZE - SRTHDR_SIZE));
 
     return min(pkts, SRTO_FC);

--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -79,7 +79,7 @@ The target size of the payload stored by the receiver buffer would be:
 
 where
 
-- `UDPHDR_SIZE` = 28 (20 bytes IPv4, 8 bytes of UDP)
+- `UDPHDR_SIZE` = 44 (20 bytes IPv4, 8 bytes of UDP, 16 bytes SRT)
 - `SRTO_MSS` is the corresponding socket option value at the moment of setting `SRTO_RCVBUF`.
 
 

--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -92,9 +92,10 @@ where
 auto CalculateTargetRBufSize(int msRTT, int bpsRate, int bytesPayloadSize, int msLatency, int SRTO_MSS)
 {
     const int UDPHDR_SIZE = 28;
+    const int SRTHDR_SIZE = 16;
     const long long targetPayloadBytes = static_cast<long long>(msLatency + msRTT / 2) * bpsRate / 1000 / 8;
     const long long targetNumPackets   = targetPayloadBytes / bytesPayloadSize;
-    const long long targetSizeValue    = targetNumPackets * (SRTO_MSS - UDPHDR_SIZE);
+    const long long targetSizeValue    = targetNumPackets * (SRTO_MSS - UDPHDR_SIZE - SRTHDR_SIZE);
     return {targetNumPackets, targetSizeValue};
 }
 

--- a/docs/API/configuration-guidelines.md
+++ b/docs/API/configuration-guidelines.md
@@ -81,7 +81,8 @@ The target size of the payload stored by the receiver buffer would be:
 
 where
 
-- `UDPHDR_SIZE` = 44 (20 bytes IPv4, 8 bytes of UDP, 16 bytes SRT)
+- `UDPHDR_SIZE` = 28 (20 bytes IPv4, 8 bytes of UDP)
+- `SRTHDR_SIZE` = 16 bytes
 - `SRTO_MSS` is the corresponding socket option value at the moment of setting `SRTO_RCVBUF`.
 
 


### PR DESCRIPTION
Updated inconsistent header size calculation

Not sure why the 16 SRT header bytes aren't included here, but if they really shouldn't be included in the calculation, then an explanation as to why should be included in the document as currently it is unclear and directly contradicts the use of the number 44 in [lines 63-66](https://github.com/Haivision/srt/blame/master/docs/API/configuration-guidelines.md#L63-L66).