### PR TITLE
Add support for RTP input in srt-live-transmit

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -534,6 +534,15 @@ int main(int argc, char** argv)
                         return 1;
                     }
                     break;
+                case UriParser::RTP:
+                    if (srt_epoll_add_ssock(pollid,
+                        src->GetSysSocket(), &events))
+                    {
+                        cerr << "Failed to add RTP source to poll, "
+                            << src->GetSysSocket() << endl;
+                        return 1;
+                    }
+                    break;
                 case UriParser::FILE:
                     if (srt_epoll_add_ssock(pollid,
                         src->GetSysSocket(), &events))

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -526,20 +526,13 @@ int main(int argc, char** argv)
                     }
                     break;
                 case UriParser::UDP:
-                    if (srt_epoll_add_ssock(pollid,
-                        src->GetSysSocket(), &events))
-                    {
-                        cerr << "Failed to add UDP source to poll, "
-                            << src->GetSysSocket() << endl;
-                        return 1;
-                    }
-                    break;
                 case UriParser::RTP:
                     if (srt_epoll_add_ssock(pollid,
                         src->GetSysSocket(), &events))
                     {
-                        cerr << "Failed to add RTP source to poll, "
-                            << src->GetSysSocket() << endl;
+                        cerr << "Failed to add " << src->uri.proto()
+                            << " source to poll, " << src->GetSysSocket()
+                            << endl;
                         return 1;
                     }
                     break;

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -1205,6 +1205,11 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
         break;
 
     case UriParser::RTP:
+        if (IsOutput<Base>())
+        {
+            cerr << "RTP not supported as an output\n";
+            throw invalid_argument("Invalid output protocol: RTP");
+        }
         iport = atoi(u.port().c_str());
         if ( iport < 1024 )
         {

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -985,6 +985,7 @@ protected:
 
 class UdpSource: public Source, public UdpCommon
 {
+protected:
     bool eof = true;
 public:
 
@@ -1082,6 +1083,68 @@ template <> struct Udp<Target> { typedef UdpTarget type; };
 template <class Iface>
 Iface* CreateUdp(const string& host, int port, const map<string,string>& par) { return new typename Udp<Iface>::type (host, port, par); }
 
+class RtpSource: public UdpSource
+{
+    // for now, make no effort to parse the header, just assume it is always
+    // fixed length and either a user-configurable value, or twelve bytes.
+    const int DEFAULT_RTP_HEADER_SIZE = 12;
+    const int rtp_header_size = DEFAULT_RTP_HEADER_SIZE;
+
+    const int bytes_to_skip = 0;
+public:
+    RtpSource(string host, int port, const map<string,string>& attr) :
+        UdpSource { host, port, attr },
+        rtp_header_size {
+            attr.count("rtpheadersize") ? stoi(attr.at("rtpheadersize"), 0, 0) : DEFAULT_RTP_HEADER_SIZE
+        },
+        bytes_to_skip {
+            (attr.count("droprtpheader") && true_names.count(attr.at("droprtpheader"))) ? rtp_header_size : 0
+        } {}
+
+    int Read(size_t chunk, MediaPacket& pkt, ostream & ignored SRT_ATR_UNUSED = cout) override
+    {
+        const int length = UdpSource::Read(chunk, pkt);
+
+        if (length < 1 || !bytes_to_skip)
+        {
+            // something went wrong, or we're passing headers through
+            // just return the length read via the base method
+            return length;
+        }
+
+        // we got some data and we're supposed to skip some of it
+        // check there's enough bytes for our intended skip
+        if (length < bytes_to_skip)
+        {
+            // something went wrong here
+            cerr << "RTP packet too short (" << length
+                << " bytes) to remove headers (needed "
+                << bytes_to_skip << ")" << endl;
+            throw std::runtime_error("Unexpected RTP packet length");
+        }
+
+        pkt.payload.erase(
+            pkt.payload.begin(),
+            pkt.payload.begin() + bytes_to_skip
+        );
+
+        return length - bytes_to_skip;
+    }
+};
+
+class RtpTarget : public UdpTarget {
+public:
+    RtpTarget(string host, int port, const map<string,string>& attr ) :
+        UdpTarget { host, port, attr } {}
+};
+
+template <class Iface> struct Rtp;
+template <> struct Rtp<Source> { typedef RtpSource type; };
+template <> struct Rtp<Target> { typedef RtpTarget type; };
+
+template <class Iface>
+Iface* CreateRtp(const string& host, int port, const map<string,string>& par) { return new typename Rtp<Iface>::type (host, port, par); }
+
 template<class Base>
 inline bool IsOutput() { return false; }
 
@@ -1141,6 +1204,15 @@ extern unique_ptr<Base> CreateMedium(const string& uri)
         ptr.reset( CreateUdp<Base>(u.host(), iport, u.parameters()) );
         break;
 
+    case UriParser::RTP:
+        iport = atoi(u.port().c_str());
+        if ( iport < 1024 )
+        {
+            cerr << "Port value invalid: " << iport << " - must be >=1024\n";
+            throw invalid_argument("Invalid port number");
+        }
+        ptr.reset( CreateRtp<Base>(u.host(), iport, u.parameters()) );
+        break;
     }
 
     if (ptr.get())

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -1087,7 +1087,7 @@ class RtpSource: public UdpSource
 {
     // for now, make no effort to parse the header, just assume it is always
     // fixed length and either a user-configurable value, or twelve bytes.
-    const int MINIMUM_RTP_HEADER_SIZE = 0;
+    const int MINIMUM_RTP_HEADER_SIZE = 12;
     int bytes_to_skip = MINIMUM_RTP_HEADER_SIZE;
 public:
     RtpSource(string host, int port, const map<string,string>& attr) :

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -16,7 +16,7 @@ srt-live-transmit <input-uri> <output-uri> [options]
 The following medium types are handled by `srt-live-transmit`:
 
 - SRT - use SRT for reading or writing, in listener, caller or rendezvous mode, with possibly additional parameters
-- UDP - read or write the given UDP address (also multicast)
+- UDP/RTP - read or write the given UDP address (also multicast)
 - Local file - read or store the stream into the file
 - Process's pipeline - use the process's `stdin` and `stdout` standard streams
 
@@ -86,6 +86,7 @@ The applications supports the following schemes:
 
 - `file` - for file or standard input and output
 - `udp` - UDP output (unicast and multicast)
+- `rtp` - RTP over UDP input or output (unicast and multicast)
 - `srt` - SRT connection
 
 Note that this application doesn't support file as a medium, but this
@@ -182,6 +183,19 @@ instead of `IP_ADD_MEMBERSHIP` and the value is set to `imr_sourceaddr` field.
 
 Explanations for the symbols and terms used above can be found in POSIX
 manual pages, like `ip(7)` and on Microsoft docs pages under `IPPROTO_IP`.
+
+### Medium: RTP
+
+RTP over UDP is supported for both input and output.
+
+As an output, and as an input with no RTP-specific URI parameters, RTP medium functions identically to UDP medium as described above. 
+
+As an input, additional RTP-specific options are available through URI parameters. These options enable dropping of bytes from the head of the input buffer allowing, for example, the RTP header to be dropped for use cases where the receiving end cannot accept RTP.
+
+- **droprtpheader**: (`bool` as defined in SRT section) - when true, drop the first 12 bytes of each received packet
+- **rtpheadersize**: sets the number of bytes to drop from the beginning of each received packet. Ignored if **droprtpheader** is not truthy.
+
+> NOTE: No effort is made in the initial implementation to attempt to parse the RTP headers in any way eg for reordering, extracting timing, detecting length.
 
 ### Medium: SRT
 

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -16,7 +16,8 @@ srt-live-transmit <input-uri> <output-uri> [options]
 The following medium types are handled by `srt-live-transmit`:
 
 - SRT - use SRT for reading or writing, in listener, caller or rendezvous mode, with possibly additional parameters
-- UDP/RTP - read or write the given UDP address (also multicast)
+- UDP - read or write the given UDP address (also multicast)
+- RTP - read RTP over UDP from the given address (also multicast)
 - Local file - read or store the stream into the file
 - Process's pipeline - use the process's `stdin` and `stdout` standard streams
 
@@ -86,7 +87,7 @@ The applications supports the following schemes:
 
 - `file` - for file or standard input and output
 - `udp` - UDP output (unicast and multicast)
-- `rtp` - RTP over UDP input or output (unicast and multicast)
+- `rtp` - RTP over UDP input (unicast and multicast)
 - `srt` - SRT connection
 
 Note that this application doesn't support file as a medium, but this
@@ -186,11 +187,11 @@ manual pages, like `ip(7)` and on Microsoft docs pages under `IPPROTO_IP`.
 
 ### Medium: RTP
 
-RTP over UDP is supported for both input and output.
+RTP over UDP is supported for input only.
 
-As an output, and as an input with no RTP-specific URI parameters, RTP medium functions identically to UDP medium as described above. 
+With no RTP-specific URI parameters, RTP medium functions identically to UDP medium as described above.
 
-As an input, additional RTP-specific options are available through URI parameters. These options enable dropping of bytes from the head of the input buffer allowing, for example, the RTP header to be dropped for use cases where the receiving end cannot accept RTP.
+Additional RTP-specific options are available through URI parameters. These options enable dropping of bytes from the head of the input buffer allowing, for example, the RTP header to be dropped for use cases where the receiving end cannot accept RTP.
 
 - **droprtpheader**: (`bool` as defined in SRT section) - when true, drop the first 12 bytes of each received packet
 - **rtpheadersize**: sets the number of bytes to drop from the beginning of each received packet. Ignored if **droprtpheader** is not truthy.

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -196,7 +196,7 @@ parameter:
 - **rtpheadersize**: sets the number of bytes to drop from the beginning of
 each received packet. Defaults to 12 if not provided. Minimum value is 12.
 
-A lenght of **rtpheadersize** bytes will always be dropped. If you wish to pass
+A length of **rtpheadersize** bytes will always be dropped. If you wish to pass
 the entire packet, including RTP header, to the output medium, you should
 instead specify UDP as the input medium.
 

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -189,12 +189,10 @@ manual pages, like `ip(7)` and on Microsoft docs pages under `IPPROTO_IP`.
 
 RTP over UDP is supported for input only.
 
-With no RTP-specific URI parameters, RTP medium functions identically to UDP medium as described above.
+RTP-specific options are available through URI parameters. These options enable dropping of bytes from the head of the input buffer allowing, for example, the RTP header to be dropped for use cases where the receiving end cannot accept RTP. When no RTP-specific URI parameters are provided, RTP medium functions identically to UDP medium as described above.
 
-Additional RTP-specific options are available through URI parameters. These options enable dropping of bytes from the head of the input buffer allowing, for example, the RTP header to be dropped for use cases where the receiving end cannot accept RTP.
-
-- **droprtpheader**: (`bool` as defined in SRT section) - when true, drop the first 12 bytes of each received packet
-- **rtpheadersize**: sets the number of bytes to drop from the beginning of each received packet. Ignored if **droprtpheader** is not truthy.
+- **droprtpheader**: (`bool` as defined in SRT section) - when true, drop the first `rtpheadersize` bytes of each received packet. Defaults to false if not provided.
+- **rtpheadersize**: sets the number of bytes to drop from the beginning of each received packet. Defaults to 12 if not provided. Ignored if **droprtpheader** is not truthy.
 
 > NOTE: No effort is made in the initial implementation to attempt to parse the RTP headers in any way eg for reordering, extracting timing, detecting length.
 

--- a/docs/apps/srt-live-transmit.md
+++ b/docs/apps/srt-live-transmit.md
@@ -17,7 +17,7 @@ The following medium types are handled by `srt-live-transmit`:
 
 - SRT - use SRT for reading or writing, in listener, caller or rendezvous mode, with possibly additional parameters
 - UDP - read or write the given UDP address (also multicast)
-- RTP - read RTP over UDP from the given address (also multicast)
+- RTP - read RTP from the given address (also multicast)
 - Local file - read or store the stream into the file
 - Process's pipeline - use the process's `stdin` and `stdout` standard streams
 
@@ -87,7 +87,7 @@ The applications supports the following schemes:
 
 - `file` - for file or standard input and output
 - `udp` - UDP output (unicast and multicast)
-- `rtp` - RTP over UDP input (unicast and multicast)
+- `rtp` - RTP input (unicast and multicast)
 - `srt` - SRT connection
 
 Note that this application doesn't support file as a medium, but this
@@ -187,14 +187,22 @@ manual pages, like `ip(7)` and on Microsoft docs pages under `IPPROTO_IP`.
 
 ### Medium: RTP
 
-RTP over UDP is supported for input only.
+RTP is supported for input only.
 
-RTP-specific options are available through URI parameters. These options enable dropping of bytes from the head of the input buffer allowing, for example, the RTP header to be dropped for use cases where the receiving end cannot accept RTP. When no RTP-specific URI parameters are provided, RTP medium functions identically to UDP medium as described above.
+All URI parameters described in the [Medium: UDP](#medium-udp) section above
+also apply to RTP. A further RTP-specific option is available as an URI
+parameter:
 
-- **droprtpheader**: (`bool` as defined in SRT section) - when true, drop the first `rtpheadersize` bytes of each received packet. Defaults to false if not provided.
-- **rtpheadersize**: sets the number of bytes to drop from the beginning of each received packet. Defaults to 12 if not provided. Ignored if **droprtpheader** is not truthy.
+- **rtpheadersize**: sets the number of bytes to drop from the beginning of
+each received packet. Defaults to 12 if not provided. Minimum value is 12.
 
-> NOTE: No effort is made in the initial implementation to attempt to parse the RTP headers in any way eg for reordering, extracting timing, detecting length.
+A lenght of **rtpheadersize** bytes will always be dropped. If you wish to pass
+the entire packet, including RTP header, to the output medium, you should
+instead specify UDP as the input medium.
+
+> NOTE: No effort is made in the initial implementation to attempt to parse
+the RTP headers in any way eg for validation, reordering, extracting timing,
+length detection of checking.
 
 ### Medium: SRT
 


### PR DESCRIPTION
Introduce a new Source type that considers RTP separately to UDP.

The intention is to drop bytes from the head of the input buffer. This enables the RTP header to be dropped for use cases where the receiving end cannot accept RTP. The default behaviour is to skip the first 12 bytes. Where `rtpheadersize` is set, the number of bytes to skip can be varied, to deal with extended RTP headers for example.

No effort is made in this initial implementation to attempt to parse the RTP headers in any way eg for reordering, extracting timing, detecting length.

This goes some way to addressing #136.