### PR TITLE
[core] Fix TSBPD thread create/join protection.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9992,12 +9992,13 @@ bool srt::CUDT::overrideSndSeqNo(int32_t seq)
 int srt::CUDT::checkLazySpawnTsbPdThread()
 {
     const bool need_tsbpd = m_bTsbPd || m_bGroupTsbPd;
+    if (!need_tsbpd)
+        return 0;
 
-    if (need_tsbpd && !m_RcvTsbPdThread.joinable())
+    ScopedLock lock(m_RcvTsbPdStartupLock);
+    if (!m_RcvTsbPdThread.joinable())
     {
-        ScopedLock lock(m_RcvTsbPdStartupLock);
-
-        if (m_bClosing) // Check again to protect join() in CUDT::releaseSync()
+        if (m_bClosing) // Check m_bClosing to protect join() in CUDT::releaseSync().
             return -1;
 
         HLOGP(qrlog.Debug, "Spawning Socket TSBPD thread");

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -995,7 +995,7 @@ private: // Receiving related data
     sync::CThread m_RcvTsbPdThread;              // Rcv TsbPD Thread handle
     sync::Condition m_RcvTsbPdCond;              // TSBPD signals if reading is ready. Use together with m_RecvLock
     bool m_bTsbPdNeedsWakeup;                    // Signal TsbPd thread to wake up on RCV buffer state change.
-    sync::Mutex m_RcvTsbPdStartupLock;           // Protects TSBPD thread creating and joining
+    sync::Mutex m_RcvTsbPdStartupLock;           // Protects TSBPD thread creation and joining.
 
     CallbackHolder<srt_listen_callback_fn> m_cbAcceptHook;
     CallbackHolder<srt_connect_callback_fn> m_cbConnectHook;


### PR DESCRIPTION
Extracted from PR #2893.

```
WARNING: ThreadSanitizer: data race (pid=5444)
  Write of size 8 at 0x7ba80005f118 by thread T1 (mutexes: write M226, write M223, write M898885562122236320, write M898604087145525592):
    #0 srt::sync::CThread::join() srt/srtcore/sync_posix.cpp:442 (srt-xtransmit+0x464f2a)
    #1 srt::CUDT::releaseSynch() srt/srtcore/core.cpp:7839 (srt-xtransmit+0x34d600)
    #2 srt::CUDT::closeInternal() srt/srtcore/core.cpp:6332 (srt-xtransmit+0x34c769)
    #3 srt::CUDTSocket::breakSocket_LOCKED() srt/srtcore/api.cpp:127 (srt-xtransmit+0x28d9e1)
    #4 srt::CUDTUnited::garbageCollect(void*) srt/srtcore/api.cpp:3328 (srt-xtransmit+0x28f180)

  Previous read of size 8 at 0x7ba80005f118 by thread T4:
    #0 srt::sync::CThread::joinable() const srt/srtcore/sync_posix.cpp:424 (srt-xtransmit+0x464ce9)
    #1 srt::CUDT::checkLazySpawnTsbPdThread() srt/srtcore/core.cpp:9997 (srt-xtransmit+0x371cd6)
    #2 srt::CUDT::processData(srt::CUnit*) srt/srtcore/core.cpp:10293 (srt-xtransmit+0x376f6b)
    #3 srt::CRcvQueue::worker_ProcessAddressedPacket(int, srt::CUnit*, srt::sockaddr_any const&) srt/srtcore/queue.cpp:1475 (srt-xtransmit+0x3f01f6)
    #4 srt::CRcvQueue::worker(void*) srt/srtcore/queue.cpp:1254 (srt-xtransmit+0x3ecfb7)
```