### PR TITLE
[BUG] Removed setting +W for a listener socket after accept ready

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -642,6 +642,9 @@ endif()
 # add extra warning flags for gccish compilers
 if (HAVE_COMPILER_GNU_COMPAT)
 	set (SRT_GCC_WARN "-Wall -Wextra")
+	if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		set (SRT_GCC_WARN "${SRT_GCC_WARN} -Wshadow=local")
+	endif()
 else()
 	# cpp debugging on Windows :D
 	#set (SRT_GCC_WARN "/showIncludes")

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -168,11 +168,7 @@ void srt::CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
     }
     else
     {
-      const sockaddr_in6* a = &addr.sin6;
-      ip[3] = (a->sin6_addr.s6_addr[15] << 24) + (a->sin6_addr.s6_addr[14] << 16) + (a->sin6_addr.s6_addr[13] << 8) + a->sin6_addr.s6_addr[12];
-      ip[2] = (a->sin6_addr.s6_addr[11] << 24) + (a->sin6_addr.s6_addr[10] << 16) + (a->sin6_addr.s6_addr[9] << 8) + a->sin6_addr.s6_addr[8];
-      ip[1] = (a->sin6_addr.s6_addr[7] << 24) + (a->sin6_addr.s6_addr[6] << 16) + (a->sin6_addr.s6_addr[5] << 8) + a->sin6_addr.s6_addr[4];
-      ip[0] = (a->sin6_addr.s6_addr[3] << 24) + (a->sin6_addr.s6_addr[2] << 16) + (a->sin6_addr.s6_addr[1] << 8) + a->sin6_addr.s6_addr[0];
+        std::memcpy(ip, addr.sin6.sin6_addr.s6_addr, 16);
     }
 }
 
@@ -223,18 +219,7 @@ void srt::CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const soc
             // Here both agent and peer use IPv6, in which case
             // `ip` contains the full IPv6 address, so just copy
             // it as is.
-
-            // XXX Possibly, a simple
-            // memcpy( (a->sin6_addr.s6_addr), ip, 16);
-            // would do the same thing, and faster. The address in `ip`,
-            // even though coded here as uint32_t, is still big endian.
-            for (int i = 0; i < 4; ++ i)
-            {
-                a->sin6_addr.s6_addr[i * 4 + 0] = ip[i] & 0xFF;
-                a->sin6_addr.s6_addr[i * 4 + 1] = (unsigned char)((ip[i] & 0xFF00) >> 8);
-                a->sin6_addr.s6_addr[i * 4 + 2] = (unsigned char)((ip[i] & 0xFF0000) >> 16);
-                a->sin6_addr.s6_addr[i * 4 + 3] = (unsigned char)((ip[i] & 0xFF000000) >> 24);
-            }
+            std::memcpy(a->sin6_addr.s6_addr, ip, 16);
             return; // The address is written, nothing left to do.
         }
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11068,21 +11068,7 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
             }
         }
 
-        if (result == 1)
-        {
-            // BUG! There is no need to update write-readiness on the listener socket once new connection is accepted.
-            // Only read-readiness has to be updated, but it is done so in the newConnection(..) function.
-            // See PR #1831 and issue #1667.
-            HLOGC(cnlog.Debug,
-                  log << CONID() << "processConnectRequest: accepted connection, updating epoll to write-ready");
-
-            // New connection has been accepted or an existing one has been found. Update epoll write-readiness.
-            // a new connection has been created, enable epoll for write
-            // Note: not using SRT_EPOLL_CONNECT symbol because this is a procedure
-            // executed for the accepted socket.
-            uglobal().m_EPoll.update_events(m_SocketID, m_sPollID, SRT_EPOLL_OUT, true);
-        }
-        else if (result == -1)
+        if (result == -1)
         {
             // The new connection failed
             // or the connection already existed, but manually sending the HS response above has failed.


### PR DESCRIPTION
Fixes #1667

There was some kinda completely "out of sense" setting of +W epoll readiness flag for a listener socket at the moment when a new accepted socket was successfully spawned.

This is actually an old UDT library bug, maybe insignificant, but might bear consequences, it's present at the end of this function (in SRT it was renamed to `processConnectionRequest`):
```
int CUDT::listen(sockaddr* addr, CPacket& packet)
```

The standard rules for setting epoll flags other than those for data-read-ready and data-write-ready should follow the manner of TCP and Linux epoll, that is:

* SRT_EPOLL_OUT is set on the connecting socket to declare connection success. This is coincidentally the same with a statement that every newly connected socket is automatically ready to write, and it remains ready as long as there's still free space in the sender buffer.

* SRT_EPOLL_IN is set on the listener socket to declare that this listener socket has spawned an accepted connection socket and it is ready for extraction. After this socket has been extracted by `srt_accept` call, this readiness is cleared, unless there's still any other socket spawned waiting for extraction.

According to the rules updated after adding the groups feature there was also an SRT_EPOLL_UPDATE event introduced, which is set on the listener at the moment when a new connection within the group has been spawned, but as the group was connected already, it was handled in the background.

In summary, there are specific conditions when the listener socket can be set SRT_EPOLL_IN and SRT_EPOLL_UPDATE events, but there's no reason no API definition to make the listener SRT_EPOLL_OUT readiness flag. It would be also hard to find any similarity to "writing" to the listener socket.

During the check it was also verified that even though this is removed, the accepted socket still gets this write-readiness, even though it isn't properly set anywhere. This is because the first time when you can add the socket to any epoll container is after accepting it, and the procedure of adding a socket to the epoll container involves also subscribing at that socket for any readiness changes. When this is done for the first time of the socket, it also updates its own readiness flags, and this is done at this moment to keep the data updated and the condition as to whether the socket is ready for particular event is verified at this time. In other words, there's no container that keeps the epoll readiness flags of the socket; there's only an epoll container that keeps these flags, but it is foreign to the socket and gets updated only per subscription.

Additionally, it turned out that the testing applications contained a bug in the non-blocking mode by subscribing the listener socket to SRT_EPOLL_OUT, which was occasionally working due to this bug. This was also fixed accordingly.

ADDITIONAL NOTES by @maxsharabayko: 

_Some notes to save the reviewing context._

Listener socket read-readiness on connection is checked with `TestEPoll.SimpleAsync`.
Write readiness is not checked. Maybe the test should be modified a bit to add `SRT_EPOLL_OUT` event type to subscription [here](https://github.com/Haivision/srt/blob/master/test/test_epoll.cpp#L659), so that we check write-readiness is never triggered.

### TODO

- [ ] Check if the change proposed would break FFMpeg integration

As noted by @rndi:

> SRT listener socket is created with `+W` and then used in the listening function. https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/libsrt.c#L186
> The "write readiness" is added in the create function itself: https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/libsrt.c#L168
> Also: https://github.com/FFmpeg/FFmpeg/blob/master/libavformat/libsrt.c#L438.

A ticket submitted to FFMPEG to fix this: https://trac.ffmpeg.org/ticket/9142

The last stance on that is that they are ok with fixing this in SRT.