### PR TITLE
Allow custom-defined SRT_ASSERT() function

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -78,8 +78,13 @@ modified by
 #endif
 
 #ifdef _DEBUG
+#if defined(SRT_ENABLE_THREADCHECK)
+#include "threadcheck.h"
+#define SRT_ASSERT(cond) ASSERT(cond)
+#else
 #include <assert.h>
 #define SRT_ASSERT(cond) assert(cond)
+#endif
 #else
 #define SRT_ASSERT(cond)
 #endif


### PR DESCRIPTION
Running our server as a daemon we get a SIGABRT crash in our logs with no indication of what the assert is. We have some occurrences of unresolved crashes reporting SIGABRT. Our ASSERT function logs the assert condition, file and line number, a stack back trace and all threads state.