### PR TITLE
[core] fix applyGroupSequences

### DIFF
--- a/docs/dev/low-level-info.md
+++ b/docs/dev/low-level-info.md
@@ -159,8 +159,6 @@ CRcvQueue::worker_TryAsyncRend_OrStore
                      [IF Responder]
                      {
                          CUDT::makeMePeerOf
-                             [LOCKS m_GroupLock]
-                                 CUDTGroup::syncWithSocket
                              CUDTGroup::find --> [LOCKED m_GroupLock]
                      }
                      debugGroup -- > [LOCKED m_GroupLock]
@@ -189,8 +187,6 @@ CRcvQueue::worker_ProcessConnectionRequest
                      [IF Responder]
                      {
                          CUDT::makeMePeerOf
-                             [LOCKS m_GroupLock]
-                                 CUDTGroup::syncWithSocket
                              CUDTGroup::find --> [LOCKED m_GroupLock]
                      }
                      debugGroup -- > [LOCKED m_GroupLock]

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3151,10 +3151,10 @@ bool srt::CUDT::interpretGroup(const int32_t groupdata[], size_t data_size SRT_A
                   log << CONID() << "HS/RSP: group $" << pg->id() << " -> peer $" << pg->peerid()
                       << ", copying characteristic data");
 
-            // The call to syncWithSocket is copying
+            // The call to syncWithFirstSocket is copying
             // some interesting data from the first connected
             // socket. This should be only done for the first successful connection.
-            pg->syncWithSocket(*this, HSD_INITIATOR);
+            pg->syncWithFirstSocket(*this, HSD_INITIATOR);
         }
         // Otherwise the peer id must be the same as existing, otherwise
         // this group is considered already bound to another peer group.
@@ -3236,7 +3236,6 @@ SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint3
 
     // Check if there exists a group that this one is a peer of.
     CUDTGroup* gp = uglobal().findPeerGroup_LOCKED(peergroup);
-    bool was_empty = true;
     if (gp)
     {
         if (gp->type() != gtp)
@@ -3248,9 +3247,6 @@ SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint3
         }
 
         HLOGC(gmlog.Debug, log << CONID() << "makeMePeerOf: group for peer=$" << peergroup << " found: $" << gp->id());
-
-        if (!gp->groupEmpty())
-            was_empty = false;
     }
     else
     {
@@ -3273,6 +3269,7 @@ SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint3
 
         gp->set_peerid(peergroup);
         gp->deriveSettings(this);
+        gp->syncWithFirstSocket(s->core(), HSD_RESPONDER);
 
         // This can only happen on a listener (it's only called on a site that is
         // HSD_RESPONDER), so it was a response for a groupwise connection.
@@ -3282,19 +3279,6 @@ SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint3
         HLOGC(gmlog.Debug,
               log << CONID() << "makeMePeerOf: no group has peer=$" << peergroup << " - creating new mirror group $"
                   << gp->id());
-    }
-
-    {
-        ScopedLock glock (*gp->exp_groupLock());
-        if (gp->closing())
-        {
-            HLOGC(gmlog.Debug, log << CONID() << "makeMePeerOf: group $" << gp->id() << " is being closed, can't process");
-        }
-
-        if (was_empty)
-        {
-            gp->syncWithSocket(s->core(), HSD_RESPONDER);
-        }
     }
 
     // Setting non-blocking reading for group socket.
@@ -3396,21 +3380,15 @@ void srt::CUDT::synchronizeWithGroup(CUDTGroup* gp)
 
     // These are the values that are normally set initially by setters.
     int32_t snd_isn = m_iSndLastAck, rcv_isn = m_iRcvLastAck;
-    if (!gp->applyGroupSequences(m_SocketID, (snd_isn), (rcv_isn)))
-    {
-        HLOGC(gmlog.Debug,
-                log << CONID() << "synchronizeWithGroup: DERIVED ISN: RCV=%" << m_iRcvLastAck << " -> %" << rcv_isn
-                << " (shift by " << CSeqNo::seqcmp(rcv_isn, m_iRcvLastAck) << ") SND=%" << m_iSndLastAck
-                << " -> %" << snd_isn << " (shift by " << CSeqNo::seqcmp(snd_isn, m_iSndLastAck) << ")");
+    gp->applyGroupSequences(m_SocketID, (snd_isn), (rcv_isn));
+    HLOGC(gmlog.Debug,
+          log << CONID() << "synchronizeWithGroup: RCV-ISN=%" << m_iRcvLastAck << " -> %" << rcv_isn << " (shift by "
+              << CSeqNo::seqoff(m_iRcvLastAck, rcv_isn) << ") SND-ISN=%" << m_iSndLastAck << " -> %" << snd_isn
+              << " (shift by " << CSeqNo::seqoff(m_iSndLastAck, snd_isn) << ")");
+    if (rcv_isn != m_iRcvLastAck)
         setInitialRcvSeq(rcv_isn);
+    if (snd_isn != m_iSndLastAck)
         setInitialSndSeq(snd_isn);
-    }
-    else
-    {
-        HLOGC(gmlog.Debug,
-                log << CONID() << "synchronizeWithGroup: DEFINED ISN: RCV=%" << m_iRcvLastAck << " SND=%"
-                << m_iSndLastAck);
-    }
 }
 #endif
 
@@ -7686,7 +7664,12 @@ void srt::CUDT::dropToGroupRecvBase()
         // Note that getRcvBaseSeqNo() will lock m_GroupOf->m_GroupLock,
         // but this is an intended order.
         if (m_parent->m_GroupOf)
+        {
             group_recv_base = m_parent->m_GroupOf->getRcvBaseSeqNo();
+            // To reduce overhead, especially the m_GlobControlLock,
+            // the group wise recv seq is updated here.
+            m_parent->m_GroupOf->updateRcvCurrSeqNo(m_iRcvCurrSeqNo);
+        }
     }
     if (group_recv_base == SRT_SEQNO_NONE)
         return;


### PR DESCRIPTION
# The issue
The log of receiver:
```
/SRT:RcvQ:w106 D:SRT.gm: applyGroupSequences: @1071584760 gets seq from @1071584834 rcv %787865610 snd %787865661 as GROUPWISE snd-seq
/SRT:RcvQ:w106 D:SRT.gm: @1071584760: synchronizeWithGroup: DERIVED ISN: RCV=%787865661 -> %787865610 (shift by -51) SND=%787865661 -> %787865661 (shift by 0)
/SRT:RcvQ:w136 D:SRT.gm: applyGroupSequences: no socket found connected and transmitting, @1071584722 not changing sequences, storing snd-seq %787865661
/SRT:RcvQ:w136 D:SRT.gm: @1071584722: synchronizeWithGroup: DEFINED ISN: RCV=%787865661 SND=%787865661
```
The correct recv base seq was `%787865610`, and then a new member `@1071584722` was comming while all other members were broken at the same time.
`@1071584722` didn't inherit the correct recv base seq, but defined it's own `%787865661`

However, at the sender side, when the peer of `@1071584722` was coming, the peer of `@1071584760` was not yet broken coincidently, so `@1071584722` succeeded to inherit the correct send base seq `%787865610` from `CUDTGroup::m_iLastSchedSeqNo`.

As a result, the sender sent from `%787865610` while the receiver received from `%787865661`, the first 51 packets triggered `DROPREQ`, so only the following packets succeeded to transmit.

# The proposed solution 1 (this PR)
`CUDTGroup::m_iLastSchedSeqNo` is a good design, because members status can't be consistent all the time in both side, we should store group-wise send-base-seq and recv-base-seq. It's defined by the first connected socket, and is updated by the ACK timer (not by every packet, to reduce overhead).

# The proposed solution 2
rm this check
```
if ((!m_config.bRendezvous) && (m_ConnRes.m_iISN != m_iISN)) // secuity check
    e = CUDTException(MJ_SETUP, MN_SECURITY, 0);
```
so that RESPONDER can just use the `CUDTGROUP::m_iLastSchedSeqNo` as `m_iISN`, instead of `w_hs.m_iISN`, then the whole `applyGroupSequences()` function can be eliminated.