### PR TITLE
[build] Removed dependancy on pthread when using CXX11 on non linux systems

### DIFF
--- a/srtcore/threadname.h
+++ b/srtcore/threadname.h
@@ -31,8 +31,8 @@ written by
 //       Linux-MUSL(MUSL-1.1.20 Partial Implementation. See below).
 //       MINGW-W64(4.0.6)
 
-#if defined(HAVE_PTHREAD_GETNAME_NP_IN_PTHREAD_NP_H) \
-   || defined(HAVE_PTHREAD_SETNAME_NP_IN_PTHREAD_NP_H)
+#if (defined(HAVE_PTHREAD_GETNAME_NP_IN_PTHREAD_NP_H) \
+   || defined(HAVE_PTHREAD_SETNAME_NP_IN_PTHREAD_NP_H)) && defined(__linux__)
    #include <pthread_np.h>
    #if defined(HAVE_PTHREAD_GETNAME_NP_IN_PTHREAD_NP_H) \
       && !defined(HAVE_PTHREAD_GETNAME_NP)

--- a/srtcore/threadname.h
+++ b/srtcore/threadname.h
@@ -32,7 +32,7 @@ written by
 //       MINGW-W64(4.0.6)
 
 #if (defined(HAVE_PTHREAD_GETNAME_NP_IN_PTHREAD_NP_H) \
-   || defined(HAVE_PTHREAD_SETNAME_NP_IN_PTHREAD_NP_H)) && defined(__linux__)
+   || defined(HAVE_PTHREAD_SETNAME_NP_IN_PTHREAD_NP_H)) && (defined(__linux__) || (!defined(__linux__)&& !defined(ENABLE_STDCXX_SYNC)))
    #include <pthread_np.h>
    #if defined(HAVE_PTHREAD_GETNAME_NP_IN_PTHREAD_NP_H) \
       && !defined(HAVE_PTHREAD_GETNAME_NP)


### PR DESCRIPTION
Fixes #2951.