### PR TITLE
[test] Added yielding for tests that spawn a thread for connect

### DIFF
--- a/test/test_fec_rebuilding.cpp
+++ b/test/test_fec_rebuilding.cpp
@@ -305,9 +305,12 @@ TEST(TestFEC, Connection)
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
 
-    SRTSOCKET la[] = { l };
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
+
     // Given 2s timeout for accepting as it has occasionally happened with Travis
     // that 1s might not be enough.
+    SRTSOCKET la[] = { l };
     SRTSOCKET a = srt_accept_bond(la, 1, 2000);
     ASSERT_NE(a, SRT_ERROR);
     EXPECT_EQ(connect_res.get(), SRT_SUCCESS);
@@ -361,6 +364,9 @@ TEST(TestFEC, ConnectionReorder)
     auto connect_res = std::async(std::launch::async, [&s, &sa]() {
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
+
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
 
     SRTSOCKET la[] = { l };
     SRTSOCKET a = srt_accept_bond(la, 1, 2000);
@@ -417,6 +423,9 @@ TEST(TestFEC, ConnectionFull1)
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
 
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
+
     SRTSOCKET la[] = { l };
     SRTSOCKET a = srt_accept_bond(la, 1, 2000);
     ASSERT_NE(a, SRT_ERROR);
@@ -471,6 +480,9 @@ TEST(TestFEC, ConnectionFull2)
     auto connect_res = std::async(std::launch::async, [&s, &sa]() {
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
+
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
 
     SRTSOCKET la[] = { l };
     SRTSOCKET a = srt_accept_bond(la, 1, 2000);
@@ -527,6 +539,9 @@ TEST(TestFEC, ConnectionMess)
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
 
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
+
     SRTSOCKET la[] = { l };
     SRTSOCKET a = srt_accept_bond(la, 1, 2000);
     ASSERT_NE(a, SRT_ERROR);
@@ -580,6 +595,9 @@ TEST(TestFEC, ConnectionForced)
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
 
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
+
     SRTSOCKET la[] = { l };
     SRTSOCKET a = srt_accept_bond(la, 1, 2000);
     ASSERT_NE(a, SRT_ERROR);
@@ -630,6 +648,9 @@ TEST(TestFEC, RejectionConflict)
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
 
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
+
     EXPECT_EQ(connect_res.get(), SRT_ERROR);
     EXPECT_EQ(srt_getrejectreason(s), SRT_REJ_FILTER);
 
@@ -670,6 +691,9 @@ TEST(TestFEC, RejectionIncompleteEmpty)
     auto connect_res = std::async(std::launch::async, [&s, &sa]() {
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
+
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
 
     EXPECT_EQ(connect_res.get(), SRT_ERROR);
     EXPECT_EQ(srt_getrejectreason(s), SRT_REJ_FILTER);
@@ -715,6 +739,9 @@ TEST(TestFEC, RejectionIncomplete)
     auto connect_res = std::async(std::launch::async, [&s, &sa]() {
         return srt_connect(s, (sockaddr*)& sa, sizeof(sa));
         });
+
+    // Make sure that the async call to srt_connect() is already kicked.
+    std::this_thread::yield();
 
     EXPECT_EQ(connect_res.get(), SRT_ERROR);
     EXPECT_EQ(srt_getrejectreason(s), SRT_REJ_FILTER);

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -70,6 +70,9 @@ public:
         };
         auto accept_res = async(launch::async, accept_async, m_listen_sock);
 
+        // Make sure the thread was kicked
+        this_thread::yield();
+
         const int connect_res = Connect();
         EXPECT_EQ(connect_res, SRT_SUCCESS);
 


### PR DESCRIPTION
The problem: although the call of `srt_accept_bond` is given 2s timeout, it may still happen to not be enough, especially when testing on a weak, loaded machine.

Added the call to `this_thread::yield()` to make the thread switched to the spawned one so that it can at least start calling the `srt_connect` method before `srt_accept_bond()` is going to pick it up. This should help with falsely failing tests in Travis.