### PR TITLE
Initialize ISN and PeerISN in CUDT, minor code clean up in CRateEstimator.

### DIFF
--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -138,20 +138,20 @@ void CRateEstimator::updateInputRate(const time_point& time, int pkts, int bytes
     const bool early_update = (m_InRatePeriod < INPUTRATE_RUNNING_US) && (m_iInRatePktsCount > INPUTRATE_MAX_PACKETS);
 
     const uint64_t period_us = count_microseconds(time - m_tsInRateStartTime);
-    if (early_update || period_us > m_InRatePeriod)
-    {
-        // Required Byte/sec rate (payload + headers)
-        m_iInRateBytesCount += (m_iInRatePktsCount * CPacket::SRT_DATA_HDR_SIZE);
-        m_iInRateBps = (int)(((int64_t)m_iInRateBytesCount * 1000000) / period_us);
-        HLOGC(bslog.Debug,
-              log << "updateInputRate: pkts:" << m_iInRateBytesCount << " bytes:" << m_iInRatePktsCount
-                  << " rate=" << (m_iInRateBps * 8) / 1000 << "kbps interval=" << period_us);
-        m_iInRatePktsCount  = 0;
-        m_iInRateBytesCount = 0;
-        m_tsInRateStartTime = time;
+    if (!early_update && period_us <= m_InRatePeriod)
+        return;
 
-        setInputRateSmpPeriod(INPUTRATE_RUNNING_US);
-    }
+    // Required Byte/sec rate (payload + headers)
+    m_iInRateBytesCount += (m_iInRatePktsCount * CPacket::SRT_DATA_HDR_SIZE);
+    m_iInRateBps = (int)(((int64_t)m_iInRateBytesCount * 1000000) / period_us);
+    HLOGC(bslog.Debug,
+            log << "updateInputRate: pkts:" << m_iInRateBytesCount << " bytes:" << m_iInRatePktsCount
+                << " rate=" << (m_iInRateBps * 8) / 1000 << "kbps interval=" << period_us);
+    m_iInRatePktsCount  = 0;
+    m_iInRateBytesCount = 0;
+    m_tsInRateStartTime = time;
+
+    setInputRateSmpPeriod(INPUTRATE_RUNNING_US);
 }
 
 

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -120,8 +120,8 @@ private:                                                       // Constants
     static const int      INPUTRATE_INITIAL_BYTESPS = BW_INFINITE;
 
 private:
-    int        m_iInRatePktsCount;  // number of payload bytes added since InRateStartTime
-    int        m_iInRateBytesCount; // number of payload bytes added since InRateStartTime
+    int        m_iInRatePktsCount;  // number of payload packets added since InRateStartTime.
+    int        m_iInRateBytesCount; // number of payload bytes added since InRateStartTime.
     time_point m_tsInRateStartTime;
     uint64_t   m_InRatePeriod;  // usec
     int        m_iInRateBps;    // Input Rate in Bytes/sec

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -305,7 +305,10 @@ void srt::CUDT::construct()
     // m_cbPacketArrival.set(this, &CUDT::defaultPacketArrival);
 }
 
-srt::CUDT::CUDT(CUDTSocket* parent): m_parent(parent)
+srt::CUDT::CUDT(CUDTSocket* parent)
+    : m_parent(parent)
+    , m_iISN(-1)
+    , m_iPeerISN(-1)
 {
     construct();
 
@@ -328,7 +331,10 @@ srt::CUDT::CUDT(CUDTSocket* parent): m_parent(parent)
 
 }
 
-srt::CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor): m_parent(parent)
+srt::CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor)
+    : m_parent(parent)
+    , m_iISN(-1)
+    , m_iPeerISN(-1)
 {
     construct();
 


### PR DESCRIPTION
- [core] Minor code cleanup in CRateEstimator. Extracted from PR #2714.
- [core] Initialize ISN and PeerISN in CUDT.