### PR TITLE
[tests] Fix warnings when compiling with g++ 11.4.0 on ubuntu 24.04

### DIFF
--- a/examples/recvlive.cpp
+++ b/examples/recvlive.cpp
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
                         clientservice, sizeof(clientservice), NI_NUMERICHOST|NI_NUMERICSERV);
             cout << "new connection: " << clienthost << ":" << clientservice << endl;
 
-            int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+            events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
             if (SRT_ERROR == srt_epoll_add_usock(epid, fhandle, &events))
             {
                cout << "srt_epoll_add_usock: " << srt_getlasterror_str() << endl;

--- a/examples/sendmsg.cpp
+++ b/examples/sendmsg.cpp
@@ -150,25 +150,25 @@ int main(int argc, char* argv[])
        }
        else
        {
-           int lpos = 0;
+           int lpos2 = 0;
 
            int nparsed = 0;
            if (line[0] == '+')
            {
-               nparsed = sscanf(line.c_str(), "+%d %d %n%*s", &ttl, &id, &lpos);
+               nparsed = sscanf(line.c_str(), "+%d %d %n%*s", &ttl, &id, &lpos2);
                if (nparsed != 2)
                {
-                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos << ")\n";
+                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos2 << ")\n";
                    status = SRT_ERROR;
                    break;
                }
            }
            else
            {
-               nparsed = sscanf(line.c_str(), "%d %n%*s", &id, &lpos);
+               nparsed = sscanf(line.c_str(), "%d %n%*s", &id, &lpos2);
                if (nparsed != 1)
                {
-                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos << ")\n";
+                   cout << "ERROR: syntax error in input (" << nparsed << " parsed pos=" << lpos2 << ")\n";
                    status = SRT_ERROR;
                    break;
                }

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -355,7 +355,7 @@ protected:
             sockaddr_any showacp = (sockaddr*)&scl;
             std::cout << "[T/S] Accepted from: " << showacp.str() << std::endl;
 
-            int epoll_in = SRT_EPOLL_IN;
+            epoll_in = SRT_EPOLL_IN;
             srt_epoll_add_usock(server_pollid, accepted_sock, &epoll_in); // wait for input
 
             char buffer[1316];

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -367,9 +367,9 @@ SrtMainLoop::SrtMainLoop(const string& srt_uri, bool input_echoback, const strin
         Verb() << "SRT set up as input source and the first output target";
 
         // Add SRT medium to output targets, and keep input medium empty.
-        unique_ptr<TargetMedium> m { new TargetMedium };
-        m->Setup(m_srt_relay.get());
-        m_output_media.push_back(move(m));
+        unique_ptr<TargetMedium> med { new TargetMedium };
+        med->Setup(m_srt_relay.get());
+        m_output_media.push_back(move(med));
     }
     else
     {

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1130,15 +1130,15 @@ Connect_Again:
     // spread the setting on all sockets.
     ConfigurePost(m_sock);
 
-    for (size_t i = 0; i < targets.size(); ++i)
+    for (size_t j = 0; j < targets.size(); ++j)
     {
         // As m_group_nodes is simply transformed into 'targets',
         // one index can be used to index them all. You don't
         // have to check if they have equal addresses because they
         // are equal by definition.
-        if (targets[i].id != -1 && targets[i].errorcode == SRT_SUCCESS)
+        if (targets[j].id != -1 && targets[j].errorcode == SRT_SUCCESS)
         {
-            m_group_nodes[i].socket = targets[i].id;
+            m_group_nodes[j].socket = targets[j].id;
         }
     }
 
@@ -1159,9 +1159,9 @@ Connect_Again:
     }
     m_group_data.resize(size);
 
-    for (size_t i = 0; i < m_group_nodes.size(); ++i)
+    for (size_t j = 0; j < m_group_nodes.size(); ++j)
     {
-        SRTSOCKET insock = m_group_nodes[i].socket;
+        SRTSOCKET insock = m_group_nodes[j].socket;
         if (insock == -1)
         {
             Verb() << "TARGET '" << sockaddr_any(targets[i].peeraddr).str() << "' connection failed.";


### PR DESCRIPTION
Fix variables shadowing that is now a warning with gcc 13