### PR TITLE
Fixed API doc: SRT_INVALID_SOCK instead of SRT_ERROR in str_accept

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -666,7 +666,7 @@ internal use only.
 |      Returns                  |                                                                         |
 |:----------------------------- |:----------------------------------------------------------------------- |
 | socket/group ID               | On success, a valid SRT socket or group ID to be used for transmission. |
-| `SRT_ERROR`                   | (-1) on failure                                                         |
+| `SRT_INVALID_SOCK`            | (-1) on failure                                                         |
 | <img width=240px height=1px/> | <img width=710px height=1px/>                      |
 
 |       Errors                      |                                                                         |
@@ -722,7 +722,7 @@ calling this function.
 |      Returns                  |                                                                        |
 |:----------------------------- |:---------------------------------------------------------------------- |
 | SRT socket<br/>group ID       | On success, a valid SRT socket or group ID to be used for transmission |
-| `SRT_ERROR`      | (-1) on failure                                                        |
+| `SRT_INVALID_SOCK`            | (-1) on failure                                                        |
 | <img width=240px height=1px/> | <img width=710px height=1px/>                      |
 
 |       Errors                      |                                                              |


### PR DESCRIPTION
The functions srt_accept() and srt_accept_bond() return a SRTSOCKET. In case of error, the returned value is SRT_INVALID_SOCK, not SRT_ERROR. In practice, the two values are identical (-1) but they do not have the same semantics.