### PR TITLE
[core] Fix : Sequence number in the ACK packet isn’t correct (#2873)

### DIFF
--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -653,6 +653,8 @@ bool srt::CRcvLossList::remove(int32_t seqno)
         }
 
         m_iLength--;
+        if (0 == m_iLength)
+            m_iLargestSeq = SRT_SEQNO_NONE;
 
         return true;
     }
@@ -708,6 +710,8 @@ bool srt::CRcvLossList::remove(int32_t seqno)
     }
 
     m_iLength--;
+    if (0 == m_iLength)
+        m_iLargestSeq = SRT_SEQNO_NONE;
 
     return true;
 }

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -653,7 +653,7 @@ bool srt::CRcvLossList::remove(int32_t seqno)
         }
 
         m_iLength--;
-        if (0 == m_iLength)
+        if (m_iLength == 0)
             m_iLargestSeq = SRT_SEQNO_NONE;
 
         return true;

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -710,7 +710,7 @@ bool srt::CRcvLossList::remove(int32_t seqno)
     }
 
     m_iLength--;
-    if (0 == m_iLength)
+    if (m_iLength == 0)
         m_iLargestSeq = SRT_SEQNO_NONE;
 
     return true;


### PR DESCRIPTION
Reset the `m_iLargestSeq` back to `SRT_SEQNO_NONE` once the loss list is empty. This way if the next packet loss seqno has a distance more than `m_iSeqNoTH` from the `m_iLargestSeq`, it is not ignored and added to the loss list.

Fixes #2873.