### PR TITLE
[core] Proposed solution for m_ConnectionLock/m_LSLock inversion

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2783,7 +2783,7 @@ void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
     m_ClosedSockets.erase(i);
 
     HLOGC(smlog.Debug, log << "GC/removeSocket: closing associated UDT @" << u);
-    s->core().closeInternal();
+    s->core().closeInternal(false /* DO NOT lock m_ConnectionLock inside */);
     HLOGC(smlog.Debug, log << "GC/removeSocket: DELETING SOCKET @" << u);
     delete s;
     HLOGC(smlog.Debug, log << "GC/removeSocket: socket @" << u << " DELETED. Checking muxer.");

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -976,23 +976,28 @@ void srt::CUDT::open()
 
 void srt::CUDT::setListenState()
 {
-    ScopedLock cg(m_ConnectionLock);
+    {
+        ScopedLock cg(m_ConnectionLock);
 
-    if (!m_bOpened)
-        throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
+        if (!m_bOpened)
+            throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
 
-    if (m_bConnecting || m_bConnected)
-        throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+        if (m_bConnecting || m_bConnected)
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
-    // listen can be called more than once
-    if (m_bListening)
-        return;
+        // listen can be called more than once
+        if (m_bListening)
+            return;
+
+        m_bListening = true;
+    }
 
     // if there is already another socket listening on the same port
     if (m_pRcvQueue->setListener(this) < 0)
+    {
+        m_bListening = false;
         throw CUDTException(MJ_NOTSUP, MN_BUSY, 0);
-
-    m_bListening = true;
+    }
 }
 
 size_t srt::CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, int hs_version)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -406,6 +406,8 @@ public: // internal API
     // immediately to free the socket
     void notListening()
     {
+        // XXX This is done when closing the socket after setting m_bBroken
+        // Likely m_ConnectionLock is not necessary in this situation.
         sync::ScopedLock cg(m_ConnectionLock);
         m_bListening = false;
         m_pRcvQueue->removeListener(this);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -408,7 +408,7 @@ public: // internal API
     {
         // XXX This is done when closing the socket after setting m_bBroken
         // Likely m_ConnectionLock is not necessary in this situation.
-        sync::ScopedLock cg(m_ConnectionLock);
+        //sync::ScopedLock cg(m_ConnectionLock);
         m_bListening = false;
         m_pRcvQueue->removeListener(this);
     }
@@ -575,7 +575,7 @@ private:
 
     /// Close the opened UDT entity.
 
-    bool closeInternal();
+    bool closeInternal(bool lock_connectionLock = true);
     void updateBrokenConnection();
     void completeBrokenConnectionDependencies(int errorcode);
 


### PR DESCRIPTION
The solution is to prevent applying m_ConnectionLock when the queue is being set the listener.

The same socket will not be attempted to be set listen by another thread because the m_bListening flag prevents this, and it's atomically checked and set under the m_ConnectionLock.

An important logical change is that m_bListening is set true when the listener is ATTEMPTED to be changed, but if this failed, and would be reported by exception, the flag is set back to false. This flag only influences the read-ready flag (which is unimportant for a socket that is not connected) and to remove the listening state when closing. This latter procedure still checks if the listener attempted to be removed is the same as the one that was set and does nothing if not.

Earlier versions: #1824 and #1844