### PR TITLE
[core] Fix some warnings when compiling with mingw

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -51,6 +51,7 @@ modified by
 *****************************************************************************/
 
 #include "platform_sys.h"
+#include <srt.h>
 #include <iostream>
 #include <iomanip> // Logging
 #include <srt_compat.h>

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -51,7 +51,6 @@ modified by
 *****************************************************************************/
 
 #include "platform_sys.h"
-#include <srt.h>
 #include <iostream>
 #include <iomanip> // Logging
 #include <srt_compat.h>

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -51,7 +51,7 @@ modified by
 *****************************************************************************/
 
 #include "platform_sys.h"
-
+#include "srt.h"
 #include <iostream>
 #include <iomanip> // Logging
 #include <srt_compat.h>
@@ -189,6 +189,7 @@ void srt::CChannel::createSocket(int family)
     m_iSocket    = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
     cloexec_flag = true;
 #endif
+
 #else  // ENABLE_SOCK_CLOEXEC
     m_iSocket = ::socket(family, SOCK_DGRAM, IPPROTO_UDP);
 #endif // ENABLE_SOCK_CLOEXEC
@@ -197,17 +198,18 @@ void srt::CChannel::createSocket(int family)
         throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
 
 #if ENABLE_SOCK_CLOEXEC
-#ifdef _WIN32
-        // XXX ::SetHandleInformation(hInputWrite, HANDLE_FLAG_INHERIT, 0)
-#else
+
     if (cloexec_flag)
     {
+#ifdef _WIN32
+       // XXX ::SetHandleInformation(hInputWrite, HANDLE_FLAG_INHERIT, 0)
+#else
         if (0 != set_cloexec(m_iSocket, 1))
         {
             throw CUDTException(MJ_SETUP, MN_NONE, NET_ERROR);
         }
+#endif //_WIN32
     }
-#endif
 #endif // ENABLE_SOCK_CLOEXEC
 
     if ((m_mcfg.iIpV6Only != -1) && (family == AF_INET6)) // (not an error if it fails)
@@ -795,8 +797,9 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
     {
         if (NET_ERROR == WSA_IO_PENDING)
         {
-            res = WSAWaitForMultipleEvents(1, &m_SendOverlapped.hEvent, TRUE, 100 /*ms*/, FALSE);
-            if (res == WAIT_FAILED)
+            DWORD res_wait = 0;
+            res_wait = WSAWaitForMultipleEvents(1, &m_SendOverlapped.hEvent, TRUE, 100 /*ms*/, FALSE);
+            if (res_wait == WAIT_FAILED)
             {
                 LOGC(kslog.Warn, log << "CChannel::WSAWaitForMultipleEvents: failed with " << NET_ERROR);
                 res = -1;

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -51,7 +51,6 @@ modified by
 *****************************************************************************/
 
 #include "platform_sys.h"
-#include "srt.h"
 #include <iostream>
 #include <iomanip> // Logging
 #include <srt_compat.h>

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -21,7 +21,6 @@
 //
 // SRT_IMPORT_TIME   (mach time on Mac, portability gettimeofday on WIN32)
 // SRT_IMPORT_EVENT  (includes kevent on Mac)
-#ifndef SRT_API
 #ifdef _WIN32
    #ifndef __MINGW32__
       // Explicitly define 32-bit and 64-bit numbers
@@ -35,18 +34,6 @@
          typedef __int64 uint64_t;
       #endif
    #endif
-   #ifdef SRT_DYNAMIC
-      #ifdef SRT_EXPORTS
-         #define SRT_API __declspec(dllexport)
-      #else
-         #define SRT_API __declspec(dllimport)
-      #endif
-   #else // !SRT_DYNAMIC
-      #define SRT_API
-   #endif
-#else
-   #define SRT_API __attribute__ ((visibility("default")))
-#endif
 #endif
 
 

--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -21,6 +21,33 @@
 //
 // SRT_IMPORT_TIME   (mach time on Mac, portability gettimeofday on WIN32)
 // SRT_IMPORT_EVENT  (includes kevent on Mac)
+#ifndef SRT_API
+#ifdef _WIN32
+   #ifndef __MINGW32__
+      // Explicitly define 32-bit and 64-bit numbers
+      typedef __int32 int32_t;
+      typedef __int64 int64_t;
+      typedef unsigned __int32 uint32_t;
+      #ifndef LEGACY_WIN32
+         typedef unsigned __int64 uint64_t;
+      #else
+         // VC 6.0 does not support unsigned __int64: may cause potential problems.
+         typedef __int64 uint64_t;
+      #endif
+   #endif
+   #ifdef SRT_DYNAMIC
+      #ifdef SRT_EXPORTS
+         #define SRT_API __declspec(dllexport)
+      #else
+         #define SRT_API __declspec(dllimport)
+      #endif
+   #else // !SRT_DYNAMIC
+      #define SRT_API
+   #endif
+#else
+   #define SRT_API __attribute__ ((visibility("default")))
+#endif
+#endif
 
 
 #ifdef _WIN32

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -33,7 +33,7 @@ written by
 //if compiling with MinGW, it only works on XP or above
 //use -D_WIN32_WINNT=0x0501
 
-
+#ifndef SRT_API
 #ifdef _WIN32
    #ifndef __MINGW32__
       // Explicitly define 32-bit and 64-bit numbers
@@ -58,6 +58,7 @@ written by
    #endif
 #else
    #define SRT_API __attribute__ ((visibility("default")))
+#endif
 #endif
 
 

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -16,6 +16,21 @@ written by
 #ifndef INC_SRTC_H
 #define INC_SRTC_H
 
+#ifndef SRT_API
+
+   #ifdef SRT_DYNAMIC
+      #ifdef SRT_EXPORTS
+         #define SRT_API __declspec(dllexport)
+      #else
+         #define SRT_API __declspec(dllimport)
+      #endif
+   #else // !SRT_DYNAMIC
+      #define SRT_API
+   #endif
+#else
+   #define SRT_API __attribute__ ((visibility("default")))
+#endif
+
 #include "version.h"
 
 #include "platform_sys.h"

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -17,7 +17,7 @@ written by
 #define INC_SRTC_H
 
 #ifndef SRT_API
-
+#ifdef _WIN32
    #ifdef SRT_DYNAMIC
       #ifdef SRT_EXPORTS
          #define SRT_API __declspec(dllexport)
@@ -29,6 +29,7 @@ written by
    #endif
 #else
    #define SRT_API __attribute__ ((visibility("default")))
+#endif
 #endif
 
 #include "version.h"

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -20,6 +20,8 @@ written by
 
 #include "platform_sys.h"
 
+#include "srt_compat.h"
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -32,35 +34,6 @@ written by
 
 //if compiling with MinGW, it only works on XP or above
 //use -D_WIN32_WINNT=0x0501
-
-#ifndef SRT_API
-#ifdef _WIN32
-   #ifndef __MINGW32__
-      // Explicitly define 32-bit and 64-bit numbers
-      typedef __int32 int32_t;
-      typedef __int64 int64_t;
-      typedef unsigned __int32 uint32_t;
-      #ifndef LEGACY_WIN32
-         typedef unsigned __int64 uint64_t;
-      #else
-         // VC 6.0 does not support unsigned __int64: may cause potential problems.
-         typedef __int64 uint64_t;
-      #endif
-   #endif
-   #ifdef SRT_DYNAMIC
-      #ifdef SRT_EXPORTS
-         #define SRT_API __declspec(dllexport)
-      #else
-         #define SRT_API __declspec(dllimport)
-      #endif
-   #else // !SRT_DYNAMIC
-      #define SRT_API
-   #endif
-#else
-   #define SRT_API __attribute__ ((visibility("default")))
-#endif
-#endif
-
 
 // For feature tests if you need.
 // You can use these constants with SRTO_MINVERSION option.

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -17,6 +17,7 @@ written by
 // Prevents from misconfiguration through preprocessor.
 
 #include "platform_sys.h"
+#include <srt.h>
 #include <srt_compat.h>
 
 #include <string.h>

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -17,7 +17,7 @@ written by
 // Prevents from misconfiguration through preprocessor.
 
 #include "platform_sys.h"
-
+#include "srt.h"
 #include <srt_compat.h>
 
 #include <string.h>

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -17,7 +17,6 @@ written by
 // Prevents from misconfiguration through preprocessor.
 
 #include "platform_sys.h"
-#include "srt.h"
 #include <srt_compat.h>
 
 #include <string.h>

--- a/srtcore/srt_compat.c
+++ b/srtcore/srt_compat.c
@@ -17,7 +17,6 @@ written by
 // Prevents from misconfiguration through preprocessor.
 
 #include "platform_sys.h"
-#include <srt.h>
 #include <srt_compat.h>
 
 #include <string.h>

--- a/srtcore/srt_compat.h
+++ b/srtcore/srt_compat.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 /* Ensures that we store the error in the buffer and return the bufer. */
-SRT_API const char * SysStrError(int errnum, char * buf, size_t buflen);
+const char * SysStrError(int errnum, char * buf, size_t buflen);
 
 #ifdef __cplusplus
 } // extern C

--- a/srtcore/srt_compat.h
+++ b/srtcore/srt_compat.h
@@ -20,49 +20,6 @@ written by
 #include <stddef.h>
 #include <time.h>
 
-#ifndef SRT_API
-#ifdef _WIN32
-   #ifndef __MINGW32__
-      #ifdef SRT_DYNAMIC
-         #ifdef SRT_EXPORTS
-            #define SRT_API __declspec(dllexport)
-         #else
-            #define SRT_API __declspec(dllimport)
-         #endif
-      #else
-         #define SRT_API
-      #endif
-   #else
-      #define SRT_API
-   #endif
-#else
-   #define SRT_API __attribute__ ((visibility("default")))
-#endif
-#endif
-
-#ifdef _WIN32
-   // https://msdn.microsoft.com/en-us/library/tcxf1dw6.aspx
-   // printf() Format for ssize_t
-   #if !defined(PRIzd)
-      #define PRIzd "Id"
-   #endif
-   // printf() Format for size_t
-   #if !defined(PRIzu)
-      #define PRIzu "Iu"
-   #endif
-#else
-   // http://www.gnu.org/software/libc/manual/html_node/Integer-Conversions.html
-   // printf() Format for ssize_t
-   #if !defined(PRIzd)
-      #define PRIzd "zd"
-   #endif
-   // printf() Format for size_t
-   #if !defined(PRIzu)
-      #define PRIzu "zu"
-   #endif
-#endif
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
fixes #2862
Removed duplicate declaration of SRT_API
Moved around variables to avoid set but not used warnings