### PR TITLE
[FIX] Added rejection handshake sent to the peer in rendezvous mode

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3686,12 +3686,14 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
                 if (cst == CONN_CONTINUE)
                     continue;
 
+                // Just in case it wasn't set, set this as a fallback
+                if (m_RejectReason == SRT_REJ_UNKNOWN)
+                    m_RejectReason = SRT_REJ_ROGUE;
+
                 // rejection or erroneous code.
                 reqpkt.setLength(m_iMaxSRTPayloadSize);
                 reqpkt.setControl(UMSG_HANDSHAKE);
                 sendRendezvousRejection(serv_addr, (reqpkt));
-
-                break; // unure if this should stay. This prevents from sending additionally SHUTDOWN message
             }
 
             if (cst == CONN_REJECT)
@@ -3886,6 +3888,9 @@ bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
             LOGC(cnlog.Warn,
                  log << CONID()
                      << "processAsyncConnectRequest: REJECT reported from processRendezvous, not processing further.");
+
+            if (m_RejectReason == SRT_REJ_UNKNOWN)
+                m_RejectReason = SRT_REJ_ROGUE;
 
             sendRendezvousRejection(serv_addr, (request));
             status = false;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2629,6 +2629,9 @@ bool srt::CUDT::interpretSrtHandshake(const CHandShake& hs,
                     {
                         // Cryptographic modes mismatch. Not acceptable at all.
                         m_RejectReason = SRT_REJ_CRYPTO;
+                        LOGC(cnlog.Error,
+                             log << CONID()
+                                 << "interpretSrtHandshake: KMREQ result: Bad crypto mode - rejecting");
                         return false;
                     }
 #endif
@@ -3682,11 +3685,21 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
                 cst = processRendezvous(&response, serv_addr, RST_OK, (reqpkt));
                 if (cst == CONN_CONTINUE)
                     continue;
-                break;
+
+                // rejection or erroneous code.
+                reqpkt.setLength(m_iMaxSRTPayloadSize);
+                reqpkt.setControl(UMSG_HANDSHAKE);
+                sendRendezvousRejection(serv_addr, (reqpkt));
+
+                break; // unure if this should stay. This prevents from sending additionally SHUTDOWN message
             }
 
             if (cst == CONN_REJECT)
+            {
+                HLOGC(cnlog.Debug,
+                        log << CONID() << "startConnect: REJECTED by processConnectResponse - sending SHUTDOWN");
                 sendCtrl(UMSG_SHUTDOWN);
+            }
 
             if (cst != CONN_CONTINUE && cst != CONN_CONFUSED)
                 break; // --> OUTSIDE-LOOP
@@ -3873,6 +3886,8 @@ bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
             LOGC(cnlog.Warn,
                  log << CONID()
                      << "processAsyncConnectRequest: REJECT reported from processRendezvous, not processing further.");
+
+            sendRendezvousRejection(serv_addr, (request));
             status = false;
         }
     }
@@ -3923,6 +3938,24 @@ bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
     m_tsLastReqTime = steady_clock::now();
     m_pSndQueue->sendto(serv_addr, request, m_SourceAddr);
     return status;
+}
+
+void srt::CUDT::sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& r_rsppkt)
+{
+    // We can reuse m_ConnReq because we are about to abandon the connection process.
+    m_ConnReq.m_iReqType = URQFailure(m_RejectReason);
+
+    // Assumed that r_rsppkt refers to a packet object that was already prepared
+    // to be used for storing the handshake there.
+    size_t size = r_rsppkt.getLength();
+    m_ConnReq.store_to((r_rsppkt.m_pcData), (size));
+    r_rsppkt.setLength(size);
+
+    HLOGC(cnlog.Debug, log << CONID() << "sendRendezvousRejection: using code=" << m_ConnReq.m_iReqType
+            << " for reject reason code " << m_RejectReason << " (" << srt_rejectreason_str(m_RejectReason) << ")");
+
+    setPacketTS(r_rsppkt, steady_clock::now());
+    m_pSndQueue->sendto(serv_addr, r_rsppkt, m_SourceAddr);
 }
 
 void srt::CUDT::cookieContest()
@@ -4427,7 +4460,25 @@ EConnectStatus srt::CUDT::processConnectResponse(const CPacket& response, CUDTEx
                      << "processConnectResponse: CONFUSED: expected UMSG_HANDSHAKE as connection not yet established, "
                         "got: "
                      << MessageTypeStr(response.getType(), response.getExtendedType()));
+
+            if (response.getType() == UMSG_SHUTDOWN)
+            {
+                LOGC(cnlog.Error,
+                        log << CONID() << "processConnectResponse: UMSG_SHUTDOWN received, rejecting connection.");
+                return CONN_REJECT;
+            }
         }
+
+        if (m_config.bRendezvous)
+        {
+            // In rendezvous mode we expect that both sides are known
+            // to the service operator (unlike a listener, which may
+            // operate connections from unknown sources). This means that
+            // the connection process should be terminated anyway, on
+            // whichever side it would happen.
+            return CONN_REJECT;
+        }
+
         return CONN_CONFUSED;
     }
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -485,6 +485,7 @@ private:
     /// @param rst Current read status to know if the HS packet was freshly received from the peer, or this is only a periodic update (RST_AGAIN)
     SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
     EConnectStatus processRendezvous(const CPacket* response, const sockaddr_any& serv_addr, EReadStatus, CPacket& reqpkt);
+    void sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& request);
 
     /// Create the CryptoControl object based on the HS packet. Allocates sender and receiver buffers and loss lists.
     SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -57,6 +57,9 @@ std::string KmStateStr(SRT_KM_STATE state)
         TAKE(SECURING);
         TAKE(NOSECRET);
         TAKE(BADSECRET);
+#ifdef ENABLE_AEAD_API_PREVIEW
+        TAKE(BADCRYPTOMODE);
+#endif
 #undef TAKE
     default:
         {

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -439,7 +439,7 @@ const char* const srt_rejection_reason_msg [] = {
     "Packet Filter settings error",
     "Group settings collision",
     "Connection timeout"
-#ifdef ENABLE_AEAD_PREVIEW
+#ifdef ENABLE_AEAD_API_PREVIEW
     ,"Crypto mode"
 #endif
 };
@@ -463,7 +463,7 @@ extern const char* const srt_rejectreason_msg[] = {
     srt_rejection_reason_msg[14],
     srt_rejection_reason_msg[15],
     srt_rejection_reason_msg[16]
-#ifdef ENABLE_AEAD_PREVIEW
+#ifdef ENABLE_AEAD_API_PREVIEW
     , srt_rejection_reason_msg[17]
 #endif
 };

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -144,7 +144,7 @@ public:
     {
         ofile.write(data.payload.data(), data.payload.size());
 #ifdef PLEASE_LOG
-        applog.Debug() << "FileTarget::Write: " << data.size() << " written to a file";
+        applog.Debug() << "FileTarget::Write: " << data.payload.size() << " written to a file";
 #endif
     }
 
@@ -1297,7 +1297,8 @@ void SrtCommon::ConnectClient(string host, int port)
         {
             int reason = srt_getrejectreason(m_sock);
 #if PLEASE_LOG
-            LOGP(applog.Error, "ERROR reported by srt_connect - closing socket @", m_sock);
+            LOGP(applog.Error, "ERROR reported by srt_connect - closing socket @", m_sock,
+                    " reject reason: ", reason, ": ", srt_rejectreason_str(reason));
 #endif
             if (transmit_retry_connect && (transmit_retry_always || reason == SRT_REJ_TIMEOUT))
             {
@@ -2360,7 +2361,7 @@ Epoll_again:
 #if PLEASE_LOG
         extern srt_logging::Logger applog;
         LOGC(applog.Debug, log << "recv: #" << mctrl.msgno << " %" << mctrl.pktseq << "  "
-                << BufferStamp(data.data(), stat) << " BELATED: " << ((CTimer::getTime()-mctrl.srctime)/1000.0) << "ms");
+                << BufferStamp(data.data(), stat) << " BELATED: " << ((srt_time_now()-mctrl.srctime)/1000.0) << "ms");
 #endif
 
         Verb() << "(#" << mctrl.msgno << " %" << mctrl.pktseq << "  " << BufferStamp(data.data(), stat) << ") " << VerbNoEOL;


### PR DESCRIPTION
This adds the procedure to craft and send the rejection response in case when the handshake in rendezvous mode in one side has resulted in rejection. Some paths for this are common with caller mode so it's taken care of that it happens only in case of rendezvous mode.

Motivation: in case of caller-listener layout, it happens the following way:

1. Caller-Listener induction exchange.
2. The listener receives conclusion handshake, which is erroneous and it is being rejected
3. The listener responds anyway (in its distinct procedure), AFTER it closes the accepted socket without allowing it to be retrieved, and the listener handler procedure is crafting and sending the rejection response to the caller.

In some rare cases when the rejection is done on the caller, while the listener accepts the handshake, the caller doesn't send any rejection handshake to the listener (and sends the shutdown message instead) because:
1. The listener has finished and it will not handle this message. This will be dispatched to the accepted socket.
2. The accepted socket now expects only data packets or some in-transmission control packets (including obviously shutdown), and not the handshake. It has already accepted the connection so no rejection could be handled this time (the application that is using this socket has already put it into the procedures using recv/send procedures, and these are not intended to return any "rejection", at worst they can find the socket disconnected).

Hence:
1. The listener already has a procedure that sends back the rejection handshake.
2. The caller can't send the rejection handshake to an already connected peer, only shutdown.

In rendezvous the situation is a little bit different: both sides handle the request in their procedures working the same way as for caller, with a special procedure handling the rendezvous part. So there wasn't so far defined any way to send any rejection packet to the peer - but then it was possible to add this only for the path referring to rendezvous connection. Unlike for the caller, it does make sense here to send the rejection handshake because it is always the first arrived conclusion handshake with extension that ignites the connection and it is awaiting a response, be it even of AGREEMENT type.