### PR TITLE
Fix incorrect behavior in message mode when too small buffer supplied

### DIFF
--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -180,7 +180,7 @@ int parse_args(FileTransmitConfig &cfg, int argc, char** argv)
         return 2;
     }
 
-    cfg.chunk_size    = stoul(Option<OutString>(params, "1456", o_chunk));
+    cfg.chunk_size    = stoul(Option<OutString>(params, "0", o_chunk));
     cfg.skip_flushing = Option<OutBool>(params, false, o_no_flush);
     cfg.bw_report     = stoi(Option<OutString>(params, "0", o_bwreport));
     cfg.stats_report  = stoi(Option<OutString>(params, "0", o_statsrep));
@@ -681,8 +681,11 @@ int main(int argc, char** argv)
     //
     // Set global config variables
     //
-    if (cfg.chunk_size != SRT_LIVE_MAX_PLSIZE)
+    if (cfg.chunk_size != 0)
         transmit_chunk_size = cfg.chunk_size;
+    else
+        transmit_chunk_size = SRT_MAX_PLSIZE_AF_INET;
+
     transmit_stats_writer = SrtStatsWriterFactory(cfg.stats_pf);
     transmit_bw_report = cfg.bw_report;
     transmit_stats_report = cfg.stats_report;

--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -172,6 +172,7 @@ Since SRT v1.5.0.
 | [SRT_REJ_GROUP](#SRT_REJ_GROUP)              | 1.4.2     | The group type or some group settings are incompatible for both connection parties                             |
 | [SRT_REJ_TIMEOUT](#SRT_REJ_TIMEOUT)          | 1.4.2     | The connection wasn't rejected, but it timed out                                                               |
 | [SRT_REJ_CRYPTO](#SRT_REJ_CRYPTO)            | 1.5.2     | The connection was rejected due to an unsupported or mismatching encryption mode                               |
+| [SRT_REJ_SETTINGS](#SRT_REJ_SETTINGS)        | 1.6.0     | The connection was rejected because settings on both parties are in collision and cannot negotiate common values |
 | <img width=290px height=1px/>                |           |                                                                                                                |
 
 <h4 id="error-codes">Error Codes</h4>
@@ -3067,6 +3068,21 @@ constants. Note that the number space from the value of `SRT_REJC_PREDEFINED`
 and above is reserved for "predefined codes" (`SRT_REJC_PREDEFINED` value plus
 adopted HTTP codes). Values above `SRT_REJC_USERDEFINED` are freely defined by
 the application.
+
+#### SRT_REJ_CRYPTO
+
+Settings for `SRTO_CRYPTOMODE` on both parties are not compatible with one another.
+See [`SRTO_CRYPTOMODE`](API-socket-options.md#SRTO_CRYPTOMODE) for details.
+
+#### SRT_REJ_SETTINGS
+
+Settings for various transmission parameters that are supposed to be negotiated
+during the handshake (in order to agree upon a common value) are under restrictions
+that make finding common values for them impossible. Cases include:
+
+* `SRTO_PAYLOADSIZE`, which is nonzero in live mode, is set to a value that
+exceeds the free space in a single packet that results from the value of the
+negotiated MSS value
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3157,7 +3157,14 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& reqaddr, cons
         m.m_pSndQueue = new CSndQueue;
         m.m_pSndQueue->init(m.m_pChannel, m.m_pTimer);
         m.m_pRcvQueue = new CRcvQueue;
-        m.m_pRcvQueue->init(128, s->core().maxPayloadSize(), m.m_iIPversion, 1024, m.m_pChannel, m.m_pTimer);
+
+        // We can't use maxPayloadSize() because this value isn't valid until the connection is established.
+        // We need to "think big", that is, allocate a size that would fit both IPv4 and IPv6.
+        const size_t payload_size = s->core().m_config.iMSS - CPacket::HDR_SIZE - CPacket::udpHeaderSize(AF_INET);
+
+        HLOGC(smlog.Debug, log << s->core().CONID() << "updateMux: config rcv queue qsize=" << 128
+                << " plsize=" << payload_size << " hsize=" << 1024);
+        m.m_pRcvQueue->init(128, payload_size, m.m_iIPversion, 1024, m.m_pChannel, m.m_pTimer);
 
         // Rewrite the port here, as it might be only known upon return
         // from CChannel::open.

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -102,12 +102,12 @@ void AvgBufSize::update(const steady_clock::time_point& now, int pkts, int bytes
     m_dTimespanMAvg   = avg_iir_w<1000, double>(m_dTimespanMAvg, timespan_ms, elapsed_ms);
 }
 
-CRateEstimator::CRateEstimator(int /*family*/)
+CRateEstimator::CRateEstimator(int family)
     : m_iInRatePktsCount(0)
     , m_iInRateBytesCount(0)
     , m_InRatePeriod(INPUTRATE_FAST_START_US) // 0.5 sec (fast start)
     , m_iInRateBps(INPUTRATE_INITIAL_BYTESPS)
-    , m_iFullHeaderSize(CPacket::UDP_HDR_SIZE + CPacket::HDR_SIZE)
+    , m_iFullHeaderSize(CPacket::udpHeaderSize(family) + CPacket::HDR_SIZE)
 {}
 
 void CRateEstimator::setInputRateSmpPeriod(int period)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -269,6 +269,7 @@ void srt::CUDT::construct()
 
     m_pSndQueue = NULL;
     m_pRcvQueue = NULL;
+    m_TransferIPVersion = AF_UNSPEC; // Will be set after connection
     m_pSNode    = NULL;
     m_pRNode    = NULL;
 
@@ -890,7 +891,7 @@ string srt::CUDT::getstreamid(SRTSOCKET u)
 // Initial sequence number, loss, acknowledgement, etc.
 void srt::CUDT::clearData()
 {
-    const size_t full_hdr_size = CPacket::UDP_HDR_SIZE - CPacket::HDR_SIZE;
+    const size_t full_hdr_size = CPacket::udpHeaderSize(AF_INET) + CPacket::HDR_SIZE;
     m_iMaxSRTPayloadSize = m_config.iMSS - full_hdr_size;
     HLOGC(cnlog.Debug, log << CONID() << "clearData: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
 
@@ -3051,7 +3052,7 @@ bool srt::CUDT::checkApplyFilterConfig(const std::string &confstr)
 
     // XXX Using less maximum payload size of IPv4 and IPv6; this is only about the payload size
     // for live.
-    size_t efc_max_payload_size = SRT_LIVE_MAX_PLSIZE - cfg.extra_size;
+    size_t efc_max_payload_size = SRT_MAX_PLSIZE_AF_INET6 - cfg.extra_size;
     if (m_config.zExpPayloadSize > efc_max_payload_size)
     {
         LOGC(cnlog.Warn,
@@ -4692,16 +4693,34 @@ bool srt::CUDT::applyResponseSettings(const CPacket* pHspkt /*[[nullable]]*/) AT
         return false;
     }
 
+    m_TransferIPVersion = m_PeerAddr.family();
+    if (m_PeerAddr.family() == AF_INET6)
+    {
+        // Check if the m_PeerAddr's address is a mapped IPv4. If so,
+        // define Transfer IP version as 4 because this one will be used.
+        if (checkMappedIPv4(m_PeerAddr.sin6))
+            m_TransferIPVersion = AF_INET;
+    }
+
     // Re-configure according to the negotiated values.
     m_config.iMSS        = m_ConnRes.m_iMSS;
 
-    const size_t full_hdr_size = CPacket::UDP_HDR_SIZE + CPacket::HDR_SIZE;
+    const size_t full_hdr_size = CPacket::udpHeaderSize(m_TransferIPVersion) + CPacket::HDR_SIZE;
     m_iMaxSRTPayloadSize = m_config.iMSS - full_hdr_size;
-    HLOGC(cnlog.Debug, log << CONID() << "applyResponseSettings: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
+    if (m_iMaxSRTPayloadSize < int(m_config.zExpPayloadSize))
+    {
+        LOGC(cnlog.Error, log << CONID() << "applyResponseSettings: negotiated MSS=" << m_config.iMSS
+                << " leaves too little payload space " << m_iMaxSRTPayloadSize << " for configured payload size "
+                << m_config.zExpPayloadSize);
+        m_RejectReason = SRT_REJ_SETTINGS;
+        return false;
+    }
+    HLOGC(cnlog.Debug, log << CONID() << "acceptAndRespond: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
     m_stats.setupHeaderSize(full_hdr_size);
 
+
     m_iFlowWindowSize    = m_ConnRes.m_iFlightFlagSize;
-    const int udpsize    = m_config.iMSS - CPacket::UDP_HDR_SIZE;
+    const int udpsize    = m_config.iMSS - CPacket::udpHeaderSize(m_TransferIPVersion);
     m_iMaxSRTPayloadSize = udpsize - CPacket::HDR_SIZE;
     m_iPeerISN           = m_ConnRes.m_iISN;
 
@@ -5646,16 +5665,31 @@ bool srt::CUDT::prepareBuffers(CUDTException* eout)
     
     try
     {
+        // XXX SND buffer may allocate more memory, but must set the size of a single
+        // packet that fits the transmission for the overall connection. For any mixed 4-6
+        // connection it should be the less size, that is, for IPv6
+
         // CryptoControl has to be initialized and in case of RESPONDER the KM REQ must be processed (interpretSrtHandshake(..)) for the crypto mode to be deduced.
-        const int authtag = (m_pCryptoControl && m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM) ? HAICRYPT_AUTHTAG_MAX : 0;
+        const int authtag = m_config.iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM ? HAICRYPT_AUTHTAG_MAX : 0;
 
         SRT_ASSERT(m_iMaxSRTPayloadSize != 0);
+        SRT_ASSERT(m_TransferIPVersion != AF_UNSPEC);
+        // IMPORTANT:
+        // The m_iMaxSRTPayloadSize is the size of the payload in the "SRT packet" that can be sent
+        // over the current connection - which means that if both parties are IPv6, then the maximum size
+        // is the one for IPv6 (1444). If any party is IPv4, this maximum size is 1456.
+        // The family as the first argument is something different - it's for the header size in order
+        // to calculate rate and statistics.
 
-        HLOGC(rslog.Debug, log << CONID() << "Creating buffers: snd-plsize=" << m_iMaxSRTPayloadSize
-                << " snd-bufsize=" << 32
+        int snd_payload_size = m_config.iMSS - CPacket::HDR_SIZE - CPacket::udpHeaderSize(m_TransferIPVersion);
+        SRT_ASSERT(m_iMaxSRTPayloadSize <= snd_payload_size);
+
+        HLOGC(rslog.Debug, log << CONID() << "Creating buffers: snd-plsize=" << snd_payload_size
+                << " snd-bufsize=" << 32 << " TF-IPv"
+                << (m_TransferIPVersion == AF_INET6 ? "6" : m_TransferIPVersion == AF_INET ? "4" : "???")
                 << " authtag=" << authtag);
 
-        m_pSndBuffer = new CSndBuffer(AF_INET, 32, m_iMaxSRTPayloadSize, authtag);
+        m_pSndBuffer = new CSndBuffer(m_TransferIPVersion, 32, snd_payload_size, authtag);
         SRT_ASSERT(m_iPeerISN != -1);
         m_pRcvBuffer = new srt::CRcvBuffer(m_iPeerISN, m_config.iRcvBufSize, m_pRcvQueue->m_pUnitQueue, m_config.bMessageAPI);
         // After introducing lite ACK, the sndlosslist may not be cleared in time, so it requires twice a space.
@@ -5703,8 +5737,16 @@ void srt::CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& 
     // Uses the smaller MSS between the peers
     m_config.iMSS = std::min(m_config.iMSS, w_hs.m_iMSS);
 
-    const size_t full_hdr_size = CPacket::UDP_HDR_SIZE + CPacket::HDR_SIZE;
+    const size_t full_hdr_size = CPacket::udpHeaderSize(m_TransferIPVersion) + CPacket::HDR_SIZE;
     m_iMaxSRTPayloadSize = m_config.iMSS - full_hdr_size;
+    if (m_iMaxSRTPayloadSize < int(m_config.zExpPayloadSize))
+    {
+        LOGC(cnlog.Error, log << CONID() << "acceptAndRespond: negotiated MSS=" << m_config.iMSS
+                << " leaves too little payload space " << m_iMaxSRTPayloadSize << " for configured payload size "
+                << m_config.zExpPayloadSize);
+        m_RejectReason = SRT_REJ_SETTINGS;
+        throw CUDTException(MJ_SETUP, MN_REJECTED, 0);
+    }
 
     HLOGC(cnlog.Debug, log << CONID() << "acceptAndRespond: PAYLOAD SIZE: " << m_iMaxSRTPayloadSize);
     m_stats.setupHeaderSize(full_hdr_size);
@@ -5729,6 +5771,15 @@ void srt::CUDT::acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& 
     CIPAddress::pton((m_parent->m_SelfAddr), m_piSelfIP, peer);
 
     rewriteHandshakeData(peer, (w_hs));
+
+    m_TransferIPVersion = peer.family();
+    if (peer.family() == AF_INET6)
+    {
+        // Check if the peer's address is a mapped IPv4. If so,
+        // define Transfer IP version as 4 because this one will be used.
+        if (checkMappedIPv4(peer.sin6))
+            m_TransferIPVersion = AF_INET;
+    }
 
 
     // Prepare all structures
@@ -7409,7 +7460,7 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
 
-    const int pktHdrSize = CPacket::HDR_SIZE + CPacket::UDP_HDR_SIZE;
+    const int pktHdrSize = CPacket::HDR_SIZE + CPacket::udpHeaderSize(m_TransferIPVersion == AF_UNSPEC ? AF_INET : m_TransferIPVersion);
     {
         int32_t flight_span = getFlightSpan();
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1170,7 +1170,7 @@ private: // Trace
         time_point tsLastSampleTime;        // last performance sample time
         int traceReorderDistance;
         double traceBelatedTime;
-        
+
         int64_t sndDuration;                // real time for sending
         time_point sndDurationCounter;      // timers to record the sending Duration
 
@@ -1214,6 +1214,7 @@ private: // for UDP multiplexer
     sockaddr_any m_PeerAddr;   // peer address
     sockaddr_any m_SourceAddr; // override UDP source address with this one when sending
     uint32_t m_piSelfIP[4];    // local UDP IP address
+    int m_TransferIPVersion;   // AF_INET/6 that should be used to determine common payload size
     CSNode* m_pSNode;          // node information for UDT list used in snd queue
     CRNode* m_pRNode;          // node information for UDT list used in rcv queue
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -236,7 +236,7 @@ CUDTGroup::SocketData* CUDTGroup::add(SocketData data)
               log << "CUDTGroup::add: taking MAX payload size from socket @" << data.ps->m_SocketID << ": " << plsize
                   << " " << (plsize ? "(explicit)" : "(unspecified = fallback to 1456)"));
         if (plsize == 0)
-            plsize = SRT_LIVE_MAX_PLSIZE;
+            plsize = CPacket::srtPayloadSize(data.agent.family());
         // It is stated that the payload size
         // is taken from first, and every next one
         // will get the same.
@@ -506,8 +506,8 @@ void CUDTGroup::deriveSettings(CUDT* u)
     IM(SRTO_FC, iFlightFlagSize);
 
     // Nonstandard
-    importOption(m_config, SRTO_SNDBUF, u->m_config.iSndBufSize * (u->m_config.iMSS - CPacket::UDP_HDR_SIZE));
-    importOption(m_config, SRTO_RCVBUF, u->m_config.iRcvBufSize * (u->m_config.iMSS - CPacket::UDP_HDR_SIZE));
+    importOption(m_config, SRTO_SNDBUF, u->m_config.iSndBufSize * (u->m_config.iMSS - CPacket::udpHeaderSize(AF_INET)));
+    importOption(m_config, SRTO_RCVBUF, u->m_config.iRcvBufSize * (u->m_config.iMSS - CPacket::udpHeaderSize(AF_INET)));
 
     IM(SRTO_LINGER, Linger);
     IM(SRTO_UDP_SNDBUF, iUDPSndBufSize);
@@ -639,7 +639,7 @@ static bool getOptDefault(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
 
     case SRTO_SNDBUF:
     case SRTO_RCVBUF:
-        w_optlen = fillValue((pw_optval), w_optlen, CSrtConfig::DEF_BUFFER_SIZE * (CSrtConfig::DEF_MSS - CPacket::UDP_HDR_SIZE));
+        w_optlen = fillValue((pw_optval), w_optlen, CSrtConfig::DEF_BUFFER_SIZE * (CSrtConfig::DEF_MSS - CPacket::udpHeaderSize(AF_INET)));
         break;
 
     case SRTO_LINGER:
@@ -3496,7 +3496,9 @@ int CUDTGroup::sendBackup(const char* buf, int len, SRT_MSGCTRL& w_mc)
     }
 
     // Only live streaming is supported
-    if (len > SRT_LIVE_MAX_PLSIZE)
+    // Also - as the group may use potentially IPv4 and IPv6 connections
+    // in the same group, use the size that fits both
+    if (len > SRT_MAX_PLSIZE_AF_INET6)
     {
         LOGC(gslog.Error, log << "grp/send(backup): buffer size=" << len << " exceeds maximum allowed in live mode");
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -3931,7 +3933,8 @@ void CUDTGroup::internalKeepalive(SocketData* gli)
     }
 }
 
-CUDTGroup::BufferedMessageStorage CUDTGroup::BufferedMessage::storage(SRT_LIVE_MAX_PLSIZE /*, 1000*/);
+// Use the bigger size of SRT_MAX_PLSIZE to potentially fit both IPv4/6
+CUDTGroup::BufferedMessageStorage CUDTGroup::BufferedMessage::storage(SRT_MAX_PLSIZE_AF_INET /*, 1000*/);
 
 // Forwarder needed due to class definition order
 int32_t CUDTGroup::generateISN()

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -364,16 +364,24 @@ public:
 
     static const size_t HDR_SIZE = sizeof(HEADER_TYPE); // packet header size = SRT_PH_E_SIZE * sizeof(uint32_t)
 
-    // Can also be calculated as: sizeof(struct ether_header) + sizeof(struct ip) + sizeof(struct udphdr).
-    static const size_t UDP_HDR_SIZE = 28; // 20 bytes IPv4 + 8 bytes of UDP { u16 sport, dport, len, csum }.
-
-    static const size_t SRT_DATA_HDR_SIZE = UDP_HDR_SIZE + HDR_SIZE;
+private: // Do not disclose ingredients to the public
+    static const size_t UDP_HDR_SIZE = 8; // 8 bytes of UDP { u16 sport, dport, len, csum }.
+    static const size_t IPv4_HDR_SIZE = 20; // 20 bytes IPv4
+    static const size_t IPv6_HDR_SIZE = 32; // 32 bytes IPv6
+public:
+    static inline size_t udpHeaderSize(int family)
+    {
+        return UDP_HDR_SIZE + (family == AF_INET ? IPv4_HDR_SIZE : IPv6_HDR_SIZE);
+    }
+    static inline size_t srtPayloadSize(int family)
+    {
+        return ETH_MAX_MTU_SIZE - (family == AF_INET ? IPv4_HDR_SIZE : IPv6_HDR_SIZE) - UDP_HDR_SIZE - HDR_SIZE;
+    }
 
     // Maximum transmission unit size. 1500 in case of Ethernet II (RFC 1191).
     static const size_t ETH_MAX_MTU_SIZE = 1500;
 
     // Maximum payload size of an SRT packet.
-    static const size_t SRT_MAX_PAYLOAD_SIZE = ETH_MAX_MTU_SIZE - SRT_DATA_HDR_SIZE;
 
     // Packet interface
     char*       data() { return m_pcData; }

--- a/srtcore/packetfilter_api.h
+++ b/srtcore/packetfilter_api.h
@@ -66,7 +66,7 @@ struct SrtFilterInitializer
 struct SrtPacket
 {
     uint32_t hdr[SRT_PH_E_SIZE];
-    char buffer[SRT_LIVE_MAX_PLSIZE];
+    char buffer[SRT_MAX_PLSIZE_AF_INET]; // Using this as the bigger one (this for AF_INET6 is smaller)
     size_t length;
 
     SrtPacket(size_t size): length(size)

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -347,7 +347,7 @@ struct CSrtConfig: CSrtMuxerConfig
 
     // This function returns the number of bytes that are allocated
     // for a single packet in the sender and receiver buffer.
-    int bytesPerPkt() const { return iMSS - int(CPacket::UDP_HDR_SIZE); }
+    int bytesPerPkt() const { return iMSS - int(CPacket::udpHeaderSize(AF_INET)); }
 };
 
 template <typename T>

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -300,9 +300,20 @@ typedef enum SRT_TRANSTYPE
 // This is for MPEG TS and it's a default SRTO_PAYLOADSIZE for SRTT_LIVE.
 static const int SRT_LIVE_DEF_PLSIZE = 1316; // = 188*7, recommended for MPEG TS
 
-// This is the maximum payload size for Live mode, should you have a different
-// payload type than MPEG TS.
-static const int SRT_LIVE_MAX_PLSIZE = 1456; // MTU(1500) - UDP.hdr(28) - SRT.hdr(16)
+// DEPRECATED. Use one of these below instead.
+SRT_ATR_DEPRECATED_PX static const int SRT_LIVE_MAX_PLSIZE SRT_ATR_DEPRECATED = 1456; // MTU(1500) - UDP.hdr(28) - SRT.hdr(16)
+
+// These constants define the maximum size of the payload
+// in a single UDP packet, depending on the IP version, and
+// with the default socket options, that is:
+// * default 1500 bytes of MTU (see SRTO_MSS)
+// * without FEC packet filter (see SRTO_PACKETFILTER)
+// * without AEAD through AES-GCM (see SRTO_CRYPTOMODE)
+static const int SRT_MAX_PLSIZE_AF_INET = 1456; // MTU(1500) - IPv4.hdr(20) - UDP.hdr(8) - SRT.hdr(16)
+static const int SRT_MAX_PLSIZE_AF_INET6 = 1444; // MTU(1500) - IPv6.hdr(32) - UDP.hdr(8) - SRT.hdr(16)
+
+// A macro for these above in case when the IP family is passed as a runtime value.
+#define SRT_MAX_PLSIZE(famspec) ((famspec) == AF_INET ? SRT_MAX_PLSIZE_AF_INET : SRT_MAX_PLSIZE_AF_INET6)
 
 // Latency for Live transmission: default is 120
 static const int SRT_LIVE_DEF_LATENCY_MS = 120;
@@ -562,6 +573,7 @@ enum SRT_REJECT_REASON
 #ifdef ENABLE_AEAD_API_PREVIEW
     SRT_REJ_CRYPTO,      // conflicting cryptographic configurations
 #endif
+    SRT_REJ_SETTINGS,    // socket settings on both sides collide and can't be negotiated
 
     SRT_REJ_E_SIZE,
 };

--- a/srtcore/stats.h
+++ b/srtcore/stats.h
@@ -103,7 +103,7 @@ public:
 
     // Set IPv4-based header size value as a fallback. This will be fixed upon connection.
     BytesPackets()
-        : m_zPacketHeaderSize(CPacket::UDP_HDR_SIZE + CPacket::HDR_SIZE)
+        : m_zPacketHeaderSize(CPacket::udpHeaderSize(AF_INET) + CPacket::HDR_SIZE)
     {}
 
 public:

--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -59,7 +59,7 @@ protected:
             source.emplace_back(new CPacket);
             CPacket& p = *source.back();
 
-            p.allocate(SRT_LIVE_MAX_PLSIZE);
+            p.allocate(SRT_MAX_PLSIZE_AF_INET);
 
             uint32_t* hdr = p.getHeader();
 
@@ -720,7 +720,7 @@ TEST_F(TestFECRebuilding, Prepare)
         seq = p.getSeqNo();
     }
 
-    SrtPacket fec_ctl(SRT_LIVE_MAX_PLSIZE);
+    SrtPacket fec_ctl(SRT_MAX_PLSIZE_AF_INET);
 
     // Use the sequence number of the last packet, as usual.
     bool have_fec_ctl = fec->packControlPacket(fec_ctl, seq);
@@ -741,7 +741,7 @@ TEST_F(TestFECRebuilding, NoRebuild)
         seq = p.getSeqNo();
     }
 
-    SrtPacket fec_ctl(SRT_LIVE_MAX_PLSIZE);
+    SrtPacket fec_ctl(SRT_MAX_PLSIZE_AF_INET);
 
     // Use the sequence number of the last packet, as usual.
     const bool have_fec_ctl = fec->packControlPacket(fec_ctl, seq);
@@ -818,7 +818,7 @@ TEST_F(TestFECRebuilding, Rebuild)
         seq = p.getSeqNo();
     }
 
-    SrtPacket fec_ctl(SRT_LIVE_MAX_PLSIZE);
+    SrtPacket fec_ctl(SRT_MAX_PLSIZE_AF_INET);
 
     // Use the sequence number of the last packet, as usual.
     const bool have_fec_ctl = fec->packControlPacket(fec_ctl, seq);

--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "srt.h"
+#include "netinet_any.h"
 
 #include <array>
 #include <thread>
@@ -28,7 +29,7 @@
 
 //#pragma comment (lib, "ws2_32.lib")
 
-TEST(Transmission, FileUpload)
+TEST(FileTransmission, Upload)
 {
     srt::TestInit srtinit;
 
@@ -195,5 +196,202 @@ TEST(Transmission, FileUpload)
 
     remove("file.source");
     remove("file.target");
+
+}
+
+TEST(FileTransmission, Setup46)
+{
+    using namespace srt;
+    SRTST_REQUIRES(IPv6);
+    TestInit srtinit;
+
+    SRTSOCKET sock_lsn = srt_create_socket(), sock_clr = srt_create_socket();
+
+    const int tt = SRTT_FILE;
+    srt_setsockflag(sock_lsn, SRTO_TRANSTYPE, &tt, sizeof tt);
+    srt_setsockflag(sock_clr, SRTO_TRANSTYPE, &tt, sizeof tt);
+
+    // Setup a connection with IPv6 caller and IPv4 listener,
+    // then send data of 1456 size and make sure two packets were used.
+
+    // So first configure a caller for IPv6 socket, capable of
+    // using IPv4. As the IP version isn't specified now when
+    // creating a socket, force binding explicitly.
+
+    // This creates the "any" spec for IPv6 with port = 0
+    sockaddr_any sa(AF_INET6);
+
+    int ipv4_and_ipv6 = 0;
+    ASSERT_NE(srt_setsockflag(sock_clr, SRTO_IPV6ONLY, &ipv4_and_ipv6, sizeof ipv4_and_ipv6), -1);
+
+    ASSERT_NE(srt_bind(sock_clr, sa.get(), sa.size()), -1);
+
+    int connect_port = 5555;
+
+    // Configure listener 
+    sockaddr_in sa_lsn = sockaddr_in();
+    sa_lsn.sin_family = AF_INET;
+    sa_lsn.sin_addr.s_addr = INADDR_ANY;
+    sa_lsn.sin_port = htons(connect_port);
+
+    // Find unused a port not used by any other service.    
+    // Otherwise srt_connect may actually connect.
+    int bind_res = -1;
+    for (connect_port = 5000; connect_port <= 5555; ++connect_port)
+    {
+        sa_lsn.sin_port = htons(connect_port);
+        bind_res = srt_bind(sock_lsn, (sockaddr*)&sa_lsn, sizeof sa_lsn);
+        if (bind_res == 0)
+        {
+            std::cout << "Running test on port " << connect_port << "\n";
+            break;
+        }
+
+        ASSERT_TRUE(bind_res == SRT_EINVOP) << "Bind failed not due to an occupied port. Result " << bind_res;
+    }
+
+    ASSERT_GE(bind_res, 0);
+
+    srt_listen(sock_lsn, 1);
+
+    ASSERT_EQ(inet_pton(AF_INET6, "::FFFF:127.0.0.1", &sa.sin6.sin6_addr), 1);
+
+    sa.hport(connect_port);
+
+    ASSERT_EQ(srt_connect(sock_clr, sa.get(), sa.size()), 0);
+
+    int sock_acp = -1;
+    ASSERT_NE(sock_acp = srt_accept(sock_lsn, sa.get(), &sa.len), -1);
+
+    const size_t SIZE = 1454; // Max payload for IPv4 minus 2 - still more than 1444 for IPv6
+    char buffer[SIZE];
+
+    std::random_device rd;
+    std::mt19937 mtrd(rd());
+    std::uniform_int_distribution<short> dis(0, UINT8_MAX);
+
+    for (size_t i = 0; i < SIZE; ++i)
+    {
+        buffer[i] = dis(mtrd);
+    }
+
+    EXPECT_EQ(srt_send(sock_acp, buffer, SIZE), SIZE) << srt_getlasterror_str();
+
+    char resultbuf[SIZE];
+    EXPECT_EQ(srt_recv(sock_clr, resultbuf, SIZE), SIZE) << srt_getlasterror_str();
+
+    // It should use the maximum payload size per packet reported from the option.
+    int payloadsize_back = 0;
+    int payloadsize_back_size = sizeof (payloadsize_back);
+    EXPECT_EQ(srt_getsockflag(sock_clr, SRTO_PAYLOADSIZE, &payloadsize_back, &payloadsize_back_size), 0);
+    EXPECT_EQ(payloadsize_back, SRT_MAX_PLSIZE_AF_INET);
+
+    SRT_TRACEBSTATS snd_stats, rcv_stats;
+    srt_bstats(sock_acp, &snd_stats, 0);
+    srt_bstats(sock_clr, &rcv_stats, 0);
+
+    EXPECT_EQ(snd_stats.pktSentUniqueTotal, 1);
+    EXPECT_EQ(rcv_stats.pktRecvUniqueTotal, 1);
+
+}
+
+TEST(FileTransmission, Setup66)
+{
+    using namespace srt;
+    SRTST_REQUIRES(IPv6);
+    TestInit srtinit;
+
+    SRTSOCKET sock_lsn = srt_create_socket(), sock_clr = srt_create_socket();
+
+    const int tt = SRTT_FILE;
+    srt_setsockflag(sock_lsn, SRTO_TRANSTYPE, &tt, sizeof tt);
+    srt_setsockflag(sock_clr, SRTO_TRANSTYPE, &tt, sizeof tt);
+
+    // Setup a connection with IPv6 caller and IPv4 listener,
+    // then send data of 1456 size and make sure two packets were used.
+
+    // So first configure a caller for IPv6 socket, capable of
+    // using IPv4. As the IP version isn't specified now when
+    // creating a socket, force binding explicitly.
+
+    // This creates the "any" spec for IPv6 with port = 0
+    sockaddr_any sa(AF_INET6);
+
+    // Require that the connection allows both IP versions.
+    int ipv4_and_ipv6 = 0;
+    ASSERT_NE(srt_setsockflag(sock_clr, SRTO_IPV6ONLY, &ipv4_and_ipv6, sizeof ipv4_and_ipv6), -1);
+    ASSERT_NE(srt_setsockflag(sock_lsn, SRTO_IPV6ONLY, &ipv4_and_ipv6, sizeof ipv4_and_ipv6), -1);
+
+    ASSERT_NE(srt_bind(sock_clr, sa.get(), sa.size()), -1);
+
+    int connect_port = 5555;
+
+    // Configure listener 
+    sockaddr_any sa_lsn(AF_INET6);
+
+    // Find unused a port not used by any other service.    
+    // Otherwise srt_connect may actually connect.
+    int bind_res = -1;
+    for (connect_port = 5000; connect_port <= 5555; ++connect_port)
+    {
+        sa_lsn.hport(connect_port);
+        bind_res = srt_bind(sock_lsn, sa_lsn.get(), sa_lsn.size());
+        if (bind_res == 0)
+        {
+            std::cout << "Running test on port " << connect_port << "\n";
+            break;
+        }
+
+        ASSERT_TRUE(bind_res == SRT_EINVOP) << "Bind failed not due to an occupied port. Result " << bind_res;
+    }
+
+    ASSERT_GE(bind_res, 0);
+
+    srt_listen(sock_lsn, 1);
+
+    ASSERT_EQ(inet_pton(AF_INET6, "::1", &sa.sin6.sin6_addr), 1);
+
+    sa.hport(connect_port);
+
+    std::cout << "Connecting to: " << sa.str() << std::endl;
+
+    int connect_result = srt_connect(sock_clr, sa.get(), sa.size());
+    ASSERT_EQ(connect_result, 0) << srt_getlasterror_str();
+
+    int sock_acp = -1;
+    ASSERT_NE(sock_acp = srt_accept(sock_lsn, sa.get(), &sa.len), SRT_ERROR);
+
+    const size_t SIZE = 1454; // Max payload for IPv4 minus 2 - still more than 1444 for IPv6
+    char buffer[SIZE];
+
+    std::random_device rd;
+    std::mt19937 mtrd(rd());
+    std::uniform_int_distribution<short> dis(0, UINT8_MAX);
+
+    for (size_t i = 0; i < SIZE; ++i)
+    {
+        buffer[i] = dis(mtrd);
+    }
+
+    EXPECT_EQ(srt_send(sock_acp, buffer, SIZE), SIZE) << srt_getlasterror_str();
+
+    char resultbuf[SIZE];
+    EXPECT_EQ(srt_recv(sock_clr, resultbuf, SIZE), SIZE) << srt_getlasterror_str();
+
+    // It should use the maximum payload size per packet reported from the option.
+    int payloadsize_back = 0;
+    int payloadsize_back_size = sizeof (payloadsize_back);
+    EXPECT_EQ(srt_getsockflag(sock_clr, SRTO_PAYLOADSIZE, &payloadsize_back, &payloadsize_back_size), 0);
+    EXPECT_EQ(payloadsize_back, SRT_MAX_PLSIZE_AF_INET6);
+    std::cout << "Payload size: " << payloadsize_back << std::endl;
+
+    SRT_TRACEBSTATS snd_stats, rcv_stats;
+    srt_bstats(sock_acp, &snd_stats, 0);
+    srt_bstats(sock_clr, &rcv_stats, 0);
+
+    // We use the same data size that fit in 1 payload IPv4, but not IPv6.
+    // Therefore sending should be here split into two packets.
+    EXPECT_EQ(snd_stats.pktSentUniqueTotal, 2);
+    EXPECT_EQ(rcv_stats.pktRecvUniqueTotal, 2);
 
 }

--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -1,12 +1,16 @@
 #include <thread>
+#include <chrono>
 #include <string>
+#include <future>
 #include "gtest/gtest.h"
 #include "test_env.h"
 
 #include "srt.h"
+#include "sync.h"
 #include "netinet_any.h"
 
 using srt::sockaddr_any;
+using namespace srt::sync;
 
 class TestIPv6
     : public srt::Test
@@ -36,6 +40,11 @@ protected:
 
         m_listener_sock = srt_create_socket();
         ASSERT_NE(m_listener_sock, SRT_ERROR);
+
+        m_CallerStarted.reset(new std::promise<void>);
+        m_ReadyCaller.reset(new std::promise<void>);
+        m_ReadyAccept.reset(new std::promise<void>);
+
     }
 
     void teardown() override
@@ -47,20 +56,71 @@ protected:
     }
 
 public:
+
+    void SetupFileMode()
+    {
+        int val = SRTT_FILE;
+        ASSERT_NE(srt_setsockflag(m_caller_sock, SRTO_TRANSTYPE, &val, sizeof val), -1);
+        ASSERT_NE(srt_setsockflag(m_listener_sock, SRTO_TRANSTYPE, &val, sizeof val), -1);
+    }
+
+    int m_CallerPayloadSize = 0;
+    int m_AcceptedPayloadSize = 0;
+
+    std::unique_ptr<std::promise<void>> m_CallerStarted, m_ReadyCaller, m_ReadyAccept;
+
+    // "default parameter" version. Can't use default parameters because this goes
+    // against binding parameters. Nor overloading.
     void ClientThread(int family, const std::string& address)
     {
+        return ClientThreadFlex(family, address, true);
+    }
+
+    void ClientThreadFlex(int family, const std::string& address, bool shouldwork)
+    {
+        std::future<void> ready_accepter = m_ReadyAccept->get_future();
+
         sockaddr_any sa (family);
         sa.hport(m_listen_port);
         EXPECT_EQ(inet_pton(family, address.c_str(), sa.get_addr()), 1);
 
-        std::cout << "Calling: " << address << "(" << fam[family] << ")\n";
+        std::cout << "Calling: " << address << "(" << fam[family] << ") [LOCK...]\n";
+
+        m_CallerStarted->set_value();
 
         const int connect_res = srt_connect(m_caller_sock, (sockaddr*)&sa, sizeof sa);
-        EXPECT_NE(connect_res, SRT_ERROR) << "srt_connect() failed with: " << srt_getlasterror_str();
-        if (connect_res == SRT_ERROR)
-            srt_close(m_listener_sock);
 
-        PrintAddresses(m_caller_sock, "CALLER");
+        if (shouldwork)
+        {
+            // Version with expected success
+            EXPECT_NE(connect_res, SRT_ERROR) << "srt_connect() failed with: " << srt_getlasterror_str();
+
+            int size = sizeof (int);
+            EXPECT_NE(srt_getsockflag(m_caller_sock, SRTO_PAYLOADSIZE, &m_CallerPayloadSize, &size), -1);
+
+            m_ReadyCaller->set_value();
+
+            PrintAddresses(m_caller_sock, "CALLER");
+
+            if (connect_res == SRT_ERROR)
+            {
+                std::cout << "Connect failed - [UNLOCK]\n";
+                srt_close(m_listener_sock);
+            }
+            else
+            {
+                std::cout << "Connect succeeded, [FUTURE-WAIT...]\n";
+                ready_accepter.wait();
+            }
+        }
+        else
+        {
+            // Version with expected failure
+            EXPECT_EQ(connect_res, SRT_ERROR);
+            EXPECT_EQ(srt_getrejectreason(m_caller_sock), SRT_REJ_SETTINGS);
+            srt_close(m_listener_sock);
+        }
+        std::cout << "Connect: exit\n";
     }
 
     std::map<int, std::string> fam = { {AF_INET, "IPv4"}, {AF_INET6, "IPv6"} };
@@ -68,24 +128,34 @@ public:
     void ShowAddress(std::string src, const sockaddr_any& w)
     {
         EXPECT_NE(fam.count(w.family()), 0U) << "INVALID FAMILY";
-        std::cout << src << ": " << w.str() << " (" << fam[w.family()] << ")" << std::endl;
+        // Printing may happen from different threads, avoid intelining.
+        std::ostringstream sout;
+        sout << src << ": " << w.str() << " (" << fam[w.family()] << ")" << std::endl;
+        std::cout << sout.str();
     }
 
     sockaddr_any DoAccept()
     {
         sockaddr_any sc1;
 
+        // Make sure the caller started
+        m_CallerStarted->get_future().wait();
+        std::cout << "DoAccept: caller started, proceeding to accept\n";
+
         SRTSOCKET accepted_sock = srt_accept(m_listener_sock, sc1.get(), &sc1.len);
         EXPECT_NE(accepted_sock, SRT_INVALID_SOCK) << "accept() failed with: " << srt_getlasterror_str();
         if (accepted_sock == SRT_INVALID_SOCK) {
             return sockaddr_any();
         }
-
         PrintAddresses(accepted_sock, "ACCEPTED");
 
         sockaddr_any sn;
         EXPECT_NE(srt_getsockname(accepted_sock, sn.get(), &sn.len), SRT_ERROR);
         EXPECT_NE(sn.get_addr(), nullptr);
+        int size = sizeof (int);
+        EXPECT_NE(srt_getsockflag(m_caller_sock, SRTO_PAYLOADSIZE, &m_AcceptedPayloadSize, &size), -1);
+
+        m_ReadyCaller->get_future().wait();
 
         if (sn.get_addr() != nullptr)
         {
@@ -93,6 +163,9 @@ public:
             EXPECT_NE(memcmp(ipv6_zero, sn.get_addr(), sizeof ipv6_zero), 0)
                 << "EMPTY address in srt_getsockname";
         }
+
+        std::cout << "DoAccept: ready accept - promise SET\n";
+        m_ReadyAccept->set_value();
 
         srt_close(accepted_sock);
         return sn;
@@ -197,3 +270,86 @@ TEST_F(TestIPv6, v6_calls_v4)
     client.join();
 }
 
+TEST_F(TestIPv6, plsize_v6)
+{
+    SRTST_REQUIRES(IPv6);
+
+    SetupFileMode();
+
+    sockaddr_any sa (AF_INET6);
+    sa.hport(m_listen_port);
+
+    // This time bind the socket exclusively to IPv6.
+    ASSERT_EQ(srt_setsockflag(m_listener_sock, SRTO_IPV6ONLY, &yes, sizeof yes), 0);
+    ASSERT_EQ(inet_pton(AF_INET6, "::1", sa.get_addr()), 1);
+
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "::1");
+
+    DoAccept();
+
+    EXPECT_EQ(m_CallerPayloadSize, 1444); // == 1500 - 32[IPv6] - 8[UDP] - 16[SRT]
+    EXPECT_EQ(m_AcceptedPayloadSize, 1444);
+
+    client.join();
+}
+
+TEST_F(TestIPv6, plsize_v4)
+{
+    SetupFileMode();
+
+    sockaddr_any sa (AF_INET);
+    sa.hport(m_listen_port);
+
+    // This time bind the socket exclusively to IPv4.
+    ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", sa.get_addr()), 1);
+
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "0::FFFF:127.0.0.1");
+
+    DoAccept();
+
+    EXPECT_EQ(m_CallerPayloadSize, 1456); // == 1500 - 20[IPv4] - 8[UDP] - 16[SRT]
+    EXPECT_EQ(m_AcceptedPayloadSize, 1456);
+
+    client.join();
+}
+
+TEST_F(TestIPv6, plsize_faux_v6)
+{
+    SRTST_REQUIRES(IPv6);
+
+    using namespace std::chrono;
+    SetupFileMode();
+
+    sockaddr_any sa (AF_INET6);
+    sa.hport(m_listen_port);
+
+    // This time bind the socket exclusively to IPv6.
+    ASSERT_EQ(srt_setsockflag(m_listener_sock, SRTO_IPV6ONLY, &yes, sizeof yes), 0);
+    ASSERT_EQ(inet_pton(AF_INET6, "::1", sa.get_addr()), 1);
+
+    ASSERT_NE(srt_bind(m_listener_sock, sa.get(), sa.size()), SRT_ERROR);
+    ASSERT_NE(srt_listen(m_listener_sock, SOMAXCONN), SRT_ERROR);
+
+    int oversize = 1450;
+    ASSERT_NE(srt_setsockflag(m_caller_sock, SRTO_PAYLOADSIZE, &oversize, sizeof (int)), -1);
+
+    std::thread client(&TestIPv6::ClientThreadFlex, this, AF_INET6, "::1", false);
+
+    // Set on sleeping to make sure that the thread started.
+    // Sleeping isn't reliable so do a dampened spinlock here.
+    // This flag also confirms that the caller acquired the mutex and will
+    // unlock it for CV waiting - so we can proceed to notifying it.
+    m_CallerStarted->get_future().wait();
+
+    // Just in case of a test failure, kick CV to avoid deadlock
+    std::cout << "TEST: [PROMISE-SET]\n";
+    m_ReadyAccept->set_value();
+
+    client.join();
+}

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -344,14 +344,15 @@ void testAccept(SRTSOCKET bindsock, std::string ip, int port, bool expect_succes
 
     char pattern[4] = {1, 2, 3, 4};
 
-    ASSERT_EQ(srt_recvmsg(accepted_sock, buffer, sizeof buffer),
+    EXPECT_EQ(srt_recvmsg(accepted_sock, buffer, sizeof buffer),
               1316);
 
     EXPECT_EQ(memcmp(pattern, buffer, sizeof pattern), 0);
 
     std::cout << "[T/S] closing sockets: ACP:@" << accepted_sock << " LSN:@" << bindsock << " CLR:@" << g_client_sock << " ...\n";
-    ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
-    ASSERT_NE(srt_close(g_client_sock), SRT_ERROR); // cannot close g_client_sock after srt_sendmsg because of issue in api.c:2346 
+    EXPECT_NE(srt_close(accepted_sock), SRT_ERROR) << "ERROR: " << srt_getlasterror_str();
+    // cannot close g_client_sock after srt_sendmsg because of issue in api.c:2346 
+    EXPECT_NE(srt_close(g_client_sock), SRT_ERROR) << "ERROR: " << srt_getlasterror_str();
 
     std::cout << "[T/S] joining client async...\n";
     launched.get();

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -192,7 +192,7 @@ const OptionTestEntry g_test_matrix_options[] =
     { SRTO_MESSAGEAPI,       "SRTO_MESSAGEAPI", RestrictionType::PRE,    sizeof(bool),             false,      true,     true,        false,     {} },
     //SRTO_MININPUTBW
     { SRTO_MINVERSION,       "SRTO_MINVERSION", RestrictionType::PRE,     sizeof(int),                 0,  INT32_MAX, 0x010000,    0x010300,    {} },
-    { SRTO_MSS,                     "SRTO_MSS", RestrictionType::PREBIND, sizeof(int),                76,     65536,     1500,        1400,    {-1, 0, 75} },
+    { SRTO_MSS,                     "SRTO_MSS", RestrictionType::PREBIND, sizeof(int),               116,     65536,     1500,        1400,    {-1, 0, 75} },
     { SRTO_NAKREPORT,         "SRTO_NAKREPORT", RestrictionType::PRE,    sizeof(bool),             false,      true,     true,        false,     {} },
     { SRTO_OHEADBW,             "SRTO_OHEADBW", RestrictionType::POST,    sizeof(int),                 5,        100,       25,          20, {-1, 0, 4, 101} },
     //SRTO_PACKETFILTER

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -240,7 +240,7 @@ int main( int argc, char** argv )
         return 2;
     }
 
-    size_t chunk = SRT_LIVE_MAX_PLSIZE;
+    size_t chunk = SRT_MAX_PLSIZE_AF_INET; // state the bigger size
 
     // Now run the loop
     try


### PR DESCRIPTION
The expected behavior in case when a too small buffer was supplied - according to the documentation - is that the message is not extracted and the call to the receiving function ends up with error code `SRT_ELARGEMSG`.

The current behavior is that if the buffer is too small, then a fragment of a message is extracted, as much as it fits in the buffer, and the rest of the mesage is abandoned. This doesn't make any sense at all, even though this resembles the behavior of UDP when a too small supplied buffer makes the packet completely extracted with only copied the possible fragment of the packet payload, although this is also reported by a flag.

Fragmentary reading should be possible, but only with some special, dedicated API. The default behavior should be as described in the documentation: if the buffer is too small to extract the message, then the operation ends up with error and the message is NOT extracted.

A special API could be also added (maybe a socket option, or using the flags field in SRT_MSGCTRL structure) that could allow extraction of a fragment of a message, while the rest remains in the buffer, and the application can call the receiving function again, to extract the rest of the message, possibly with a need to specify the message number (the same that was extracted by the previous call). If this was called with this flag set, then the returned value could be the total length of the message, and another appropriate flag should be set that says that the buffer has been filled up to the cork and the returned value is greater than its size. This requires some implementation effort to have an appropriate packet flag in the receiver buffer so that it is known how big part of the message was already extracted. The "notch" could be still reused the one used for stream mode.

CURRENTLY this is not a fix - it's only a test case that demonstrates the problem.

PREMATURELY MERGED: #2677 because this PR also modifies the tests for file transmission, so this is to avoid future merge problems.