### PR TITLE
[core] Include packet header in rexmit BW calculation.

### DIFF
--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -234,7 +234,7 @@ void CSndRateEstimator::addSample(const time_point& ts, int pkts, size_t bytes)
         }
         else
         {
-            m_iRateBps = sum.m_iBytesCount * 1000 / (iNumPeriods * SAMPLE_DURATION_MS);
+            m_iRateBps = (sum.m_iBytesCount + CPacket::HDR_SIZE * sum.m_iPktsCount) * 1000 / (iNumPeriods * SAMPLE_DURATION_MS);
         }
 
         HLOGC(bslog.Note,
@@ -260,7 +260,8 @@ void CSndRateEstimator::addSample(const time_point& ts, int pkts, size_t bytes)
 int CSndRateEstimator::getCurrentRate() const
 {
     SRT_ASSERT(m_iCurSampleIdx >= 0 && m_iCurSampleIdx < NUM_PERIODS);
-    return (int) avg_iir<16, unsigned long long>(m_iRateBps, m_Samples[m_iCurSampleIdx].m_iBytesCount * 1000 / SAMPLE_DURATION_MS);
+    const Sample& s = m_Samples[m_iCurSampleIdx];
+    return (int) avg_iir<16, unsigned long long>(m_iRateBps, (CPacket::HDR_SIZE * s.m_iPktsCount + s.m_iBytesCount) * 1000 / SAMPLE_DURATION_MS);
 }
 
 int CSndRateEstimator::incSampleIdx(int val, int inc) const

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -141,10 +141,11 @@ public:
     /// @param [in] bytes  number of payload bytes in the sample.
     void addSample(const time_point& time, int pkts = 0, size_t bytes = 0);
 
-    /// Retrieve estimated bitrate in bytes per second
+    /// Retrieve estimated bitrate in bytes per second with 16-byte packet header.
     int getRate() const { return m_iRateBps; }
 
-    /// Retrieve estimated bitrate in bytes per second inluding the current sampling interval.
+    /// Retrieve estimated bitrate in bytes per second (with 16-byte packet header)
+    /// including the current sampling interval.
     int getCurrentRate() const;
 
 private:
@@ -191,10 +192,10 @@ private:
 
     Sample m_Samples[NUM_PERIODS];
 
-    time_point m_tsFirstSampleTime; //< Start time of the first sameple.
+    time_point m_tsFirstSampleTime; //< Start time of the first sample.
     int        m_iFirstSampleIdx;   //< Index of the first sample.
     int        m_iCurSampleIdx;     //< Index of the current sample being collected.
-    int        m_iRateBps;          // Input Rate in Bytes/sec
+    int        m_iRateBps;          //< Rate in Bytes/sec.
 };
 
 } // namespace srt


### PR DESCRIPTION
Likely the initial idea was to make the `CSndRateEstimator` class independent from SRT-specific constants. But packet header sizes were missing in the retransmission rate estimation.

Fixes #3006.

SRT version affected: v1.5.3.