### PR TITLE
[core] Drop noenc packets if RcvKmState is "secured".

### DIFF
--- a/docs/API/API-socket-options.md
+++ b/docs/API/API-socket-options.md
@@ -58,7 +58,7 @@ Exchange for the initial key is done in the handshake.
 
 - `SRT_KM_S_SECURED` (`2`): KM exchange was successful and the data will be sent
 encrypted and will be decrypted by the receiver. This state is only possible on
-both sides in both directions simultaneously.
+both sides in both directions simultaneously. Any unencrypted packet will be dropped by the receiver.
 
 - `SRT_KM_S_NOSECRET` (`3`): If this state is in the sending direction (`SRTO_SNDKMSTATE`),
 then it means that the sending party has set a passphrase, but the peer did not.

--- a/docs/API/statistics.md
+++ b/docs/API/statistics.md
@@ -245,6 +245,8 @@ Packets may be dropped conditionally when both `SRTO_TSBPDMODE` and `SRTO_TLPKTD
 #### pktRcvUndecryptTotal
 
 The total number of packets that failed to be decrypted at the receiver side. Available for receiver.
+The statistic also counts unencrypted packets that were expected to be uncrypted on a secured connection (see [SRTO_KM_S_SECURED](API-socket-options.md#srt_km_state))
+and hence dropped as not encrypted (undecrypted).
 
 #### pktSndFilterExtraTotal
 

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -10190,7 +10190,7 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
 #endif
                 }
             }
-            else if (m_pCryptoControl && m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM)
+            else if (m_pCryptoControl && m_pCryptoControl->m_RcvKmState == SRT_KM_S_SECURED)
             {
                 // Unencrypted packets are not allowed.
                 const int iDropCnt = m_pRcvBuffer->dropMessage(u->m_Packet.getSeqNo(), u->m_Packet.getSeqNo(), SRT_MSGNO_NONE, CRcvBuffer::DROP_EXISTING);


### PR DESCRIPTION
Previously unencrypted packets were being dropped in case AES-GCM mode was used.
With this change, they are being dropped if the KM connection state is "Secured".
It respects the SRTO_ENFORCED_ENCRYPTION option that allows connections without encryption, in which case the RCV KM state would be "Unsecured".