### PR TITLE
[core] Carry over also the interface number with PKTINFO

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -662,12 +662,12 @@ void srt::CChannel::getPeerAddr(sockaddr_any& w_addr) const
     w_addr.len = namelen;
 }
 
-int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const sockaddr_any& source_addr SRT_ATR_UNUSED) const
+int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const CNetworkInterface& source_ni SRT_ATR_UNUSED) const
 {
 #if ENABLE_HEAVY_LOGGING
     ostringstream dsrc;
 #ifdef SRT_ENABLE_PKTINFO
-    dsrc << " sourceIP=" << (m_bBindMasked && !source_addr.isany() ? source_addr.str() : "default");
+    dsrc << " sourceIP=" << (m_bBindMasked && !source_ni.address.isany() ? source_ni.address.str() : "default");
 #endif
 
     LOGC(kslog.Debug,
@@ -750,15 +750,15 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const socka
     // Note that even if PKTINFO is desired, the first caller's packet will be sent
     // without ancillary info anyway because there's no "peer" yet to know where to send it.
     char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
-    if (m_bBindMasked && source_addr.family() != AF_UNSPEC && !source_addr.isany())
+    if (m_bBindMasked && source_ni.address.family() != AF_UNSPEC && !source_ni.address.isany())
     {
-        if (!setSourceAddress(mh, mh_crtl_buf, source_addr))
+        if (!setSourceAddress(mh, mh_crtl_buf, source_ni))
         {
-            LOGC(kslog.Error, log << "CChannel::setSourceAddress: source address invalid family #" << source_addr.family() << ", NOT setting.");
+            LOGC(kslog.Error, log << "CChannel::setSourceAddress: source address invalid family #" << source_ni.address.family() << ", NOT setting.");
         }
         else
         {
-            HLOGC(kslog.Debug, log << "CChannel::setSourceAddress: setting as " << source_addr.str());
+            HLOGC(kslog.Debug, log << "CChannel::setSourceAddress: setting as " << source_ni.address.str());
             have_set_src = true;
         }
     }

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -54,6 +54,7 @@ modified by
 #define INC_SRT_COMMON_H
 
 #include <memory>
+#include <exception>
 #include <cstdlib>
 #include <cstdio>
 #ifndef _WIN32
@@ -95,7 +96,36 @@ modified by
 #define SRT_STATIC_ASSERT(cond, msg)
 #endif
 
-#include <exception>
+namespace srt
+{
+
+struct CNetworkInterface
+{
+    sockaddr_any address;
+    int interface_index;
+
+    template<class InAddrType>
+    CNetworkInterface(const InAddrType& sa, int index)
+        : address(sa, 0)
+        , interface_index(index)
+    {
+    }
+
+    CNetworkInterface() // blank fallback
+        : address(AF_UNSPEC)
+        , interface_index(0)
+    {
+    }
+
+    std::string str() const
+    {
+        std::ostringstream buf;
+        buf << address.str() << "/" << interface_index;
+        return buf.str();
+    }
+};
+
+}
 
 namespace srt_logging
 {

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3651,7 +3651,7 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     EConnectStatus cst = CONN_CONTINUE;
     // This is a temporary place to store the DESTINATION IP from the incoming packet.
     // We can't record this address yet until the cookie-confirmation is done, for safety reasons.
-    sockaddr_any use_source_adr(serv_addr.family());
+    CNetworkInterface use_source_adr;
 
     while (!m_bClosing)
     {
@@ -9591,7 +9591,7 @@ bool srt::CUDT::isRetransmissionAllowed(const time_point& tnow SRT_ATR_UNUSED)
     return true;
 }
 
-bool srt::CUDT::packData(CPacket& w_packet, steady_clock::time_point& w_nexttime, sockaddr_any& w_src_addr)
+bool srt::CUDT::packData(CPacket& w_packet, steady_clock::time_point& w_nexttime, CNetworkInterface& w_src_addr)
 {
     int payload = 0;
     bool probe = false;
@@ -11063,7 +11063,7 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
     // because this happens still in the frames of the listener socket. Only
     // when processing switches to the newly spawned accepted socket can the
     // address be recorded in its m_SourceAddr field.
-    sockaddr_any use_source_addr = packet.udpDestAddr();
+    CNetworkInterface use_source_addr = packet.udpDestAddr();
 
     // REQUEST:INDUCTION.
     // Set a cookie, a target ID, and send back the same as

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -1124,7 +1124,7 @@ private: // Generation and processing of packets
     ///
     /// @retval true A packet was extracted for sending, the socket should be rechecked at @a nexttime
     /// @retval false Nothing was extracted for sending, @a nexttime should be ignored
-    bool packData(CPacket& packet, time_point& nexttime, sockaddr_any& src_addr);
+    bool packData(CPacket& packet, time_point& nexttime, CNetworkInterface& src_addr);
 
     int processData(CUnit* unit);
 
@@ -1220,7 +1220,7 @@ private: // for UDP multiplexer
     CSndQueue* m_pSndQueue;    // packet sending queue
     CRcvQueue* m_pRcvQueue;    // packet receiving queue
     sockaddr_any m_PeerAddr;   // peer address
-    sockaddr_any m_SourceAddr; // override UDP source address with this one when sending
+    CNetworkInterface m_SourceAddr; // override UDP source address with this one when sending
     uint32_t m_piSelfIP[4];    // local UDP IP address
     CSNode* m_pSNode;          // node information for UDT list used in snd queue
     CRNode* m_pRNode;          // node information for UDT list used in rcv queue

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -307,7 +307,7 @@ public:
     /// @return packet header field [2] (bit 0~31, bit 0-26 if SRT_DEBUG_TSBPD_WRAP).
     uint32_t getMsgTimeStamp() const;
 
-    sockaddr_any udpDestAddr() const { return m_DestAddr; }
+    CNetworkInterface udpDestAddr() const { return m_DestAddr; }
 
 #ifdef SRT_DEBUG_TSBPD_WRAP                           // Receiver
     static const uint32_t MAX_TIMESTAMP = 0x07FFFFFF; // 27 bit fast wraparound for tests (~2m15s)
@@ -346,7 +346,7 @@ protected:
 
     int32_t m_extra_pad;
     bool    m_data_owned;
-    sockaddr_any m_DestAddr;
+    CNetworkInterface m_DestAddr;
     size_t  m_zCapacity;
 
 protected:

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -579,7 +579,7 @@ void* srt::CSndQueue::worker(void* param)
         // pack a packet from the socket
         CPacket pkt;
         steady_clock::time_point next_send_time;
-        sockaddr_any source_addr;
+        CNetworkInterface source_addr;
         const bool res = u->packData((pkt), (next_send_time), (source_addr));
 
         // Check if extracted anything to send
@@ -603,7 +603,7 @@ void* srt::CSndQueue::worker(void* param)
     return NULL;
 }
 
-int srt::CSndQueue::sendto(const sockaddr_any& addr, CPacket& w_packet, const sockaddr_any& src)
+int srt::CSndQueue::sendto(const sockaddr_any& addr, CPacket& w_packet, const CNetworkInterface& src)
 {
     // send out the packet immediately (high priority), this is a control packet
     // NOTE: w_packet is passed by mutable reference because this function will do

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -420,7 +420,7 @@ public:
     /// @param [in,ref] packet packet to be sent out
     /// @param [in] src The source IP address (details above)
     /// @return Size of data sent out.
-    int sendto(const sockaddr_any& addr, CPacket& packet, const sockaddr_any& src);
+    int sendto(const sockaddr_any& addr, CPacket& packet, const CNetworkInterface& src);
 
     /// Get the IP TTL.
     /// @param [in] ttl IP Time To Live.


### PR DESCRIPTION
Fixes #2980 

This introduces `CNetworkInterface` structure that replaces the use of bare `sockaddr_any` in cases when the source should be forcefully set through PKTINFO.

(NOT YET TESTED)