### PR TITLE
[devel] Fixed atomic setting of locked line in Verb

### DIFF
--- a/apps/verbose.hpp
+++ b/apps/verbose.hpp
@@ -14,6 +14,7 @@
 #include <iostream>
 #if SRT_ENABLE_VERBOSE_LOCK
 #include <mutex>
+#include "atomic.h"
 #endif
 
 namespace Verbose
@@ -31,13 +32,17 @@ class Log
 {
     bool noeol = false;
 #if SRT_ENABLE_VERBOSE_LOCK
-    bool lockline = false;
+    srt::sync::atomic<bool> lockline;
 #endif
 
     // Disallow creating dynamic objects
     void* operator new(size_t);
 
 public:
+
+    Log() {}
+    Log(const Log& ) {}
+
 
     template <class V>
     Log& operator<<(const V& arg)
@@ -80,7 +85,7 @@ inline void Print(Log& ) {}
 template <typename Arg1, typename... Args>
 inline void Print(Log& out, Arg1&& arg1, Args&&... args)
 {
-    out << std::forward(arg1);
+    out << arg1;
     Print(out, args...);
 }
 
@@ -93,6 +98,13 @@ template <typename... Args>
 inline void Verb(Args&&... args)
 {
     Verbose::Log log;
+    Verbose::Print(log, args...);
+}
+
+template <typename... Args>
+inline void Verror(Args&&... args)
+{
+    Verbose::ErrLog log;
     Verbose::Print(log, args...);
 }
 

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -268,7 +268,7 @@ bool CheckMediaSpec(const string& prefix, const vector<string>& spec, string& w_
     for (string& a: adrs)
         w_outspec += a + ",";
 
-    Verb() << "NOTE: " << prefix << " specification set as: " << (w_outspec);
+    Verb("NOTE: ", prefix, " specification set as: ", (w_outspec));
 
     return true;
 }
@@ -294,7 +294,7 @@ extern "C" int SrtCheckGroupHook(void* , SRTSOCKET acpsock, int , const sockaddr
     int type;
     int size = sizeof type;
     srt_getsockflag(acpsock, SRTO_GROUPCONNECT, &type, &size);
-    Verb() << "listener: @" << acpsock << " - accepting " << (type ? "GROUP" : "SINGLE") << VerbNoEOL;
+    Verb("listener: @", acpsock, " - accepting ", (type ? "GROUP" : "SINGLE"), VerbNoEOL);
     if (type != 0)
     {
         SRT_GROUP_TYPE gt;
@@ -302,12 +302,12 @@ extern "C" int SrtCheckGroupHook(void* , SRTSOCKET acpsock, int , const sockaddr
         if (-1 != srt_getsockflag(acpsock, SRTO_GROUPTYPE, &gt, &size))
         {
             if (gt < Size(gtypes))
-                Verb() << " type=" << gtypes[gt] << VerbNoEOL;
+                Verb(" type=", gtypes[gt], VerbNoEOL);
             else
-                Verb() << " type=" << int(gt) << VerbNoEOL;
+                Verb(" type=", int(gt), VerbNoEOL);
         }
     }
-    Verb() << " connection";
+    Verb(" connection");
 
     return 0;
 }
@@ -317,7 +317,7 @@ extern "C" int SrtUserPasswordHook(void* , SRTSOCKET acpsock, int hsv, const soc
 {
     if (hsv < 5)
     {
-        Verb() << "SrtUserPasswordHook: HS version 4 doesn't support extended handshake";
+        Verb("SrtUserPasswordHook: HS version 4 doesn't support extended handshake");
         return -1;
     }
 
@@ -818,7 +818,7 @@ int main( int argc, char** argv )
             return 0;
         }
 
-        Verb() << "MEDIA CREATION FAILED: " << x.what() << " - exiting.";
+        Verb("MEDIA CREATION FAILED: ", x.what(), " - exiting.");
 
         // Don't speak anything when no -v option.
         // (the "requested interrupt" will be printed anyway)
@@ -847,10 +847,10 @@ int main( int argc, char** argv )
 
     if (transmit_use_sourcetime && src->uri.type() != UriParser::SRT)
     {
-        Verb() << "WARNING: -st option is effective only if the target type is SRT";
+        Verb("WARNING: -st option is effective only if the target type is SRT");
     }
 
-    Verb() << "STARTING TRANSMISSION: '" << source_spec << "' --> '" << target_spec << "'";
+    Verb("STARTING TRANSMISSION: '", source_spec, "' --> '", target_spec, "'");
 
     // After the time has been spent in the creation
     // (including waiting for connection)
@@ -876,41 +876,41 @@ int main( int argc, char** argv )
         {
             if (stoptime == 0 && timeout != -1 )
             {
-                Verb() << "[." << VerbNoEOL;
+                Verb("[.", VerbNoEOL);
                 alarm(timeout);
             }
             else
             {
                 alarm(0);
             }
-            Verb() << " << ... " << VerbNoEOL;
+            Verb(", ... ", VerbNoEOL);
             g_interrupt_reason = "reading";
             const MediaPacket& data = src->Read(chunk);
-            Verb() << " << " << data.payload.size() << "  ->  " << VerbNoEOL;
+            Verb(", ", data.payload.size(), "  ->  ", VerbNoEOL);
             if ( data.payload.empty() && src->End() )
             {
-                Verb() << "EOS";
+                Verb("EOS");
                 break;
             }
             g_interrupt_reason = "writing";
             tar->Write(data);
             if (stoptime == 0 && timeout != -1 )
             {
-                Verb() << ".] " << VerbNoEOL;
+                Verb(".] ", VerbNoEOL);
                 alarm(0);
             }
 
             if ( tar->Broken() )
             {
-                Verb() << " OUTPUT broken";
+                Verb(" OUTPUT broken");
                 break;
             }
 
-            Verb() << "sent";
+            Verb("sent");
 
             if (::transmit_int_state)
             {
-                Verror() << "\n (interrupted on request)";
+                Verror("\n (interrupted on request)");
                 break;
             }
 
@@ -922,7 +922,7 @@ int main( int argc, char** argv )
                 int remain = int(stoptime - final_delay - elapsed);
                 if (remain < 0)
                 {
-                    Verror() << "\n (interrupted on timeout: elapsed " << elapsed << "s) - waiting " << final_delay << "s for cleanup";
+                    Verror("\n (interrupted on timeout: elapsed ", elapsed, "s) - waiting ", final_delay, "s for cleanup");
                     this_thread::sleep_for(chrono::seconds(final_delay));
                     break;
                 }
@@ -934,17 +934,17 @@ int main( int argc, char** argv )
 
         if (!skip_flushing)
         {
-            Verror() << "(DEBUG) EOF when reading file. Looping until the sending bufer depletes.\n";
+            Verror("(DEBUG) EOF when reading file. Looping until the sending bufer depletes.\n");
             for (;;)
             {
                 size_t still = tar->Still();
                 if (still == 0)
                 {
-                    Verror() << "(DEBUG) DEPLETED. Done.\n";
+                    Verror("(DEBUG) DEPLETED. Done.\n");
                     break;
                 }
 
-                Verror() << "(DEBUG)... still " << still << " bytes (sleep 1s)\n";
+                Verror("(DEBUG)... still ", still, " bytes (sleep 1s)\n");
                 this_thread::sleep_for(chrono::seconds(1));
             }
         }
@@ -952,16 +952,16 @@ int main( int argc, char** argv )
 
         if (stoptime != 0 && ::timer_state)
         {
-            Verror() << "Exit on timeout.";
+            Verror("Exit on timeout.");
         }
         else if (::transmit_int_state)
         {
-            Verror() << "Exit on interrupt.";
+            Verror("Exit on interrupt.");
             // Do nothing.
         }
         else
         {
-            Verror() << "STD EXCEPTION: " << x.what();
+            Verror("STD EXCEPTION: ", x.what());
         }
 
         if ( crashonx )
@@ -969,7 +969,7 @@ int main( int argc, char** argv )
 
         if (final_delay > 0)
         {
-            Verror() << "Waiting " << final_delay << "s for possible cleanup...";
+            Verror("Waiting ", final_delay, "s for possible cleanup...");
             this_thread::sleep_for(chrono::seconds(final_delay));
         }
         if (stoptime != 0 && ::timer_state)
@@ -979,7 +979,7 @@ int main( int argc, char** argv )
 
     } catch (...) {
 
-        Verror() << "UNKNOWN type of EXCEPTION";
+        Verror("UNKNOWN type of EXCEPTION");
         if ( crashonx )
             throw;
 

--- a/testing/srt-test-multiplex.cpp
+++ b/testing/srt-test-multiplex.cpp
@@ -403,7 +403,7 @@ void Stall()
             ++i_next;
             if (i->has_quit)
             {
-                Verb() << "Found QUIT mediumpair: " << i->name << " - removing from base";
+                Verb("Found QUIT mediumpair: ", i->name, " - removing from base");
                 i->Stop();
                 g_media_base.media.erase(i);
             }
@@ -411,7 +411,7 @@ void Stall()
 
         if (g_media_base.media.empty())
         {
-            Verb() << "All media have quit. Marking exit.";
+            Verb("All media have quit. Marking exit.");
             break;
         }
     }


### PR DESCRIPTION
1. Fixed: added atomic for lockline to avoid races when using line locking in Verb.
2. Added empty constructors in Log class to avoid copying when returning temporary object as proxy for operator <<.
3. Fixed invalid call to std::forward to allow variadic versions of Verb().
4. Changed operator<< to variadic Verb version in two app files.