### PR TITLE
[core] Removed a wrong assertion about ACK timestamp.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8044,7 +8044,6 @@ bool srt::CUDT::getFirstNoncontSequence(int32_t& w_seq, string& w_log_reason)
 
 int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 {
-    SRT_ASSERT(ctrlpkt.getMsgTimeStamp() != 0);
     int nbsent = 0;
     int local_prevack = 0;
 #if ENABLE_HEAVY_LOGGING


### PR DESCRIPTION
The debug assertion was added in PR #1628 (SRT v1.4.3). It assumes a timestamp of an ACK packet is positive.
However, a timestamp value of 0 is a valid value. For an ACK it is unlikely to happen as the first full ACK is sent only after 10 ms (except for issue #2829 in SRT v1.5.3). Also handshaking takes some time.
Still lite ACK may be sent earlier in case of higher data rates.

Anyway, removing the debug assertion.