### PR TITLE
[core] Removed the possibility to use optlen==-1 for null terminated strings in srt_setsockopt

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -3793,7 +3793,7 @@ int srt::CUDT::getsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_optval
 
 int srt::CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, int optlen)
 {
-    if (!optval)
+    if (!optval || optlen < 0)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
 
     try

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -292,10 +292,8 @@ struct CSrtConfigSetter<SRTO_BINDTODEVICE>
         using namespace std;
 
         string val;
-        if (optlen == -1)
-            val = (const char *)optval;
-        else
-            val.assign((const char *)optval, optlen);
+
+        val.assign((const char *)optval, optlen);
         if (val.size() >= IFNAMSIZ)
         {
             LOGC(kmlog.Error, log << "SRTO_BINDTODEVICE: device name too long (max: IFNAMSIZ=" << IFNAMSIZ << ")");
@@ -597,10 +595,7 @@ struct CSrtConfigSetter<SRTO_CONGESTION>
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
         std::string val;
-        if (optlen == -1)
-            val = (const char*)optval;
-        else
-            val.assign((const char*)optval, optlen);
+        val.assign((const char*)optval, optlen);
 
         // Translate alias
         if (val == "vod")

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -850,6 +850,15 @@ TEST_F(TestSocketOptions, StreamIDWrongLen)
     EXPECT_EQ(srt_getlasterror(NULL), SRT_EINVPARAM);
 }
 
+//Check if setting -1 as optlen returns an error 
+TEST_F(TestSocketOptions, StringOptLenInvalid)
+{
+
+    string stream_id = "test123";
+    EXPECT_EQ(srt_setsockopt(m_caller_sock, 0, SRTO_STREAMID, stream_id.c_str(), -1), SRT_ERROR);
+    EXPECT_EQ(srt_getlasterror(NULL), SRT_EINVPARAM);
+}
+
 // Try to set/get a 13-character string in SRTO_STREAMID.
 // This tests checks that the StreamID is set to the correct size
 // while it is transmitted as 16 characters in the Stream ID HS extension.


### PR DESCRIPTION
Added a check in srt_setsockopt so that it returns SRT_EINVPARAM when optlen is -1 (see #2845)
Added an unit test to verify this behaviour 