### PR TITLE
[BUG] Rejection not undertaken in rendezvous after KMX failure

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4273,6 +4273,7 @@ EConnectStatus srt::CUDT::processRendezvous(
             {
                 // m_RejectReason is already set, so set the reqtype accordingly
                 m_ConnReq.m_iReqType = URQFailure(m_RejectReason);
+                return CONN_REJECT;
             }
         }
         // This should be false, make a kinda assert here.


### PR DESCRIPTION
Fixes #2684 

The problem: the KMX failure was recognized and the response code was set, but the function didn't exit immediately with rejection state. This led to sending back the AGREEMENT while it should have responded with rejection to the peer.