### PR TITLE
Fixed bug with GCM retransmits when server in AUTO AEAD mode

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9193,7 +9193,7 @@ int srt::CUDT::packLostData(CPacket& w_packet)
 
         // The packet has been ecrypted, thus the authentication tag is expected to be stored
         // in the SND buffer as well right after the payload.
-        if (m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM)
+        if (m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM)
         {
             w_packet.setLength(w_packet.getLength() + HAICRYPT_AUTHTAG_MAX);
         }


### PR DESCRIPTION
After further testing with the new Botan cryspr I noticed that there were sporadic decryption failures occurring on the client when in AES-GCM mode.

Further investigation revealed that re-transmitted packets from the server were not having space accounted for the GCM auth tag and this was leading to failure to decrypt on the client.

The reason is this piece of code:

```
        if (m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM)
        {
            w_packet.setLength(w_packet.getLength() + HAICRYPT_AUTHTAG_MAX);
        }
```

In the configuration I was testing, my server was set to auto mode; i.e. m_config.iCryptoMode was set to CSrtConfig::CIPHER_MODE_AUTO so the packet length wasn't getting adjusted.

The fix is to use the actual crypto mode being used, from the crypto control:

```
        if (m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM)
        {
            w_packet.setLength(w_packet.getLength() + HAICRYPT_AUTHTAG_MAX);
        }
```

After the above change, the decrypt failures disappeared.

Presumably the same bug exists when using OpenSSL-EVP.

