### PR TITLE
[docs] Added SonarCloud badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 [![License: MPLv2.0][license-badge]](./LICENSE)
 [![Latest release][release-badge]][github releases]
+[![Quality Gate Status][sonarcloud-badge]][sonarcloud-project]
 [![codecov][codecov-badge]][codecov-project]
 [![Build Status Linux and macOS][travis-badge]][travis]
 [![Build Status Windows][appveyor-badge]][appveyor]
@@ -224,6 +225,9 @@ By contributing code to the SRT project, you agree to license your contribution 
 
 [ConanCenter-package]: https://repology.org/project/srt/versions
 [ConanCenter-badge]: https://repology.org/badge/version-for-repo/conancenter/srt.svg
+
+[sonarcloud-project]: https://sonarcloud.io/project/overview?id=srt
+[sonarcloud-badge]: https://sonarcloud.io/api/project_badges/measure?project=srt&metric=alert_status
 
 [codecov-project]: https://codecov.io/gh/haivision/srt
 [codecov-badge]: https://codecov.io/gh/haivision/srt/branch/master/graph/badge.svg


### PR DESCRIPTION
Added SonarCloud badge. The quality gate is now passing after C++11 and higher warnings have been disabled on the project due to support of C++03.