### PR TITLE
[core] Fixed the RCV buffer non-read position update condition

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -239,7 +239,7 @@ int CRcvBuffer::dropUpTo(int32_t seqno)
 
     // If the nonread position is now behind the starting position, set it to the starting position and update.
     // Preceding packets were likely missing, and the non read position can probably be moved further now.
-    if (CSeqNo::seqcmp(m_iFirstNonreadPos, m_iStartPos) < 0)
+    if (!isInRange(m_iStartPos, m_iMaxPosOff, m_szSize, m_iFirstNonreadPos))
     {
         m_iFirstNonreadPos = m_iStartPos;
         updateNonreadPos();

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -239,9 +239,15 @@ private:
     inline int incPos(int pos, int inc = 1) const { return (pos + inc) % m_szSize; }
     inline int decPos(int pos) const { return (pos - 1) >= 0 ? (pos - 1) : int(m_szSize - 1); }
     inline int offPos(int pos1, int pos2) const { return (pos2 >= pos1) ? (pos2 - pos1) : int(m_szSize + pos2 - pos1); }
+
+    /// @brief Compares the two positions in the receiver buffer relative to the starting position.
+    /// @param pos2 a position in the receiver buffer.
+    /// @param pos1 a position in the receiver buffer.
+    /// @return a positive value if pos2 is ahead of pos1; a negative value, if pos2 is behind pos1; otherwise returns 0.
     inline int cmpPos(int pos2, int pos1) const
     {
-        // XXX maybe not the best implementation, but this keeps up to the rule
+        // XXX maybe not the best implementation, but this keeps up to the rule.
+        // Maybe use m_iMaxPosOff to ensure a position is not behind the m_iStartPos.
         const int off1 = pos1 >= m_iStartPos ? pos1 - m_iStartPos : pos1 + (int)m_szSize - m_iStartPos;
         const int off2 = pos2 >= m_iStartPos ? pos2 - m_iStartPos : pos2 + (int)m_szSize - m_iStartPos;
 


### PR DESCRIPTION
Fixed the condition in the receiver buffer to update the first non-read position in case of dropping upto a sequence number.

Both `m_iFirstNonreadPos` and `m_iStartPos` are positions in the RCV buffer, but were compared using the `CSeqNo::seqcmp` as if they were packet sequence numbers. This bug was causing an extra loop over packets in the receiver buffer to find the first gap. The position was restored correctly, but costs extra CPU resources.

Mainly noticeable in a broadcast group connection, when a packet is read from one member, but dropped from all the rest members.