### PR TITLE
[core] Apply lock on RCV buffer read-ready check.

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7124,7 +7124,7 @@ int srt::CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_
 
     do
     {
-        if (stillConnected() && !timeout && !m_pRcvBuffer->isRcvDataReady(steady_clock::now()))
+        if (stillConnected() && !timeout && !isRcvBufferReady())
         {
             /* Kick TsbPd thread to schedule next wakeup (if running) */
             if (m_bTsbPd)

--- a/srtcore/logging.h
+++ b/srtcore/logging.h
@@ -112,7 +112,7 @@ struct LogConfig
     std::ostream* log_stream;
     SRT_LOG_HANDLER_FN* loghandler_fn;
     void* loghandler_opaque;
-    srt::sync::Mutex mutex;
+    mutable srt::sync::Mutex mutex;
     int flags;
 
     LogConfig(const fa_bitset_t& efa,
@@ -132,10 +132,10 @@ struct LogConfig
     }
 
     SRT_ATTR_ACQUIRE(mutex)
-    void lock() { mutex.lock(); }
+    void lock() const { mutex.lock(); }
 
     SRT_ATTR_RELEASE(mutex)
-    void unlock() { mutex.unlock(); }
+    void unlock() const { mutex.unlock(); }
 };
 
 // The LogDispatcher class represents the object that is responsible for
@@ -424,8 +424,10 @@ inline bool LogDispatcher::CheckEnabled()
     // when the enabler check is tested here. Worst case, the log
     // will be printed just a moment after it was turned off.
     const LogConfig* config = src_config; // to enforce using const operator[]
+    config->lock();
     int configured_enabled_fa = config->enabled_fa[fa];
     int configured_maxlevel = config->max_level;
+    config->unlock();
 
     return configured_enabled_fa && level <= configured_maxlevel;
 }

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -74,6 +74,8 @@ class IOVector
 #endif
 {
 public:
+    IOVector() { set(NULL, 0); }
+
     inline void set(void* buffer, size_t length)
     {
 #ifdef _WIN32


### PR DESCRIPTION
The lock was missing. The change is extracted from PR #2893.