### PR TITLE
Fix downversioning of _WIN32_WINNT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,13 @@ if(WIN32)
 	if(ENABLE_INET_PTON)
 		set(CMAKE_REQUIRED_LIBRARIES ws2_32)
 		check_function_exists(inet_pton HAVE_INET_PTON)
-		add_definitions(-D_WIN32_WINNT=0x0600)
+		try_compile(AT_LEAST_VISTA
+			${CMAKE_BINARY_DIR}
+			"${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_vista.c")
+		if(NOT AT_LEAST_VISTA)
+			# force targeting Vista
+			add_definitions(-D_WIN32_WINNT=0x0600)
+		endif()
 	else()
 		add_definitions(-D_WIN32_WINNT=0x0501)
 	endif()

--- a/scripts/test_vista.c
+++ b/scripts/test_vista.c
@@ -1,0 +1,10 @@
+/* Copyright © 2023 Steve Lhomme */
+/* SPDX-License-Identifier: ISC */
+#include <windows.h>
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0600 /* _WIN32_WINNT_VISTA */
+#error NOPE
+#endif
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Forcing the _WIN32_WINNT when the environment is already forcing a value results in a lot of warning.

If the user compiles for a higher version of Windows, we don't need to force compilation for Vista.