### PR TITLE
[core] Fixed missing traceBelatedTime initialization.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -929,6 +929,7 @@ void srt::CUDT::clearData()
 
         m_stats.tsLastSampleTime = steady_clock::now();
         m_stats.traceReorderDistance = 0;
+        m_stats.traceBelatedTime = 0;
         m_stats.sndDuration = m_stats.m_sndDurationTotal = 0;
     }
 


### PR DESCRIPTION
Conditional jump or move depends on uninitialised value of `m_stats.traceBelatedTime`.

```shell
==15925== Thread 4 SRT:RcvQ:w1:
==15925== Conditional jump or move depends on uninitialised value(s)
==15925==    at 0x32B6BB: unsigned long CountIIR<unsigned long>(unsigned long, unsigned long, double) (core.h:89)
==15925==    by 0x31E4E3: srt::CUDT::handleSocketPacketReception(std::vector<srt::CUnit*, std::allocator<srt::CUnit*> > const&, bool&, bool&, std::vector<std::pair<int, int>, std::allocator<std::pair<int, int> > >&) (core.cpp:10078)
==15925==    by 0x31FD3C: srt::CUDT::processData(srt::CUnit*) (core.cpp:10475)
==15925==    by 0x3593AF: srt::CRcvQueue::worker_ProcessAddressedPacket(int, srt::CUnit*, srt::sockaddr_any const&) (queue.cpp:1475)
==15925==    by 0x358586: srt::CRcvQueue::worker(void*) (queue.cpp:1254)
==15925==    by 0x36C773: void* std::__invoke_impl<void*, void* (*)(void*), void*>(std::__invoke_other, void* (*&&)(void*), void*&&) (invoke.h:61)
==15925==    by 0x36C6D5: std::__invoke_result<void* (*)(void*), void*>::type std::__invoke<void* (*)(void*), void*>(void* (*&&)(void*), void*&&) (invoke.h:96)
==15925==    by 0x36C636: void* std::thread::_Invoker<std::tuple<void* (*)(void*), void*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) (std_thread.h:279)
==15925==    by 0x36C5ED: std::thread::_Invoker<std::tuple<void* (*)(void*), void*> >::operator()() (std_thread.h:286)
==15925==    by 0x36C5CD: std::thread::_State_impl<std::thread::_Invoker<std::tuple<void* (*)(void*), void*> > >::_M_run() (std_thread.h:231)
==15925==    by 0x4D912B2: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.32)
==15925==    by 0x50B9AC2: start_thread (pthread_create.c:442)
```