### PR TITLE
[core] Fixed THREAD_STATE_INIT usage in CRcvQueue.

### DIFF
--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -504,11 +504,9 @@ void* srt::CSndQueue::worker(void* param)
 {
     CSndQueue* self = (CSndQueue*)param;
 
-#if ENABLE_LOGGING
-    THREAD_STATE_INIT(("SRT:SndQ:w" + Sprint(m_counter)).c_str());
-#else
-    THREAD_STATE_INIT("SRT:SndQ:worker");
-#endif
+    std::string thname;
+    ThreadName::get(thname);
+    THREAD_STATE_INIT(thname.c_str());
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
 #define IF_DEBUG_HIGHRATE(statement) statement
@@ -1206,13 +1204,9 @@ void* srt::CRcvQueue::worker(void* param)
     sockaddr_any sa(self->getIPversion());
     int32_t      id = 0;
 
-#if ENABLE_LOGGING
     std::string thname;
     ThreadName::get(thname);
     THREAD_STATE_INIT(thname.c_str());
-#else
-    THREAD_STATE_INIT("SRT:RcvQ:worker");
-#endif
 
     CUnit*         unit = 0;
     EConnectStatus cst  = CONN_AGAIN;

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1207,7 +1207,9 @@ void* srt::CRcvQueue::worker(void* param)
     int32_t      id = 0;
 
 #if ENABLE_LOGGING
-    THREAD_STATE_INIT(("SRT:RcvQ:w" + Sprint(m_counter)).c_str());
+    std::string thname;
+    ThreadName::get(thname);
+    THREAD_STATE_INIT(thname.c_str());
 #else
     THREAD_STATE_INIT("SRT:RcvQ:worker");
 #endif


### PR DESCRIPTION
The `CRcvQueue::m_counter` variable is shared between threads. The `THREAD_STATE_INIT` macro used the value to form the thread name, but the value could be the same for several threads.
The thread must already have a name set via `ThreadName`. Therefore just extract it via `ThreadName::get(std::string&)`.

Fixes #2973.