### PR TITLE
[core] Fixed group RCV drop sequence range log.

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2319,7 +2319,7 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
                 m_stats.recvDrop.count(stats::BytesPackets(iNumDropped * static_cast<uint64_t>(avgRcvPacketSize()), iNumDropped));
                 LOGC(grlog.Warn,
                     log << "@" << m_GroupID << " GROUP RCV-DROPPED " << iNumDropped << " packet(s): seqno %"
-                    << m_RcvBaseSeqNo << " to %" << w_mc.pktseq);
+                        << CSeqNo::incseq(m_RcvBaseSeqNo) << " to %" << CSeqNo::decseq(w_mc.pktseq));
             }
         }
 


### PR DESCRIPTION
A follow-up for #2934.

Only show sequence numbers of packets being dropped by a group.