### PR TITLE
[core] Minor fix of variable shadowing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,6 +642,9 @@ endif()
 # add extra warning flags for gccish compilers
 if (HAVE_COMPILER_GNU_COMPAT)
 	set (SRT_GCC_WARN "-Wall -Wextra")
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		set (SRT_GCC_WARN "${SRT_GCC_WARN} -Wshadow=local")
+	endif()
 else()
 	# cpp debugging on Windows :D
 	#set (SRT_GCC_WARN "/showIncludes")

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -674,7 +674,7 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
             // XXX this might require another check of group type.
             // For redundancy group, at least, update the status in the group
             CUDTGroup* g = ns->m_GroupOf;
-            ScopedLock glock(g->m_GroupLock);
+            ScopedLock grlock(g->m_GroupLock);
             if (g->m_bClosing)
             {
                 error = 1; // "INTERNAL REJECTION"

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9726,8 +9726,6 @@ void srt::CUDT::processClose()
 
 void srt::CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
 {
-    typedef vector<pair<int32_t, int32_t> > loss_seqs_t;
-
     vector<int32_t> seqbuffer;
     seqbuffer.reserve(2 * loss_seqs.size()); // pessimistic
     for (loss_seqs_t::const_iterator i = loss_seqs.begin(); i != loss_seqs.end(); ++i)

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -215,8 +215,8 @@ void srt::CEPoll::clear_ready_usocks(CEPollDesc& d, int direction)
         }
     }
 
-    for (size_t i = 0; i < cleared.size(); ++i)
-        d.removeSubscription(cleared[i]);
+    for (size_t j = 0; j < cleared.size(); ++j)
+        d.removeSubscription(cleared[j]);
 }
 
 int srt::CEPoll::add_ssock(const int eid, const SYSSOCKET& s, const int* events)

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -29,10 +29,10 @@ TEST(Bonding, SRTConnectGroup)
         targets.push_back(gd);
     }
 
-    std::future<void> closing_promise = std::async(std::launch::async, [](int ss) {
+    std::future<void> closing_promise = std::async(std::launch::async, [](int s) {
         std::this_thread::sleep_for(std::chrono::seconds(2));
         std::cerr << "Closing group" << std::endl;
-        srt_close(ss);
+        srt_close(s);
     }, ss);
 
     std::cout << "srt_connect_group calling " << std::endl;

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -385,9 +385,9 @@ TEST(SyncEvent, WaitForNotifyOne)
 
     const steady_clock::duration timeout = seconds_from(5);
 
-    auto wait_async = [](Condition* cond, Mutex* mutex, const steady_clock::duration& timeout) {
-        CUniqueSync cc (*mutex, *cond);
-        return cc.wait_for(timeout);
+    auto wait_async = [](Condition* cv, Mutex* m, const steady_clock::duration& tmo) {
+        CUniqueSync cc (*m, *cv);
+        return cc.wait_for(tmo);
     };
     auto wait_async_res = async(launch::async, wait_async, &cond, &mutex, timeout);
 
@@ -406,9 +406,9 @@ TEST(SyncEvent, WaitNotifyOne)
     Condition cond;
     cond.init();
 
-    auto wait_async = [](Condition* cond, Mutex* mutex) {
-        UniqueLock lock(*mutex);
-        return cond->wait(lock);
+    auto wait_async = [](Condition* cv, Mutex* m) {
+        UniqueLock lock(*m);
+        return cv->wait(lock);
     };
     auto wait_async_res = async(launch::async, wait_async, &cond, &mutex);
 
@@ -432,9 +432,9 @@ TEST(SyncEvent, WaitForTwoNotifyOne)
 
     srt::sync::atomic<bool> resource_ready(true);
 
-    auto wait_async = [&](Condition* cond, Mutex* mutex, const steady_clock::duration& timeout, int id) {
-        UniqueLock lock(*mutex);
-        if (cond->wait_for(lock, timeout) && resource_ready)
+    auto wait_async = [&](Condition* cv, Mutex* m, const steady_clock::duration& tmo, int id) {
+        UniqueLock lock(*m);
+        if (cv->wait_for(lock, tmo) && resource_ready)
         {
             notified_clients.push_back(id);
             resource_ready = false;
@@ -536,9 +536,9 @@ TEST(SyncEvent, WaitForTwoNotifyAll)
     cond.init();
     const steady_clock::duration timeout = seconds_from(3);
 
-    auto wait_async = [](Condition* cond, Mutex* mutex, const steady_clock::duration& timeout) {
-        UniqueLock lock(*mutex);
-        return cond->wait_for(lock, timeout);
+    auto wait_async = [](Condition* cv, Mutex* m, const steady_clock::duration& tmo) {
+        UniqueLock lock(*m);
+        return cv->wait_for(lock, tmo);
     };
     auto wait_async1_res = async(launch::async, wait_async, &cond, &mutex, timeout);
     auto wait_async2_res = async(launch::async, wait_async, &cond, &mutex, timeout);
@@ -565,9 +565,9 @@ TEST(SyncEvent, WaitForNotifyAll)
     cond.init();
     const steady_clock::duration timeout = seconds_from(5);
 
-    auto wait_async = [](Condition* cond, Mutex* mutex, const steady_clock::duration& timeout) {
-        UniqueLock lock(*mutex);
-        return cond->wait_for(lock, timeout);
+    auto wait_async = [](Condition* cv, Mutex* m, const steady_clock::duration& tmo) {
+        UniqueLock lock(*m);
+        return cv->wait_for(lock, tmo);
     };
     auto wait_async_res = async(launch::async, wait_async, &cond, &mutex, timeout);
 


### PR DESCRIPTION
Fixed variable shadowing in the core and tests.
Added `-Wshadow=local` in CMake build for GCC v7.0 and above.

Fixes #2725.