### PR TITLE
[core][maint] Formal errors fixed

### DIFF
--- a/apps/verbose.hpp
+++ b/apps/verbose.hpp
@@ -80,7 +80,7 @@ inline void Print(Log& ) {}
 template <typename Arg1, typename... Args>
 inline void Print(Log& out, Arg1&& arg1, Args&&... args)
 {
-    out << arg1;
+    out << std::forward(arg1);
     Print(out, args...);
 }
 

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -204,16 +204,16 @@ public:
     template <class... Args>
     void PrintLogLine(const char* file, int line, const std::string& area, Args&&... args);
 
-    template<class Arg1, class... Args>
-    void operator()(Arg1&& arg1, Args&&... args)
+    template<class... Args>
+    void operator()(Args&&... args)
     {
-        PrintLogLine("UNKNOWN.c++", 0, "UNKNOWN", arg1, args...);
+        PrintLogLine("UNKNOWN.c++", 0, "UNKNOWN", args...);
     }
 
-    template<class Arg1, class... Args>
-    void printloc(const char* file, int line, const std::string& area, Arg1&& arg1, Args&&... args)
+    template<class... Args>
+    void printloc(const char* file, int line, const std::string& area, Args&&... args)
     {
-        PrintLogLine(file, line, area, arg1, args...);
+        PrintLogLine(file, line, area, args...);
     }
 #else
     template <class Arg>
@@ -441,7 +441,7 @@ inline void PrintArgs(std::ostream&) {}
 template <class Arg1, class... Args>
 inline void PrintArgs(std::ostream& serr, Arg1&& arg1, Args&&... args)
 {
-    serr << arg1;
+    serr << std::forward<Arg1>(arg1);
     PrintArgs(serr, args...);
 }
 

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -35,6 +35,7 @@ written by
 #include <memory>
 #include <iomanip>
 #include <sstream>
+#include <utility>
 
 #if HAVE_CXX11
 #include <type_traits>
@@ -575,7 +576,7 @@ inline Stream& Print(Stream& in) { return in;}
 template <class Stream, class Arg1, class... Args>
 inline Stream& Print(Stream& sout, Arg1&& arg1, Args&&... args)
 {
-    sout << arg1;
+    sout << std::forward<Arg1>(arg1);
     return Print(sout, args...);
 }
 

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -42,15 +42,16 @@
 
 srt_logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-mpbond");
 
+using namespace srt;
+using namespace std;
+
+
 volatile bool mpbond_int_state = false;
 void OnINT_SetIntState(int)
 {
     cerr << "\n-------- REQUESTED INTERRUPT!\n";
     mpbond_int_state = true;
 }
-
-using namespace srt;
-
 
 int main( int argc, char** argv )
 {

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -45,6 +45,7 @@ written by
 #include "threadname.h"
 
 
+using namespace std;
 
 
 bool Upload(UriParser& srt, UriParser& file);

--- a/testing/testactivemedia.cpp
+++ b/testing/testactivemedia.cpp
@@ -1,6 +1,9 @@
 
 #include "testactivemedia.hpp"
 
+using namespace std;
+
+
 void SourceMedium::Runner()
 {
     srt::ThreadName::set("SourceRN");

--- a/testing/testactivemedia.hpp
+++ b/testing/testactivemedia.hpp
@@ -59,7 +59,7 @@ struct Medium
         std::ostringstream tns;
         tns << typeid(*this).name() << ":" << this;
         srt::ThreadName tn(tns.str());
-        thr = thread( [this] { RunnerBase(); } );
+        thr = std::thread( [this] { RunnerBase(); } );
     }
 
     void quit()
@@ -89,12 +89,12 @@ struct Medium
                 if (Verbose::on)
                     Verb() << VerbLock << "Medium " << this << " exited with Transmission Error:\n\t" << e.what();
                 else
-                    cerr << "Transmission Error: " << e.what() << endl;
+                    std::cerr << "Transmission Error: " << e.what() << std::endl;
             } catch (...) {
                 if (Verbose::on)
                     Verb() << VerbLock << "Medium " << this << " exited with UNKNOWN EXCEPTION:";
                 else
-                    cerr << "UNKNOWN EXCEPTION on medium\n";
+                    std::cerr << "UNKNOWN EXCEPTION on medium\n";
             }
         }
 
@@ -150,7 +150,7 @@ struct TargetMedium: Medium<Target>
     bool Schedule(const MediaPacket& data)
     {
         LOGP(applog.Debug, "TargetMedium::Schedule LOCK ... ");
-        lock_guard<std::mutex> lg(buffer_lock);
+        std::lock_guard<std::mutex> lg(buffer_lock);
         LOGP(applog.Debug, "TargetMedium::Schedule LOCKED - checking: running=", running, " interrupt=", ::transmit_int_state);
         if (!running || ::transmit_int_state)
         {
@@ -166,13 +166,13 @@ struct TargetMedium: Medium<Target>
 
     void Clear()
     {
-        lock_guard<std::mutex> lg(buffer_lock);
+        std::lock_guard<std::mutex> lg(buffer_lock);
         buffer.clear();
     }
 
     void Interrupt()
     {
-        lock_guard<std::mutex> lg(buffer_lock);
+        std::lock_guard<std::mutex> lg(buffer_lock);
         running = false;
         ready.notify_one();
     }

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -29,8 +29,6 @@ extern std::atomic<bool> transmit_int_state;
 
 extern std::shared_ptr<SrtStatsWriter> transmit_stats_writer;
 
-using namespace std;
-
 const srt_logging::LogFA SRT_LOGFA_APP = 10;
 extern srt_logging::Logger applog;
 
@@ -57,7 +55,7 @@ protected:
 
     struct ConnectionBase
     {
-        string host;
+        std::string host;
         int port;
         int weight = 0;
         SRTSOCKET socket = SRT_INVALID_SOCK;
@@ -65,7 +63,7 @@ protected:
         srt::sockaddr_any target;
         int token = -1;
 
-        ConnectionBase(string h, int p): host(h), port(p), source(AF_INET) {}
+        ConnectionBase(std::string h, int p): host(h), port(p), source(AF_INET) {}
     };
 
     struct Connection: ConnectionBase
@@ -76,7 +74,7 @@ protected:
         int error = SRT_SUCCESS;
         int reason = SRT_REJ_UNKNOWN;
 
-        Connection(string h, int p): ConnectionBase(h, p) {}
+        Connection(std::string h, int p): ConnectionBase(h, p) {}
         Connection(Connection&& old): ConnectionBase(old)
         {
 #if ENABLE_BONDING
@@ -101,14 +99,14 @@ protected:
     int m_timeout = 0; //< enforces using SRTO_SNDTIMEO or SRTO_RCVTIMEO, depending on @a m_direction
     bool m_tsbpdmode = true;
     int m_outgoing_port = 0;
-    string m_mode;
-    string m_adapter;
-    map<string, string> m_options; // All other options, as provided in the URI
-    vector<Connection> m_group_nodes;
-    string m_group_type;
-    string m_group_config;
+    std::string m_mode;
+    std::string m_adapter;
+    std::map<std::string, std::string> m_options; // All other options, as provided in the URI
+    std::vector<Connection> m_group_nodes;
+    std::string m_group_type;
+    std::string m_group_config;
 #if ENABLE_BONDING
-    vector<SRT_SOCKGROUPDATA> m_group_data;
+    std::vector<SRT_SOCKGROUPDATA> m_group_data;
 #ifdef SRT_OLD_APP_READER
     int32_t m_group_seqno = -1;
 
@@ -117,7 +115,7 @@ protected:
         int32_t sequence;
         bytevector packet;
     };
-    map<SRTSOCKET, ReadPos> m_group_positions;
+    std::map<SRTSOCKET, ReadPos> m_group_positions;
     SRTSOCKET m_group_active; // The link from which the last packet was delivered
 #endif
 #endif
@@ -131,8 +129,8 @@ protected:
     void UpdateGroupStatus(const SRT_SOCKGROUPDATA* grpdata, size_t grpdata_size);
 
 public:
-    void InitParameters(string host, string path, map<string,string> par);
-    void PrepareListener(string host, int port, int backlog);
+    void InitParameters(std::string host, std::string path, std::map<std::string,std::string> par);
+    void PrepareListener(std::string host, int port, int backlog);
     void StealFrom(SrtCommon& src);
     void AcceptNewClient();
 
@@ -150,22 +148,22 @@ public:
 
 protected:
 
-    void Error(string src, int reason = SRT_REJ_UNKNOWN, int force_result = 0);
-    void Init(string host, int port, string path, map<string,string> par, SRT_EPOLL_OPT dir);
+    void Error(std::string src, int reason = SRT_REJ_UNKNOWN, int force_result = 0);
+    void Init(std::string host, int port, std::string path, std::map<std::string,std::string> par, SRT_EPOLL_OPT dir);
     int AddPoller(SRTSOCKET socket, int modes);
     virtual int ConfigurePost(SRTSOCKET sock);
     virtual int ConfigurePre(SRTSOCKET sock);
 
-    void OpenClient(string host, int port);
+    void OpenClient(std::string host, int port);
 #if ENABLE_BONDING
     void OpenGroupClient();
 #endif
     void PrepareClient();
     void SetupAdapter(const std::string& host, int port);
-    void ConnectClient(string host, int port);
-    void SetupRendezvous(string adapter, string host, int port);
+    void ConnectClient(std::string host, int port);
+    void SetupRendezvous(std::string adapter, std::string host, int port);
 
-    void OpenServer(string host, int port, int backlog = 1)
+    void OpenServer(std::string host, int port, int backlog = 1)
     {
         PrepareListener(host, port, backlog);
         if (transmit_accept_hook_fn)
@@ -175,7 +173,7 @@ protected:
         AcceptNewClient();
     }
 
-    void OpenRendezvous(string adapter, string host, int port)
+    void OpenRendezvous(std::string adapter, std::string host, int port)
     {
         PrepareClient();
         SetupRendezvous(adapter, host, port);
@@ -284,11 +282,11 @@ class SrtModel: public SrtCommon
 public:
     bool is_caller = false;
     bool is_rend = false;
-    string m_host;
+    std::string m_host;
     int m_port = 0;
 
 
-    SrtModel(string host, int port, map<string,string> par);
+    SrtModel(std::string host, int port, std::map<std::string,std::string> par);
     void Establish(std::string& w_name);
 
     void Close()
@@ -320,7 +318,7 @@ class UdpSource: public virtual Source, public virtual UdpCommon
     bool eof = true;
 public:
 
-    UdpSource(string host, int port, const map<string,string>& attr);
+    UdpSource(std::string host, int port, const std::map<std::string,std::string>& attr);
 
     MediaPacket Read(size_t chunk) override;
 
@@ -331,7 +329,7 @@ public:
 class UdpTarget: public virtual Target, public virtual UdpCommon
 {
 public:
-    UdpTarget(string host, int port, const map<string,string>& attr);
+    UdpTarget(std::string host, int port, const std::map<std::string,std::string>& attr);
 
     void Write(const MediaPacket& data) override;
     bool IsOpen() override { return m_sock != -1; }
@@ -341,7 +339,7 @@ public:
 class UdpRelay: public Relay, public UdpSource, public UdpTarget
 {
 public:
-    UdpRelay(string host, int port, const map<string,string>& attr):
+    UdpRelay(std::string host, int port, const std::map<std::string,std::string>& attr):
         UdpSource(host, port, attr),
         UdpTarget(host, port, attr)
     {


### PR DESCRIPTION
Fixed:

1. Wrong use of `using namespace std` in a header file
2. Added lacking `std::forward` in variadic print functions.