### PR TITLE
[core] Fixed stats counting packets dropped by a group.

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -259,6 +259,7 @@ CUDTGroup::CUDTGroup(SRT_GROUP_TYPE gtype)
     , m_uOPT_MinStabilityTimeout_us(1000 * CSrtConfig::COMM_DEF_MIN_STABILITY_TIMEOUT_MS)
     // -1 = "undefined"; will become defined with first added socket
     , m_iMaxPayloadSize(-1)
+    , m_iAvgPayloadSize(-1)
     , m_bSynRecving(true)
     , m_bSynSending(true)
     , m_bTsbPd(true)

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2310,13 +2310,17 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
         }
         fillGroupData((w_mc), w_mc);
 
-        const int32_t iNumDropped = (CSeqNo(w_mc.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;
-        if (iNumDropped > 0)
+        // TODO: What if a drop happens before the very first packet was read? Maybe set to ISN?
+        if (m_RcvBaseSeqNo != SRT_SEQNO_NONE)
         {
-            m_stats.recvDrop.count(stats::BytesPackets(iNumDropped * static_cast<uint64_t>(avgRcvPacketSize()), iNumDropped));
-            LOGC(grlog.Warn,
-                log << "@" << m_GroupID << " GROUP RCV-DROPPED " << iNumDropped << " packet(s): seqno %"
-                << m_RcvBaseSeqNo << " to %" << w_mc.pktseq);
+            const int32_t iNumDropped = (CSeqNo(w_mc.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;
+            if (iNumDropped > 0)
+            {
+                m_stats.recvDrop.count(stats::BytesPackets(iNumDropped * static_cast<uint64_t>(avgRcvPacketSize()), iNumDropped));
+                LOGC(grlog.Warn,
+                    log << "@" << m_GroupID << " GROUP RCV-DROPPED " << iNumDropped << " packet(s): seqno %"
+                    << m_RcvBaseSeqNo << " to %" << w_mc.pktseq);
+            }
         }
 
         HLOGC(grlog.Debug,

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2309,6 +2309,15 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
         }
         fillGroupData((w_mc), w_mc);
 
+        const int32_t iNumDropped = (CSeqNo(w_mc.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;
+        if (iNumDropped > 0)
+        {
+            m_stats.recvDrop.count(stats::BytesPackets(iNumDropped * static_cast<uint64_t>(avgRcvPacketSize()), iNumDropped));
+            LOGC(grlog.Warn,
+                log << "@" << m_GroupID << " GROUP RCV-DROPPED " << iNumDropped << " packet(s): seqno %"
+                << m_RcvBaseSeqNo << " to %" << w_mc.pktseq);
+        }
+
         HLOGC(grlog.Debug,
               log << "grp/recv: $" << id() << ": Update m_RcvBaseSeqNo: %" << m_RcvBaseSeqNo << " -> %" << w_mc.pktseq);
         m_RcvBaseSeqNo = w_mc.pktseq;


### PR DESCRIPTION
Count the number of packets dropped by a group based on the offset of the base RCV seqno towards seqno of a packet being read.

Fixes #2933.