### PR TITLE
Added missing public header files in Windows binary installer

### DIFF
--- a/scripts/win-installer/libsrt.nsi
+++ b/scripts/win-installer/libsrt.nsi
@@ -125,9 +125,11 @@ Section "Install"
     ; Header files.
     CreateDirectory "$INSTDIR\include\srt"
     SetOutPath "$INSTDIR\include\srt"
+    File "${RepoDir}\srtcore\access_control.h"
     File "${RepoDir}\srtcore\logging_api.h"
     File "${RepoDir}\srtcore\platform_sys.h"
     File "${RepoDir}\srtcore\srt.h"
+    File "${RepoDir}\srtcore\udt.h"
     File "${Build64Dir}\version.h"
 
     CreateDirectory "$INSTDIR\include\win"


### PR DESCRIPTION
The header file access_control.h was added in the source tree at some point but was not added in the Windows installer.

Please make sure to merge this one before release 1.5.3 in order to get valid Windows installers for that version.