### PR TITLE
[core] Minor connection logging improvement.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -657,8 +657,8 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
                     << " to that socket (" << ns->m_SocketID << ")");
             m_PeerRec[ns->getPeerSpec()].insert(ns->m_SocketID);
 
-            LOGC(cnlog.Note, log << "New connection @" << ns->m_SocketID << " on listener @" << listen
-                << " (" << ns->m_SelfAddr.str() << ") from @" << ns->m_PeerID << " (" << peer.str() << ")");
+            LOGC(cnlog.Note, log << "@" << ns->m_SocketID << " connection on listener @" << listen
+                << " (" << ns->m_SelfAddr.str() << ") from peer @" << ns->m_PeerID << " (" << peer.str() << ")");
         }
         catch (...)
         {

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -656,6 +656,9 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
             HLOGC(cnlog.Debug, log << "newConnection: mapping peer " << ns->m_PeerID
                     << " to that socket (" << ns->m_SocketID << ")");
             m_PeerRec[ns->getPeerSpec()].insert(ns->m_SocketID);
+
+            LOGC(cnlog.Note, log << "New connection @" << ns->m_SocketID << " on listener @" << listen
+                << " (" << ns->m_SelfAddr.str() << ") from @" << ns->m_PeerID << " (" << peer.str() << ")");
         }
         catch (...)
         {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4968,8 +4968,9 @@ EConnectStatus srt::CUDT::postConnect(const CPacket* pResponse, bool rendezvous,
     }
 
     */
-
-    LOGC(cnlog.Note, log << CONID() << "Connection established to: " << m_PeerAddr.str());
+    
+    LOGC(cnlog.Note, log << CONID() << "Connection established from ("
+        << m_SourceAddr.str() << ") to peer @" << m_PeerID << " (" << m_PeerAddr.str() << ")");
 
     return CONN_ACCEPT;
 }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2101,9 +2101,9 @@ int srt::CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint
         return SRT_CMD_NONE;
     }
 
-    LOGC(cnlog.Note, log << "HSREQ/rcv: cmd=" << SRT_CMD_HSREQ << "(HSREQ) len=" << bytelen
-                         << hex << " vers=0x" << srtdata[SRT_HS_VERSION] << " opts=0x" << srtdata[SRT_HS_FLAGS]
-                         << dec << " delay=" << SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]));
+    LOGC(cnlog.Debug, log << "HSREQ/rcv: cmd=" << SRT_CMD_HSREQ << "(HSREQ) len=" << bytelen
+                          << hex << " vers=0x" << srtdata[SRT_HS_VERSION] << " opts=0x" << srtdata[SRT_HS_FLAGS]
+                          << dec << " delay=" << SRT_HS_LATENCY_RCV::unwrap(srtdata[SRT_HS_LATENCY]));
 
     m_uPeerSrtVersion = srtdata[SRT_HS_VERSION];
     m_uPeerSrtFlags   = srtdata[SRT_HS_FLAGS];
@@ -11289,6 +11289,8 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
             // See PR #1831 and issue #1667.
             HLOGC(cnlog.Debug,
                   log << CONID() << "processConnectRequest: accepted connection, updating epoll to write-ready");
+
+            LOGC(cnlog.Note, log << CONID() << "Listener accepted connection @" << hs.m_iReqType << " - " << RequestTypeStr(hs.m_iReqType));
 
             // New connection has been accepted or an existing one has been found. Update epoll write-readiness.
             // a new connection has been created, enable epoll for write

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11291,8 +11291,6 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
             HLOGC(cnlog.Debug,
                   log << CONID() << "processConnectRequest: accepted connection, updating epoll to write-ready");
 
-            LOGC(cnlog.Note, log << CONID() << "Listener accepted connection @" << hs.m_iReqType << " - " << RequestTypeStr(hs.m_iReqType));
-
             // New connection has been accepted or an existing one has been found. Update epoll write-readiness.
             // a new connection has been created, enable epoll for write
             // Note: not using SRT_EPOLL_CONNECT symbol because this is a procedure
@@ -11331,7 +11329,7 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
             }
         }
     }
-    LOGC(cnlog.Note, log << CONID() << "listen ret: " << hs.m_iReqType << " - " << RequestTypeStr(hs.m_iReqType));
+    LOGC(cnlog.Debug, log << CONID() << "listen ret: " << hs.m_iReqType << " - " << RequestTypeStr(hs.m_iReqType));
 
     return RejectReasonForURQ(hs.m_iReqType);
 }

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1407,7 +1407,7 @@ srt::EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit,
         ScopedLock cg(m_LSLock);
         if (m_pListener)
         {
-            LOGC(cnlog.Note, log << "PASSING request from: " << addr.str() << " to agent:" << m_pListener->socketID());
+            LOGC(cnlog.Debug, log << "PASSING request from: " << addr.str() << " to listener:" << m_pListener->socketID());
             listener_ret = m_pListener->processConnectRequest(addr, unit->m_Packet);
 
             // This function does return a code, but it's hard to say as to whether
@@ -1426,8 +1426,8 @@ srt::EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit,
 
     if (have_listener) // That is, the above block with m_pListener->processConnectRequest was executed
     {
-        LOGC(cnlog.Note,
-             log << CONID() << "Listener managed the connection request from: " << addr.str()
+        LOGC(cnlog.Debug,
+             log << CONID() << "Listener got the connection request from: " << addr.str()
                  << " result:" << RequestTypeStr(UDTRequestType(listener_ret)));
         return listener_ret == SRT_REJ_UNKNOWN ? CONN_CONTINUE : CONN_REJECT;
     }


### PR DESCRIPTION
It is not clear from SRT logs which SRT socket ID is associated with which local and remote IP. It is even more viable in group connections. Therefore a 'note'-level log message has been added one a connection is accepted by the listener.
Some logs were downgraded from 'note' to 'debug'.

### Before

```shell
srt-xtransmit receive "srt://:4200?groupconnect=1" --enable-metrics -v --loglevel note
12:34:57.347682 [I] Log level set to note
12:34:57.359667 [I] SOCKET::SRT srt://:4200: bound to ':4200'.
12:34:58.939000/T18380.N:SRT.cn: PASSING request from: 127.0.0.1:5200 to agent:121901312
12:34:58.939000/T18380.N:SRT.cn: Listener managed the connection request from: 127.0.0.1:5200 result:waveahand
12:34:58.940000/T18380.N:SRT.cn: PASSING request from: 127.0.0.1:55596 to agent:121901312
12:34:58.940000/T18380.N:SRT.cn: Listener managed the connection request from: 127.0.0.1:55596 result:waveahand
12:34:58.940000/T18380.N:SRT.cn: PASSING request from: 127.0.0.1:5200 to agent:121901312
12:34:58.940000/T18380.N:SRT.cn: HSREQ/rcv: cmd=1(HSREQ) len=12 vers=0x10503 opts=0xbf delay=120
12:34:58.941000/T18380.N:SRT.gm: group/add: adding member @121901311 into group $1195643134
12:34:58.941000/T18380.N:SRT.cn: @121901312: listen ret: -1 - conclusion
12:34:58.942000/T18380.N:SRT.cn: Listener managed the connection request from: 127.0.0.1:5200 result:waveahand
12:34:58.942435/T18380.N:SRT.cn: PASSING request from: 127.0.0.1:55596 to agent:121901312
12:34:58.942000/T18380.N:SRT.cn: HSREQ/rcv: cmd=1(HSREQ) len=12 vers=0x10503 opts=0xbf delay=120
12:34:58.942769/T18380.N:SRT.gm: group/add: adding member @121901309 into group $1195643134
12:34:58.943183 [I] SOCKET::SRT @121901312 (srt://:4200) Accepted connection @1195643134. TSBPD Latency RCV 120ms, peer 0ms. KM state INVALID (RCV UNSECURED, SND UNSECURED). PB key length: -1. Cryptomode INVALID. Stream ID: not set.
12:34:58.943000/T18380.N:SRT.cn: @121901312: listen ret: -1 - conclusion
12:34:58.943000/T18380.N:SRT.cn: Listener managed the connection request from: 127.0.0.1:55596 result:waveahand
```

### After

Listener

```shell
srt-xtransmit receive "srt://:4200?groupconnect=1" --enable-metrics -v --loglevel note
11:32:34.221383 [I] Log level set to note
11:32:34.236246 [I] SOCKET::SRT srt://:4200: bound to ':4200'.
11:32:45.411000/T30680.N:SRT.gm: group/add: adding member @748136174 into group $1821877997
11:32:45.413000/T30680.N:SRT.cn: @748136174 connection on listener @748136175 (127.0.0.1:4200) from peer @559345310 (127.0.0.1:5200)
11:32:45.414000/T30680.N:SRT.gm: group/add: adding member @748136172 into group $1821877997
11:32:45.416000/T30680.N:SRT.cn: @748136172 connection on listener @748136175 (127.0.0.1:4200) from peer @559345309 (127.0.0.1:58766)
11:32:45.417000 [I] SOCKET::SRT @748136175 (srt://:4200) Accepted connection @1821877997. TSBPD Latency RCV 120ms, peer 0ms. KM state INVALID (RCV UNSECURED, SND UNSECURED). PB key length: -1. Cryptomode INVALID. Stream ID: not set.
11:32:45.418948 [I] RECEIVE Latency, us: avg n/a, min n/a, max n/a. Jitter: 0us. Delay Factor: 1us. Pkts: rcvd 0, reordered 0 (dist 0), lost 0, MD5 err 0, bad len 0.
...
11:32:49.459000/T10276.N:SRT.gm: group/remove: removing member @748136172 from group $1821877997
11:32:49.460000/T10276.N:SRT.gm: group/remove: removing member @748136174 from group $1821877997
11:32:49.460000/T41776*E:SRT.gr: grp/recv: $1821877997: ABANDONING: opened=false connected=false
11:32:49.461063 [W] RECEIVE read::recv: Connection does not exist
```

Caller

```shell
srt-xtransmit generate "srt://127.0.0.1:4200?bind=:5200"
 "srt://127.0.0.1:4200" --enable-metrics -v --sendrate 10Mbps --duration 3s --loglevel note
11:32:45.394061 [I] Log level set to note
11:32:45.407000/T34896.N:SRT.gm: group/add: adding member @559345310 into group $1633087135
11:32:45.408000/T34896.N:SRT.gm: group/add: adding member @559345309 into group $1633087135
11:32:45.414000/T40032.N:SRT.cn: @559345310: Connection established from (unknown:0) to peer @748136174 (127.0.0.1:4200)
11:32:45.417000/T14588.N:SRT.cn: @559345309: Connection established from (unknown:0) to peer @748136172 (127.0.0.1:4200)
11:32:45.418150 [I] PACER sendrate 10000000 bps (inter send interval 1052 us)
11:32:46.420488 [I] GENERATE Sending at 9855 kbps
11:32:47.433989 [I] GENERATE Sending at 9997 kbps
```

### To Consider

- [x] Maybe `@121901312: listen ret: -1 - conclusion` should also be Debug-level log message.