### PR TITLE
[crypto] HaiCrypt_Clone(): sets up receiver clone properly

### DIFF
--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -320,6 +320,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         cryptoClone->ctx_pair[1].flags &= ~HCRYPT_CTX_F_ENCRYPT;
         memset(cryptoClone->ctx_pair[0].salt, 0, sizeof(cryptoClone->ctx_pair[0].salt));
         cryptoClone->ctx_pair[0].salt_len = 0;
+        cryptoClone->ctx = &cryptoClone->ctx_pair[0];
     }
 
     *phhc = (void *)cryptoClone;


### PR DESCRIPTION
This fixes key rotation when kk changes
Remote TX sends one even key on initial handshake, and later sends two (even and odd) keys in a KMREQ USER packet

Here is srt-live-transmit showing initial handshake, and key update:

--------------------
15:45:37.523916/SRT:RcvQ:w1.N:SRT.cn: processSrtMsg_KMRSP: cmd=4(KMRSP) len=224 KmState: SND=SECURED RCV=SECURED 15:45:37.524445/SRT:RcvQ:w1.N:SRT.cn: @234271448: Connection established to: 10.129.73.178:5000 SRT source connected

15:45:42.285301/SRT:RcvQ:w1!W:SRT.cn: KMREQ/rcv: (snd) Rx process failure - BADSECRET 15:45:42.285372/SRT:RcvQ:w1.N:SRT.cn: processSrtMsg_KMREQ: cmd=3(KMREQ) len=288 KmState: SND=BADSECRET RCV=BADSECRET 15:45:42.285410/SRT:RcvQ:w1!W:SRT.cn: @234271448: KMREQ FAILURE: BADSECRET - rejecting per enforced encryption --------------------