### PR TITLE
[build] Switch default enclib from openssl to openssl-evp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,12 +237,12 @@ if (NOT USE_ENCLIB)
 		message("NOTE: USE_GNUTLS is deprecated. Use -DUSE_ENCLIB=gnutls instead.")
 		set (USE_ENCLIB gnutls)
 	else()
-		set (USE_ENCLIB openssl)
+		set (USE_ENCLIB openssl-evp)
 	endif()
 endif()
 
 set(USE_ENCLIB "${USE_ENCLIB}" CACHE STRING "The crypto library that SRT uses")
-set_property(CACHE USE_ENCLIB PROPERTY STRINGS "openssl" "gnutls" "mbedtls" "botan")
+set_property(CACHE USE_ENCLIB PROPERTY STRINGS "openssl" "openssl-evp" "gnutls" "mbedtls" "botan")
 
 # Make sure DLLs and executabes go to the same path regardles of subdirectory
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/docs/build/build-options.md
+++ b/docs/build/build-options.md
@@ -597,8 +597,8 @@ remember that:
 
 Encryption library to be used. Possible options for `<name>`:
 
-* openssl (default)
-* openssl-evp (OpenSSL EVP API, since 1.5.1)
+* openssl-evp (default)
+* openssl 
 * gnutls (with nettle)
 * mbedtls
 * botan


### PR DESCRIPTION
If -DUSE_ENCLIB is not specified, openssl-evp will now be the default encryption used 