### PR TITLE
Fixed bug: packetfilter configuration did not include AUTH tag when AEAD is on

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -5649,6 +5649,14 @@ bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd
     return true;
 }
 
+int srt::CUDT::getAuthTagSize() const
+{
+    if (m_pCryptoControl && m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM)
+        return HAICRYPT_AUTHTAG_MAX;
+
+    return 0;
+}
+
 bool srt::CUDT::prepareBuffers(CUDTException* eout)
 {
     if (m_pSndBuffer)
@@ -5660,7 +5668,7 @@ bool srt::CUDT::prepareBuffers(CUDTException* eout)
     try
     {
         // CryptoControl has to be initialized and in case of RESPONDER the KM REQ must be processed (interpretSrtHandshake(..)) for the crypto mode to be deduced.
-        const int authtag = (m_pCryptoControl && m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM) ? HAICRYPT_AUTHTAG_MAX : 0;
+        const int authtag = getAuthTagSize();
 
         SRT_ASSERT(m_iMaxSRTPayloadSize != 0);
 

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -517,6 +517,7 @@ private:
     /// Allocates sender and receiver buffers and loss lists.
     SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
     bool prepareBuffers(CUDTException* eout);
+    int getAuthTagSize() const;
 
     SRT_ATR_NODISCARD SRT_ATTR_REQUIRES(m_ConnectionLock)
     EConnectStatus postConnect(const CPacket* response, bool rendezvous, CUDTException* eout) ATR_NOEXCEPT;

--- a/srtcore/fec.cpp
+++ b/srtcore/fec.cpp
@@ -598,6 +598,9 @@ void FECFilterBuiltin::ClipData(Group& g, uint16_t length_net, uint8_t kflg,
     g.flag_clip = g.flag_clip ^ kflg;
     g.timestamp_clip = g.timestamp_clip ^ timestamp_hw;
 
+    HLOGC(pflog.Debug, log << "FEC CLIP: data pkt.size=" << payload_size
+            << " to a clip buffer size=" << payloadSize());
+
     // Payload goes "as is".
     for (size_t i = 0; i < payload_size; ++i)
     {

--- a/srtcore/packetfilter.cpp
+++ b/srtcore/packetfilter.cpp
@@ -314,8 +314,14 @@ bool srt::PacketFilter::configure(CUDT* parent, CUnitQueue* uq, const std::strin
     init.socket_id = parent->socketID();
     init.snd_isn = parent->sndSeqNo();
     init.rcv_isn = parent->rcvSeqNo();
-    init.payload_size = parent->OPT_PayloadSize();
+
+    // XXX This is a formula for a full "SRT payload" part that undergoes transmission,
+    // might be nice to have this formula as something more general.
+    init.payload_size = parent->OPT_PayloadSize() + parent->getAuthTagSize();
     init.rcvbuf_size = parent->m_config.iRcvBufSize;
+
+    HLOGC(pflog.Debug, log << "PFILTER: @" << init.socket_id << " payload size="
+            << init.payload_size << " rcvbuf size=" << init.rcvbuf_size);
 
     // Found a filter, so call the creation function
     m_filter = selector->second->Create(init, m_provided, confstr);

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -682,7 +682,7 @@ public:
     bool operator==(const element_type* two) const { return get() == two; }
     bool operator!=(const element_type* two) const { return get() != two; }
 
-    operator bool () { return 0!= get(); }
+    operator bool () const { return 0!= get(); }
 };
 
 // A primitive one-argument versions of Sprint and Printable


### PR DESCRIPTION
Fixes #2876 

The problem: To FEC for recording the EXOR from the data packet included is the whole packet as the sending unit, that is, including the auth tag, if AEAD is enabled. This was not regarded in the packet filter configuration and hence if AEAD was on the FEC facility has allocated too small buffer and caused this way a memory override.

Some more logs around FEC were added to show this case, they better stay there.