### PR TITLE
[core] Fix alignment issues in cmsg header managment (#2830)

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -756,12 +756,12 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
     mh.msg_iov        = (iovec*)packet.m_PacketVector;
     mh.msg_iovlen     = 2;
     bool have_set_src = false;
-    char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
 
 #ifdef SRT_ENABLE_PKTINFO
 
     // Note that even if PKTINFO is desired, the first caller's packet will be sent
     // without ancillary info anyway because there's no "peer" yet to know where to send it.
+    char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
     if (m_bBindMasked && source_addr.family() != AF_UNSPEC && !source_addr.isany())
     {
         if (!setSourceAddress(mh, mh_crtl_buf, source_addr))
@@ -848,7 +848,6 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
 
 #ifndef _WIN32
     msghdr mh; // will not be used on failure
-    char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
 
     if (select_ret > 0)
     {
@@ -864,6 +863,7 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
 #ifdef SRT_ENABLE_PKTINFO
         // Without m_bBindMasked, we don't need ancillary data - the source
         // address will always be the bound address.
+        char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
         if (m_bBindMasked)
         {
             // Extract the destination IP address from the ancillary

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -870,8 +870,8 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
             // data. This might be interesting for the connection to
             // know to which address the packet should be sent back during
             // the handshake and then addressed when sending during connection.
-            mh.msg_control = mh_crtl_buf;
-            mh.msg_controllen = (sizeof(mh_crtl_buf));
+            mh.msg_control = (mh_crtl_buf);
+            mh.msg_controllen = sizeof mh_crtl_buf;
         }
 #endif
 

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -872,7 +872,6 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
             // the handshake and then addressed when sending during connection.
             mh.msg_control = mh_crtl_buf;
             mh.msg_controllen = (sizeof(mh_crtl_buf));
-
         }
 #endif
 

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -176,6 +176,9 @@ private:
 
 private:
     UDPSOCKET m_iSocket; // socket descriptor
+#ifdef _WIN32
+    mutable WSAOVERLAPPED m_SendOverlapped;
+#endif
 
     // Mutable because when querying original settings
     // this comprises the cache for extracted values,

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -185,6 +185,7 @@ private:
 
     // This feature is not enabled on Windows, for now.
     // This is also turned off in case of MinGW
+#ifdef SRT_ENABLE_PKTINFO
     bool                    m_bBindMasked; // True if m_BindAddr is INADDR_ANY. Need for quick check.
 
     // Calculating the required space is extremely tricky, and whereas on most
@@ -290,6 +291,7 @@ private:
         return false;
     }
 
+#endif //SRT_ENABLE_PKTINFO
 
 };
 

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -223,14 +223,14 @@ private:
             // IPv4 headers or IPv6 headers.
             if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_PKTINFO)
             {
-                in_pktinfo dest_ip_ptr;// = (in_pktinfo*)CMSG_DATA(cmsg);
+                in_pktinfo dest_ip_ptr;
                 memcpy(&dest_ip_ptr, CMSG_DATA(cmsg), sizeof(struct in_pktinfo));
                 return sockaddr_any(dest_ip_ptr.ipi_addr, 0);
             }
 
             if (cmsg->cmsg_level == IPPROTO_IPV6 && cmsg->cmsg_type == IPV6_PKTINFO)
             {
-                in6_pktinfo dest_ip_ptr;// = (in6_pktinfo*)CMSG_DATA(cmsg);
+                in6_pktinfo dest_ip_ptr;
                 memcpy(&dest_ip_ptr, CMSG_DATA(cmsg), sizeof(struct in6_pktinfo));
                 return sockaddr_any(dest_ip_ptr.ipi6_addr, 0);
             }


### PR DESCRIPTION
We used to directly cast the result of CMSG_DATA to in_pktinfo or in6_pktinfo. As stated in CMSG_FIRSTHDR manpage, alignement of the return value of this method is not guaranteed, and a memcpy should be done to manipulate it. 

For some reason, the use of the mutable m_acCmsgRecvBuffer and m_acCmsgSendBuffer also caused alignemnt issues when using it as msg_control field of msghdr. Declaring a new char each time instead of using the mutable one solved this issue. 