### PR TITLE
[core] Set ACK position based on RCV buffer first nonread seqno.

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -752,6 +752,12 @@ CRcvBuffer::PacketInfo CRcvBuffer::getFirstReadablePacketInfo(time_point time_no
         return unreadableInfo;
 }
 
+int32_t CRcvBuffer::getFirstNonreadSeqNo() const
+{
+    const int offset = offPos(m_iStartPos, m_iFirstNonreadPos);
+    return CSeqNo::incseq(m_iStartSeqNo, offset);
+}
+
 void CRcvBuffer::countBytes(int pkts, int bytes)
 {
     ScopedLock lock(m_BytesCountLock);

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -187,6 +187,11 @@ public:
 
     PacketInfo getFirstReadablePacketInfo(time_point time_now) const;
 
+    /// @brief Get the sequence number of the first packet that can't be read
+	/// (either because it is missing, or because it is a part of a bigger message
+	/// that is not fully available yet).
+    int32_t getFirstNonreadSeqNo() const;
+
     /// Get information on packets available to be read.
     /// @returns a pair of sequence numbers (first available; first unavailable).
     /// 


### PR DESCRIPTION
This is an experimental proposal for issue #2881.

The `CRcvBuffer::getFirstNonreadSeqNo()` returns the sequence number of the first packet that cannot be read from the buffer. This includes the first missing packet and the first packet of a several packets long message, if not all packets of the message exist yet. Due to the latter case, the proposed solution is not accurate in a message mode of SRT when TSBPD is disabled. When TSBPD is enabled, a message must always be one packet long.

There is a broader rework of the RCV buffer in PR #2527. However it may not end up in v1.5.4 due to some testing already performed with the existing RCV buffer implementation. Therefore this PR may be considered a temporal fix of #2881 until #2527 is merged.