### PR TITLE
Added explicit closing the sockets. To prevent messing with UDP sockets keeping ports busy.

### DIFF
--- a/test/test_env.h
+++ b/test/test_env.h
@@ -49,9 +49,17 @@ class TestInit
 {
 public:
     int ninst;
+    // Directly use int32_t instead of SRTSOCKET in order
+    // not to derive the srt.h API
+    static std::vector<int32_t> used_sockets;
 
     static void start(int& w_retstatus);
     static void stop();
+
+    static void remember(int32_t s)
+    {
+        used_sockets.push_back(s);
+    }
 
     TestInit() { start((ninst)); }
     ~TestInit() { stop(); }

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -68,6 +68,7 @@ TEST(CEPoll, WaitEmptyCall)
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int no = 0;
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -91,6 +92,7 @@ TEST(CEPoll, UWaitEmptyCall)
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int no = 0;
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -114,6 +116,7 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased)
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int yes = 1;
     const int no = 0;
@@ -148,6 +151,7 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased2)
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int yes = 1;
     const int no = 0;
@@ -168,7 +172,6 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased2)
     ASSERT_EQ(srt_epoll_uwait(epoll_id, events, 2, -1), SRT_ERROR);
 
     EXPECT_EQ(srt_epoll_release(epoll_id), 0);
-
 }
 
 TEST(CEPoll, WrongEpoll_idOnAddUSock)
@@ -177,6 +180,7 @@ TEST(CEPoll, WrongEpoll_idOnAddUSock)
 
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int no  = 0;
     ASSERT_NE(srt_setsockopt(client_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -200,6 +204,7 @@ TEST(CEPoll, HandleEpollEvent)
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int yes = 1;
     const int no  = 0;
@@ -261,6 +266,7 @@ TEST(CEPoll, NotifyConnectionBreak)
     // 1. Prepare client
     SRTSOCKET client_sock = srt_create_socket();
     ASSERT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int yes SRT_ATR_UNUSED = 1;
     const int no SRT_ATR_UNUSED = 0;
@@ -283,6 +289,7 @@ TEST(CEPoll, NotifyConnectionBreak)
     // 2. Prepare server
     SRTSOCKET server_sock = srt_create_socket();
     ASSERT_NE(server_sock, SRT_ERROR);
+    srtinit.remember(server_sock);
 
     ASSERT_NE(srt_setsockopt(server_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
     ASSERT_NE(srt_setsockopt(server_sock, 0, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -375,6 +382,7 @@ TEST(CEPoll, HandleEpollEvent2)
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int yes = 1;
     const int no  = 0;
@@ -436,6 +444,7 @@ TEST(CEPoll, HandleEpollNoEvent)
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int yes = 1;
     const int no  = 0;
@@ -486,6 +495,7 @@ TEST(CEPoll, ThreadedUpdate)
 
     SRTSOCKET client_sock = srt_create_socket();
     EXPECT_NE(client_sock, SRT_ERROR);
+    srtinit.remember(client_sock);
 
     const int no  = 0;
     EXPECT_NE(srt_setsockopt (client_sock, 0, SRTO_RCVSYN,    &no,  sizeof no),  SRT_ERROR); // for async connect
@@ -764,5 +774,6 @@ TEST_F(TestEPoll, SimpleAsync)
     client.join(); // Make sure client has exit before you delete the socket
 
     srt_close(m_client_sock); // cannot close m_client_sock after srt_sendmsg because of issue in api.c:2346 
+    srt_close(ss);
 }
 

--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -235,6 +235,7 @@ TEST(TestFEC, ConfigExchange)
     string exp_config = "fec,cols:10,rows:10,arq:never,layout:staircase";
 
     EXPECT_TRUE(filterConfigSame(fec_configback, exp_config));
+    srt_close(sid1);
 }
 
 TEST(TestFEC, ConfigExchangeFaux)
@@ -273,6 +274,7 @@ TEST(TestFEC, ConfigExchangeFaux)
     cout << "(NOTE: expecting a failure message)\n";
     EXPECT_FALSE(m1.checkApplyFilterConfig("fec,cols:10,arq:never"));
 
+    srt_close(sid1);
 }
 
 TEST(TestFEC, Connection)
@@ -327,6 +329,9 @@ TEST(TestFEC, Connection)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
+    srt_close(a);
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, ConnectionReorder)
@@ -379,6 +384,9 @@ TEST(TestFEC, ConnectionReorder)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
+    srt_close(a);
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, ConnectionFull1)
@@ -431,6 +439,9 @@ TEST(TestFEC, ConnectionFull1)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
+    srt_close(a);
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, ConnectionFull2)
@@ -483,6 +494,9 @@ TEST(TestFEC, ConnectionFull2)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
+    srt_close(a);
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, ConnectionMess)
@@ -535,6 +549,9 @@ TEST(TestFEC, ConnectionMess)
     EXPECT_TRUE(filterConfigSame(caller_config, fec_config_final));
     EXPECT_TRUE(filterConfigSame(accept_config, fec_config_final));
 
+    srt_close(a);
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, ConnectionForced)
@@ -581,6 +598,9 @@ TEST(TestFEC, ConnectionForced)
     EXPECT_TRUE(filterConfigSame(result_config1, fec_config_final));
     EXPECT_TRUE(filterConfigSame(result_config2, fec_config_final));
 
+    srt_close(a);
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, RejectionConflict)
@@ -623,6 +643,8 @@ TEST(TestFEC, RejectionConflict)
     int sclen = sizeof scl;
     EXPECT_EQ(srt_accept(l, (sockaddr*)& scl, &sclen), SRT_ERROR);
 
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST(TestFEC, RejectionIncompleteEmpty)
@@ -662,6 +684,8 @@ TEST(TestFEC, RejectionIncompleteEmpty)
     int sclen = sizeof scl;
     EXPECT_EQ(srt_accept(l, (sockaddr*)& scl, &sclen), SRT_ERROR);
 
+    srt_close(s);
+    srt_close(l);
 }
 
 
@@ -705,6 +729,8 @@ TEST(TestFEC, RejectionIncomplete)
     int sclen = sizeof scl;
     EXPECT_EQ(srt_accept(l, (sockaddr*)& scl, &sclen), SRT_ERROR);
 
+    srt_close(s);
+    srt_close(l);
 }
 
 TEST_F(TestFECRebuilding, Prepare)

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -91,14 +91,19 @@ bool TestEnv::Allowed_IPv6()
     return true;
 }
 
+std::vector<int32_t> TestInit::used_sockets;
 
 void TestInit::start(int& w_retstatus)
 {
     ASSERT_GE(w_retstatus = srt_startup(), 0);
+    used_sockets.clear(); // just in case
 }
 
 void TestInit::stop()
 {
+    for (SRTSOCKET s: used_sockets)
+        srt_close(s);
+    used_sockets.clear();
     EXPECT_NE(srt_cleanup(), -1);
 }
 


### PR DESCRIPTION
The reason why this is necessary is that it has been observed in some test CI environments that sometimes sockets fail to bind a port, for which the reason could be that the sockets may be deleted with too large delay and cause the next test to fail due to inability to bind the port.