### PR TITLE
[core] Use common functions for byte order conversion.

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -748,7 +748,7 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
 #endif
 
     // convert control information into network order
-    packet.toNL();
+    packet.toNetworkByteOrder();
 
 #ifndef _WIN32
     msghdr mh;
@@ -818,7 +818,7 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
     res = (0 == res) ? size : -1;
 #endif
 
-    packet.toHL();
+    packet.toHostByteOrder();
 
     return res;
 }
@@ -1067,25 +1067,7 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
     }
 
     w_packet.setLength(recv_size - CPacket::HDR_SIZE);
-
-    // convert back into local host order
-    // XXX use NtoHLA().
-    // for (int i = 0; i < 4; ++ i)
-    //   w_packet.m_nHeader[i] = ntohl(w_packet.m_nHeader[i]);
-    {
-        uint32_t* p = w_packet.m_nHeader;
-        for (size_t i = 0; i < SRT_PH_E_SIZE; ++i)
-        {
-            *p = ntohl(*p);
-            ++p;
-        }
-    }
-
-    if (w_packet.isControl())
-    {
-        for (size_t j = 0, n = w_packet.getLength() / sizeof(uint32_t); j < n; ++j)
-            *((uint32_t*)w_packet.m_pcData + j) = ntohl(*((uint32_t*)w_packet.m_pcData + j));
-    }
+    w_packet.toHostByteOrder();
 
     return RST_OK;
 

--- a/srtcore/packet.cpp
+++ b/srtcore/packet.cpp
@@ -432,38 +432,29 @@ void CPacket::pack(UDTMessageType pkttype, const int32_t* lparam, void* rparam, 
     }
 }
 
-void CPacket::toNL()
+void CPacket::toNetworkByteOrder()
 {
-    // XXX USE HtoNLA!
+    // The payload of data packet should remain in network byte order.
     if (isControl())
     {
-        for (ptrdiff_t i = 0, n = getLength() / 4; i < n; ++i)
-            *((uint32_t*)m_pcData + i) = htonl(*((uint32_t*)m_pcData + i));
+        HtoNLA((uint32_t*) m_pcData, (const uint32_t*) m_pcData, getLength() / 4);
     }
 
-    // convert packet header into network order
+    // Convert packet header independent of packet type.
     uint32_t* p = m_nHeader;
-    for (int j = 0; j < 4; ++j)
-    {
-        *p = htonl(*p);
-        ++p;
-    }
+    HtoNLA(p, p, 4);
 }
 
-void CPacket::toHL()
+void CPacket::toHostByteOrder()
 {
-    // convert back into local host order
+    // Convert packet header independent of packet type.
     uint32_t* p = m_nHeader;
-    for (int k = 0; k < 4; ++k)
-    {
-        *p = ntohl(*p);
-        ++p;
-    }
+    NtoHLA(p, p, 4);
 
+	// The payload of data packet should remain in network byte order.
     if (isControl())
     {
-        for (ptrdiff_t l = 0, n = getLength() / 4; l < n; ++l)
-            *((uint32_t*)m_pcData + l) = ntohl(*((uint32_t*)m_pcData + l));
+        NtoHLA((uint32_t*)m_pcData, (const uint32_t*)m_pcData, getLength() / 4);
     }
 }
 

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -331,8 +331,10 @@ public:
     };
 
 public:
-    void toNL();
-    void toHL();
+    /// @brief Convert the packet inline to a network byte order (Little-endian).
+    void toNetworkByteOrder();
+	/// @brief Convert the packet inline to a host byte order.
+    void toHostByteOrder();
 
 protected:
     // DynamicStruct is the same as array of given type and size, just it

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -237,17 +237,20 @@ written by
 
 #endif
 
-// Hardware <--> Network (big endian) convention
+/// Hardware --> Network (big-endian) byte order conversion
+/// @param size source length in four octets
 inline void HtoNLA(uint32_t* dst, const uint32_t* src, size_t size)
 {
     for (size_t i = 0; i < size; ++ i)
-        dst[i] = htonl(src[i]);
+        dst[i] = htobe32(src[i]);
 }
 
+/// Network (big-endian) --> Hardware byte order conversion
+/// @param size source length in four octets
 inline void NtoHLA(uint32_t* dst, const uint32_t* src, size_t size)
 {
     for (size_t i = 0; i < size; ++ i)
-        dst[i] = ntohl(src[i]);
+        dst[i] = be32toh(src[i]);
 }
 
 // Hardware <--> Intel (little endian) convention


### PR DESCRIPTION
Use `CPacket::toNetworkByteOrder()` and `CPacket::toHostByteOrder()` for byte order conversion instead of byte-level `htonl` and `ntohl` functions.

The length of the control packet is always a multiple of 4.

Tested receiving and sending without encryption using `srt-xtransmit`.