### PR TITLE
[apps] Fixed verbose linkage difference.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1383,7 +1383,6 @@ if (ENABLE_APPS)
 		# srt-multiplex temporarily blocked
 		#srt_add_application(srt-multiplex ${VIRTUAL_srtsupport})
 		srt_add_application(srt-tunnel ${VIRTUAL_srtsupport})
-		target_compile_definitions(srt-tunnel PUBLIC -DSRT_ENABLE_VERBOSE_LOCK)
 	endif()
 
 	if (ENABLE_TESTING)
@@ -1421,7 +1420,6 @@ if (ENABLE_APPS)
 
 		srt_add_testprogram(srt-test-relay)
 		srt_make_application(srt-test-relay)
-		target_compile_definitions(srt-test-relay PUBLIC -DSRT_ENABLE_VERBOSE_LOCK)
 
 		srt_add_testprogram(srt-test-multiplex)
 		srt_make_application(srt-test-multiplex)

--- a/apps/verbose.cpp
+++ b/apps/verbose.cpp
@@ -9,13 +9,13 @@
  */
 
 #include "verbose.hpp"
-#include <mutex>
+#include "sync.h" // srt::sync
 
 namespace Verbose
 {
     bool on = false;
     std::ostream* cverb = &std::cerr;
-    std::mutex vlock;
+    srt::sync::Mutex vlock;
 
     Log& Log::operator<<(LogNoEol)
     {
@@ -44,7 +44,7 @@ namespace Verbose
             }
             else if (vlock.try_lock())
             {
-                // Successfully locked, so unlock immediately, locking wasn't required.
+                // Successfully locked, so unlock immediately, locking wasn't requested.
                 vlock.unlock();
             }
             else

--- a/apps/verbose.hpp
+++ b/apps/verbose.hpp
@@ -12,9 +12,6 @@
 #define INC_SRT_VERBOSE_HPP
 
 #include <iostream>
-#if SRT_ENABLE_VERBOSE_LOCK
-#include <mutex>
-#endif
 
 namespace Verbose
 {
@@ -23,19 +20,15 @@ extern bool on;
 extern std::ostream* cverb;
 
 struct LogNoEol { LogNoEol() {} };
-#if SRT_ENABLE_VERBOSE_LOCK
 struct LogLock { LogLock() {} };
-#endif
 
 class Log
 {
     bool noeol = false;
-#if SRT_ENABLE_VERBOSE_LOCK
     bool lockline = false;
-#endif
 
     // Disallow creating dynamic objects
-    void* operator new(size_t);
+    void* operator new(size_t) = delete;
 
 public:
 
@@ -50,9 +43,7 @@ public:
     }
 
     Log& operator<<(LogNoEol);
-#if SRT_ENABLE_VERBOSE_LOCK
     Log& operator<<(LogLock);
-#endif
     ~Log();
 };
 
@@ -99,8 +90,6 @@ inline void Verb(Args&&... args)
 
 // Manipulator tags
 static const Verbose::LogNoEol VerbNoEOL;
-#if SRT_ENABLE_VERBOSE_LOCK
 static const Verbose::LogLock VerbLock;
-#endif
 
 #endif


### PR DESCRIPTION
- Verbose log now has a single version with a mutex lock.
- Removed `SRT_ENABLE_VERBOSE_LOCK` build definition.

Fixes #2145.

## Notes

I am not quite sure if the implementation of the Verbose::Log with a mutex is thread safe given the `template <class V> Log& operator<<(const V& arg)` is not protected by a mutex lock. What's protected is putting the end of line symbol on log destruction.

```c++
Verb() << VerbLock << "Starting TargetMedium: " << this;
```