### PR TITLE
fix build issue when configure --enable-testing

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2574,7 +2574,7 @@ private:
             str_tnow.replace(str_tnow.find(':'), 1, 1, '_');
         }
         const std::string fname = "stability_trace_" + str_tnow + ".csv";
-        m_fout.open(fname, std::ofstream::out);
+        m_fout.open(fname.c_str(), std::ofstream::out);
         if (!m_fout)
             std::cerr << "IPE: Failed to open " << fname << "!!!\n";
 


### PR DESCRIPTION
make fails when ./confgure --enable-testing

`/home/build/srt_kageds/srtcore/group.cpp: In member function ‘void srt::StabilityTracer::create_file()’:
/home/build/srt_kageds/srtcore/group.cpp:2577:46: error: no matching function for call to ‘std::basic_ofstream<char>::open(const string&, const openmode&)’
         m_fout.open(fname, std::ofstream::out);
                                              ^
/home/build/srt_kageds/srtcore/group.cpp:2577:46: note: candidate is:
In file included from /home/build/srt_kageds/srtcore/udt.h:86:0,
                 from /home/build/srt_kageds/srtcore/api.h:60,
                 from /home/build/srt_kageds/srtcore/group.cpp:5:
/usr/include/c++/4.8.2/fstream:713:7: note: void std::basic_ofstream<_CharT, _Traits>::open(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::_Ios_Openmode]
       open(const char* __s,
       ^
/usr/include/c++/4.8.2/fstream:713:7: note:   no known conversion for argument 1 from ‘const string {aka const std::basic_string<char>}’ to ‘const char*’
make[2]: *** [CMakeFiles/srt_virtual.dir/srtcore/group.cpp.o] Error 1
make[1]: *** [CMakeFiles/srt_virtual.dir/all] Error 2
make: *** [all] Error 2
`