### PR TITLE
[MAINT/TEST] Added custom main with transparent parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ script:
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ulimit -c unlimited;
-        ./test-srt -disable-ipv6
+        ./test-srt -disable-ipv6;
         SUCCESS=$?;
         if [ -f core ]; then gdb -batch ./test-srt -c core -ex bt -ex "info thread" -ex quit; else echo "NO CORE - NO CRY!"; fi;
         test $SUCCESS == 0;

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ matrix:
           - BUILD_TYPE=Release
           - BUILD_OPTS='-DENABLE_MONOTONIC_CLOCK=ON'
 script:
-    - TESTS_IPv6="TestMuxer.IPv4_and_IPv6:TestIPv6.v6_calls_v6*:ReuseAddr.ProtocolVersion:ReuseAddr.*6" ; # Tests to skip due to lack of IPv6 support
     - if [ "$TRAVIS_COMPILER" == "x86_64-w64-mingw32-g++" ]; then
         export CC="x86_64-w64-mingw32-gcc";
         export CXX="x86_64-w64-mingw32-g++";
@@ -95,7 +94,7 @@ script:
       fi
     - if [ "$TRAVIS_COMPILER" != "x86_64-w64-mingw32-g++" ]; then
         ulimit -c unlimited;
-        ./test-srt --gtest_filter="-$TESTS_IPv6";
+        ./test-srt -disable-ipv6
         SUCCESS=$?;
         if [ -f core ]; then gdb -batch ./test-srt -c core -ex bt -ex "info thread" -ex quit; else echo "NO CORE - NO CRY!"; fi;
         test $SUCCESS == 0;

--- a/test/TESTS_HOWTO.md
+++ b/test/TESTS_HOWTO.md
@@ -1,0 +1,107 @@
+# Rules for writing tests for SRT
+
+## 1. Use automatic startup/cleanup management
+
+Note that most of the test require SRT library to be initialized for the
+time of running the test. There are two methods how you can do it:
+
+* In a free test (`TEST` macro), declare this in the beginning:
+`srt::TestInit srtinit;`
+
+* In a fixture (`TEST_F` macro), draw your class off `srt::Test`
+(instead of `testing::Test`)
+
+In the fixture case you should also use names `setup/teardown` instead of
+`SetUp/TearDown`. Both these things will properly initialize and destroy the
+library resources.
+
+## 2. Do not misuse ASSERT macros
+
+**Be careful** where you are using `ASSERT_*` macros. In distinction to
+`EXPECT_*` macros, they interrupt the testing procedure by throwing an exception.
+This means that if this fires, nothing will be executed up to the end of the
+current testing procedure, unless it's a destructor of some object constructed
+inside the procedure.
+
+This means, however, that if you have any resource deallocation procedures, which
+must be placed there for completion regardless of the test result, the call to
+`ASSERT_*` macro will skip them, which may often lead to misexecution of the
+remaining tests and have them falsely failed. If this interruption is necessary,
+there are the following methods you can use to prevent skipping resource cleanup:
+
+* Do not cleanup anything in the testing procedure. Use the fixture's teardown
+method for any cleaning. Remember also that it is not allowed to use `ASSERT_*`
+macros in the teardown procedure, should you need to test additionally to the
+cleanup.
+
+* You can also use a local class with a destructor so that cleanups will execute
+no matter what happened inside the procedure
+
+* Last resort, keep the code that might use `ASSERT_*` macro in the try-catch
+block and free the resources in the `catch` clause, then rethrow the exception.
+A disadvantage of this solution is that you'll have to repeat the cleanup
+procedure outside the try-catch block.
+
+* Use `EXPECT_` macros, but still check the condition again and skip required
+parts of the test that could not be done without this resource.
+
+# Useful SRT test features
+
+## Test command line parameters
+
+The SRT tests support command-line parameters. They are available in test
+procedures, startups, and through this you can control some execution
+aspects. The gtest-specific options are being removed from the command
+line by the gtest library itself; all other parameters are available for
+the user. The main API access function for this is `srt::TestEnv`. This
+is a fixed singleton object accessed through `srt::TestEnv::me` pointer.
+These arguments are accessible through two fields:
+
+* `TestEnv::args`: a plain vector with all the command line arguments
+* `TestEnv::argmap`: a map of arguments parsed according to the option syntax
+
+The option syntax is the following:
+
+* `-option` : single option without argument; can be tested for presence
+* `-option param1 param2 param3` : multiple parameters assigned to an option
+
+Special markers:
+
+* `--`: end of options
+* `-/`: end of parameters for the current option
+
+To specify free parameters after an option (and possibly its own parameters),
+end the parameter list with the `-/` phrase. The `--` phrase means that the
+rest of command line parameters are arguments for the last specified option,
+even if they start with a dash. Note that a single dash has no special meaning.
+
+From the API perspective, in the `TestEnv::argmap` container there are option
+parameters collected in a vector assigned to particular option as a map key,
+with skipped the initial dash. Free parameters are assigned to an empty string
+key. You can use also two helper methods:
+
+* `OptionPresent(name)`: returns true if the option of `name` is present in the
+map (note that options without parameters have simply an empty vector assigned)
+
+* `OptionValue(name)`: returns a string that contains all parameters for that
+option separated by a space (note that the value type in the map is a vector
+of strings)
+
+## Test environment feature checks
+
+The macro `SRTST_REQUIRE` can be used to check if particular feature of the
+test environment is available. This binds to the `TestEnv::Available_FEATURE`
+option if used as `SRTST_REQUIRE(FEATURE)`. This macro makes the test function
+exit immediately with success and prints the information that the test is
+forced to pass due to unavailable features.
+
+To add more environment availability features, add more `TestEnv::Available_`
+methods. Methods must return `bool`, but may have parameters, which are passed
+next to the first argument in the macro transparently. Availability can be
+tested internally, or taken as a good deal from options, as it is currently
+done with the IPv6 feature - it is declared as not available when the test
+application gets the `-disable-ipv6` option.
+
+It is unknown what future tests could require particular system features,
+so this solution is open for further extensions.
+

--- a/test/TESTS_HOWTO.md
+++ b/test/TESTS_HOWTO.md
@@ -75,10 +75,10 @@ end the parameter list with the `-/` phrase. The `--` phrase means that the
 rest of command line parameters are arguments for the last specified option,
 even if they start with a dash. Note that a single dash has no special meaning.
 
-From the API perspective, in the `TestEnv::argmap` container there are option
-parameters collected in a vector assigned to particular option as a map key,
-with skipped the initial dash. Free parameters are assigned to an empty string
-key. You can use also two helper methods:
+The `TestEnv::argmap` is using option names (except the initial dash) as keys
+and the value is a vector of the parameters specified after the option. Free
+parameters are collected under an empty string key. For convenience you can
+also use two `TestEnv` helper methods:
 
 * `OptionPresent(name)`: returns true if the option of `name` is present in the
 map (note that options without parameters have simply an empty vector assigned)
@@ -92,15 +92,15 @@ of strings)
 The macro `SRTST_REQUIRE` can be used to check if particular feature of the
 test environment is available. This binds to the `TestEnv::Available_FEATURE`
 option if used as `SRTST_REQUIRE(FEATURE)`. This macro makes the test function
-exit immediately with success and prints the information that the test is
-forced to pass due to unavailable features.
+exit immediately with success. The checking function should take care of
+printing appropriate information about that the test was forcefully passed.
 
-To add more environment availability features, add more `TestEnv::Available_`
+To add more environment availability features, add more `TestEnv::Available_*`
 methods. Methods must return `bool`, but may have parameters, which are passed
 next to the first argument in the macro transparently. Availability can be
-tested internally, or taken as a good deal from options, as it is currently
-done with the IPv6 feature - it is declared as not available when the test
-application gets the `-disable-ipv6` option.
+tested internally, or taken as a good deal basing on options, as it is
+currently done with the IPv6 feature - it is declared as not available when the
+test application gets the `-disable-ipv6` option.
 
 It is unknown what future tests could require particular system features,
 so this solution is open for further extensions.

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -2,6 +2,7 @@ HEADERS
 any.hpp
 
 SOURCES
+test_main.cpp
 test_buffer_rcv.cpp
 test_common.cpp
 test_connection_timeout.cpp

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -1,5 +1,6 @@
 HEADERS
 any.hpp
+test_env.h
 
 SOURCES
 test_main.cpp

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -5,15 +5,15 @@
 #include <functional>
 
 #include "gtest/gtest.h"
+#include "test_env.h"
 
 #include "srt.h"
 #include "netinet_any.h"
 
 TEST(Bonding, SRTConnectGroup)
 {
+	srt::TestInit srtinit;
     struct sockaddr_in sa;
-
-    srt_startup();
 
     const int ss = srt_create_group(SRT_GTYPE_BROADCAST);
     ASSERT_NE(ss, SRT_ERROR);
@@ -54,8 +54,6 @@ TEST(Bonding, SRTConnectGroup)
     {
         std::cerr << "srt_close: " << srt_getlasterror_str() << std::endl;
     }
-
-    srt_cleanup();
 }
 
 #define ASSERT_SRT_SUCCESS(callform) ASSERT_NE(callform, -1) << "SRT ERROR: " << srt_getlasterror_str()
@@ -133,7 +131,7 @@ void ConnectCallback(void* /*opaq*/, SRTSOCKET sock, int error, const sockaddr* 
 
 TEST(Bonding, NonBlockingGroupConnect)
 {
-    srt_startup();
+	srt::TestInit srtinit;
     
     const int ss = srt_create_group(SRT_GTYPE_BROADCAST);
     ASSERT_NE(ss, SRT_ERROR);
@@ -207,8 +205,6 @@ TEST(Bonding, NonBlockingGroupConnect)
     listen_promise.wait();
 
     EXPECT_EQ(srt_close(ss), 0) << "srt_close: %s\n" << srt_getlasterror_str();
-
-    srt_cleanup();
 }
 
 void ConnectCallback_Close(void* /*opaq*/, SRTSOCKET sock, int error, const sockaddr* /*peer*/, int token)
@@ -226,7 +222,7 @@ void ConnectCallback_Close(void* /*opaq*/, SRTSOCKET sock, int error, const sock
 
 TEST(Bonding, CloseGroupAndSocket)
 {
-    srt_startup();
+	srt::TestInit srtinit;
     
     const int ss = srt_create_group(SRT_GTYPE_BROADCAST);
     ASSERT_NE(ss, SRT_ERROR);
@@ -332,7 +328,5 @@ TEST(Bonding, CloseGroupAndSocket)
     std::cout << "CLOSED GROUP. Now waiting for sender to exit...\n";
     sender.join();
     listen_promise.wait();
-
-    srt_cleanup();
 }
 

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -12,7 +12,7 @@
 
 TEST(Bonding, SRTConnectGroup)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     struct sockaddr_in sa;
 
     const int ss = srt_create_group(SRT_GTYPE_BROADCAST);
@@ -131,8 +131,8 @@ void ConnectCallback(void* /*opaq*/, SRTSOCKET sock, int error, const sockaddr* 
 
 TEST(Bonding, NonBlockingGroupConnect)
 {
-	srt::TestInit srtinit;
-    
+    srt::TestInit srtinit;
+
     const int ss = srt_create_group(SRT_GTYPE_BROADCAST);
     ASSERT_NE(ss, SRT_ERROR);
     std::cout << "Created group socket: " << ss << '\n';
@@ -222,8 +222,8 @@ void ConnectCallback_Close(void* /*opaq*/, SRTSOCKET sock, int error, const sock
 
 TEST(Bonding, CloseGroupAndSocket)
 {
-	srt::TestInit srtinit;
-    
+    srt::TestInit srtinit;
+
     const int ss = srt_create_group(SRT_GTYPE_BROADCAST);
     ASSERT_NE(ss, SRT_ERROR);
     std::cout << "Created group socket: " << ss << '\n';

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -44,7 +44,7 @@ void test_cipaddress_pton(const char* peer_ip, int family, const uint32_t (&ip)[
 // Example IPv4 address: 192.168.0.1
 TEST(CIPAddress, IPv4_pton)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const char*    peer_ip = "192.168.0.1";
     const uint32_t ip[4]   = {htobe32(0xC0A80001), 0, 0, 0};
     test_cipaddress_pton(peer_ip, AF_INET, ip);
@@ -53,7 +53,7 @@ TEST(CIPAddress, IPv4_pton)
 // Example IPv6 address: 2001:db8:85a3:8d3:1319:8a2e:370:7348
 TEST(CIPAddress, IPv6_pton)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const char*    peer_ip = "2001:db8:85a3:8d3:1319:8a2e:370:7348";
     const uint32_t ip[4]   = {htobe32(0x20010db8), htobe32(0x85a308d3), htobe32(0x13198a2e), htobe32(0x03707348)};
 
@@ -62,10 +62,10 @@ TEST(CIPAddress, IPv6_pton)
 
 // Example IPv4 address: 192.168.0.1
 // Maps to IPv6 address: 0:0:0:0:0:FFFF:192.168.0.1
-// Simplified: 	                 ::FFFF:192.168.0.1
+// Simplified:                   ::FFFF:192.168.0.1
 TEST(CIPAddress, IPv4_in_IPv6_pton)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const char*    peer_ip = "::ffff:192.168.0.1";
     const uint32_t ip[4]   = {0, 0, htobe32(0x0000FFFF), htobe32(0xC0A80001)};
 

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #include "gtest/gtest.h"
+#include "test_env.h"
 #include "utilities.h"
 #include "common.h"
 
@@ -43,6 +44,7 @@ void test_cipaddress_pton(const char* peer_ip, int family, const uint32_t (&ip)[
 // Example IPv4 address: 192.168.0.1
 TEST(CIPAddress, IPv4_pton)
 {
+	srt::TestInit srtinit;
     const char*    peer_ip = "192.168.0.1";
     const uint32_t ip[4]   = {htobe32(0xC0A80001), 0, 0, 0};
     test_cipaddress_pton(peer_ip, AF_INET, ip);
@@ -51,6 +53,7 @@ TEST(CIPAddress, IPv4_pton)
 // Example IPv6 address: 2001:db8:85a3:8d3:1319:8a2e:370:7348
 TEST(CIPAddress, IPv6_pton)
 {
+	srt::TestInit srtinit;
     const char*    peer_ip = "2001:db8:85a3:8d3:1319:8a2e:370:7348";
     const uint32_t ip[4]   = {htobe32(0x20010db8), htobe32(0x85a308d3), htobe32(0x13198a2e), htobe32(0x03707348)};
 
@@ -62,6 +65,7 @@ TEST(CIPAddress, IPv6_pton)
 // Simplified: 	                 ::FFFF:192.168.0.1
 TEST(CIPAddress, IPv4_in_IPv6_pton)
 {
+	srt::TestInit srtinit;
     const char*    peer_ip = "::ffff:192.168.0.1";
     const uint32_t ip[4]   = {0, 0, htobe32(0x0000FFFF), htobe32(0xC0A80001)};
 

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -1,5 +1,6 @@
-#include <gtest/gtest.h>
 #include <chrono>
+#include <gtest/gtest.h>
+#include "test_env.h"
 
 #ifdef _WIN32
 #define INC_SRT_WIN_WINTIME // exclude gettimeofday from srt headers
@@ -16,7 +17,7 @@ using namespace std;
 
 
 class TestConnectionTimeout
-    : public ::testing::Test
+    : public ::srt::Test
 {
 protected:
     TestConnectionTimeout()
@@ -32,10 +33,8 @@ protected:
 protected:
 
     // SetUp() is run immediately before a test starts.
-    void SetUp() override
+    void setup() override
     {
-        ASSERT_EQ(srt_startup(), 0);
-
         m_sa.sin_family = AF_INET;
         m_sa.sin_addr.s_addr = INADDR_ANY;
         m_udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -60,12 +59,11 @@ protected:
         ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &m_sa.sin_addr), 1);
     }
 
-    void TearDown() override
+    void teardown() override
     {
         // Code here will be called just after the test completes.
         // OK to throw exceptions from here if needed.
-        ASSERT_NE(closesocket(m_udp_sock), -1);
-        srt_cleanup();
+        EXPECT_NE(closesocket(m_udp_sock), -1);
     }
 
 protected:

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -10,10 +10,11 @@
  *             Haivision Systems Inc.
  */
 
-#include <gtest/gtest.h>
 #include <thread>
 #include <condition_variable> 
 #include <mutex>
+#include <gtest/gtest.h>
+#include "test_env.h"
 
 #include "srt.h"
 #include "sync.h"
@@ -214,7 +215,7 @@ const TestCaseBlocking g_test_matrix_blocking[] =
 
 
 class TestEnforcedEncryption
-    : public ::testing::Test
+    : public srt::Test
 {
 protected:
     TestEnforcedEncryption()
@@ -230,10 +231,8 @@ protected:
 protected:
 
     // SetUp() is run immediately before a test starts.
-    void SetUp()
+    void setup() override
     {
-        ASSERT_EQ(srt_startup(), 0);
-
         m_pollid = srt_epoll_create();
         ASSERT_GE(m_pollid, 0);
 
@@ -254,13 +253,12 @@ protected:
         ASSERT_NE(srt_epoll_add_usock(m_pollid, m_listener_socket, &epoll_out), SRT_ERROR);
     }
 
-    void TearDown()
+    void teardown() override
     {
         // Code here will be called just after the test completes.
         // OK to throw exceptions from here if needed.
-        ASSERT_NE(srt_close(m_caller_socket),   SRT_ERROR);
-        ASSERT_NE(srt_close(m_listener_socket), SRT_ERROR);
-        srt_cleanup();
+        EXPECT_NE(srt_close(m_caller_socket),   SRT_ERROR) << srt_getlasterror_str();
+        EXPECT_NE(srt_close(m_listener_socket), SRT_ERROR) << srt_getlasterror_str();
     }
 
 

--- a/test/test_env.h
+++ b/test/test_env.h
@@ -56,7 +56,7 @@ public:
     TestInit() { start((ninst)); }
     ~TestInit() { stop(); }
 
-    void HandleOptions();
+    void HandlePerTestOptions();
 
 };
 
@@ -71,6 +71,7 @@ public:
     void SetUp() override final
     {
         init_holder.reset(new TestInit);
+        init_holder->HandlePerTestOptions();
         setup();
     }
 

--- a/test/test_env.h
+++ b/test/test_env.h
@@ -1,0 +1,20 @@
+#include <string>
+#include <vector>
+#include <stdexcept>
+#include "gtest/gtest.h"
+
+class SrtTestEnv: public testing::Environment
+{
+public:
+    static SrtTestEnv* me;
+
+    std::vector<std::string> args;
+    explicit SrtTestEnv(int argc, char** argv)
+        : args(argv+1, argv+argc)
+    {
+        if (me)
+            throw std::invalid_argument("singleton");
+
+        me = this;
+    }
+};

--- a/test/test_env.h
+++ b/test/test_env.h
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+#include <map>
 #include <stdexcept>
 #include "gtest/gtest.h"
 
@@ -9,6 +10,8 @@ public:
     static SrtTestEnv* me;
 
     std::vector<std::string> args;
+    std::map<std::string, std::vector<std::string>> argmap;
+
     explicit SrtTestEnv(int argc, char** argv)
         : args(argv+1, argv+argc)
     {
@@ -16,5 +19,15 @@ public:
             throw std::invalid_argument("singleton");
 
         me = this;
+        FillArgMap();
     }
+
+    void FillArgMap();
+
+    bool OptionPresent(const std::string& key)
+    {
+        return argmap.count(key) > 0;
+    }
+
+    std::string OptionValue(const std::string& key);
 };

--- a/test/test_env.h
+++ b/test/test_env.h
@@ -1,18 +1,23 @@
+#ifndef INC_SRT_TESTENV_H
+#define INC_SRT_TESTENV_H
+
 #include <string>
 #include <vector>
 #include <map>
 #include <stdexcept>
 #include "gtest/gtest.h"
 
-class SrtTestEnv: public testing::Environment
+
+namespace srt
+{
+class TestEnv: public testing::Environment
 {
 public:
-    static SrtTestEnv* me;
-
+    static TestEnv* me;
     std::vector<std::string> args;
     std::map<std::string, std::vector<std::string>> argmap;
 
-    explicit SrtTestEnv(int argc, char** argv)
+    explicit TestEnv(int argc, char** argv)
         : args(argv+1, argv+argc)
     {
         if (me)
@@ -30,4 +35,54 @@ public:
     }
 
     std::string OptionValue(const std::string& key);
+
+    // Specific test environment options
+    // All must be static, return bool. Arguments allowed.
+    // The name must start with Allowed_.
+    static bool Allowed_IPv6();
 };
+
+#define SRTST_REQUIRES(feature,...) if (!srt::TestEnv::Allowed_##feature(__VA_ARGS__)) { return; }
+
+
+class TestInit
+{
+public:
+    int ninst;
+
+    static void start(int& w_retstatus);
+    static void stop();
+
+    TestInit() { start((ninst)); }
+    ~TestInit() { stop(); }
+
+    void HandleOptions();
+
+};
+
+class Test: public testing::Test
+{
+    std::unique_ptr<TestInit> init_holder;
+public:
+
+    virtual void setup() = 0;
+    virtual void teardown() = 0;
+
+    void SetUp() override final
+    {
+        init_holder.reset(new TestInit);
+        setup();
+    }
+
+    void TearDown() override final
+    {
+        teardown();
+        init_holder.reset();
+    }
+};
+
+struct sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_family);
+
+} //namespace
+
+#endif

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -15,7 +15,7 @@ using namespace srt;
 
 TEST(CEPoll, InfiniteWait)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);
 
@@ -29,7 +29,7 @@ TEST(CEPoll, InfiniteWait)
 
 TEST(CEPoll, WaitNoSocketsInEpoll)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);
@@ -49,7 +49,7 @@ TEST(CEPoll, WaitNoSocketsInEpoll)
 
 TEST(CEPoll, WaitNoSocketsInEpoll2)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);
@@ -64,7 +64,7 @@ TEST(CEPoll, WaitNoSocketsInEpoll2)
 
 TEST(CEPoll, WaitEmptyCall)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -87,7 +87,7 @@ TEST(CEPoll, WaitEmptyCall)
 
 TEST(CEPoll, UWaitEmptyCall)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -110,7 +110,7 @@ TEST(CEPoll, UWaitEmptyCall)
 
 TEST(CEPoll, WaitAllSocketsInEpollReleased)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -144,7 +144,7 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased)
 
 TEST(CEPoll, WaitAllSocketsInEpollReleased2)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -173,7 +173,7 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased2)
 
 TEST(CEPoll, WrongEpoll_idOnAddUSock)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -196,7 +196,7 @@ TEST(CEPoll, WrongEpoll_idOnAddUSock)
 
 TEST(CEPoll, HandleEpollEvent)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -256,7 +256,7 @@ TEST(CEPoll, HandleEpollEvent)
 // be notified about connection break via polling the accepted socket.
 TEST(CEPoll, NotifyConnectionBreak)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     // 1. Prepare client
     SRTSOCKET client_sock = srt_create_socket();
@@ -371,7 +371,7 @@ TEST(CEPoll, NotifyConnectionBreak)
 
 TEST(CEPoll, HandleEpollEvent2)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -432,7 +432,7 @@ TEST(CEPoll, HandleEpollEvent2)
 
 TEST(CEPoll, HandleEpollNoEvent)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -482,7 +482,7 @@ TEST(CEPoll, HandleEpollNoEvent)
 
 TEST(CEPoll, ThreadedUpdate)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -676,7 +676,7 @@ protected:
 
             ASSERT_EQ(rlen, 1); // get exactly one read event without writes
             ASSERT_EQ(wlen, 0); // get exactly one read event without writes
-            ASSERT_EQ(read[0], servsock); // read event is for bind socket    	
+            ASSERT_EQ(read[0], servsock); // read event is for bind socket
         }
 
         sockaddr_in scl;

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <condition_variable>
 #include "gtest/gtest.h"
+#include "test_env.h"
 #include "api.h"
 #include "epoll.h"
 
@@ -14,8 +15,7 @@ using namespace srt;
 
 TEST(CEPoll, InfiniteWait)
 {
-    ASSERT_EQ(srt_startup(), 0);
-
+	srt::TestInit srtinit;
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);
 
@@ -25,13 +25,11 @@ TEST(CEPoll, InfiniteWait)
         0, 0, 0, 0), SRT_ERROR);
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
-
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, WaitNoSocketsInEpoll)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);
@@ -47,12 +45,11 @@ TEST(CEPoll, WaitNoSocketsInEpoll)
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, WaitNoSocketsInEpoll2)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     const int epoll_id = srt_epoll_create();
     ASSERT_GE(epoll_id, 0);
@@ -63,12 +60,11 @@ TEST(CEPoll, WaitNoSocketsInEpoll2)
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, WaitEmptyCall)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -87,12 +83,11 @@ TEST(CEPoll, WaitEmptyCall)
                 -1, 0, 0, 0, 0), SRT_ERROR);
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, UWaitEmptyCall)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -111,12 +106,11 @@ TEST(CEPoll, UWaitEmptyCall)
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, WaitAllSocketsInEpollReleased)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -146,12 +140,11 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased)
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, WaitAllSocketsInEpollReleased2)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -176,12 +169,11 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased2)
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, WrongEpoll_idOnAddUSock)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
@@ -199,13 +191,12 @@ TEST(CEPoll, WrongEpoll_idOnAddUSock)
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 
 TEST(CEPoll, HandleEpollEvent)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -256,7 +247,6 @@ TEST(CEPoll, HandleEpollEvent)
         throw;
     }
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 
@@ -266,7 +256,7 @@ TEST(CEPoll, HandleEpollEvent)
 // be notified about connection break via polling the accepted socket.
 TEST(CEPoll, NotifyConnectionBreak)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     // 1. Prepare client
     SRTSOCKET client_sock = srt_create_socket();
@@ -376,13 +366,12 @@ TEST(CEPoll, NotifyConnectionBreak)
     if (!state_valid)
         cerr << "socket state: " << state << endl;
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 
 TEST(CEPoll, HandleEpollEvent2)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -438,13 +427,12 @@ TEST(CEPoll, HandleEpollEvent2)
         throw;
     }
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 
 TEST(CEPoll, HandleEpollNoEvent)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -490,12 +478,11 @@ TEST(CEPoll, HandleEpollNoEvent)
         throw;
     }
 
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 TEST(CEPoll, ThreadedUpdate)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
@@ -556,13 +543,10 @@ TEST(CEPoll, ThreadedUpdate)
         cerr << ex.getErrorMessage() << endl;
         throw;
     }
-
-
-    EXPECT_EQ(srt_cleanup(), 0);
 }
 
 
-class TestEPoll: public testing::Test
+class TestEPoll: public srt::Test
 {
 protected:
 
@@ -750,10 +734,8 @@ protected:
         srt_close(servsock);
     }
 
-    void SetUp() override
+    void setup() override
     {
-        ASSERT_EQ(srt_startup(), 0);
-
         m_client_pollid = srt_epoll_create();
         ASSERT_NE(SRT_ERROR, m_client_pollid);
 
@@ -762,11 +744,10 @@ protected:
 
     }
 
-    void TearDown() override
+    void teardown() override
     {
         (void)srt_epoll_release(m_client_pollid);
         (void)srt_epoll_release(m_server_pollid);
-        srt_cleanup();
     }
 };
 

--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -208,7 +208,7 @@ bool filterConfigSame(const string& config1, const string& config2)
 
 TEST(TestFEC, ConfigExchange)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     CUDTSocket* s1;
 
@@ -239,7 +239,7 @@ TEST(TestFEC, ConfigExchange)
 
 TEST(TestFEC, ConfigExchangeFaux)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     CUDTSocket* s1;
 
@@ -277,7 +277,7 @@ TEST(TestFEC, ConfigExchangeFaux)
 
 TEST(TestFEC, Connection)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -331,7 +331,7 @@ TEST(TestFEC, Connection)
 
 TEST(TestFEC, ConnectionReorder)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -383,7 +383,7 @@ TEST(TestFEC, ConnectionReorder)
 
 TEST(TestFEC, ConnectionFull1)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -435,7 +435,7 @@ TEST(TestFEC, ConnectionFull1)
 
 TEST(TestFEC, ConnectionFull2)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -487,7 +487,7 @@ TEST(TestFEC, ConnectionFull2)
 
 TEST(TestFEC, ConnectionMess)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -539,7 +539,7 @@ TEST(TestFEC, ConnectionMess)
 
 TEST(TestFEC, ConnectionForced)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -585,7 +585,7 @@ TEST(TestFEC, ConnectionForced)
 
 TEST(TestFEC, RejectionConflict)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -627,7 +627,7 @@ TEST(TestFEC, RejectionConflict)
 
 TEST(TestFEC, RejectionIncompleteEmpty)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -667,7 +667,7 @@ TEST(TestFEC, RejectionIncompleteEmpty)
 
 TEST(TestFEC, RejectionIncomplete)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();

--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -3,6 +3,7 @@
 #include <future>
 
 #include "gtest/gtest.h"
+#include "test_env.h"
 #include "packet.h"
 #include "fec.h"
 #include "core.h"
@@ -15,7 +16,7 @@
 using namespace std;
 using namespace srt;
 
-class TestFECRebuilding: public testing::Test
+class TestFECRebuilding: public srt::Test
 {
 protected:
     FECFilterBuiltin* fec = nullptr;
@@ -31,7 +32,7 @@ protected:
         PacketFilter::globalInit();
     }
 
-    void SetUp() override
+    void setup() override
     {
         int timestamp = 10;
 
@@ -86,7 +87,7 @@ protected:
         }
     }
 
-    void TearDown() override
+    void teardown() override
     {
         delete fec;
     }
@@ -207,7 +208,7 @@ bool filterConfigSame(const string& config1, const string& config2)
 
 TEST(TestFEC, ConfigExchange)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     CUDTSocket* s1;
 
@@ -234,12 +235,11 @@ TEST(TestFEC, ConfigExchange)
     string exp_config = "fec,cols:10,rows:10,arq:never,layout:staircase";
 
     EXPECT_TRUE(filterConfigSame(fec_configback, exp_config));
-    srt_cleanup();
 }
 
 TEST(TestFEC, ConfigExchangeFaux)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     CUDTSocket* s1;
 
@@ -273,12 +273,11 @@ TEST(TestFEC, ConfigExchangeFaux)
     cout << "(NOTE: expecting a failure message)\n";
     EXPECT_FALSE(m1.checkApplyFilterConfig("fec,cols:10,arq:never"));
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, Connection)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -328,12 +327,11 @@ TEST(TestFEC, Connection)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, ConnectionReorder)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -381,12 +379,11 @@ TEST(TestFEC, ConnectionReorder)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, ConnectionFull1)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -434,11 +431,11 @@ TEST(TestFEC, ConnectionFull1)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
-    srt_cleanup();
 }
+
 TEST(TestFEC, ConnectionFull2)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -486,12 +483,11 @@ TEST(TestFEC, ConnectionFull2)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, ConnectionMess)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -539,12 +535,11 @@ TEST(TestFEC, ConnectionMess)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, ConnectionForced)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -586,12 +581,11 @@ TEST(TestFEC, ConnectionForced)
     EXPECT_TRUE(filterConfigSame(result_config1, fec_config_final));
     EXPECT_TRUE(filterConfigSame(result_config2, fec_config_final));
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, RejectionConflict)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -629,12 +623,11 @@ TEST(TestFEC, RejectionConflict)
     int sclen = sizeof scl;
     EXPECT_EQ(srt_accept(l, (sockaddr*)& scl, &sclen), SRT_ERROR);
 
-    srt_cleanup();
 }
 
 TEST(TestFEC, RejectionIncompleteEmpty)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -669,13 +662,12 @@ TEST(TestFEC, RejectionIncompleteEmpty)
     int sclen = sizeof scl;
     EXPECT_EQ(srt_accept(l, (sockaddr*)& scl, &sclen), SRT_ERROR);
 
-    srt_cleanup();
 }
 
 
 TEST(TestFEC, RejectionIncomplete)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     SRTSOCKET s = srt_create_socket();
     SRTSOCKET l = srt_create_socket();
@@ -713,7 +705,6 @@ TEST(TestFEC, RejectionIncomplete)
     int sclen = sizeof scl;
     EXPECT_EQ(srt_accept(l, (sockaddr*)& scl, &sclen), SRT_ERROR);
 
-    srt_cleanup();
 }
 
 TEST_F(TestFECRebuilding, Prepare)

--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -30,7 +30,7 @@
 
 TEST(Transmission, FileUpload)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     // Generate the source file
     // We need a file that will contain more data

--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <gtest/gtest.h>
+#include "test_env.h"
 
 #ifdef _WIN32
 #define INC_SRT_WIN_WINTIME // exclude gettimeofday from srt headers
@@ -29,7 +30,7 @@
 
 TEST(Transmission, FileUpload)
 {
-    srt_startup();
+	srt::TestInit srtinit;
 
     // Generate the source file
     // We need a file that will contain more data
@@ -195,5 +196,4 @@ TEST(Transmission, FileUpload)
     remove("file.source");
     remove("file.target");
 
-    (void)srt_cleanup();
 }

--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -1,13 +1,15 @@
-#include "gtest/gtest.h"
 #include <thread>
 #include <string>
+#include "gtest/gtest.h"
+#include "test_env.h"
+
 #include "srt.h"
 #include "netinet_any.h"
 
 using srt::sockaddr_any;
 
 class TestIPv6
-    : public ::testing::Test
+    : public srt::Test
 {
 protected:
     int yes = 1;
@@ -25,10 +27,8 @@ protected:
 
 protected:
     // SetUp() is run immediately before a test starts.
-    void SetUp()
+    void setup() override
     {
-        ASSERT_GE(srt_startup(), 0);
-
         m_caller_sock = srt_create_socket();
         ASSERT_NE(m_caller_sock, SRT_ERROR);
         // IPv6 calling IPv4 would otherwise fail if the system-default net.ipv6.bindv6only=1.
@@ -38,13 +38,12 @@ protected:
         ASSERT_NE(m_listener_sock, SRT_ERROR);
     }
 
-    void TearDown()
+    void teardown() override
     {
         // Code here will be called just after the test completes.
         // OK to throw exceptions from here if needed.
         srt_close(m_listener_sock);
         srt_close(m_caller_sock);
-        srt_cleanup();
     }
 
 public:
@@ -140,6 +139,8 @@ TEST_F(TestIPv6, v4_calls_v6_mapped)
 
 TEST_F(TestIPv6, v6_calls_v6_mapped)
 {
+    SRTST_REQUIRES(IPv6);
+
     sockaddr_any sa (AF_INET6);
     sa.hport(m_listen_port);
 
@@ -157,6 +158,8 @@ TEST_F(TestIPv6, v6_calls_v6_mapped)
 
 TEST_F(TestIPv6, v6_calls_v6)
 {
+    SRTST_REQUIRES(IPv6);
+
     sockaddr_any sa (AF_INET6);
     sa.hport(m_listen_port);
 

--- a/test/test_listen_callback.cpp
+++ b/test/test_listen_callback.cpp
@@ -1,8 +1,9 @@
-#include <gtest/gtest.h>
 #include <thread>
 #include <chrono>
 #include <string>
 #include <map>
+#include <gtest/gtest.h>
+#include "test_env.h"
 
 #ifdef _WIN32
 #define INC_SRT_WIN_WINTIME // exclude gettimeofday from srt headers
@@ -15,7 +16,7 @@
 srt_listen_callback_fn SrtTestListenCallback;
 
 class ListenerCallback
-    : public testing::Test
+    : public srt::Test
 {
 protected:
     ListenerCallback()
@@ -34,10 +35,8 @@ public:
     sockaddr_in sa;
     sockaddr* psa;
 
-    void SetUp()
+    void setup()
     {
-        ASSERT_EQ(srt_startup(), 0);
-
         // Create server on 127.0.0.1:5555
 
         server_sock = srt_create_socket();
@@ -124,7 +123,7 @@ public:
         srt_epoll_release(eid);
     }
 
-    void TearDown()
+    void teardown()
     {
         std::cout << "TeadDown: closing all sockets\n";
         // Close the socket
@@ -132,11 +131,9 @@ public:
         EXPECT_EQ(srt_close(server_sock), SRT_SUCCESS);
 
         // After that, the thread should exit
-        std::cout << "TearDown: joining accept thread\n";
+        std::cout << "teardown: joining accept thread\n";
         accept_thread.join();
-        std::cout << "TearDown: SRT exit\n";
-
-        srt_cleanup();
+        std::cout << "teardown: SRT exit\n";
     }
 
 };

--- a/test/test_losslist_rcv.cpp
+++ b/test/test_losslist_rcv.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "gtest/gtest.h"
+#include "test_env.h"
 #include "common.h"
 #include "list.h"
 
@@ -72,6 +73,7 @@ TEST_F(CRcvLossListTest, InsertTwoElemsEdge)
 
 TEST(CRcvFreshLossListTest, CheckFreshLossList)
 {
+	srt::TestInit srtinit;
     std::deque<CRcvFreshLoss> floss {
         CRcvFreshLoss (10, 15, 5),
         CRcvFreshLoss (25, 29, 10),

--- a/test/test_losslist_rcv.cpp
+++ b/test/test_losslist_rcv.cpp
@@ -73,7 +73,7 @@ TEST_F(CRcvLossListTest, InsertTwoElemsEdge)
 
 TEST(CRcvFreshLossListTest, CheckFreshLossList)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     std::deque<CRcvFreshLoss> floss {
         CRcvFreshLoss (10, 15, 5),
         CRcvFreshLoss (25, 29, 10),

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <iterator>
 #include <vector>
+#include <sstream>
 
 #include "gtest/gtest.h"
 #include "test_env.h"
@@ -11,10 +12,60 @@ SrtTestEnv* SrtTestEnv::me = 0;
 
 int main(int argc, char **argv)
 {
-    cout << "CUSTOM MAIN\n";
-
     string command_line_arg(argc == 2 ? argv[1] : "");
     testing::InitGoogleTest(&argc, argv);
     testing::AddGlobalTestEnvironment(new SrtTestEnv(argc, argv));
     return RUN_ALL_TESTS();
+}
+
+void SrtTestEnv::FillArgMap()
+{
+    // The rule is:
+    // - first arguments go to an empty string key
+    // - if an argument has - in the beginning, name the key
+    // - key followed by args collected in a list
+    // - double dash prevents interpreting further args as option keys
+
+    string key;
+    bool expectkey = true;
+
+    for (auto& a: args)
+    {
+        if (a.size() > 1)
+        {
+            if (expectkey && a[0] == '-')
+            {
+                if (a[1] == '-')
+                    expectkey = false;
+                else if (a[1] == '/')
+                    key = "";
+                else
+                    key = a.substr(1);
+
+                continue;
+            }
+        }
+        argmap[key].push_back(a);
+    }
+
+    return;
+}
+
+
+std::string SrtTestEnv::OptionValue(const std::string& key)
+{
+    std::ostringstream out;
+
+    auto it = argmap.find(key);
+    if (it != argmap.end() && !it->second.empty())
+    {
+        auto iv = it->second.begin();
+        out << (*iv);
+        while (++iv != it->second.end())
+        {
+            out << " " << (*iv);
+        }
+    }
+
+    return out.str();
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1,0 +1,20 @@
+#include <string>
+#include <iterator>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "test_env.h"
+
+using namespace std;
+
+SrtTestEnv* SrtTestEnv::me = 0;
+
+int main(int argc, char **argv)
+{
+    cout << "CUSTOM MAIN\n";
+
+    string command_line_arg(argc == 2 ? argv[1] : "");
+    testing::InitGoogleTest(&argc, argv);
+    testing::AddGlobalTestEnvironment(new SrtTestEnv(argc, argv));
+    return RUN_ALL_TESTS();
+}

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -6,19 +6,25 @@
 #include "gtest/gtest.h"
 #include "test_env.h"
 
-using namespace std;
+#include "srt.h"
+#include "netinet_any.h"
 
-SrtTestEnv* SrtTestEnv::me = 0;
+using namespace std;
 
 int main(int argc, char **argv)
 {
     string command_line_arg(argc == 2 ? argv[1] : "");
     testing::InitGoogleTest(&argc, argv);
-    testing::AddGlobalTestEnvironment(new SrtTestEnv(argc, argv));
+    testing::AddGlobalTestEnvironment(new srt::TestEnv(argc, argv));
     return RUN_ALL_TESTS();
 }
 
-void SrtTestEnv::FillArgMap()
+namespace srt
+{
+
+TestEnv* TestEnv::me = 0;
+
+void TestEnv::FillArgMap()
 {
     // The rule is:
     // - first arguments go to an empty string key
@@ -28,6 +34,8 @@ void SrtTestEnv::FillArgMap()
 
     string key;
     bool expectkey = true;
+
+    argmap[""];
 
     for (auto& a: args)
     {
@@ -40,7 +48,10 @@ void SrtTestEnv::FillArgMap()
                 else if (a[1] == '/')
                     key = "";
                 else
+                {
                     key = a.substr(1);
+                    argmap[key]; // Make sure it exists even empty
+                }
 
                 continue;
             }
@@ -51,8 +62,7 @@ void SrtTestEnv::FillArgMap()
     return;
 }
 
-
-std::string SrtTestEnv::OptionValue(const std::string& key)
+std::string TestEnv::OptionValue(const std::string& key)
 {
     std::ostringstream out;
 
@@ -68,4 +78,103 @@ std::string SrtTestEnv::OptionValue(const std::string& key)
     }
 
     return out.str();
+}
+
+// Specific functions
+bool TestEnv::Allowed_IPv6()
+{
+    if (TestEnv::me->OptionPresent("disable-ipv6"))
+    {
+        std::cout << "TEST: IPv6 testing disabled, FORCED PASS\n";
+        return false;
+    }
+    return true;
+}
+
+
+void TestInit::start(int& w_retstatus)
+{
+    ASSERT_GE(w_retstatus = srt_startup(), 0);
+}
+
+void TestInit::stop()
+{
+    EXPECT_NE(srt_cleanup(), -1);
+}
+
+// This function finds some interesting options among command
+// line arguments and does specific things.
+void TestInit::HandleOptions()
+{
+    // As a short example:
+    // use '-logdebug' option to turn on debug logging.
+
+    if (TestEnv::me->OptionPresent("logdebug"))
+    {
+        srt_setloglevel(LOG_DEBUG);
+    }
+}
+
+// Copied from ../apps/apputil.cpp, can't really link this file here.
+sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_family)
+{
+    using namespace std;
+
+    // Handle empty name.
+    // If family is specified, empty string resolves to ANY of that family.
+    // If not, it resolves to IPv4 ANY (to specify IPv6 any, use [::]).
+    if (name == "")
+    {
+        sockaddr_any result(pref_family == AF_INET6 ? pref_family : AF_INET);
+        result.hport(port);
+        return result;
+    }
+
+    bool first6 = pref_family != AF_INET;
+    int families[2] = {AF_INET6, AF_INET};
+    if (!first6)
+    {
+        families[0] = AF_INET;
+        families[1] = AF_INET6;
+    }
+
+    for (int i = 0; i < 2; ++i)
+    {
+        int family = families[i];
+        sockaddr_any result (family);
+
+        // Try to resolve the name by pton first
+        if (inet_pton(family, name.c_str(), result.get_addr()) == 1)
+        {
+            result.hport(port); // same addr location in ipv4 and ipv6
+            return result;
+        }
+    }
+
+    // If not, try to resolve by getaddrinfo
+    // This time, use the exact value of pref_family
+
+    sockaddr_any result;
+    addrinfo fo = {
+        0,
+        pref_family,
+        0, 0,
+        0, 0,
+        NULL, NULL
+    };
+
+    addrinfo* val = nullptr;
+    int erc = getaddrinfo(name.c_str(), nullptr, &fo, &val);
+    if (erc == 0)
+    {
+        result.set(val->ai_addr);
+        result.len = result.size();
+        result.hport(port); // same addr location in ipv4 and ipv6
+    }
+    freeaddrinfo(val);
+
+    return result;
+}
+
+
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -104,7 +104,7 @@ void TestInit::stop()
 
 // This function finds some interesting options among command
 // line arguments and does specific things.
-void TestInit::HandleOptions()
+void TestInit::HandlePerTestOptions()
 {
     // As a short example:
     // use '-logdebug' option to turn on debug logging.

--- a/test/test_many_connections.cpp
+++ b/test/test_many_connections.cpp
@@ -1,10 +1,11 @@
 #define _CRT_RAND_S // For Windows, rand_s 
 
-#include <gtest/gtest.h>
 #include <array>
 #include <chrono>
 #include <future>
 #include <random>
+#include <gtest/gtest.h>
+#include "test_env.h"
 
 #ifdef _WIN32
 #include <stdlib.h>
@@ -26,7 +27,7 @@ using srt::sockaddr_any;
 
 
 class TestConnection
-    : public ::testing::Test
+    : public ::srt::Test
 {
 protected:
     TestConnection()
@@ -45,11 +46,8 @@ protected:
     static const size_t NSOCK = 60;
 
 protected:
-    // SetUp() is run immediately before a test starts.
-    void SetUp() override
+    void setup() override
     {
-        ASSERT_EQ(srt_startup(), 0);
-
         m_sa.sin_family = AF_INET;
         m_sa.sin_addr.s_addr = INADDR_ANY;
 
@@ -83,9 +81,8 @@ protected:
         ASSERT_NE(srt_listen(m_server_sock, NSOCK), -1);
     }
 
-    void TearDown() override
+    void teardown() override
     {
-        srt_cleanup();
     }
 
     void AcceptLoop()

--- a/test/test_muxer.cpp
+++ b/test/test_muxer.cpp
@@ -1,9 +1,11 @@
 #include "gtest/gtest.h"
+#include "test_env.h"
+
 #include <thread>
 #include "srt.h"
 
 class TestMuxer
-    : public ::testing::Test
+    : public srt::Test
 {
 protected:
     TestMuxer()
@@ -18,10 +20,8 @@ protected:
 
 protected:
     // SetUp() is run immediately before a test starts.
-    void SetUp()
+    void setup() override
     {
-        ASSERT_GE(srt_startup(), 0);
-        
         m_caller_sock = srt_create_socket();
         ASSERT_NE(m_caller_sock, SRT_ERROR);
 
@@ -41,7 +41,7 @@ protected:
         srt_epoll_add_usock(m_client_pollid, m_caller_sock, &epoll_out);
     }
 
-    void TearDown()
+    void teardown() override
     {
         // Code here will be called just after the test completes.
         // OK to throw exceptions from here if needed.
@@ -49,7 +49,6 @@ protected:
         srt_epoll_release(m_server_pollid);
         srt_close(m_listener_sock_ipv4);
         srt_close(m_listener_sock_ipv6);
-        srt_cleanup();
     }
 
 public:
@@ -100,6 +99,8 @@ protected:
 
 TEST_F(TestMuxer, IPv4_and_IPv6)
 {
+    SRTST_REQUIRES(IPv6);
+
     int yes = 1;
     int no = 0;
 

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -1,9 +1,10 @@
-#include "gtest/gtest.h"
 #include <thread>
 #include <future>
 #ifndef _WIN32
 #include <ifaddrs.h>
 #endif
+#include "gtest/gtest.h"
+#include "test_env.h"
 
 #include "common.h"
 #include "srt.h"
@@ -22,67 +23,6 @@ struct AtReturnJoin
             which_future.wait();
     }
 };
-
-// Copied from ../apps/apputil.cpp, can't really link this file here.
-sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_family = AF_INET)
-{
-    using namespace std;
-
-    // Handle empty name.
-    // If family is specified, empty string resolves to ANY of that family.
-    // If not, it resolves to IPv4 ANY (to specify IPv6 any, use [::]).
-    if (name == "")
-    {
-        sockaddr_any result(pref_family == AF_INET6 ? pref_family : AF_INET);
-        result.hport(port);
-        return result;
-    }
-
-    bool first6 = pref_family != AF_INET;
-    int families[2] = {AF_INET6, AF_INET};
-    if (!first6)
-    {
-        families[0] = AF_INET;
-        families[1] = AF_INET6;
-    }
-
-    for (int i = 0; i < 2; ++i)
-    {
-        int family = families[i];
-        sockaddr_any result (family);
-
-        // Try to resolve the name by pton first
-        if (inet_pton(family, name.c_str(), result.get_addr()) == 1)
-        {
-            result.hport(port); // same addr location in ipv4 and ipv6
-            return result;
-        }
-    }
-
-    // If not, try to resolve by getaddrinfo
-    // This time, use the exact value of pref_family
-
-    sockaddr_any result;
-    addrinfo fo = {
-        0,
-        pref_family,
-        0, 0,
-        0, 0,
-        NULL, NULL
-    };
-
-    addrinfo* val = nullptr;
-    int erc = getaddrinfo(name.c_str(), nullptr, &fo, &val);
-    if (erc == 0)
-    {
-        result.set(val->ai_addr);
-        result.len = result.size();
-        result.hport(port); // same addr location in ipv4 and ipv6
-    }
-    freeaddrinfo(val);
-
-    return result;
-}
 
 #ifdef _WIN32
 
@@ -191,7 +131,7 @@ void clientSocket(std::string ip, int port, bool expect_success)
     int epoll_out = SRT_EPOLL_OUT;
     srt_epoll_add_usock(client_pollid, g_client_sock, &epoll_out);
 
-    sockaddr_any sa = CreateAddr(ip, port, family);
+    sockaddr_any sa = srt::CreateAddr(ip, port, family);
 
     std::cout << "[T/C] Connecting to: " << sa.str() << " (" << famname << ")" << std::endl;
 
@@ -274,7 +214,7 @@ SRTSOCKET prepareSocket()
 
 bool bindSocket(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
 {
-    sockaddr_any sa = CreateAddr(ip, port);
+    sockaddr_any sa = srt::CreateAddr(ip, port, AF_INET);
 
     std::string fam = (sa.family() == AF_INET) ? "IPv4" : "IPv6";
 
@@ -454,7 +394,7 @@ void shutdownListener(SRTSOCKET bindsock)
 
 TEST(ReuseAddr, SameAddr1)
 {
-    ASSERT_EQ(srt_startup(), 0);
+	srt::TestInit srtinit;
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -475,16 +415,15 @@ TEST(ReuseAddr, SameAddr1)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 TEST(ReuseAddr, SameAddr2)
 {
+	srt::TestInit srtinit;
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
 
-    ASSERT_EQ(srt_startup(), 0);
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -509,12 +448,12 @@ TEST(ReuseAddr, SameAddr2)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 TEST(ReuseAddr, SameAddrV6)
 {
-    ASSERT_EQ(srt_startup(), 0);
+    SRTST_REQUIRES(IPv6);
+	srt::TestInit srtinit;
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -539,17 +478,16 @@ TEST(ReuseAddr, SameAddrV6)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 
 TEST(ReuseAddr, DiffAddr)
 {
+	srt::TestInit srtinit;
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
 
-    ASSERT_EQ(srt_startup(), 0);
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -570,11 +508,11 @@ TEST(ReuseAddr, DiffAddr)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 TEST(ReuseAddr, Wildcard)
 {
+	srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -587,7 +525,6 @@ TEST(ReuseAddr, Wildcard)
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
 
-    ASSERT_EQ(srt_startup(), 0);
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -607,11 +544,12 @@ TEST(ReuseAddr, Wildcard)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 TEST(ReuseAddr, Wildcard6)
 {
+    SRTST_REQUIRES(IPv6);
+	srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -629,7 +567,6 @@ TEST(ReuseAddr, Wildcard6)
     // performed there.
     std::string localip_v4 = GetLocalIP(AF_INET);
 
-    ASSERT_EQ(srt_startup(), 0);
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -686,17 +623,18 @@ TEST(ReuseAddr, Wildcard6)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 TEST(ReuseAddr, ProtocolVersion6)
 {
+    SRTST_REQUIRES(IPv6);
+
+	srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
     return;
 #endif
-    ASSERT_EQ(srt_startup(), 0);
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -724,17 +662,17 @@ TEST(ReuseAddr, ProtocolVersion6)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }
 
 TEST(ReuseAddr, ProtocolVersionFaux6)
 {
+    SRTST_REQUIRES(IPv6);
+	srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
     return;
 #endif
-    ASSERT_EQ(srt_startup(), 0);
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -761,5 +699,4 @@ TEST(ReuseAddr, ProtocolVersionFaux6)
 
     (void)srt_epoll_release(client_pollid);
     (void)srt_epoll_release(server_pollid);
-    srt_cleanup();
 }

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -301,7 +301,7 @@ void testAccept(SRTSOCKET bindsock, std::string ip, int port, bool expect_succes
 
         ASSERT_EQ(rlen, 1); // get exactly one read event without writes
         ASSERT_EQ(wlen, 0); // get exactly one read event without writes
-        ASSERT_EQ(read[0], bindsock); // read event is for bind socket    	
+        ASSERT_EQ(read[0], bindsock); // read event is for bind socket
     }
 
     sockaddr_any scl;
@@ -394,7 +394,7 @@ void shutdownListener(SRTSOCKET bindsock)
 
 TEST(ReuseAddr, SameAddr1)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -419,7 +419,7 @@ TEST(ReuseAddr, SameAddr1)
 
 TEST(ReuseAddr, SameAddr2)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
@@ -453,7 +453,7 @@ TEST(ReuseAddr, SameAddr2)
 TEST(ReuseAddr, SameAddrV6)
 {
     SRTST_REQUIRES(IPv6);
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 
     client_pollid = srt_epoll_create();
     ASSERT_NE(SRT_ERROR, client_pollid);
@@ -483,7 +483,7 @@ TEST(ReuseAddr, SameAddrV6)
 
 TEST(ReuseAddr, DiffAddr)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
@@ -512,7 +512,7 @@ TEST(ReuseAddr, DiffAddr)
 
 TEST(ReuseAddr, Wildcard)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -549,7 +549,7 @@ TEST(ReuseAddr, Wildcard)
 TEST(ReuseAddr, Wildcard6)
 {
     SRTST_REQUIRES(IPv6);
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -629,7 +629,7 @@ TEST(ReuseAddr, ProtocolVersion6)
 {
     SRTST_REQUIRES(IPv6);
 
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -667,7 +667,7 @@ TEST(ReuseAddr, ProtocolVersion6)
 TEST(ReuseAddr, ProtocolVersionFaux6)
 {
     SRTST_REQUIRES(IPv6);
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -10,10 +10,11 @@
  *             Haivision Systems Inc.
  */
 
-#include <gtest/gtest.h>
 #include <future>
 #include <thread>
 #include <string>
+#include <gtest/gtest.h>
+#include "test_env.h"
 
 // SRT includes
 #include "any.hpp"
@@ -25,7 +26,7 @@ using namespace srt;
 
 
 class TestSocketOptions
-    : public ::testing::Test
+    : public ::srt::Test
 {
 protected:
     TestSocketOptions()
@@ -79,10 +80,9 @@ public:
     }
 
 protected:
-    // SetUp() is run immediately before a test starts.
-    void SetUp()
+    // setup() is run immediately before a test starts.
+    void setup()
     {
-        ASSERT_GE(srt_startup(), 0);
         const int yes = 1;
 
         memset(&m_sa, 0, sizeof m_sa);
@@ -101,13 +101,12 @@ protected:
         ASSERT_EQ(srt_setsockopt(m_listen_sock, 0, SRTO_SNDSYN, &yes, sizeof yes), SRT_SUCCESS); // for async connect
     }
 
-    void TearDown()
+    void teardown()
     {
         // Code here will be called just after the test completes.
         // OK to throw exceptions from here if needed.
-        ASSERT_NE(srt_close(m_caller_sock), SRT_ERROR);
-        ASSERT_NE(srt_close(m_listen_sock), SRT_ERROR);
-        srt_cleanup();
+        EXPECT_NE(srt_close(m_caller_sock), SRT_ERROR);
+        EXPECT_NE(srt_close(m_listen_sock), SRT_ERROR);
     }
 
 protected:

--- a/test/test_socketdata.cpp
+++ b/test/test_socketdata.cpp
@@ -4,10 +4,10 @@
 #include <iostream>
 
 #include "gtest/gtest.h"
+#include "test_env.h"
 
 #include "srt.h"
 #include "netinet_any.h"
-#include "apputil.hpp"
 
 using namespace std;
 using namespace std::chrono;
@@ -15,6 +15,8 @@ using namespace srt;
 
 TEST(SocketData, PeerName)
 {
+    srt::TestInit srtinit;
+
     // Single-threaded one-app connect/accept action
 
     int csock = srt_create_socket();
@@ -25,7 +27,7 @@ TEST(SocketData, PeerName)
     srt_setsockflag(csock, SRTO_RCVSYN, &rd_nonblocking, sizeof (rd_nonblocking));
     //srt_setsockflag(lsock, SRTO_RCVSYN, &rd_nonblocking, sizeof (rd_nonblocking));
 
-    sockaddr_any addr = CreateAddr("127.0.0.1", 5000, AF_INET);
+    sockaddr_any addr = srt::CreateAddr("127.0.0.1", 5000, AF_INET);
 
     ASSERT_NE(srt_bind(lsock, addr.get(), addr.size()), -1);
 

--- a/test/test_unitqueue.cpp
+++ b/test/test_unitqueue.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <vector>
 #include "gtest/gtest.h"
+#include "test_env.h"
 #include "queue.h"
 
 using namespace std;
@@ -15,6 +16,7 @@ using namespace srt;
 /// the very last element of the queue (it was skipped).
 TEST(CUnitQueue, Increase)
 {
+	srt::TestInit srtinit;
     const int buffer_size_pkts = 4;
     CUnitQueue unit_queue(buffer_size_pkts, 1500);
 
@@ -35,6 +37,7 @@ TEST(CUnitQueue, Increase)
 /// beginning of the same queue.
 TEST(CUnitQueue, IncreaseAndFree)
 {
+	srt::TestInit srtinit;
     const int buffer_size_pkts = 4;
     CUnitQueue unit_queue(buffer_size_pkts, 1500);
 
@@ -59,6 +62,7 @@ TEST(CUnitQueue, IncreaseAndFree)
 /// Thus the test checks if 
 TEST(CUnitQueue, IncreaseAndFreeGrouped)
 {
+	srt::TestInit srtinit;
     const int buffer_size_pkts = 4;
     CUnitQueue unit_queue(buffer_size_pkts, 1500);
 

--- a/test/test_unitqueue.cpp
+++ b/test/test_unitqueue.cpp
@@ -16,7 +16,7 @@ using namespace srt;
 /// the very last element of the queue (it was skipped).
 TEST(CUnitQueue, Increase)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const int buffer_size_pkts = 4;
     CUnitQueue unit_queue(buffer_size_pkts, 1500);
 
@@ -37,7 +37,7 @@ TEST(CUnitQueue, Increase)
 /// beginning of the same queue.
 TEST(CUnitQueue, IncreaseAndFree)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const int buffer_size_pkts = 4;
     CUnitQueue unit_queue(buffer_size_pkts, 1500);
 
@@ -62,7 +62,7 @@ TEST(CUnitQueue, IncreaseAndFree)
 /// Thus the test checks if 
 TEST(CUnitQueue, IncreaseAndFreeGrouped)
 {
-	srt::TestInit srtinit;
+    srt::TestInit srtinit;
     const int buffer_size_pkts = 4;
     CUnitQueue unit_queue(buffer_size_pkts, 1500);
 


### PR DESCRIPTION
Fixes #2611 

This adds the custom main function for gtest and allows parameters to be interpreted in the test function.

This is waiting for a solution for startup/cleanup part consistency with gtest exception policy. This PR provides an extra singleton class that would prepare the parameters; this can be linked with a special per-test used object that would interpret these parameters.

The syntax for the test options is beside the options for gtest. All gtest options start with `--gtest` and parameters are passed by  equal sign. All of them are removed from the command line by gtest and the others are free to take. Syntax:

`free_value1 -option1 value -option2 value1 value2 value3 -/ free_value2 free_value3 -option3 -- -value4 -value5 value6`

Here `free_value` represents an argument without an option and options are provided by dash prefix. The `-/` ends the list of argument for a current option and can separate per-option parameter from the following parameters.

Options can be potentially used for general options as well as per-test options. Options can be extracted either from `SrtTestEnv::me->args` as the original command line and from `SrtTestEnv::me->argmap` using the option names as keys (without the initial dash). Multiple arguments are packed into a vector and can be glued together on demand by `OptionValue` method. 

Currently there are two options handled (no arguments):

* `-logdebug`: if present, every test gets an additional call to `srt_setloglevel(LOG_DEBUG)`
* `-disable-ipv6`: tests that have the declaration `SRTST_REQUIRE(IPv6)` will be forcefully-passed and not executed