### PR TITLE
[core] Fixed a data race on listener's config.

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -537,6 +537,8 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
 
     try
     {
+        // Protect the config of the listener socket from a data race.
+        ScopedLock lck(ls->core().m_ConnectionLock);
         ns = new CUDTSocket(*ls);
         // No need to check the peer, this is the address from which the request has come.
         ns->m_PeerAddr = peer;


### PR DESCRIPTION
Fixed a data race upon a simultaneous access to listener's config (`CUDT::m_config`) from SRT internal `newConnection(..)` and the app thread called for `srt_listen()`. Locking the listener's `m_ConnectionLock`.

Replaces #2961.
Fixes #2970.