### PR TITLE
[core] Fix some indirect inclusion issues 

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -65,7 +65,7 @@
 #include <thread>
 #include <list>
 
-
+#include "srt_compat.h"
 #include "apputil.hpp"  // CreateAddr
 #include "uriparser.hpp"  // UriParser
 #include "socketoptions.hpp"

--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <condition_variable>
 
+#include "srt_compat.h"
 #include "apputil.hpp"  // CreateAddr
 #include "uriparser.hpp"  // UriParser
 #include "socketoptions.hpp"

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -68,8 +68,6 @@ modified by
 #include "packet.h"
 #include "threadname.h"
 
-#include <srt_compat.h> // SysStrError
-
 using namespace std;
 using namespace srt::sync;
 using namespace srt_logging;

--- a/srtcore/logging.cpp
+++ b/srtcore/logging.cpp
@@ -14,7 +14,7 @@ written by
  *****************************************************************************/
 
 
-
+#include "srt_compat.h"
 #include "logging.h"
 
 using namespace std;

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -33,7 +33,6 @@ written by
 #include "utilities.h"
 #include "threadname.h"
 #include "logging_api.h"
-#include "srt_compat.h"
 #include "sync.h"
 
 #ifdef __GNUC__

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -159,7 +159,7 @@ modified by
 //      the original sequence numbers in the field.
 
 #include "platform_sys.h"
-
+#include <cstddef>
 #include <cstring>
 #include "packet.h"
 #include "handshake.h"

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -36,8 +36,6 @@ written by
 
 #include "platform_sys.h"
 
-#include "srt_compat.h"
-
 #include <string.h>
 #include <stdlib.h>
 

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -64,6 +64,7 @@
 #include <chrono>
 #include <thread>
 
+#include "srt_compat.h"
 #include "apputil.hpp"
 #include "uriparser.hpp"  // UriParser
 #include "socketoptions.hpp"


### PR DESCRIPTION
Last merge (PR #2868) introduced a bug which makes ffmpeg impossible to build with SRT because of an incorrect include of srt_compat.h in srt.h 