### PR TITLE
[core] A minor change (use reference to const).

### DIFF
--- a/.github/workflows/cxx11-ubuntu.yaml
+++ b/.github/workflows/cxx11-ubuntu.yaml
@@ -30,6 +30,7 @@ jobs:
         source ./scripts/collect-gcov.sh
         bash <(curl -s https://codecov.io/bash)
     - name: Run SonarCloud Scan for C and C++
+      if: ${{ !github.event.pull_request.head.repo.fork }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2926,7 +2926,7 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& reqaddr, cons
         bool reuse_attempt = false;
         for (map<int, CMultiplexer>::iterator i = m_mMultiplexer.begin(); i != m_mMultiplexer.end(); ++i)
         {
-            CMultiplexer& m = i->second;
+            CMultiplexer const& m = i->second;
 
             // First, we need to find a multiplexer with the same port.
             if (m.m_iPort != port)


### PR DESCRIPTION
Also disabled sonarscanner of PRs from forks.
There seems to be some workaround for scanning PRs from a fork discussed here:
https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/34