### PR TITLE
[core] Fix a data race 

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1711,10 +1711,8 @@ void srt::CRcvQueue::removeListener(const CUDT* u)
     m_pListener.lockWrite();
 
     if (u == m_pListener.m_pObj)
-    {
-    m_pListener.m_pObj = NULL;
-    }
-
+        m_pListener.m_pObj = NULL;
+    
     m_pListener.unlockWrite();
 }
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -554,9 +554,9 @@ private:
     void storePktClone(int32_t id, const CPacket& pkt);
 
 private:
-    sync::Mutex             m_LSLock;
-    sync::CSharedObject<CUDT>     m_pListener;        // pointer to the (unique, if any) listening UDT entity
-    CRendezvousQueue*       m_pRendezvousQueue; // The list of sockets in rendezvous mode
+    sync::Mutex                 m_LSLock;
+    sync::CSharedObject<CUDT>   m_pListener;        // pointer to the (unique, if any) listening UDT entity
+    CRendezvousQueue*           m_pRendezvousQueue; // The list of sockets in rendezvous mode
 
     std::vector<CUDT*> m_vNewEntry; // newly added entries, to be inserted
     sync::Mutex        m_IDLock;

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -554,9 +554,9 @@ private:
     void storePktClone(int32_t id, const CPacket& pkt);
 
 private:
-    sync::Mutex       m_LSLock;
-    CUDT*             m_pListener;        // pointer to the (unique, if any) listening UDT entity
-    CRendezvousQueue* m_pRendezvousQueue; // The list of sockets in rendezvous mode
+    sync::Mutex             m_LSLock;
+    sync::CSharedObject<CUDT>     m_pListener;        // pointer to the (unique, if any) listening UDT entity
+    CRendezvousQueue*       m_pRendezvousQueue; // The list of sockets in rendezvous mode
 
     std::vector<CUDT*> m_vNewEntry; // newly added entries, to be inserted
     sync::Mutex        m_IDLock;

--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -375,10 +375,9 @@ srt::sync::SharedMutex::SharedMutex()
 {
     m_iCountRead = 0;
     m_bWriterLocked = false;
-
     setupCond(m_LockReadCond, "SharedMutex::m_pLockReadCond");
     setupCond(m_LockWriteCond, "SharedMutex::m_pLockWriteCond");
-    setupMutex(m_Mutex, "SharedMutex::m_pMutex");
+    setupMutex(m_Mutex, "SharedMutex::m_Mutex");
 }
 
 srt::sync::SharedMutex::~SharedMutex()
@@ -461,3 +460,5 @@ int srt::sync::SharedMutex::getReaderCount()
 {
     return m_iCountRead;
 }
+
+

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -979,6 +979,42 @@ class SharedMutex
 
 };
 
+template <class T>
+class CSharedObject
+{
+    public:
+    T* m_pObj;
+    sync::SharedMutex m_Mtx;
+
+    public:
+    CSharedObject<T>()
+    :m_pObj()
+    ,m_Mtx()
+    {
+    }
+    
+    void lockWrite()
+    {
+        m_Mtx.lock();
+    }
+
+    void unlockWrite()
+    {
+        m_Mtx.unlock();
+    }
+
+    void lockRead()
+    {
+        m_Mtx.lock_shared();
+    }
+
+    void unlockRead()
+    {
+        m_Mtx.unlock_shared();
+    }
+    
+};
+
 } // namespace sync
 } // namespace srt
 

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -964,15 +964,15 @@ class SharedMutex
     // Acquire the lock for writting purposes. Only one thread can acquire this lock at a time
     // Once it is locked, no reader can acquire it 
     public:
-    void lock() SRT_ATTR_ACQUIRE();
-    bool try_lock() SRT_ATTR_TRY_ACQUIRE();
-    void unlock() SRT_ATTR_RELEASE();
+    void lock();
+    bool try_lock();
+    void unlock();
 
     // Acquire the lock if no writter already has it. For read purpose only
     // Several readers can lock this at the same time. 
-    void lock_shared() SRT_ATTR_ACQUIRE_SHARED();
-    bool try_lock_shared() SRT_ATTR_TRY_ACQUIRE_SHARED();
-    void unlock_shared() SRT_ATTR_RELEASE_SHARED();
+    void lock_shared();
+    bool try_lock_shared();
+    void unlock_shared();
 
     int getReaderCount();
 

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -611,6 +611,91 @@ TEST(SyncThread, Joinable)
 
 /*****************************************************************************/
 /*
+ * SharedMutex
+ */
+ /*****************************************************************************/
+TEST(SharedMutex, LockWriteRead)
+{
+    SharedMutex mut;
+        
+    mut.lock();
+    EXPECT_FALSE(mut.try_lock_shared());
+
+}
+
+TEST(SharedMutex, LockReadWrite)
+{
+    SharedMutex mut;
+
+    mut.lock_shared();
+    EXPECT_FALSE(mut.try_lock());
+
+}
+
+TEST(SharedMutex, LockReadTwice)
+{
+    SharedMutex mut;
+
+    mut.lock_shared();
+    mut.lock_shared();
+    EXPECT_TRUE(mut.try_lock_shared());
+}
+
+TEST(SharedMutex, LockWriteTwice)
+{
+    SharedMutex mut;
+
+    mut.lock();
+    EXPECT_FALSE(mut.try_lock());
+}
+
+TEST(SharedMutex, LockUnlockWrite)
+{
+    SharedMutex mut;
+    mut.lock();
+    EXPECT_FALSE(mut.try_lock());
+    mut.unlock();
+    EXPECT_TRUE(mut.try_lock());
+}
+
+TEST(SharedMutex, LockUnlockRead)
+{
+    SharedMutex mut;
+
+    mut.lock_shared();
+    EXPECT_FALSE(mut.try_lock());
+
+    mut.unlock_shared();
+    EXPECT_TRUE(mut.try_lock());
+}
+
+TEST(SharedMutex, LockedReadCount)
+{
+    SharedMutex mut;
+    int count = 0;
+
+    mut.lock_shared();
+    count++;
+    ASSERT_EQ(mut.getReaderCount(), count);
+
+    mut.lock_shared();
+    count++;
+    ASSERT_EQ(mut.getReaderCount(), count);
+
+    mut.unlock_shared();
+    count--;
+    ASSERT_EQ(mut.getReaderCount(), count);
+
+    mut.unlock_shared();
+    count--;
+    ASSERT_EQ(mut.getReaderCount(), count);
+
+    EXPECT_TRUE(mut.try_lock());
+}
+
+
+/*****************************************************************************/
+/*
  * FormatTime
  */
 /*****************************************************************************/


### PR DESCRIPTION
Based on #PR2981
Add a shared mutex on m_pListener to avoid a data race condition.
This fixes #2970  