### PR TITLE
Improved AES GCM encryption, changed IV length to 12 bytes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
-set (SRT_VERSION 1.5.3)
+set (SRT_VERSION 1.5.4)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil) # needed for set_version_variables

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -456,7 +456,7 @@ static int crysprFallback_MsEncrypt(
 
 			if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
 			{
-				const bool old_aead = false; // SRT v1.5.2 to v1.5.3.
+				const bool old_aead = ctx->use_gcm_153; // SRT v1.5.2 to v1.5.3.
 				if (old_aead)
 				{
 					hcrypt_SetCtrIV((unsigned char*)&pki, ctx->salt, iv);
@@ -594,15 +594,15 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 				/* Get current key (odd|even) from context */
 				CRYSPR_AESCTX *aes_key = CRYSPR_GETSEK(cryspr_cb, hcryptCtx_GetKeyIndex(ctx));
 				unsigned char iv[CRYSPR_AESBLKSZ];
-				/* Additional authenticated data used by AES-GCM. */
-				unsigned char aad[HAICRYPT_AAD_MAX];
 
 				/* Get input packet index (in network order) */
 				hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
 
 				if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
 				{
-					const bool old_aead = false; // SRT v1.5.2 to v1.5.3.
+					/* Additional authenticated data used by AES-GCM. */
+					unsigned char aad[HAICRYPT_AAD_MAX];
+					const bool old_aead = ctx->use_gcm_153; // SRT v1.5.2 to v1.5.3.
 					if (old_aead)
 					{
 						hcrypt_SetCtrIV((unsigned char*)&pki, ctx->salt, iv);

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -17,6 +17,10 @@ written by
 		CRYSPR/4SRT Initial implementation.
 *****************************************************************************/
 
+#ifndef _WIN32
+#include <arpa/inet.h>  /* htonl */
+#endif
+
 #include "hcrypt.h"
 #include "cryspr.h"
 

--- a/haicrypt/cryspr.c
+++ b/haicrypt/cryspr.c
@@ -429,6 +429,8 @@ static int crysprFallback_MsEncrypt(
 
 	/* Auth tag produced by AES GCM. */
 	unsigned char tag[HAICRYPT_AUTHTAG_MAX];
+	/* Additional authenticated data used by AES-GCM. */
+	unsigned char aad[HAICRYPT_AAD_MAX];
 
 	/*
 	 * Get buffer room from the internal circular output buffer.
@@ -452,33 +454,30 @@ static int crysprFallback_MsEncrypt(
 			/* Get input packet index (in network order) */
 			hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
 
-			/*
-			 * Compute the Initial Vector
-			 * IV (128-bit):
-			 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
-			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-			 * |                   0s                  |      pki      |  ctr  |
-			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-			 *                            XOR
-			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-			 * |                         nonce                         +
-			 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-			 *
-			 * pki    (32-bit): packet index
-			 * ctr    (16-bit): block counter
-			 * nonce (112-bit): number used once (salt)
-			*/
-			hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
-
 			if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
 			{
-				const int iret = cryspr_cb->cryspr->aes_gcm_cipher(true, aes_key, iv, in_data[0].pfx, pfx_len, in_data[0].payload, in_data[0].len,
+				const bool old_aead = false; // SRT v1.5.2 to v1.5.3.
+				if (old_aead)
+				{
+					hcrypt_SetCtrIV((unsigned char*)&pki, ctx->salt, iv);
+					memcpy(aad, in_data[0].pfx, sizeof(aad));
+				}
+				else
+				{
+					hcrypt_SetGcmIV((unsigned char*)&pki, ctx->salt, iv);
+
+					for (size_t i = 0; i < sizeof(aad) / 4; ++i)
+						*((uint32_t*)aad + i) = htonl(*((uint32_t*)in_data[0].pfx + i));
+				}
+
+				const int iret = cryspr_cb->cryspr->aes_gcm_cipher(true, aes_key, iv, aad, sizeof(aad), in_data[0].payload, in_data[0].len,
 						&out_msg[pfx_len], tag);
 				if (iret) {
 					return(iret);
 				}
 			}
 			else {
+				hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
 #if CRYSPR_HAS_AESCTR
 				cryspr_cb->cryspr->aes_ctr_cipher(true, aes_key, iv, in_data[0].payload, in_data[0].len,
 						&out_msg[pfx_len]);
@@ -595,32 +594,30 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 				/* Get current key (odd|even) from context */
 				CRYSPR_AESCTX *aes_key = CRYSPR_GETSEK(cryspr_cb, hcryptCtx_GetKeyIndex(ctx));
 				unsigned char iv[CRYSPR_AESBLKSZ];
+				/* Additional authenticated data used by AES-GCM. */
+				unsigned char aad[HAICRYPT_AAD_MAX];
 
 				/* Get input packet index (in network order) */
 				hcrypt_Pki pki = hcryptMsg_GetPki(ctx->msg_info, in_data[0].pfx, 1);
 
-				/*
-				 * Compute the Initial Vector
-				 * IV (128-bit):
-				 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 * |                   0s                  |      pki      |  ctr  |
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 *                            XOR
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 * |                         nonce                         +
-				 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-				 *
-				 * pki    (32-bit): packet index
-				 * ctr    (16-bit): block counter
-				 * nonce (112-bit): number used once (salt)
-				 */
-				hcrypt_SetCtrIV((unsigned char *)&pki, ctx->salt, iv);
-
 				if (ctx->mode == HCRYPT_CTX_MODE_AESGCM)
 				{
+					const bool old_aead = false; // SRT v1.5.2 to v1.5.3.
+					if (old_aead)
+					{
+						hcrypt_SetCtrIV((unsigned char*)&pki, ctx->salt, iv);
+						memcpy(aad, in_data[0].pfx, sizeof(aad));
+					}
+					else
+					{
+						hcrypt_SetGcmIV((unsigned char*)&pki, ctx->salt, iv);
+
+						for (size_t i = 0; i < sizeof(aad) / 4; ++i)
+							*((uint32_t*)aad + i) = htonl(*((uint32_t*)in_data[0].pfx + i));
+					}
+
 					unsigned char* tag = in_data[0].payload + in_data[0].len - HAICRYPT_AUTHTAG_MAX;
-					int liret = cryspr_cb->cryspr->aes_gcm_cipher(false, aes_key, iv, in_data[0].pfx, ctx->msg_info->pfx_len, in_data[0].payload, in_data[0].len - HAICRYPT_AUTHTAG_MAX,
+					int liret = cryspr_cb->cryspr->aes_gcm_cipher(false, aes_key, iv, aad, sizeof(aad), in_data[0].payload, in_data[0].len - HAICRYPT_AUTHTAG_MAX,
 						out_txt, tag);
 					if (liret) {
 						return(liret);
@@ -628,6 +625,7 @@ static int crysprFallback_MsDecrypt(CRYSPR_cb *cryspr_cb, hcrypt_Ctx *ctx,
 					out_len = in_data[0].len - HAICRYPT_AUTHTAG_MAX;
 				}
 				else {
+					hcrypt_SetCtrIV((unsigned char*)&pki, ctx->salt, iv);
 #if CRYSPR_HAS_AESCTR
 					cryspr_cb->cryspr->aes_ctr_cipher(false, aes_key, iv, in_data[0].payload, in_data[0].len,
 						out_txt);

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -37,6 +37,7 @@ HaiCrypt_Cryspr HaiCryptCryspr_Get_Instance (void);     /* Return a default crys
 #define HAICRYPT_KEY_MAX_SZ         32  /* MAX key */
 #define HAICRYPT_SECRET_MAX_SZ      (HAICRYPT_PWD_MAX_SZ > HAICRYPT_KEY_MAX_SZ ? HAICRYPT_PWD_MAX_SZ : HAICRYPT_KEY_MAX_SZ)
 #define	HAICRYPT_AUTHTAG_MAX        16  /* maximum length of the auth tag (e.g. GCM) */
+#define	HAICRYPT_AAD_MAX            16  /* maximum length of the additional authenticated data (GCM mode) */
 
 #define HAICRYPT_SALT_SZ            16
 

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -62,6 +62,7 @@ typedef struct {
 #define HAICRYPT_CFG_F_CRYPTO   0x02        /* Perform crypto Tx:Encrypt Rx:Decrypt */
 #define HAICRYPT_CFG_F_FEC      0x04        /* Do Forward Error Correction */
 #define HAICRYPT_CFG_F_GCM      0x08        /* Use AES-GCM */
+#define HAICRYPT_CFG_F_GCM_153  0x10        /* Use AES-GCM compatibility mode with SRT v1.5.3 or earlier */
         unsigned        flags;
 
         HaiCrypt_Secret secret;             /* Security Association */
@@ -97,6 +98,7 @@ typedef struct hcrypt_Session_str* HaiCrypt_Handle;
 int  HaiCrypt_SetLogLevel(int level, int logfa);
 
 int  HaiCrypt_Create(const HaiCrypt_Cfg *cfg, HaiCrypt_Handle *phhc);
+int  HaiCrypt_UpdateGcm153(HaiCrypt_Handle hhc, unsigned use_gcm_153);
 int  HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handle *phhc);
 int  HaiCrypt_Close(HaiCrypt_Handle hhc);
 int  HaiCrypt_Tx_GetBuf(HaiCrypt_Handle hhc, size_t data_len, unsigned char **in_p);

--- a/haicrypt/haicrypt.h
+++ b/haicrypt/haicrypt.h
@@ -62,7 +62,6 @@ typedef struct {
 #define HAICRYPT_CFG_F_CRYPTO   0x02        /* Perform crypto Tx:Encrypt Rx:Decrypt */
 #define HAICRYPT_CFG_F_FEC      0x04        /* Do Forward Error Correction */
 #define HAICRYPT_CFG_F_GCM      0x08        /* Use AES-GCM */
-#define HAICRYPT_CFG_F_GCM_153  0x10        /* Use AES-GCM compatibility mode with SRT v1.5.3 or earlier */
         unsigned        flags;
 
         HaiCrypt_Secret secret;             /* Security Association */

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -278,7 +278,6 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         cryptoClone->ctx = &cryptoClone->ctx_pair[0];
         cryptoClone->ctx->flags |= (HCRYPT_CTX_F_ANNOUNCE | HCRYPT_CTX_F_TTSEND);
         cryptoClone->ctx->status = HCRYPT_CTX_S_ACTIVE;
-        cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
 
     } else { /* Receiver */
 
@@ -334,7 +333,6 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         memset(cryptoClone->ctx_pair[0].salt, 0, sizeof(cryptoClone->ctx_pair[0].salt));
         cryptoClone->ctx_pair[0].salt_len = 0;
         cryptoClone->ctx = &cryptoClone->ctx_pair[0];
-        cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
     }
 
     *phhc = (void *)cryptoClone;

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -178,6 +178,18 @@ int HaiCrypt_Create(const HaiCrypt_Cfg *cfg, HaiCrypt_Handle *phhc)
     return(0);
 }
 
+int HaiCrypt_UpdateGcm153(HaiCrypt_Handle hhc, unsigned use_gcm_153)
+{
+	ASSERT(hhc != NULL);
+	hcrypt_Session* crypto = hhc;
+	if (!crypto)
+		return(-1);
+
+	crypto->ctx_pair[0].use_gcm_153 = use_gcm_153;
+	crypto->ctx_pair[1].use_gcm_153 = use_gcm_153;
+	return(0);
+}
+
 int HaiCrypt_ExtractConfig(HaiCrypt_Handle hhcSrc, HaiCrypt_Cfg* pcfg)
 {
     hcrypt_Session *crypto = (hcrypt_Session *)hhcSrc;
@@ -266,6 +278,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         cryptoClone->ctx = &cryptoClone->ctx_pair[0];
         cryptoClone->ctx->flags |= (HCRYPT_CTX_F_ANNOUNCE | HCRYPT_CTX_F_TTSEND);
         cryptoClone->ctx->status = HCRYPT_CTX_S_ACTIVE;
+		cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
 
     } else { /* Receiver */
 
@@ -321,6 +334,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         memset(cryptoClone->ctx_pair[0].salt, 0, sizeof(cryptoClone->ctx_pair[0].salt));
         cryptoClone->ctx_pair[0].salt_len = 0;
         cryptoClone->ctx = &cryptoClone->ctx_pair[0];
+		cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
     }
 
     *phhc = (void *)cryptoClone;

--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -180,14 +180,14 @@ int HaiCrypt_Create(const HaiCrypt_Cfg *cfg, HaiCrypt_Handle *phhc)
 
 int HaiCrypt_UpdateGcm153(HaiCrypt_Handle hhc, unsigned use_gcm_153)
 {
-	ASSERT(hhc != NULL);
-	hcrypt_Session* crypto = hhc;
-	if (!crypto)
-		return(-1);
+    ASSERT(hhc != NULL);
+    hcrypt_Session* crypto = hhc;
+    if (!crypto)
+        return (-1);
 
-	crypto->ctx_pair[0].use_gcm_153 = use_gcm_153;
-	crypto->ctx_pair[1].use_gcm_153 = use_gcm_153;
-	return(0);
+    crypto->ctx_pair[0].use_gcm_153 = use_gcm_153;
+    crypto->ctx_pair[1].use_gcm_153 = use_gcm_153;
+    return (0);
 }
 
 int HaiCrypt_ExtractConfig(HaiCrypt_Handle hhcSrc, HaiCrypt_Cfg* pcfg)
@@ -278,7 +278,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         cryptoClone->ctx = &cryptoClone->ctx_pair[0];
         cryptoClone->ctx->flags |= (HCRYPT_CTX_F_ANNOUNCE | HCRYPT_CTX_F_TTSEND);
         cryptoClone->ctx->status = HCRYPT_CTX_S_ACTIVE;
-		cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
+        cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
 
     } else { /* Receiver */
 
@@ -334,7 +334,7 @@ int HaiCrypt_Clone(HaiCrypt_Handle hhcSrc, HaiCrypt_CryptoDir tx, HaiCrypt_Handl
         memset(cryptoClone->ctx_pair[0].salt, 0, sizeof(cryptoClone->ctx_pair[0].salt));
         cryptoClone->ctx_pair[0].salt_len = 0;
         cryptoClone->ctx = &cryptoClone->ctx_pair[0];
-		cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
+        cryptoClone->ctx->use_gcm_153 = cryptoSrc->ctx->use_gcm_153;
     }
 
     *phhc = (void *)cryptoClone;

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -81,7 +81,6 @@ typedef struct hcrypt_Session_str {
 
         struct {
             size_t          data_max_len;
-			bool            aes_gcm_153;    /* AES-GCM compatibility mode (SRT v1.5.3 and earlier) */
         }cfg;
 
         struct {

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -81,6 +81,7 @@ typedef struct hcrypt_Session_str {
 
         struct {
             size_t          data_max_len;
+			bool            aes_gcm_153;    /* AES-GCM compatibility mode (SRT v1.5.3 and earlier) */
         }cfg;
 
         struct {

--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -135,6 +135,25 @@ typedef struct hcrypt_Session_str {
             hcrypt_XorStream(&(iv)[0], (nonce), 112/8); \
         } while(0)
 
+/* HaiCrypt-TP GCM mode IV (96-bit) - SRT 1.5.4:
+ *    0   1   2   3   4   5  6   7   8   9   10  11 
+ * +---+---+---+---+---+---+---+---+---+---+---+---+
+ * |                   0s          |      pki      |
+ * +---+---+---+---+---+---+---+---+---+---+---+---+
+ *                         XOR                   
+ * +---+---+---+---+---+---+---+---+---+---+---+---+
+ * |                      nonce                    +
+ * +---+---+---+---+---+---+---+---+---+---+---+---+
+ *
+ * pki   (32-bit): packet index
+ * nonce (96-bit): number used once (salt)
+ */
+#define hcrypt_SetGcmIV(pki, nonce, iv) do { \
+            memset(&(iv)[0], 0, 96/8); \
+            memcpy(&(iv)[8], (pki), HCRYPT_PKI_SZ); \
+            hcrypt_XorStream(&(iv)[0], (nonce), 96/8); \
+        } while(0)
+
 #define hcrypt_XorStream(dst, strm, len) do { \
             int __XORSTREAMi; \
             for (__XORSTREAMi = 0 \

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -53,7 +53,6 @@ typedef struct tag_hcrypt_Ctx {
 #define HCRYPT_CTX_F_ENCRYPT    0x0100  /* 0:decrypt 1:encrypt */
 #define HCRYPT_CTX_F_ANNOUNCE   0x0200  /* Announce KM */
 #define HCRYPT_CTX_F_TTSEND     0x0400  /* time to send */
-#define HCRYPT_CTX_F_GCM_153    0x0800  /* AES-GCM compatibility mode (SRT v1.5.3 and earlier) */
         unsigned         flags;
 #define hcryptCtx_GetKeyFlags(ctx)      ((ctx)->flags & HCRYPT_CTX_F_xSEK)
 #define hcryptCtx_GetKeyIndex(ctx)      (((ctx)->flags & HCRYPT_CTX_F_xSEK)>>1)

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -53,6 +53,7 @@ typedef struct tag_hcrypt_Ctx {
 #define HCRYPT_CTX_F_ENCRYPT    0x0100  /* 0:decrypt 1:encrypt */
 #define HCRYPT_CTX_F_ANNOUNCE   0x0200  /* Announce KM */
 #define HCRYPT_CTX_F_TTSEND     0x0400  /* time to send */
+#define HCRYPT_CTX_F_GCM_153    0x0800  /* AES-GCM compatibility mode (SRT v1.5.3 and earlier) */
         unsigned         flags;
 #define hcryptCtx_GetKeyFlags(ctx)      ((ctx)->flags & HCRYPT_CTX_F_xSEK)
 #define hcryptCtx_GetKeyIndex(ctx)      (((ctx)->flags & HCRYPT_CTX_F_xSEK)>>1)
@@ -70,6 +71,7 @@ typedef struct tag_hcrypt_Ctx {
 #define HCRYPT_CTX_MODE_AESCBC  3   /* Cipher-block chaining mode */
 #define HCRYPT_CTX_MODE_AESGCM  4   /* AES GCM authenticated encryption */
         unsigned         mode;
+        bool             use_gcm_153; /* AES-GCM compatibility mode (SRT v1.5.3 and earlier) */
 
         struct {
             size_t       key_len;

--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -26,9 +26,9 @@ int hcryptCtx_Rx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 {
 	if (cfg) {
 		ctx->mode = (cfg->flags & HAICRYPT_CFG_F_GCM) ? HCRYPT_CTX_MODE_AESGCM : HCRYPT_CTX_MODE_AESCTR;
+		ctx->use_gcm_153 = (cfg->flags & HAICRYPT_CFG_F_GCM_153) ? true : false;
 	}
 	ctx->status = HCRYPT_CTX_S_INIT;
-
 	ctx->msg_info = crypto->msg_info;
 
 	if (cfg && hcryptCtx_SetSecret(crypto, ctx, &cfg->secret)) {

--- a/haicrypt/hcrypt_ctx_rx.c
+++ b/haicrypt/hcrypt_ctx_rx.c
@@ -26,10 +26,10 @@ int hcryptCtx_Rx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 {
 	if (cfg) {
 		ctx->mode = (cfg->flags & HAICRYPT_CFG_F_GCM) ? HCRYPT_CTX_MODE_AESGCM : HCRYPT_CTX_MODE_AESCTR;
-		ctx->use_gcm_153 = (cfg->flags & HAICRYPT_CFG_F_GCM_153) ? true : false;
 	}
 	ctx->status = HCRYPT_CTX_S_INIT;
 	ctx->msg_info = crypto->msg_info;
+	ctx->use_gcm_153 = false; // Default initialization.
 
 	if (cfg && hcryptCtx_SetSecret(crypto, ctx, &cfg->secret)) {
 		return(-1);

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -35,7 +35,7 @@ int hcryptCtx_Tx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 
 	ctx->mode = (cfg->flags & HAICRYPT_CFG_F_GCM) ? HCRYPT_CTX_MODE_AESGCM : HCRYPT_CTX_MODE_AESCTR;
 	ctx->status = HCRYPT_CTX_S_INIT;
-
+	ctx->use_gcm_153 = (cfg->flags & HAICRYPT_CFG_F_GCM_153) ? true : false;
 	ctx->msg_info = crypto->msg_info;
 
 	if (hcryptCtx_SetSecret(crypto, ctx, &cfg->secret)) {
@@ -184,7 +184,6 @@ int hcryptCtx_Tx_Refresh(hcrypt_Session *crypto)
 	ASSERT(HCRYPT_CTX_S_SARDY <= new_ctx->status);
 
 	/* Keep same KEK, configuration, and salt */
-//	memcpy(&new_ctx->aes_kek, &ctx->aes_kek, sizeof(new_ctx->aes_kek));
 	memcpy(&new_ctx->cfg, &ctx->cfg, sizeof(new_ctx->cfg));
 
 	new_ctx->salt_len = ctx->salt_len;

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -35,7 +35,7 @@ int hcryptCtx_Tx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 
 	ctx->mode = (cfg->flags & HAICRYPT_CFG_F_GCM) ? HCRYPT_CTX_MODE_AESGCM : HCRYPT_CTX_MODE_AESCTR;
 	ctx->status = HCRYPT_CTX_S_INIT;
-	ctx->use_gcm_153 = false; // Defaul initialization.
+	ctx->use_gcm_153 = false; // Default initialization.
 	ctx->msg_info = crypto->msg_info;
 
 	if (hcryptCtx_SetSecret(crypto, ctx, &cfg->secret)) {

--- a/haicrypt/hcrypt_ctx_tx.c
+++ b/haicrypt/hcrypt_ctx_tx.c
@@ -35,7 +35,7 @@ int hcryptCtx_Tx_Init(hcrypt_Session *crypto, hcrypt_Ctx *ctx, const HaiCrypt_Cf
 
 	ctx->mode = (cfg->flags & HAICRYPT_CFG_F_GCM) ? HCRYPT_CTX_MODE_AESGCM : HCRYPT_CTX_MODE_AESCTR;
 	ctx->status = HCRYPT_CTX_S_INIT;
-	ctx->use_gcm_153 = (cfg->flags & HAICRYPT_CFG_F_GCM_153) ? true : false;
+	ctx->use_gcm_153 = false; // Defaul initialization.
 	ctx->msg_info = crypto->msg_info;
 
 	if (hcryptCtx_SetSecret(crypto, ctx, &cfg->secret)) {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -6022,7 +6022,7 @@ bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     // they have outdated values.
     m_pCryptoControl->setCryptoSecret(m_config.CryptoSecret);
 
-	const bool useGcm153 = m_uPeerSrtVersion <= SrtVersion(1, 5, 3);
+    const bool useGcm153 = m_uPeerSrtVersion <= SrtVersion(1, 5, 3);
 
     if (bidirectional || m_config.bDataSender)
     {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2020,7 +2020,7 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
         {
             uint32_t srtdata_out[SRTDATA_MAXSIZE];
             size_t   len_out = 0;
-            res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4,
+            res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4, m_uPeerSrtVersion,
                     (srtdata_out), (len_out));
             if (res == SRT_CMD_KMRSP)
             {
@@ -2057,7 +2057,7 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
     case SRT_CMD_KMRSP:
     {
         // KMRSP doesn't expect any following action
-        m_pCryptoControl->processSrtMsg_KMRSP(srtdata, len, CUDT::HS_VERSION_UDT4);
+        m_pCryptoControl->processSrtMsg_KMRSP(srtdata, len, m_uPeerSrtVersion);
         return true; // nothing to do
     }
 
@@ -2646,7 +2646,7 @@ bool srt::CUDT::interpretSrtHandshake(const CHandShake& hs,
                     return false;
                 }
 
-                int res = m_pCryptoControl->processSrtMsg_KMREQ(begin + 1, bytelen, HS_VERSION_SRT1,
+                int res = m_pCryptoControl->processSrtMsg_KMREQ(begin + 1, bytelen, HS_VERSION_SRT1, m_uPeerSrtVersion,
                             (out_data), (*pw_len));
                 if (res != SRT_CMD_KMRSP)
                 {
@@ -2693,7 +2693,7 @@ bool srt::CUDT::interpretSrtHandshake(const CHandShake& hs,
             }
             else if (cmd == SRT_CMD_KMRSP)
             {
-                int res = m_pCryptoControl->processSrtMsg_KMRSP(begin + 1, bytelen, HS_VERSION_SRT1);
+                int res = m_pCryptoControl->processSrtMsg_KMRSP(begin + 1, bytelen, m_uPeerSrtVersion);
                 if (m_config.bEnforcedEnc && res == -1)
                 {
                     if (m_pCryptoControl->m_SndKmState == SRT_KM_S_BADSECRET)
@@ -6022,13 +6022,15 @@ bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     // they have outdated values.
     m_pCryptoControl->setCryptoSecret(m_config.CryptoSecret);
 
+	const bool useGcm153 = m_uPeerSrtVersion <= SrtVersion(1, 5, 3);
+
     if (bidirectional || m_config.bDataSender)
     {
         HLOGC(rslog.Debug, log << CONID() << "createCrypter: setting RCV/SND KeyLen=" << m_config.iSndCryptoKeyLen);
         m_pCryptoControl->setCryptoKeylen(m_config.iSndCryptoKeyLen);
     }
 
-    return m_pCryptoControl->init(side, m_config, bidirectional);
+    return m_pCryptoControl->init(side, m_config, bidirectional, useGcm153);
 }
 
 SRT_REJECT_REASON srt::CUDT::setupCC()
@@ -7762,7 +7764,7 @@ bool srt::CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
         // - m_dCWndSize
         m_tdSendInterval    = microseconds_from((int64_t)m_CongCtl->pktSndPeriod_us());
         const double cgwindow = m_CongCtl->cgWindowSize();
-        m_iCongestionWindow = cgwindow;
+        m_iCongestionWindow = (int) cgwindow;
 #if ENABLE_HEAVY_LOGGING
         HLOGC(rslog.Debug,
               log << CONID() << "updateCC: updated values from congctl: interval=" << FormatDuration<DUNIT_US>(m_tdSendInterval)

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -460,10 +460,12 @@ int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len
             << "; key[1]: len=" << m_SndKmMsg[1].MsgLen << " retry=" << m_SndKmMsg[1].iPeerRetry);
 
         m_bUseGcm153 = srtv <= SrtVersion(1, 5, 3);
+#ifdef SRT_ENABLE_ENCRYPTION
         if (m_hRcvCrypto != NULL)
             HaiCrypt_UpdateGcm153(m_hRcvCrypto, m_bUseGcm153);
         if (m_hSndCrypto != NULL)
             HaiCrypt_UpdateGcm153(m_hSndCrypto, m_bUseGcm153);
+#endif
     }
 
     LOGP(cnlog.Note, FormatKmMessage("processSrtMsg_KMRSP", SRT_CMD_KMRSP, len));
@@ -796,11 +798,6 @@ bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t key
 bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle&, size_t, HaiCrypt_CryptoDir, bool)
 {
     return false;
-}
-
-bool srt::CCryptoControl::updateCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t keylen, HaiCrypt_CryptoDir cdir, bool bAESGCM)
-{
-	return false;
 }
 #endif // SRT_ENABLE_ENCRYPTION
 

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -333,6 +333,13 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
         HLOGC(cnlog.Debug, log << "processSrtMsg_KMREQ: NOT REPLAYING the key update to TX CRYPTO CTX.");
     }
 
+#ifdef SRT_ENABLE_ENCRYPTION
+    if (m_hRcvCrypto != NULL)
+        HaiCrypt_UpdateGcm153(m_hRcvCrypto, m_bUseGcm153);
+    if (m_hSndCrypto != NULL)
+        HaiCrypt_UpdateGcm153(m_hSndCrypto, m_bUseGcm153);
+#endif
+
     return SRT_CMD_KMRSP;
 
 HSv4_ErrorReport:

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -172,7 +172,7 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
         (m_iCryptoMode == CSrtConfig::CIPHER_MODE_AUTO && kmdata[HCRYPT_MSG_KM_OFS_CIPHER] == HCRYPT_CIPHER_AES_GCM) ||
         (m_iCryptoMode == CSrtConfig::CIPHER_MODE_AES_GCM);
 
-	m_bUseGcm153 = srtv <= SrtVersion(1, 5, 3);
+    m_bUseGcm153 = srtv <= SrtVersion(1, 5, 3);
 
     // What we have to do:
     // If encryption is on (we know that by having m_KmSecret nonempty), create
@@ -459,11 +459,11 @@ int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len
         HLOGC(cnlog.Debug, log << "processSrtMsg_KMRSP: key[0]: len=" << m_SndKmMsg[0].MsgLen << " retry=" << m_SndKmMsg[0].iPeerRetry
             << "; key[1]: len=" << m_SndKmMsg[1].MsgLen << " retry=" << m_SndKmMsg[1].iPeerRetry);
 
-		m_bUseGcm153 = srtv <= SrtVersion(1, 5, 3);
-		if (m_hRcvCrypto != NULL)
-			HaiCrypt_UpdateGcm153(m_hRcvCrypto, m_bUseGcm153);
-		if (m_hSndCrypto != NULL)
-			HaiCrypt_UpdateGcm153(m_hSndCrypto, m_bUseGcm153);
+        m_bUseGcm153 = srtv <= SrtVersion(1, 5, 3);
+        if (m_hRcvCrypto != NULL)
+            HaiCrypt_UpdateGcm153(m_hRcvCrypto, m_bUseGcm153);
+        if (m_hSndCrypto != NULL)
+            HaiCrypt_UpdateGcm153(m_hSndCrypto, m_bUseGcm153);
     }
 
     LOGP(cnlog.Note, FormatKmMessage("processSrtMsg_KMRSP", SRT_CMD_KMRSP, len));
@@ -598,7 +598,7 @@ srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     , m_KmRefreshRatePkt(0)
     , m_KmPreAnnouncePkt(0)
     , m_iCryptoMode(CSrtConfig::CIPHER_MODE_AUTO)
-	, m_bUseGcm153(false)
+    , m_bUseGcm153(false)
     , m_bErrorReported(false)
 {
     m_KmSecret.len = 0;
@@ -626,7 +626,7 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
     // Set UNSECURED state as default
     m_RcvKmState = SRT_KM_S_UNSECURED;
     m_iCryptoMode = cfg.iCryptoMode;
-	m_bUseGcm153 = bUseGcm153;
+    m_bUseGcm153 = bUseGcm153;
 
 #ifdef SRT_ENABLE_ENCRYPTION
     if (!cfg.bTSBPD && m_iCryptoMode == CSrtConfig::CIPHER_MODE_AUTO)
@@ -769,9 +769,7 @@ bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t key
     m_KmRefreshRatePkt = 2000;
     m_KmPreAnnouncePkt = 500;
 #endif
-    crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (cdir == HAICRYPT_CRYPTO_DIR_TX ? HAICRYPT_CFG_F_TX : 0) | (bAESGCM ? HAICRYPT_CFG_F_GCM : 0)
-                       | (m_bUseGcm153 ? HAICRYPT_CFG_F_GCM_153 : 0);
-
+    crypto_cfg.flags = HAICRYPT_CFG_F_CRYPTO | (cdir == HAICRYPT_CRYPTO_DIR_TX ? HAICRYPT_CFG_F_TX : 0) | (bAESGCM ? HAICRYPT_CFG_F_GCM : 0);
     crypto_cfg.xport = HAICRYPT_XPT_SRT;
     crypto_cfg.cryspr = HaiCryptCryspr_Get_Instance();
     crypto_cfg.key_len = (size_t)keylen;
@@ -794,7 +792,6 @@ bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t key
 
     return true;
 }
-
 #else
 bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle&, size_t, HaiCrypt_CryptoDir, bool)
 {

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -68,7 +68,7 @@ private:
     int m_KmRefreshRatePkt;
     int m_KmPreAnnouncePkt;
     int m_iCryptoMode;
-	bool m_bUseGcm153; // Older AES-GCM version existed up to SRT v1.5.3.
+    bool m_bUseGcm153; // Older AES-GCM version existed up to SRT v1.5.3.
 
     HaiCrypt_Secret m_KmSecret;     //Key material shared secret
     // Sender
@@ -128,14 +128,14 @@ public:
     // Needed for CUDT
     void updateKmState(int cmd, size_t srtlen);
 
-	/// Process the KM request message.
-	/// @param srtv peer's SRT version.
+    /// Process the KM request message.
+    /// @param srtv peer's SRT version.
     int processSrtMsg_KMREQ(const uint32_t* srtdata, size_t len, int hsv, unsigned srtv,
             uint32_t srtdata_out[], size_t&);
 
     /// Process the KM response message.
-	/// @param srtv peer's SRT version.
-	/// @returns
+    /// @param srtv peer's SRT version.
+    /// @returns
     /// 1 - the given payload is the same as the currently used key
     /// 0 - there's no key in agent or the payload is error message with agent NOSECRET.
     /// -1 - the payload is error message with other state or it doesn't match the key

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -68,6 +68,7 @@ private:
     int m_KmRefreshRatePkt;
     int m_KmPreAnnouncePkt;
     int m_iCryptoMode;
+	bool m_bUseGcm153; // Older AES-GCM version existed up to SRT v1.5.3.
 
     HaiCrypt_Secret m_KmSecret;     //Key material shared secret
     // Sender
@@ -127,15 +128,18 @@ public:
     // Needed for CUDT
     void updateKmState(int cmd, size_t srtlen);
 
-    // Detailed processing
-    int processSrtMsg_KMREQ(const uint32_t* srtdata, size_t len, int hsv,
+	/// Process the KM request message.
+	/// @param srtv peer's SRT version.
+    int processSrtMsg_KMREQ(const uint32_t* srtdata, size_t len, int hsv, unsigned srtv,
             uint32_t srtdata_out[], size_t&);
 
-    // This returns:
-    // 1 - the given payload is the same as the currently used key
-    // 0 - there's no key in agent or the payload is error message with agent NOSECRET.
-    // -1 - the payload is error message with other state or it doesn't match the key
-    int processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, int hsv);
+    /// Process the KM response message.
+	/// @param srtv peer's SRT version.
+	/// @returns
+    /// 1 - the given payload is the same as the currently used key
+    /// 0 - there's no key in agent or the payload is error message with agent NOSECRET.
+    /// -1 - the payload is error message with other state or it doesn't match the key
+    int processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, unsigned srtv);
     void createFakeSndContext();
 
     const unsigned char* getKmMsg_data(size_t ki) const { return m_SndKmMsg[ki].Msg; }
@@ -207,7 +211,7 @@ public:
     std::string CONID() const;
     std::string FormatKmMessage(std::string hdr, int cmd, size_t srtlen);
 
-    bool init(HandshakeSide, const CSrtConfig&, bool);
+    bool init(HandshakeSide, const CSrtConfig&, bool bidir, bool bUseGcm153);
     SRT_ATTR_EXCLUDES(m_mtxLock)
     void close();
 


### PR DESCRIPTION
## Changes

- Changed the IV vector length to 12 bytes in the case of AES-GCM when peer's SRT version is 1.5.4 or above;
- Fixed AAD byte order when peer's SRT version is 1.5.4 or above.

## TODO

- [x] Raise SRT version to 1.5.4.

### AES-CTR Initialisation Vector (IV)

The Initialisation Vector (IV) for the AES-CTR encryption mode is derived by exclusive ORing the first 112 bits of the Salt provided in the Keying Material with the packet sequence number (PktSeqNo) in the SRT header, and left-shifting the resulting value by 16 bits:

~~~~~~~~~~~
IV = (MSB(112, Salt) XOR PktSeqNo) << 16
~~~~~~~~~~~

Thus the counter (keystream) used by the AES engine is the 128-bit value obtained by concatenating the IV with the block counter ("ctr"):

~~~~
 *    0   1   2   3   4   5  6   7   8   9   10  11  12  13  14  15   bytes
 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+  ^
 * |                   0s                  |   PktSeqNo    |   0s  |  |
 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+  |
 *                            XOR                                     | IV
 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+          |
 * |                  nonce = MSB(112, Salt)               +          |
 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+          v
 *                            (+)
 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
 * |                   0s                                 |   ctr  |
 * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
~~~~

To avoid using the same keystream twice the payload size MUST be less than 2^16 blocks of 128 bits.

### AES-GCM Initialisation Vector (IV)

**_Starting from v1.5.4._**

The Initialisation Vector (IV) for the AES-GCM encryption mode is derived by exclusive ORing the first 96 bits of the Salt provided in the Keying Material with the packet sequence number (PktSeqNo) in the SRT header:

~~~~~~~~~~~
IV = MSB(96, Salt) XOR PktSeqNo
~~~~~~~~~~~

Each outbound packet uses a 12-octet IV and an encryption key to form two outputs (RFC-7714):
- a 16-octet first key block, which is used in forming the authentication tag, and
- a keystream of octets, formed in blocks of 16 octets each.

With an IV taking 96 bits, there are always `128-96=32` bits for the block counter until it wraps around.
