### PR TITLE
[maint] Moved declaration of SRT_ATR_ALIGNAS to fix a warning

### DIFF
--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -49,13 +49,6 @@ written by
 modified by
    Haivision Systems Inc.
 *****************************************************************************/
-#if HAVE_CXX11
-#define SRT_ATR_ALIGNAS(n) alignas(n)
-#elif HAVE_GCC
-#define SRT_ATR_ALIGNAS(n) __attribute__((aligned(n)))
-#else
-#define SRT_ATR_ALIGNAS(n)
-#endif
 #ifndef INC_SRT_CHANNEL_H
 #define INC_SRT_CHANNEL_H
 

--- a/srtcore/srt_attr_defs.h
+++ b/srtcore/srt_attr_defs.h
@@ -31,6 +31,14 @@ used by SRT library internally.
 #define ATR_DEPRECATED
 #endif
 
+#if HAVE_CXX11
+#define SRT_ATR_ALIGNAS(n) alignas(n)
+#elif HAVE_GCC
+#define SRT_ATR_ALIGNAS(n) __attribute__((aligned(n)))
+#else
+#define SRT_ATR_ALIGNAS(n)
+#endif
+
 #if defined(__cplusplus) && __cplusplus > 199711L
 #define HAVE_CXX11 1
 // For gcc 4.7, claim C++11 is supported, as long as experimental C++0x is on,


### PR DESCRIPTION
SRT_ATR_ALIGNAS was defined in the wrong place 

fixes  #2865