### PR TITLE
[core] Fixed group read-ready epoll events.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -236,10 +236,14 @@ int CRcvBuffer::dropUpTo(int32_t seqno)
     m_iStartSeqNo = seqno;
     // Move forward if there are "read/drop" entries.
     releaseNextFillerEntries();
-    // Set nonread position to the starting position before updating,
-    // because start position was increased, and preceding packets are invalid.
-    m_iFirstNonreadPos = m_iStartPos;
-    updateNonreadPos();
+
+    // If the nonread position is now behind the starting position, set it to the starting position and update.
+    // Preceding packets were likely missing, and the non read position can probably be moved further now.
+    if (CSeqNo::seqcmp(m_iFirstNonreadPos, m_iStartPos) < 0)
+    {
+        m_iFirstNonreadPos = m_iStartPos;
+        updateNonreadPos();
+    }
     if (!m_tsbpd.isEnabled() && m_bMessageAPI)
         updateFirstReadableOutOfOrder();
     return iDropCnt;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6804,6 +6804,11 @@ bool srt::CUDT::isRcvBufferReady() const
     return m_pRcvBuffer->isRcvDataReady(steady_clock::now());
 }
 
+bool srt::CUDT::isRcvBufferReadyNoLock() const
+{
+    return m_pRcvBuffer->isRcvDataReady(steady_clock::now());
+}
+
 // int by_exception: accepts values of CUDTUnited::ErrorHandling:
 // - 0 - by return value
 // - 1 - by exception

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -720,6 +720,9 @@ private:
     SRT_ATTR_EXCLUDES(m_RcvBufferLock)
     bool isRcvBufferReady() const;
 
+    SRT_ATTR_REQUIRES2(m_RcvBufferLock)
+    bool isRcvBufferReadyNoLock() const;
+
     // TSBPD thread main function.
     static void* tsbpd(void* param);
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2310,12 +2310,18 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 }
             }
         }
+        bool canReadFurther = false;
         for (vector<CUDTSocket*>::const_iterator si = aliveMembers.begin(); si != aliveMembers.end(); ++si)
         {
             CUDTSocket* ps = *si;
             if (!ps->core().isRcvBufferReady())
                 m_Global.m_EPoll.update_events(ps->m_SocketID, ps->core().m_sPollID, SRT_EPOLL_IN, false);
+            else
+                canReadFurther = true;
         }
+
+        if (!canReadFurther)
+            m_Global.m_EPoll.update_events(id(), m_sPollID, SRT_EPOLL_IN, false);
 
         return res;
     }

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -194,9 +194,6 @@ public:
             m_bConnected = false;
         }
 
-        // XXX BUGFIX
-        m_Positions.erase(id);
-
         return !empty;
     }
 
@@ -645,20 +642,6 @@ private:
     // this has been already set.
     time_point m_tsStartTime;
     time_point m_tsRcvPeerStartTime;
-
-    struct ReadPos
-    {
-        std::vector<char> packet;
-        SRT_MSGCTRL       mctrl;
-        ReadPos(int32_t s)
-            : mctrl(srt_msgctrl_default)
-        {
-            mctrl.pktseq = s;
-        }
-    };
-    std::map<SRTSOCKET, ReadPos> m_Positions;
-
-    ReadPos* checkPacketAhead();
 
     void recv_CollectAliveAndBroken(std::vector<srt::CUDTSocket*>& w_alive, std::set<srt::CUDTSocket*>& w_broken);
 


### PR DESCRIPTION
There are two bugs found.

1. After reading a message the group's read-ready state is not updated.
2. There is no more need (I think) to update read-readiness upon sending an ACK. With the new receiver buffer reading is no longer blocked by the ACK position.

The function was introduced (changed) in v1.5.0 with the new receiver buffer in PR #2218. Maybe v1.5.0 with the old receiver buffer or earlier SRT versions didn't have this read-ready issue. In any case, there might have been other issues with the previous reading function.

### TODO

- [x] `CUDTGroup::m_Positions` is no longer used. Remove.
- [x] Remove unused variable `group_read_seq`.
