### PR TITLE
[MAINT] Fixed unhandled error in haicrypt

### DIFF
--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -240,7 +240,8 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
 
     if (tx) {
         HaiCrypt_Cfg crypto_config;
-        HaiCrypt_ExtractConfig(hhcSrc, &crypto_config);
+        if (-1 == HaiCrypt_ExtractConfig(hhcSrc, &crypto_config))
+            return -1;
 
         /*
          * Just invert the direction written in flags and use the


### PR DESCRIPTION
The compiler reported possibly uninitialized value.

This theoretically could have happened because in case of error and returned -1 the variable isn't rewritten with anything. This was allowed to happen only because the error from this call wasn't handled.