### PR TITLE
Add volatile keyword to asm block in rdtsc

### DIFF
--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -52,7 +52,7 @@ static void rdtsc(uint64_t& x)
     asm("mov %0=ar.itc" : "=r"(x)::"memory");
 #elif SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_AMD64_RDTSC
     uint32_t lval, hval;
-    asm("rdtsc" : "=a"(lval), "=d"(hval));
+    asm volatile("rdtsc" : "=a"(lval), "=d"(hval));
     x = hval;
     x = (x << 32) | lval;
 #elif SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_WINQPC


### PR DESCRIPTION
I've created a fork of this repo so that I can compile it directly into a golang project so that there is no libsrt dependency. Whilst doing this, I came across a bug where the cpu_frequency was being set to 0 resulting in a floating point exception.

for some reason I never saw this bug when building using the cmake build system, so I assume there must be a workaround for this or something, but I figured you'd want to see this.

My changes are:
```c++
#elif SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_AMD64_RDTSC
    uint32_t lval, hval;
    asm("rdtsc" : "=a"(lval), "=d"(hval));
    x = hval;
    x = (x << 32) | lval;
#elif SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_WINQPC
```
to
```c++
#elif SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_AMD64_RDTSC
    uint32_t lval, hval;
    asm volatile("rdtsc" : "=a"(lval), "=d"(hval));
    x = hval;
    x = (x << 32) | lval;
#elif SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_WINQPC
```
I suggest this because I assume that you're trying to do some sort of processor interrupt here, but haven't marked the registers as volatile so that cpu can't write into them for the response, this results in `rdtsc` always returning undefined (but usually 0).

## Note
I only ever saw this occur on Centos7, when I ran this on Ubuntu everything worked just fine
The compile flags I'm using are:
```
-DLINUX -DAMD64 -DSRT_ENABLE_ENCRYPTION=0
-lssh -lcrypto
```