### PR TITLE
[core] Group set the RCV base seqno using peer ISN.

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -870,18 +870,9 @@ void CUDTGroup::syncWithSocket(const CUDT& core, const HandshakeSide side)
         set_currentSchedSequence(core.ISN());
     }
 
-    // XXX
-    // Might need further investigation as to whether this isn't
-    // wrong for some cases. By having this -1 here the value will be
-    // laziliy set from the first reading one. It is believed that
-    // it covers all possible scenarios, that is:
-    //
-    // - no readers - no problem!
-    // - have some readers and a new is attached - this is set already
-    // - connect multiple links, but none has read yet - you'll be the first.
-    //
-    // Previous implementation used setting to: core.m_iPeerISN
-    resetInitialRxSequence();
+    // Only set if was not initialized to avoid problems on a running connection.
+    if (m_RcvBaseSeqNo == SRT_SEQNO_NONE) 
+        m_RcvBaseSeqNo = CSeqNo::decseq(core.m_iPeerISN);
 
     // Get the latency (possibly fixed against the opposite side)
     // from the first socket (core.m_iTsbPdDelay_ms),
@@ -2310,7 +2301,8 @@ int CUDTGroup::recv(char* buf, int len, SRT_MSGCTRL& w_mc)
         }
         fillGroupData((w_mc), w_mc);
 
-        // TODO: What if a drop happens before the very first packet was read? Maybe set to ISN?
+        // m_RcvBaseSeqNo is expected to be set to the PeerISN with the first connected member,
+        // so a packet drop at the start should also be detected by this condition.
         if (m_RcvBaseSeqNo != SRT_SEQNO_NONE)
         {
             const int32_t iNumDropped = (CSeqNo(w_mc.pktseq) - CSeqNo(m_RcvBaseSeqNo)) - 1;


### PR DESCRIPTION
Fixes #2936.