### PR TITLE
Pre-refax of change-independent parts for 2677

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -130,7 +130,7 @@ CRcvBuffer::CRcvBuffer(int initSeqNo, size_t size, CUnitQueue* unitqueue, bool b
     , m_bMessageAPI(bMessageAPI)
     , m_iBytesCount(0)
     , m_iPktsCount(0)
-    , m_uAvgPayloadSz(SRT_LIVE_DEF_PLSIZE)
+    , m_uAvgPayloadSz(0)
 {
     SRT_ASSERT(size < size_t(std::numeric_limits<int>::max())); // All position pointers are integers
 }
@@ -758,7 +758,12 @@ void CRcvBuffer::countBytes(int pkts, int bytes)
     m_iBytesCount += bytes; // added or removed bytes from rcv buffer
     m_iPktsCount  += pkts;
     if (bytes > 0)          // Assuming one pkt when adding bytes
-        m_uAvgPayloadSz = avg_iir<100>(m_uAvgPayloadSz, (unsigned) bytes);
+    {
+        if (!m_uAvgPayloadSz)
+            m_uAvgPayloadSz = bytes;
+        else
+            m_uAvgPayloadSz = avg_iir<100>(m_uAvgPayloadSz, (unsigned) bytes);
+    }
 }
 
 void CRcvBuffer::releaseUnitInPos(int pos)

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -1016,6 +1016,15 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
             if ((msg_flags & errmsgflg[i].first) != 0)
                 flg << " " << errmsgflg[i].second;
 
+        if (msg_flags & MSG_TRUNC)
+        {
+            // Additionally show buffer information in this case
+            flg << " buffers: ";
+            for (size_t i = 0; i < CPacket::PV_SIZE; ++i)
+            {
+                flg << "[" << w_packet.m_PacketVector[i].iov_len << "] ";
+            }
+        }
         // This doesn't work the same way on Windows, so on Windows just skip it.
 #endif
 

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -205,7 +205,7 @@ void srt::CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const soc
     {
         // Check if the peer address is a model of IPv4-mapped-on-IPv6.
         // If so, it means that the `ip` array should be interpreted as IPv4.
-        const bool is_mapped_ipv4 = checkMappedIPv4((uint16_t*)peer.sin6.sin6_addr.s6_addr);
+        const bool is_mapped_ipv4 = checkMappedIPv4(peer.sin6);
 
         sockaddr_in6* a = (&w_addr.sin6);
 

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -1422,6 +1422,15 @@ inline std::string SrtVersionString(int version)
 
 bool SrtParseConfig(const std::string& s, SrtConfig& w_config);
 
+bool checkMappedIPv4(const uint16_t* sa);
+
+inline bool checkMappedIPv4(const sockaddr_in6& sa)
+{
+    const uint16_t* addr = reinterpret_cast<const uint16_t*>(&sa.sin6_addr.s6_addr);
+    return checkMappedIPv4(addr);
+}
+
+
 } // namespace srt
 
 #endif


### PR DESCRIPTION
Changes:

1. In LiveCC, the header size is taken now from CUDT::maxPayloadSize() and the current MSS size, to stay in sync with the value possibly differently elaborated in the future.
2. MSG TRUNC flag is now traced in the debug logs, to detect any problems resulting in getting bigger packets than expected.
3. checkIPv4Mapped added a simple wrapper to simplify its use.
4. In the receiver buffer, the average payload size is used without the initial size value, instead it recognizes a trap 0 value as "no packet received so far".
