### PR TITLE
[core] Fix attempt for bug #2297

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -934,7 +934,7 @@ private: // Receiving related data
     int32_t m_iAckSeqNo;                         // Last ACK sequence number
     sync::atomic<int32_t> m_iRcvCurrSeqNo;       // (RCV) Largest received sequence number. RcvQTh, TSBPDTh.
     int32_t m_iRcvCurrPhySeqNo;                  // Same as m_iRcvCurrSeqNo, but physical only (disregarding a filter)
-
+    bool m_bufferWasFull;                        // Indicate that RX buffer was full last time a ack was sent
     int32_t m_iPeerISN;                          // Initial Sequence Number of the peer side
 
     uint32_t m_uPeerSrtVersion;


### PR DESCRIPTION
When there is space available in the receiving buffer after it has been fulled, send an ack to allow the transmitter to resume transmission