### PR TITLE
Extracted IP family dependent changes in stats tools for 2677

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1163,6 +1163,13 @@ private: // Trace
         
         int64_t sndDuration;                // real time for sending
         time_point sndDurationCounter;      // timers to record the sending Duration
+
+        void setupHeaderSize(int hsize)
+        {
+            sndr.setupHeaderSize(hsize);
+            rcvr.setupHeaderSize(hsize);
+        }
+
     } m_stats;
 
 public:

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -345,6 +345,9 @@ struct CSrtConfig: CSrtMuxerConfig
 
     bool payloadSizeFits(size_t val, int ip_family, std::string& w_errmsg) ATR_NOTHROW;
 
+    // This function returns the number of bytes that are allocated
+    // for a single packet in the sender and receiver buffer.
+    int bytesPerPkt() const { return iMSS - int(CPacket::UDP_HDR_SIZE); }
 };
 
 template <typename T>

--- a/srtcore/stats.h
+++ b/srtcore/stats.h
@@ -22,6 +22,8 @@ namespace stats
 class Packets
 {
 public:
+    typedef Packets count_type;
+
     Packets() : m_count(0) {}
 
     Packets(uint32_t num) : m_count(num) {}
@@ -46,27 +48,20 @@ private:
     uint32_t m_count;
 };
 
-class BytesPackets
+class BytesPacketsCount
 {
 public:
-    BytesPackets()
+    BytesPacketsCount()
         : m_bytes(0)
         , m_packets(0)
     {}
 
-    BytesPackets(uint64_t bytes, uint32_t n = 1)
+    BytesPacketsCount(uint64_t bytes, uint32_t n = 1)
         : m_bytes(bytes)
         , m_packets(n)
     {}
 
-    BytesPackets& operator+= (const BytesPackets& other)
-    {
-        m_bytes   += other.m_bytes;
-        m_packets += other.m_packets;
-        return *this;
-    }
 
-public:
     void reset()
     {
         m_packets = 0;
@@ -89,26 +84,60 @@ public:
         return m_packets;
     }
 
-    uint64_t bytesWithHdr() const
+    BytesPacketsCount& operator+= (const BytesPacketsCount& other)
     {
-        return m_bytes + m_packets * CPacket::SRT_DATA_HDR_SIZE;
+        m_bytes   += other.m_bytes;
+        m_packets += other.m_packets;
+        return *this;
     }
 
-private:
+protected:
     uint64_t m_bytes;
     uint32_t m_packets;
 };
 
-template <class METRIC_TYPE>
+class BytesPackets: public BytesPacketsCount
+{
+public:
+    typedef BytesPacketsCount count_type;
+
+    // Set IPv4-based header size value as a fallback. This will be fixed upon connection.
+    BytesPackets()
+        : m_zPacketHeaderSize(CPacket::UDP_HDR_SIZE + CPacket::HDR_SIZE)
+    {}
+
+public:
+
+    void setupHeaderSize(int size)
+    {
+        m_zPacketHeaderSize = uint64_t(size);
+    }
+
+    uint64_t bytesWithHdr() const
+    {
+        return m_bytes + m_packets * m_zPacketHeaderSize;
+    }
+
+private:
+    uint64_t m_zPacketHeaderSize;
+};
+
+template <class METRIC_TYPE, class BASE_METRIC_TYPE = METRIC_TYPE>
 struct Metric
 {
     METRIC_TYPE trace;
     METRIC_TYPE total;
 
-    void count(METRIC_TYPE val)
+    void count(typename METRIC_TYPE::count_type val)
     {
         trace += val;
         total += val;
+    }
+
+    void setupHeaderSize(int loc)
+    {
+        trace.setupHeaderSize(loc);
+        total.setupHeaderSize(loc);
     }
 
     void reset()
@@ -136,6 +165,16 @@ struct Sender
     
     Metric<Packets> recvdAck; // The number of ACK packets received by the sender.
     Metric<Packets> recvdNak; // The number of ACK packets received by the sender.
+
+    void setupHeaderSize(int hdr_size)
+    {
+#define SETHSIZE(var) var.setupHeaderSize(hdr_size)
+        SETHSIZE(sent);
+        SETHSIZE(sentUnique);
+        SETHSIZE(sentRetrans);
+        SETHSIZE(dropped);
+#undef SETHSIZE
+    }
 
     void reset()
     {
@@ -179,6 +218,19 @@ struct Receiver
 
     Metric<Packets> sentAck; // The number of ACK packets sent by the receiver.
     Metric<Packets> sentNak; // The number of NACK packets sent by the receiver.
+
+    void setupHeaderSize(int hdr_size)
+    {
+#define SETHSIZE(var) var.setupHeaderSize(hdr_size)
+        SETHSIZE(recvd);
+        SETHSIZE(recvdUnique);
+        SETHSIZE(recvdRetrans);
+        SETHSIZE(lost);
+        SETHSIZE(dropped);
+        SETHSIZE(recvdBelated);
+        SETHSIZE(undecrypted);
+#undef SETHSIZE
+    }
 
     void reset()
     {

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -145,7 +145,7 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeWindow, int* r_bytesWindow, size_t asize, size_t psize)
+void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeWindow, int* r_bytesWindow, size_t asize, size_t psize, size_t max_payload_size)
 {
    for (size_t i = 0; i < asize; ++ i)
       r_pktWindow[i] = 1000000;   //1 sec -> 1 pkt/sec
@@ -154,11 +154,11 @@ void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_p
       r_probeWindow[k] = 1000;    //1 msec -> 1000 pkts/sec
 
    for (size_t i = 0; i < asize; ++ i)
-      r_bytesWindow[i] = srt::CPacket::SRT_MAX_PAYLOAD_SIZE; //based on 1 pkt/sec set in r_pktWindow[i]
+      r_bytesWindow[i] = max_payload_size; //based on 1 pkt/sec set in r_pktWindow[i]
 }
 
 
-int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, int& bytesps)
+int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, size_t hdr_size, int& bytesps)
 {
    // get median value, but cannot change the original value order in the window
    std::copy(window, window + asize, replica);
@@ -191,7 +191,7 @@ int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica,
    // claculate speed, or return 0 if not enough valid value
    if (count > (asize >> 1))
    {
-      bytes += (srt::CPacket::SRT_DATA_HDR_SIZE * count); //Add protocol headers to bytes received
+      bytes += (hdr_size * count); //Add protocol headers to bytes received
       bytesps = (int)ceil(1000000.0 / (double(sum) / double(bytes)));
       return (int)ceil(1000000.0 / (sum / count));
    }


### PR DESCRIPTION
Changes:
* stats and window tools can be now configured the size of the network header per packet