### PR TITLE
[core] Excluded drops due to group member seq shifting from counting as dropped

### DIFF
--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -750,11 +750,18 @@ private:
     // TSBPD thread main function.
     static void* tsbpd(void* param);
 
+    enum DropReason
+    {
+        DROP_FORGET, //< Drop to keep up to the live pace (TLPKTDROP)
+        DROP_WINK    //< Drop because another member already provided these packets (group synch)
+    };
+
     /// Drop too late packets (receiver side). Update loss lists and ACK positions.
     /// The @a seqno packet itself is not dropped.
     /// @param seqno [in] The sequence number of the first packets following those to be dropped.
+    /// @param rsn Declare why dropping is requested (see @a DropReason)
     /// @return The number of packets dropped.
-    int rcvDropTooLateUpTo(int seqno);
+    int rcvDropTooLateUpTo(int seqno, DropReason rsn = DROP_FORGET);
 
     static loss_seqs_t defaultPacketArrival(void* vself, CPacket& pkt);
     static loss_seqs_t groupPacketArrival(void* vself, CPacket& pkt);


### PR DESCRIPTION
Fixes #2879

The change: One call to `CUDT::rcvDropTooLateUpTo` was done in the group management so that all other links in the broadcast group are synchronized up to the sequence that was just "played" (the packet was delivered to the application). This may include, however, unreceived packets, which are this way counted as dropped. This modification uses a special parameter that allows to declare this drop-shift as "wink" (packets are delivered over an alternative link) and this way even if this shift required to drop the missing packets, they will not be counted as dropped in the stats.