### PR TITLE
[test] Improved tests to avoid all-breaking asserts and inter-test messup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ if (NOT MICROSOFT)
 	# that ENABLE_DEBUG is set as it should.
 	if (ENABLE_DEBUG EQUAL 2)
 		set (CMAKE_BUILD_TYPE "RelWithDebInfo")
-        if (ENABLE_ASSERT)
+		if (ENABLE_ASSERT)
 			# Add _DEBUG macro if explicitly requested, to enable SRT_ASSERT().
 			add_definitions(-D_DEBUG)
 		else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,12 @@ if (NOT MICROSOFT)
 	# that ENABLE_DEBUG is set as it should.
 	if (ENABLE_DEBUG EQUAL 2)
 		set (CMAKE_BUILD_TYPE "RelWithDebInfo")
-		add_definitions(-DNDEBUG)
+        if (ENABLE_ASSERT)
+			# Add _DEBUG macro if explicitly requested, to enable SRT_ASSERT().
+			add_definitions(-D_DEBUG)
+		else()
+			add_definitions(-DNDEBUG)
+		endif()
 	elseif (ENABLE_DEBUG) # 1, ON, YES, TRUE, Y, or any other non-zero number
 		set (CMAKE_BUILD_TYPE "Debug")
 

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2662,31 +2662,34 @@ void srt::CUDTUnited::checkBrokenSockets()
 
     for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
     {
+        CUDTSocket* ps = j->second;
+        CUDT& u = ps->core();
+
         // HLOGC(smlog.Debug, log << "checking CLOSED socket: " << j->first);
-        if (!is_zero(j->second->core().m_tsLingerExpiration))
+        if (!is_zero(u.m_tsLingerExpiration))
         {
             // asynchronous close:
-            if ((!j->second->core().m_pSndBuffer) || (0 == j->second->core().m_pSndBuffer->getCurrBufSize()) ||
-                (j->second->core().m_tsLingerExpiration <= steady_clock::now()))
+            if ((!u.m_pSndBuffer) || (0 == u.m_pSndBuffer->getCurrBufSize()) ||
+                (u.m_tsLingerExpiration <= steady_clock::now()))
             {
-                HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << j->second->m_SocketID);
-                j->second->core().m_tsLingerExpiration = steady_clock::time_point();
-                j->second->core().m_bClosing           = true;
-                j->second->m_tsClosureTimeStamp        = steady_clock::now();
+                HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << ps->m_SocketID);
+                u.m_tsLingerExpiration = steady_clock::time_point();
+                u.m_bClosing           = true;
+                ps->m_tsClosureTimeStamp        = steady_clock::now();
             }
         }
 
         // timeout 1 second to destroy a socket AND it has been removed from
         // RcvUList
         const steady_clock::time_point now        = steady_clock::now();
-        const steady_clock::duration   closed_ago = now - j->second->m_tsClosureTimeStamp;
+        const steady_clock::duration   closed_ago = now - ps->m_tsClosureTimeStamp;
         if (closed_ago > seconds_from(1))
         {
-            CRNode* rnode = j->second->core().m_pRNode;
+            CRNode* rnode = u.m_pRNode;
             if (!rnode || !rnode->m_bOnList)
             {
                 HLOGC(smlog.Debug,
-                      log << "checkBrokenSockets: @" << j->second->m_SocketID << " closed "
+                      log << "checkBrokenSockets: @" << ps->m_SocketID << " closed "
                           << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
 
                 // HLOGC(smlog.Debug, log << "will unref socket: " << j->first);

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -154,7 +154,7 @@ private:
     LogLevel::type level;
     static const size_t MAX_PREFIX_SIZE = 32;
     char prefix[MAX_PREFIX_SIZE+1];
-    bool enabled;
+    srt::sync::atomic<bool> enabled;
     LogConfig* src_config;
 
     bool isset(int flg) { return (src_config->flags & flg) != 0; }

--- a/test/test_env.h
+++ b/test/test_env.h
@@ -82,6 +82,7 @@ public:
     {
     }
 
+    void close();
     ~UniqueSocket();
 
     operator int32_t() const

--- a/test/test_env.h
+++ b/test/test_env.h
@@ -63,15 +63,22 @@ public:
 class UniqueSocket
 {
     int32_t sock;
+    std::string lab, f;
+    int l;
 
 public:
-    UniqueSocket(int32_t s): sock(s)
+    UniqueSocket(int32_t s, const char* label, const char* file, int line): sock(s)
     {
         if (s == -1)
             throw std::invalid_argument("Invalid socket");
+        lab = label;
+        f = file;
+        l = line;
     }
 
-    UniqueSocket(): sock(-1)
+#define MAKE_UNIQUE_SOCK(name, label, expr) srt::UniqueSocket name (expr, label, __FILE__, __LINE__)
+
+    UniqueSocket(): sock(-1), l(0)
     {
     }
 

--- a/test/test_epoll.cpp
+++ b/test/test_epoll.cpp
@@ -66,7 +66,7 @@ TEST(CEPoll, WaitEmptyCall)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     ASSERT_NE(client_sock, SRT_ERROR);
 
     const int no = 0;
@@ -89,7 +89,7 @@ TEST(CEPoll, UWaitEmptyCall)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     ASSERT_NE(client_sock, SRT_ERROR);
 
     const int no = 0;
@@ -112,7 +112,7 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     ASSERT_NE(client_sock, SRT_ERROR);
 
     const int yes = 1;
@@ -146,7 +146,7 @@ TEST(CEPoll, WaitAllSocketsInEpollReleased2)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     ASSERT_NE(client_sock, SRT_ERROR);
 
     const int yes = 1;
@@ -174,7 +174,7 @@ TEST(CEPoll, WrongEpoll_idOnAddUSock)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     ASSERT_NE(client_sock, SRT_ERROR);
 
     const int no  = 0;
@@ -197,7 +197,7 @@ TEST(CEPoll, HandleEpollEvent)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     EXPECT_NE(client_sock, SRT_ERROR);
 
     const int yes = 1;
@@ -258,7 +258,7 @@ TEST(CEPoll, NotifyConnectionBreak)
     srt::TestInit srtinit;
 
     // 1. Prepare client
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     ASSERT_NE(client_sock, SRT_ERROR);
 
     const int yes SRT_ATR_UNUSED = 1;
@@ -280,7 +280,7 @@ TEST(CEPoll, NotifyConnectionBreak)
     ASSERT_EQ(inet_pton(AF_INET, "127.0.0.1", &sa_client.sin_addr), 1);
 
     // 2. Prepare server
-    srt::UniqueSocket server_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(server_sock, "server_sock", srt_create_socket());
     ASSERT_NE(server_sock, SRT_ERROR);
 
     ASSERT_NE(srt_setsockopt(server_sock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
@@ -372,7 +372,7 @@ TEST(CEPoll, HandleEpollEvent2)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     EXPECT_NE(client_sock, SRT_ERROR);
 
     const int yes = 1;
@@ -433,7 +433,7 @@ TEST(CEPoll, HandleEpollNoEvent)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     EXPECT_NE(client_sock, SRT_ERROR);
 
     const int yes = 1;
@@ -483,7 +483,7 @@ TEST(CEPoll, ThreadedUpdate)
 {
     srt::TestInit srtinit;
 
-    srt::UniqueSocket client_sock = srt_create_socket();
+    MAKE_UNIQUE_SOCK(client_sock, "client", srt_create_socket());
     EXPECT_NE(client_sock, SRT_ERROR);
 
     const int no  = 0;

--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -31,6 +31,7 @@
 TEST(Transmission, FileUpload)
 {
     srt::TestInit srtinit;
+    srtinit.HandlePerTestOptions();
 
     // Generate the source file
     // We need a file that will contain more data

--- a/test/test_file_transmission.cpp
+++ b/test/test_file_transmission.cpp
@@ -180,7 +180,7 @@ TEST(Transmission, FileUpload)
     std::cout << "Sockets closed, joining receiver thread\n";
     client.join();
 
-    std::ifstream tarfile("file.target");
+    std::ifstream tarfile("file.target", std::ios::in | std::ios::binary);
     EXPECT_EQ(!!tarfile, true);
 
     tarfile.seekg(0, std::ios::end);
@@ -189,7 +189,11 @@ TEST(Transmission, FileUpload)
 
     std::cout << "Comparing files\n";
     // Compare files
-    tarfile.seekg(0, std::ios::beg);
+
+    // Theoretically it should work if you just rewind to 0, but
+    // on Windows this somehow doesn't work. 
+    tarfile.close();
+    tarfile.open("file.target", std::ios::in | std::ios::binary);
 
     ifile.close();
     ifile.open("file.source", std::ios::in | std::ios::binary);

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -183,7 +183,7 @@ sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_f
 
 UniqueSocket::~UniqueSocket()
 {
-    EXPECT_NE(srt_close(sock), SRT_ERROR);
+    EXPECT_NE(srt_close(sock), SRT_ERROR) << lab << " CREATED:"<< f << ":" << l;
 }
 
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -183,7 +183,14 @@ sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_f
 
 UniqueSocket::~UniqueSocket()
 {
-    EXPECT_NE(srt_close(sock), SRT_ERROR) << lab << " CREATED:"<< f << ":" << l;
+    // Could be closed explicitly
+    if (sock != -1)
+        close();
+}
+
+void UniqueSocket::close()
+{
+    EXPECT_NE(srt_close(sock), SRT_ERROR) << lab << " CREATED: "<< f << ":" << l;
 }
 
 }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -113,6 +113,11 @@ void TestInit::HandlePerTestOptions()
     {
         srt_setloglevel(LOG_DEBUG);
     }
+
+    if (TestEnv::me->OptionPresent("lognote"))
+    {
+        srt_setloglevel(LOG_NOTICE);
+    }
 }
 
 // Copied from ../apps/apputil.cpp, can't really link this file here.
@@ -178,7 +183,7 @@ sockaddr_any CreateAddr(const std::string& name, unsigned short port, int pref_f
 
 UniqueSocket::~UniqueSocket()
 {
-    srt_close(sock);
+    EXPECT_NE(srt_close(sock), SRT_ERROR);
 }
 
 }

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -30,7 +30,7 @@ struct AtReturnJoin
 // iphlp library to be attached to the executable, which is kinda
 // problematic. Temporarily block tests using this function on Windows.
 
-std::string GetLocalIP(int af = AF_UNSPEC)
+static std::string GetLocalIP(int af = AF_UNSPEC)
 {
     std::cout << "!!!WARNING!!!: GetLocalIP not supported, test FORCEFULLY passed\n";
     return "";
@@ -50,7 +50,7 @@ struct IfAddr
     }
 };
 
-std::string GetLocalIP(int af = AF_UNSPEC)
+static std::string GetLocalIP(int af = AF_UNSPEC)
 {
     struct ifaddrs * ifa=NULL;
     void * tmpAddrPtr=NULL;
@@ -101,306 +101,320 @@ std::string GetLocalIP(int af = AF_UNSPEC)
 }
 #endif
 
-int client_pollid = SRT_ERROR;
-SRTSOCKET g_client_sock = SRT_ERROR;
-
-void clientSocket(std::string ip, int port, bool expect_success)
+class ReuseAddr : public srt::Test
 {
-    int yes = 1;
-    int no = 0;
+    int m_client_pollid = SRT_ERROR;
+    int m_server_pollid = SRT_ERROR;
 
-    int family = AF_INET;
-    std::string famname = "IPv4";
-    if (ip.substr(0, 2) == "6.")
+
+protected:
+    void clientSocket(SRTSOCKET client_sock, std::string ip, int port, bool expect_success)
     {
-        family = AF_INET6;
-        ip = ip.substr(2);
-        famname = "IPv6";
-    }
+        using namespace std;
 
-    std::cout << "[T/C] Creating client socket\n";
+        int yes = 1;
+        int no = 0;
 
-    g_client_sock = srt_create_socket();
-    ASSERT_NE(g_client_sock, SRT_ERROR);
-
-    ASSERT_NE(srt_setsockopt(g_client_sock, 0, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
-    ASSERT_NE(srt_setsockflag(g_client_sock, SRTO_SENDER, &yes, sizeof yes), SRT_ERROR);
-
-    ASSERT_NE(srt_setsockopt(g_client_sock, 0, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
-
-    int epoll_out = SRT_EPOLL_OUT;
-    srt_epoll_add_usock(client_pollid, g_client_sock, &epoll_out);
-
-    sockaddr_any sa = srt::CreateAddr(ip, port, family);
-
-    std::cout << "[T/C] Connecting to: " << sa.str() << " (" << famname << ")" << std::endl;
-
-    int connect_res = srt_connect(g_client_sock, sa.get(), sa.size());
-
-    if (connect_res == -1)
-    {
-        std::cout << "srt_connect: " << srt_getlasterror_str() << std::endl;
-    }
-
-    if (expect_success)
-    {
-        EXPECT_NE(connect_res, -1);
-        if (connect_res == -1)
-            return;
-
-        // Socket readiness for connection is checked by polling on WRITE allowed sockets.
-
-        if (connect_res != -1)
+        int family = AF_INET;
+        string famname = "IPv4";
+        if (ip.substr(0, 2) == "6.")
         {
+            family = AF_INET6;
+            ip = ip.substr(2);
+            famname = "IPv6";
+        }
+
+        cout << "[T/C] Setting up client socket\n";
+        ASSERT_NE(client_sock, SRT_INVALID_SOCK);
+        ASSERT_EQ(srt_getsockstate(client_sock), SRTS_INIT);
+
+        EXPECT_NE(srt_setsockflag(client_sock, SRTO_SNDSYN, &no, sizeof no), SRT_ERROR); // for async connect
+        EXPECT_NE(srt_setsockflag(client_sock, SRTO_SENDER, &yes, sizeof yes), SRT_ERROR);
+        EXPECT_NE(srt_setsockflag(client_sock, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
+
+        int epoll_out = SRT_EPOLL_OUT;
+        srt_epoll_add_usock(m_client_pollid, client_sock, &epoll_out);
+
+        sockaddr_any sa = srt::CreateAddr(ip, port, family);
+
+        cout << "[T/C] Connecting to: " << sa.str() << " (" << famname << ")" << endl;
+
+        int connect_res = srt_connect(client_sock, sa.get(), sa.size());
+
+        if (connect_res == -1)
+        {
+            cout << "srt_connect: " << srt_getlasterror_str() << endl;
+        }
+
+        if (expect_success)
+        {
+            EXPECT_NE(connect_res, -1);
+            if (connect_res == -1)
+                return;
+
+            // Socket readiness for connection is checked by polling on WRITE allowed sockets.
+
+            if (connect_res != -1)
+            {
+                int rlen = 2;
+                SRTSOCKET read[2];
+
+                int wlen = 2;
+                SRTSOCKET write[2];
+
+                cout << "[T/C] Waiting for connection readiness...\n";
+
+                EXPECT_NE(srt_epoll_wait(m_client_pollid, read, &rlen,
+                            write, &wlen,
+                            -1, // -1 is set for debuging purpose.
+                            // in case of production we need to set appropriate value
+                            0, 0, 0, 0), SRT_ERROR);
+
+                EXPECT_EQ(rlen, 0) << "[T/C] read-ready"; // get exactly one write event without reads
+                EXPECT_EQ(wlen, 1) << "[T/C] write-ready"; // get exactly one write event without reads
+                EXPECT_EQ(write[0], client_sock); // for our client socket
+
+                char buffer[1316] = {1, 2, 3, 4};
+                EXPECT_NE(srt_sendmsg(client_sock, buffer, sizeof buffer,
+                            -1, // infinit ttl
+                            true // in order must be set to true
+                            ),
+                        SRT_ERROR);
+            }
+            else
+            {
+                cout << "[T/C] (NOT TESTING TRANSMISSION - CONNECTION FAILED ALREADY)\n";
+            }
+        }
+        else
+        {
+            EXPECT_EQ(connect_res, -1);
+        }
+
+        cout << "[T/C] Client exit\n";
+    }
+
+    SRTSOCKET prepareSocket()
+    {
+        SRTSOCKET bindsock = srt_create_socket();
+        EXPECT_NE(bindsock, SRT_ERROR);
+
+        int yes = 1;
+        int no = 0;
+
+        EXPECT_NE(srt_setsockopt(bindsock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
+        EXPECT_NE(srt_setsockopt(bindsock, 0, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
+
+        int epoll_in = SRT_EPOLL_IN;
+
+        std::cout << "[T/S] Listener/binder sock @" << bindsock << " added to m_server_pollid\n";
+        srt_epoll_add_usock(m_server_pollid, bindsock, &epoll_in);
+
+        return bindsock;
+    }
+
+    bool bindSocket(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
+    {
+        sockaddr_any sa = srt::CreateAddr(ip, port, AF_INET);
+
+        std::string fam = (sa.family() == AF_INET) ? "IPv4" : "IPv6";
+
+        std::cout << "[T/S] Bind @" << bindsock << " to: " << sa.str() << " (" << fam << ")" << std::endl;
+
+        int bind_res = srt_bind(bindsock, sa.get(), sa.size());
+
+        std::cout << "[T/S] ... result " << bind_res << " (expected to "
+            << (expect_success ? "succeed" : "fail") << ")\n";
+
+        if (!expect_success)
+        {
+            std::cout << "[T/S] Binding should fail: " << srt_getlasterror_str() << std::endl;
+            EXPECT_EQ(bind_res, SRT_ERROR);
+            return false;
+        }
+
+        EXPECT_NE(bind_res, SRT_ERROR);
+        return true;
+    }
+
+    bool bindListener(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
+    {
+        if (!bindSocket(bindsock, ip, port, expect_success))
+            return false;
+
+        EXPECT_NE(srt_listen(bindsock, SOMAXCONN), SRT_ERROR);
+
+        return true;
+    }
+
+    SRTSOCKET createListener(std::string ip, int port, bool expect_success)
+    {
+        std::cout << "[T/S] serverSocket: creating listener socket\n";
+
+        SRTSOCKET bindsock = prepareSocket();
+
+        if (!bindListener(bindsock, ip, port, expect_success))
+            return SRT_INVALID_SOCK;
+
+        return bindsock;
+    }
+
+    SRTSOCKET createBinder(std::string ip, int port, bool expect_success)
+    {
+        std::cout << "[T/S] serverSocket: creating binder socket\n";
+
+        SRTSOCKET bindsock = prepareSocket();
+
+        if (!bindSocket(bindsock, ip, port, expect_success))
+        {
+            srt_close(bindsock);
+            return SRT_INVALID_SOCK;
+        }
+
+        return bindsock;
+    }
+
+    void testAccept(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
+    {
+        srt::UniqueSocket client_sock = srt_create_socket();
+
+        auto run = [this, &client_sock, ip, port, expect_success]() { clientSocket(client_sock, ip, port, expect_success); };
+
+        auto launched = std::async(std::launch::async, run);
+
+        AtReturnJoin<decltype(launched)> atreturn_join {launched};
+
+        { // wait for connection from client
             int rlen = 2;
             SRTSOCKET read[2];
 
             int wlen = 2;
             SRTSOCKET write[2];
 
-            std::cout << "[T/C] Waiting for connection readiness...\n";
+            std::cout << "[T/S] Wait 10s for acceptance on @" << bindsock << " ...\n";
 
-            EXPECT_NE(srt_epoll_wait(client_pollid, read, &rlen,
+            EXPECT_NE(srt_epoll_wait(m_server_pollid,
+                        read,  &rlen,
                         write, &wlen,
-                        -1, // -1 is set for debuging purpose.
+                        10000, // -1 is set for debuging purpose.
                         // in case of production we need to set appropriate value
-                        0, 0, 0, 0), SRT_ERROR);
+                        0, 0, 0, 0), SRT_ERROR );
 
 
-            EXPECT_EQ(rlen, 0); // get exactly one write event without reads
-            EXPECT_EQ(wlen, 1); // get exactly one write event without reads
-            EXPECT_EQ(write[0], g_client_sock); // for our client socket
-
-            char buffer[1316] = {1, 2, 3, 4};
-            EXPECT_NE(srt_sendmsg(g_client_sock, buffer, sizeof buffer,
-                        -1, // infinit ttl
-                        true // in order must be set to true
-                        ),
-                    SRT_ERROR);
+            EXPECT_EQ(rlen, 1); // get exactly one read event without writes
+            EXPECT_EQ(wlen, 0); // get exactly one read event without writes
+            ASSERT_EQ(read[0], bindsock); // read event is for bind socket
         }
-        else
+
         {
-            std::cout << "[T/C] (NOT TESTING TRANSMISSION - CONNECTION FAILED ALREADY)\n";
+            sockaddr_any scl;
+            srt::UniqueSocket accepted_sock = srt_accept(bindsock, scl.get(), &scl.len);
+            if (accepted_sock == -1)
+            {
+                std::cout << "srt_accept: " << srt_getlasterror_str() << std::endl;
+            }
+            EXPECT_NE(accepted_sock.ref(), SRT_INVALID_SOCK);
+
+            sockaddr_any showacp = (sockaddr*)&scl;
+            std::cout << "[T/S] Accepted from: " << showacp.str() << std::endl;
+
+            int epoll_in = SRT_EPOLL_IN;
+            srt_epoll_add_usock(m_server_pollid, accepted_sock, &epoll_in); // wait for input
+
+            char buffer[1316];
+            { // wait for 1316 packet from client
+                int rlen = 2;
+                SRTSOCKET read[2];
+
+                int wlen = 2;
+                SRTSOCKET write[2];
+
+                std::cout << "[T/S] Wait for data reception...\n";
+
+                EXPECT_NE(srt_epoll_wait(m_server_pollid,
+                            read,  &rlen,
+                            write, &wlen,
+                            -1, // -1 is set for debuging purpose.
+                            // in case of production we need to set appropriate value
+                            0, 0, 0, 0), SRT_ERROR );
+
+
+                EXPECT_EQ(rlen, 1) << "[T/S] read-ready"; // get exactly one read event without writes
+                EXPECT_EQ(wlen, 0) << "[T/S] write-ready"; // get exactly one read event without writes
+                EXPECT_EQ(read[0], accepted_sock.ref()); // read event is for bind socket        
+            }
+
+            char pattern[4] = {1, 2, 3, 4};
+
+            EXPECT_EQ(srt_recvmsg(accepted_sock, buffer, sizeof buffer),
+                    1316);
+
+            EXPECT_EQ(memcmp(pattern, buffer, sizeof pattern), 0);
+
+            std::cout << "[T/S] closing sockets: ACP:@" << accepted_sock << " LSN:@" << bindsock << "...\n";
         }
+        // client_sock closed through UniqueSocket.
+        // cannot close client_sock after srt_sendmsg because of issue in api.c:2346 
+
+        std::cout << "[T/S] joining client async (should close client socket)...\n";
+        launched.get();
     }
-    else
+
+    static void shutdownListener(SRTSOCKET bindsock)
     {
-        EXPECT_EQ(connect_res, -1);
+        // Silently ignore. Usually it should have been checked earlier,
+        // and an invalid sock might be expected in particular tests.
+        if (bindsock == SRT_INVALID_SOCK)
+            return;
+
+        int yes = 1;
+        EXPECT_NE(srt_setsockopt(bindsock, 0, SRTO_RCVSYN, &yes, sizeof yes), SRT_ERROR); // for async connect
+        EXPECT_NE(srt_close(bindsock), SRT_ERROR);
+
+        std::chrono::milliseconds check_period (100);
+        int credit = 400; // 10 seconds
+        auto then = std::chrono::steady_clock::now();
+
+        std::cout << "[T/S] waiting for cleanup of @" << bindsock << " up to 10s" << std::endl;
+        while (srt_getsockstate(bindsock) != SRTS_NONEXIST)
+        {
+            std::this_thread::sleep_for(check_period);
+            --credit;
+            if (!credit)
+                break;
+        }
+        auto now = std::chrono::steady_clock::now();
+        auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(now - then);
+
+        // Keep as single string because this tends to be mixed from 2 threads.
+        std::ostringstream sout;
+        sout << "[T/S] @" << bindsock << " dissolved after "
+            << (dur.count() / 1000.0) << "s" << std::endl;
+        std::cout << sout.str() << std::flush;
+
+        EXPECT_NE(credit, 0);
     }
 
-    std::cout << "[T/C] Client exit\n";
-}
+private:
 
-int server_pollid = SRT_ERROR;
-
-SRTSOCKET prepareSocket()
-{
-    SRTSOCKET bindsock = srt_create_socket();
-    EXPECT_NE(bindsock, SRT_ERROR);
-
-    int yes = 1;
-    int no = 0;
-
-    EXPECT_NE(srt_setsockopt(bindsock, 0, SRTO_RCVSYN, &no, sizeof no), SRT_ERROR); // for async connect
-    EXPECT_NE(srt_setsockopt(bindsock, 0, SRTO_TSBPDMODE, &yes, sizeof yes), SRT_ERROR);
-
-    int epoll_in = SRT_EPOLL_IN;
-
-    std::cout << "[T/S] Listener/binder sock @" << bindsock << " added to server_pollid\n";
-    srt_epoll_add_usock(server_pollid, bindsock, &epoll_in);
-
-    return bindsock;
-}
-
-bool bindSocket(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
-{
-    sockaddr_any sa = srt::CreateAddr(ip, port, AF_INET);
-
-    std::string fam = (sa.family() == AF_INET) ? "IPv4" : "IPv6";
-
-    std::cout << "[T/S] Bind @" << bindsock << " to: " << sa.str() << " (" << fam << ")" << std::endl;
-
-    int bind_res = srt_bind(bindsock, sa.get(), sa.size());
-
-    std::cout << "[T/S] ... result " << bind_res << " (expected to "
-        << (expect_success ? "succeed" : "fail") << ")\n";
-
-    if (!expect_success)
+    void setup()
     {
-        std::cout << "[T/S] Binding should fail: " << srt_getlasterror_str() << std::endl;
-        EXPECT_EQ(bind_res, SRT_ERROR);
-        return false;
+        m_client_pollid = srt_epoll_create();
+        ASSERT_NE(m_client_pollid, SRT_ERROR);
+
+        m_server_pollid = srt_epoll_create();
+        ASSERT_NE(m_server_pollid, SRT_ERROR);
     }
 
-    EXPECT_NE(bind_res, SRT_ERROR);
-    return true;
-}
-
-bool bindListener(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
-{
-    if (!bindSocket(bindsock, ip, port, expect_success))
-        return false;
-
-    EXPECT_NE(srt_listen(bindsock, SOMAXCONN), SRT_ERROR);
-
-    return true;
-}
-
-SRTSOCKET createListener(std::string ip, int port, bool expect_success)
-{
-    std::cout << "[T/S] serverSocket: creating listener socket\n";
-
-    SRTSOCKET bindsock = prepareSocket();
-
-    if (!bindListener(bindsock, ip, port, expect_success))
-        return SRT_INVALID_SOCK;
-
-    return bindsock;
-}
-
-SRTSOCKET createBinder(std::string ip, int port, bool expect_success)
-{
-    std::cout << "[T/S] serverSocket: creating binder socket\n";
-
-    SRTSOCKET bindsock = prepareSocket();
-
-    if (!bindSocket(bindsock, ip, port, expect_success))
+    void teardown()
     {
-        srt_close(bindsock);
-        return SRT_INVALID_SOCK;
+        (void)srt_epoll_release(m_client_pollid);
+        (void)srt_epoll_release(m_server_pollid);
     }
+};
 
-    return bindsock;
-}
-
-void testAccept(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
+TEST_F(ReuseAddr, SameAddr1)
 {
-
-    auto run = [ip, port, expect_success]() { clientSocket(ip, port, expect_success); };
-
-    auto launched = std::async(std::launch::async, run);
-
-    AtReturnJoin<decltype(launched)> atreturn_join {launched};
-
-    { // wait for connection from client
-        int rlen = 2;
-        SRTSOCKET read[2];
-
-        int wlen = 2;
-        SRTSOCKET write[2];
-
-        std::cout << "[T/S] Wait 10s for acceptance on @" << bindsock << " ...\n";
-
-        ASSERT_NE(srt_epoll_wait(server_pollid,
-                                         read,  &rlen,
-                                         write, &wlen,
-                                         10000, // -1 is set for debuging purpose.
-                                             // in case of production we need to set appropriate value
-                                         0, 0, 0, 0), SRT_ERROR );
-
-
-        ASSERT_EQ(rlen, 1); // get exactly one read event without writes
-        ASSERT_EQ(wlen, 0); // get exactly one read event without writes
-        ASSERT_EQ(read[0], bindsock); // read event is for bind socket
-    }
-
-    sockaddr_any scl;
-
-    SRTSOCKET accepted_sock = srt_accept(bindsock, scl.get(), &scl.len);
-    if (accepted_sock == -1)
-    {
-        std::cout << "srt_accept: " << srt_getlasterror_str() << std::endl;
-    }
-    ASSERT_NE(accepted_sock, SRT_INVALID_SOCK);
-
-    sockaddr_any showacp = (sockaddr*)&scl;
-    std::cout << "[T/S] Accepted from: " << showacp.str() << std::endl;
-
-    int epoll_in = SRT_EPOLL_IN;
-    srt_epoll_add_usock(server_pollid, accepted_sock, &epoll_in); // wait for input
-
-    char buffer[1316];
-    { // wait for 1316 packet from client
-        int rlen = 2;
-        SRTSOCKET read[2];
-
-        int wlen = 2;
-        SRTSOCKET write[2];
-
-        std::cout << "[T/S] Wait for data reception...\n";
-
-        ASSERT_NE(srt_epoll_wait(server_pollid,
-                                         read,  &rlen,
-                                         write, &wlen,
-                                         -1, // -1 is set for debuging purpose.
-                                             // in case of production we need to set appropriate value
-                                         0, 0, 0, 0), SRT_ERROR );
-
-
-        ASSERT_EQ(rlen, 1); // get exactly one read event without writes
-        ASSERT_EQ(wlen, 0); // get exactly one read event without writes
-        ASSERT_EQ(read[0], accepted_sock); // read event is for bind socket        
-    }
-
-    char pattern[4] = {1, 2, 3, 4};
-
-    ASSERT_EQ(srt_recvmsg(accepted_sock, buffer, sizeof buffer),
-              1316);
-
-    EXPECT_EQ(memcmp(pattern, buffer, sizeof pattern), 0);
-
-    std::cout << "[T/S] closing sockets: ACP:@" << accepted_sock << " LSN:@" << bindsock << " CLR:@" << g_client_sock << " ...\n";
-    ASSERT_NE(srt_close(accepted_sock), SRT_ERROR);
-    ASSERT_NE(srt_close(g_client_sock), SRT_ERROR); // cannot close g_client_sock after srt_sendmsg because of issue in api.c:2346 
-
-    std::cout << "[T/S] joining client async...\n";
-    launched.get();
-}
-
-void shutdownListener(SRTSOCKET bindsock)
-{
-    // Silently ignore. Usually it should have been checked earlier,
-    // and an invalid sock might be expected in particular tests.
-    if (bindsock == SRT_INVALID_SOCK)
-        return;
-
-    int yes = 1;
-    EXPECT_NE(srt_setsockopt(bindsock, 0, SRTO_RCVSYN, &yes, sizeof yes), SRT_ERROR); // for async connect
-    EXPECT_NE(srt_close(bindsock), SRT_ERROR);
-
-    std::chrono::milliseconds check_period (100);
-    int credit = 400; // 10 seconds
-    auto then = std::chrono::steady_clock::now();
-
-    std::cout << "[T/S] waiting for cleanup of @" << bindsock << " up to 10s" << std::endl;
-    while (srt_getsockstate(bindsock) != SRTS_NONEXIST)
-    {
-        std::this_thread::sleep_for(check_period);
-        --credit;
-        if (!credit)
-            break;
-    }
-    auto now = std::chrono::steady_clock::now();
-    auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(now - then);
-
-    // Keep as single string because this tends to be mixed from 2 threads.
-    std::ostringstream sout;
-    sout << "[T/S] @" << bindsock << " dissolved after "
-        << (dur.count() / 1000.0) << "s" << std::endl;
-    std::cout << sout.str() << std::flush;
-
-    EXPECT_NE(credit, 0);
-}
-
-TEST(ReuseAddr, SameAddr1)
-{
-    srt::TestInit srtinit;
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     SRTSOCKET bindsock_1 = createBinder("127.0.0.1", 5000, true);
     SRTSOCKET bindsock_2 = createListener("127.0.0.1", 5000, true);
@@ -413,23 +427,13 @@ TEST(ReuseAddr, SameAddr1)
     s1.join();
     s2.join();
 
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
-TEST(ReuseAddr, SameAddr2)
+TEST_F(ReuseAddr, SameAddr2)
 {
-    srt::TestInit srtinit;
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
-
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     SRTSOCKET bindsock_1 = createBinder(localip, 5000, true);
     SRTSOCKET bindsock_2 = createListener(localip, 5000, true);
@@ -445,21 +449,11 @@ TEST(ReuseAddr, SameAddr2)
     testAccept(bindsock_3, localip, 5000, true);
 
     shutdownListener(bindsock_3);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
-TEST(ReuseAddr, SameAddrV6)
+TEST_F(ReuseAddr, SameAddrV6)
 {
     SRTST_REQUIRES(IPv6);
-    srt::TestInit srtinit;
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     SRTSOCKET bindsock_1 = createBinder("::1", 5000, true);
     SRTSOCKET bindsock_2 = createListener("::1", 5000, true);
@@ -475,25 +469,14 @@ TEST(ReuseAddr, SameAddrV6)
     testAccept(bindsock_3, "::1", 5000, true);
 
     shutdownListener(bindsock_3);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
 
-TEST(ReuseAddr, DiffAddr)
+TEST_F(ReuseAddr, DiffAddr)
 {
-    srt::TestInit srtinit;
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
-
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     SRTSOCKET bindsock_1 = createBinder("127.0.0.1", 5000, true);
     SRTSOCKET bindsock_2 = createListener(localip, 5000, true);
@@ -505,14 +488,10 @@ TEST(ReuseAddr, DiffAddr)
 
     shutdownListener(bindsock_1);
     shutdownListener(bindsock_2);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
-TEST(ReuseAddr, Wildcard)
+TEST_F(ReuseAddr, Wildcard)
 {
-    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -524,14 +503,6 @@ TEST(ReuseAddr, Wildcard)
     std::string localip = GetLocalIP(AF_INET);
     if (localip == "")
         return; // DISABLE TEST if this doesn't work.
-
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
-
     SRTSOCKET bindsock_1 = createListener("0.0.0.0", 5000, true);
 
     // Binding a certain address when wildcard is already bound should fail.
@@ -541,15 +512,11 @@ TEST(ReuseAddr, Wildcard)
 
     shutdownListener(bindsock_1);
     shutdownListener(bindsock_2);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
-TEST(ReuseAddr, Wildcard6)
+TEST_F(ReuseAddr, Wildcard6)
 {
     SRTST_REQUIRES(IPv6);
-    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
@@ -566,13 +533,6 @@ TEST(ReuseAddr, Wildcard6)
     // that do not have IPv4, in which case this test can't be
     // performed there.
     std::string localip_v4 = GetLocalIP(AF_INET);
-
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     // This must be obligatory set before binding a socket to "::"
     int strict_ipv6 = 1;
@@ -620,27 +580,17 @@ TEST(ReuseAddr, Wildcard6)
     shutdownListener(bindsock_1);
     shutdownListener(bindsock_2);
     shutdownListener(bindsock_3);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
-TEST(ReuseAddr, ProtocolVersion6)
+TEST_F(ReuseAddr, ProtocolVersion6)
 {
     SRTST_REQUIRES(IPv6);
 
-    srt::TestInit srtinit;
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
     return;
 #endif
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     SRTSOCKET bindsock_1 = createListener("0.0.0.0", 5000, true);
 
@@ -659,26 +609,17 @@ TEST(ReuseAddr, ProtocolVersion6)
 
     shutdownListener(bindsock_1);
     shutdownListener(bindsock_2);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }
 
-TEST(ReuseAddr, ProtocolVersionFaux6)
+TEST_F(ReuseAddr, ProtocolVersionFaux6)
 {
     SRTST_REQUIRES(IPv6);
-    srt::TestInit srtinit;
+
 #if defined(_WIN32) || defined(CYGWIN)
     std::cout << "!!!WARNING!!!: On Windows connection to localhost this way isn't possible.\n"
         "Forcing test to pass, PLEASE FIX.\n";
     return;
 #endif
-
-    client_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, client_pollid);
-
-    server_pollid = srt_epoll_create();
-    ASSERT_NE(SRT_ERROR, server_pollid);
 
     SRTSOCKET bindsock_1 = createListener("0.0.0.0", 5000, true);
 
@@ -696,7 +637,4 @@ TEST(ReuseAddr, ProtocolVersionFaux6)
 
     shutdownListener(bindsock_1);
     shutdownListener(bindsock_2);
-
-    (void)srt_epoll_release(client_pollid);
-    (void)srt_epoll_release(server_pollid);
 }

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -390,16 +390,22 @@ protected:
 
             EXPECT_EQ(memcmp(pattern, buffer, sizeof pattern), 0);
 
-            std::cout << "[T/S] closing sockets: ACP:@" << accepted_sock << " LSN:@" << bindsock << "...\n";
+            // XXX There is a possibility that a broken socket can be closed automatically,
+            // just the srt_close() call would simply return error in case of nonexistent
+            // socket. Therefore close them both at once; this problem needs to be fixed
+            // separately.
+            //
+            // The test only intends to send one portion of data from the client, so once
+            // received, the client has nothing more to do and should exit.
+            std::cout << "[T/S] closing client socket\n";
+            client_sock.close();
+            std::cout << "[T/S] closing sockets: ACP:@" << accepted_sock << "...\n";
         }
         // client_sock closed through UniqueSocket.
         // cannot close client_sock after srt_sendmsg because of issue in api.c:2346 
 
         std::cout << "[T/S] joining client async \n";
-        EXPECT_EQ(srt_getsockstate(client_sock), SRTS_CONNECTED);
         launched.get();
-        EXPECT_EQ(srt_getsockstate(client_sock), SRTS_CONNECTED);
-        std::cout << "[T/S] closing client socket\n";
     }
 
     static void shutdownListener(SRTSOCKET bindsock)

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -396,7 +396,9 @@ protected:
         // cannot close client_sock after srt_sendmsg because of issue in api.c:2346 
 
         std::cout << "[T/S] joining client async \n";
+        EXPECT_EQ(srt_getsockstate(client_sock), SRTS_CONNECTED);
         launched.get();
+        EXPECT_EQ(srt_getsockstate(client_sock), SRTS_CONNECTED);
         std::cout << "[T/S] closing client socket\n";
     }
 

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -314,7 +314,7 @@ protected:
 
     void testAccept(SRTSOCKET bindsock, std::string ip, int port, bool expect_success)
     {
-        srt::UniqueSocket client_sock = srt_create_socket();
+        MAKE_UNIQUE_SOCK(client_sock, "[T/C]connect", srt_create_socket());
 
         auto run = [this, &client_sock, ip, port, expect_success]() { clientSocket(client_sock, ip, port, expect_success); };
 
@@ -346,7 +346,8 @@ protected:
 
         {
             sockaddr_any scl;
-            srt::UniqueSocket accepted_sock = srt_accept(bindsock, scl.get(), &scl.len);
+            MAKE_UNIQUE_SOCK(accepted_sock, "[T/S]accept", srt_accept(bindsock, scl.get(), &scl.len));
+
             if (accepted_sock == -1)
             {
                 std::cout << "srt_accept: " << srt_getlasterror_str() << std::endl;

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -587,7 +587,8 @@ TEST(SyncEvent, WaitForNotifyAll)
  /*****************************************************************************/
 void* dummythread(void* param)
 {
-    *(bool*)(param) = true;
+    auto& thread_finished = *(srt::sync::atomic<bool>*)param;
+    thread_finished = true;
     return nullptr;
 }
 


### PR DESCRIPTION
1. Some small refax in api.cpp (shortcut variables, preparing for another change)
2. Added possibly handling -lognote option and added handling in FileUpload test.
3. Reworked test_reuseaddr.cpp to use a fixture and a propoer resource management.
4. Added similar fixes in other tests.