### PR TITLE
[core] New moving average value for sent/recv rates over last second

### DIFF
--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -331,7 +331,7 @@ void CMovingRateEstimator::computeAverageValue()
         newRateBps += (m_Samples[i].m_iBytesCount + (CPacket::HDR_SIZE * m_Samples[i].m_iPktsCount));
 
     if (isFirstPeriod)
-        newRateBps = newRateBps * 1000 / startDelta;
+        newRateBps = newRateBps * SAMPLE_DURATION_MS * NUM_PERIODS / max(1, startDelta);
 
     m_iRateBps = newRateBps;
 }

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -275,7 +275,6 @@ int CSndRateEstimator::incSampleIdx(int val, int inc) const
 
 CMovingRateEstimator::CMovingRateEstimator()
     : m_tsFirstSampleTime(sync::steady_clock::now())
-    , m_iFirstSampleIdx(0)
     , m_iCurSampleIdx(0)
     , m_iRateBps(0)
     , m_Samples(NUM_PERIODS)

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -157,9 +157,10 @@ void CRateEstimator::updateInputRate(const time_point& time, int pkts, int bytes
 
 CSndRateEstimator::CSndRateEstimator(const time_point& tsNow)
     : m_tsFirstSampleTime(tsNow)
-    , m_iFirstSampleIdx(0)
     , m_iCurSampleIdx(0)
     , m_iRateBps(0)
+    , m_Samples(NUM_PERIODS)
+    , m_iFirstSampleIdx(0)
 {
     
 }
@@ -275,7 +276,6 @@ int CSndRateEstimator::incSampleIdx(int val, int inc) const
 
 CMovingRateEstimator::CMovingRateEstimator()
     : CSndRateEstimator(sync::steady_clock::now())
-    , m_Samples(NUM_PERIODS)
 {
     resetRate(0, NUM_PERIODS);
 }

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -312,9 +312,9 @@ void CMobileRateEstimator::computeAverageValueFromTable(){
     m_iRateKbps = 0;
 
     for(int i = 0; i < NUM_PERIODS; i++)
-            m_iRateKbps += m_Samples[i].m_iBytesCount;
+            m_iRateKbps += (m_Samples[i].m_iBytesCount + (CPacket::HDR_SIZE * m_Samples[i].m_iPktsCount)) * 8;
 
-    m_iRateKbps = m_iRateKbps  * 8 / (NUM_PERIODS * SAMPLE_DURATION_MS);
+    m_iRateKbps = m_iRateKbps / (NUM_PERIODS * SAMPLE_DURATION_MS);
 }
 }
 

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -275,7 +275,11 @@ int CSndRateEstimator::incSampleIdx(int val, int inc) const
 }
 
 CMovingRateEstimator::CMovingRateEstimator()
-    : CSndRateEstimator(sync::steady_clock::now())
+    : m_tsFirstSampleTime(sync::steady_clock::now())
+    , m_iFirstSampleIdx(0)
+    , m_iCurSampleIdx(0)
+    , m_iRateBps(0)
+    , m_Samples(NUM_PERIODS)
 {
     resetRate(0, NUM_PERIODS);
 }

--- a/srtcore/buffer_tools.cpp
+++ b/srtcore/buffer_tools.cpp
@@ -157,10 +157,9 @@ void CRateEstimator::updateInputRate(const time_point& time, int pkts, int bytes
 
 CSndRateEstimator::CSndRateEstimator(const time_point& tsNow)
     : m_tsFirstSampleTime(tsNow)
+    , m_iFirstSampleIdx(0)
     , m_iCurSampleIdx(0)
     , m_iRateBps(0)
-    , m_Samples(NUM_PERIODS)
-    , m_iFirstSampleIdx(0)
 {
     
 }

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -148,11 +148,9 @@ public:
     /// including the current sampling interval.
     int getCurrentRate() const;
 
-protected:
-    time_point m_tsFirstSampleTime; //< Start time of the first sample.
-    int        m_iCurSampleIdx;     //< Index of the current sample being collected.
-    int        m_iRateBps;          //< Rate in Bytes/sec.
-
+private:
+    static const int NUM_PERIODS        = 10;
+    static const int SAMPLE_DURATION_MS = 100; // 100 ms
     struct Sample
     {
         int m_iPktsCount;  // number of payload packets
@@ -190,14 +188,14 @@ protected:
         bool empty() const { return m_iPktsCount == 0; }
     };
 
-    srt::FixedArray<Sample> m_Samples; // Table of stored data
-
-private:
-    static const int NUM_PERIODS        = 10;
-    static const int SAMPLE_DURATION_MS = 100; // 100 ms
-    int              m_iFirstSampleIdx;        //< Index of the first sample.
-
     int incSampleIdx(int val, int inc = 1) const;
+
+    Sample m_Samples[NUM_PERIODS];
+
+    time_point m_tsFirstSampleTime; //< Start time of the first sameple.
+    int        m_iFirstSampleIdx;   //< Index of the first sample.
+    int        m_iCurSampleIdx;     //< Index of the current sample being collected.
+    int        m_iRateBps;          // Input Rate in Bytes/sec
 };
 
 class CMovingRateEstimator

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -219,13 +219,13 @@ public:
 private:
     // We would like responsiveness (accuracy) of rate estimation higher than 100 ms
     // (ideally around 50 ms) for network adaptive algorithms.
-    const int  NUM_PERIODS        = 100; // To get 1s of values
-    const int  SAMPLE_DURATION_MS = 10;  // 10 ms
-    time_point m_tsFirstSampleTime;      //< Start time of the first sample.
-    time_point lastSlotTimestamp;        // Used to compute the delta between 2 calls
-    int        m_iFirstSampleIdx;        //< Index of the first sample.
-    int        m_iCurSampleIdx;          //< Index of the current sample being collected.
-    int        m_iRateBps;               //< Rate in Bytes/sec.
+    static const int NUM_PERIODS        = 100; // To get 1s of values
+    static const int SAMPLE_DURATION_MS = 10;  // 10 ms
+    time_point       m_tsFirstSampleTime;      //< Start time of the first sample.
+    time_point       m_tsLastSlotTimestamp;    // Used to compute the delta between 2 calls
+    int              m_iFirstSampleIdx;        //< Index of the first sample.
+    int              m_iCurSampleIdx;          //< Index of the current sample being collected.
+    int              m_iRateBps;               //< Rate in Bytes/sec.
 
     struct Sample
     {

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -197,6 +197,8 @@ private:
     int        m_iFirstSampleIdx;   //< Index of the first sample.
     int        m_iCurSampleIdx;     //< Index of the current sample being collected.
     int        m_iRateBps;          //< Rate in Bytes/sec.
+
+    int incSampleIdx(int val, int inc = 1) const;
 };
 
 class CMobileRateEstimator:CSndRateEstimator

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -223,7 +223,6 @@ private:
     static const int SAMPLE_DURATION_MS = 10;  // 10 ms
     time_point       m_tsFirstSampleTime;      //< Start time of the first sample.
     time_point       m_tsLastSlotTimestamp;    // Used to compute the delta between 2 calls
-    int              m_iFirstSampleIdx;        //< Index of the first sample.
     int              m_iCurSampleIdx;          //< Index of the current sample being collected.
     int              m_iRateBps;               //< Rate in Bytes/sec.
 

--- a/srtcore/buffer_tools.h
+++ b/srtcore/buffer_tools.h
@@ -149,9 +149,9 @@ public:
     int getCurrentRate() const;
 
 protected:
+    time_point m_tsFirstSampleTime; //< Start time of the first sample.
     int        m_iCurSampleIdx;     //< Index of the current sample being collected.
     int        m_iRateBps;          //< Rate in Bytes/sec.
-    time_point m_tsFirstSampleTime; //< Start time of the first sample.
 
     struct Sample
     {
@@ -190,11 +190,12 @@ protected:
         bool empty() const { return m_iPktsCount == 0; }
     };
 
+    srt::FixedArray<Sample> m_Samples; // Table of stored data
+
 private:
     static const int NUM_PERIODS        = 10;
     static const int SAMPLE_DURATION_MS = 100; // 100 ms
-    Sample           m_Samples[NUM_PERIODS];
-    int              m_iFirstSampleIdx; //< Index of the first sample.
+    int              m_iFirstSampleIdx;        //< Index of the first sample.
 
     int incSampleIdx(int val, int inc = 1) const;
 };
@@ -218,10 +219,9 @@ public:
     int getRate() const { return m_iRateBps; }
 
 private:
-    const int               NUM_PERIODS        = 100; // To get 1s of values
-    const int               SAMPLE_DURATION_MS = 10;  // 10 ms
-    time_point              lastSlotTimestamp;        // Used to compute the delta between 2 calls
-    srt::FixedArray<Sample> m_Samples;                // Table of stored data
+    const int  NUM_PERIODS        = 100; // To get 1s of values
+    const int  SAMPLE_DURATION_MS = 10;  // 10 ms
+    time_point lastSlotTimestamp;        // Used to compute the delta between 2 calls
 
     /// This method will compute the average value based on all table's measures and the period
     /// (NUM_PERIODS*SAMPLE_DURATION_MS)

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7571,13 +7571,13 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 
         
         // Average values management
+        // We are updating rate with 0 Byte 0 packet to ensure an up to date compute in case we are not sending packet for a while.
+        m_stats.sndr.updateRate(0, 0);
+        m_stats.rcvr.updateRate(0, 0);
         perf->mbpsSendRate = Bps2Mbps(m_stats.sndr.getAverageValue());
         perf->mbpsRecvRate = Bps2Mbps(m_stats.rcvr.getAverageValue());
 
         // TODO: The following class members must be protected with a different mutex, not the m_StatsLock.
-        const double interval     = (double) count_microseconds(currtime - m_stats.tsLastSampleTime);
-        perf->mbpsSendRate        = double(perf->byteSent) * 8.0 / interval;
-        perf->mbpsRecvRate        = double(perf->byteRecv) * 8.0 / interval;
         perf->usPktSndPeriod      = (double) count_microseconds(m_tdSendInterval.load());
         perf->pktFlowWindow       = m_iFlowWindowSize.load();
         perf->pktCongestionWindow = m_iCongestionWindow;
@@ -9730,6 +9730,7 @@ bool srt::CUDT::packData(CPacket& w_packet, steady_clock::time_point& w_nexttime
     m_stats.sndr.sent.count(payload);
     if (new_packet_packed)
         m_stats.sndr.sentUnique.count(payload);
+    m_stats.sndr.updateRate(1, payload);
     leaveCS(m_StatsLock);
 
     const duration sendint = m_tdSendInterval;
@@ -10406,6 +10407,7 @@ int srt::CUDT::processData(CUnit* in_unit)
 
     enterCS(m_StatsLock);
     m_stats.rcvr.recvd.count(pktsz);
+    m_stats.rcvr.updateRate(1, pktsz);
     leaveCS(m_StatsLock);
 
     loss_seqs_t                             filter_loss_seqs;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7569,6 +7569,13 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
         perf->pktRcvUndecryptTotal  = m_stats.rcvr.undecrypted.total.count();
         perf->byteRcvUndecryptTotal = m_stats.rcvr.undecrypted.total.bytes();
 
+        
+        // Average values management
+        m_stats.sndr.fulfillMeasuresTable(perf->pktSent, double(perf->byteSent));
+        m_stats.rcvr.fulfillMeasuresTable(perf->pktRecv, double(perf->byteRecv));
+        perf->mbpsSendRate        = m_stats.sndr.getAverageValueFromTable();
+        perf->mbpsRecvRate        = m_stats.rcvr.getAverageValueFromTable();
+        
         // TODO: The following class members must be protected with a different mutex, not the m_StatsLock.
         const double interval     = (double) count_microseconds(currtime - m_stats.tsLastSampleTime);
         perf->mbpsSendRate        = double(perf->byteSent) * 8.0 / interval;

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -7571,11 +7571,9 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 
         
         // Average values management
-        m_stats.sndr.fulfillMeasuresTable(perf->pktSent, double(perf->byteSent));
-        m_stats.rcvr.fulfillMeasuresTable(perf->pktRecv, double(perf->byteRecv));
-        perf->mbpsSendRate        = m_stats.sndr.getAverageValueFromTable();
-        perf->mbpsRecvRate        = m_stats.rcvr.getAverageValueFromTable();
-        
+        perf->mbpsSendRate = Bps2Mbps(m_stats.sndr.getAverageValue());
+        perf->mbpsRecvRate = Bps2Mbps(m_stats.rcvr.getAverageValue());
+
         // TODO: The following class members must be protected with a different mutex, not the m_StatsLock.
         const double interval     = (double) count_microseconds(currtime - m_stats.tsLastSampleTime);
         perf->mbpsSendRate        = double(perf->byteSent) * 8.0 / interval;

--- a/srtcore/stats.h
+++ b/srtcore/stats.h
@@ -145,7 +145,7 @@ struct Sender
     Metric<Packets> recvdAck; // The number of ACK packets received by the sender.
     Metric<Packets> recvdNak; // The number of ACK packets received by the sender.
 
-    CMobileRateEstimator mobileRateEstimator; // The average Mbps over last second
+    CMovingRateEstimator mobileRateEstimator; // The average Mbps over last second
 
     void reset()
     {
@@ -171,17 +171,11 @@ struct Sender
         sentFilterExtra.resetTrace();
     }
 
-    void fulfillMeasuresTable(int pkts, double bytes) {
-        mobileRateEstimator.addSample(pkts, bytes);
-    }
+    void updateRate(int pkts, double bytes) { mobileRateEstimator.addSample(pkts, bytes); }
 
-    void resetMeasuresTable() {
-        mobileRateEstimator.resetMeasuresTable();
-    }
+    void resetRate() { mobileRateEstimator.resetRate(); }
 
-    int getAverageValueFromTable(){
-       return mobileRateEstimator.getRateKbps();
-    }
+    int getAverageValue() { return mobileRateEstimator.getRate(); }
 };
 
 /// Receiver-side statistics.
@@ -202,7 +196,7 @@ struct Receiver
     Metric<Packets> sentAck; // The number of ACK packets sent by the receiver.
     Metric<Packets> sentNak; // The number of NACK packets sent by the receiver.
 
-    CMobileRateEstimator mobileRateEstimator; // The average Mbps over last second
+    CMovingRateEstimator mobileRateEstimator; // The average Mbps over last second
 
     void reset()
     {
@@ -236,17 +230,11 @@ struct Receiver
         sentNak.resetTrace();
     }
 
-    void fulfillMeasuresTable(int pkts, double bytes) {
-        mobileRateEstimator.addSample(pkts, bytes);
-    }
+    void updateRate(int pkts, double bytes) { mobileRateEstimator.addSample(pkts, bytes); }
 
-    void resetMeasuresTable() {
-        mobileRateEstimator.resetMeasuresTable();
-    }
+    void resetRate() { mobileRateEstimator.resetRate(); }
 
-    int getAverageValueFromTable(){
-       return mobileRateEstimator.getRateKbps();
-    }
+    int getAverageValue() { return mobileRateEstimator.getRate(); }
 };
 
 } // namespace stats

--- a/srtcore/stats.h
+++ b/srtcore/stats.h
@@ -13,6 +13,7 @@
 
 #include "platform_sys.h"
 #include "packet.h"
+#include "buffer_tools.h"
 
 namespace srt
 {
@@ -144,6 +145,8 @@ struct Sender
     Metric<Packets> recvdAck; // The number of ACK packets received by the sender.
     Metric<Packets> recvdNak; // The number of ACK packets received by the sender.
 
+    CMobileRateEstimator mobileRateEstimator; // The average Mbps over last second
+
     void reset()
     {
         sent.reset();
@@ -167,6 +170,18 @@ struct Sender
         recvdNak.resetTrace();
         sentFilterExtra.resetTrace();
     }
+
+    void fulfillMeasuresTable(int pkts, double bytes) {
+        mobileRateEstimator.addSample(pkts, bytes);
+    }
+
+    void resetMeasuresTable() {
+        mobileRateEstimator.resetMeasuresTable();
+    }
+
+    int getAverageValueFromTable(){
+       return mobileRateEstimator.getRateKbps();
+    }
 };
 
 /// Receiver-side statistics.
@@ -186,6 +201,8 @@ struct Receiver
 
     Metric<Packets> sentAck; // The number of ACK packets sent by the receiver.
     Metric<Packets> sentNak; // The number of NACK packets sent by the receiver.
+
+    CMobileRateEstimator mobileRateEstimator; // The average Mbps over last second
 
     void reset()
     {
@@ -217,6 +234,18 @@ struct Receiver
         lossFilter.resetTrace();
         sentAck.resetTrace();
         sentNak.resetTrace();
+    }
+
+    void fulfillMeasuresTable(int pkts, double bytes) {
+        mobileRateEstimator.addSample(pkts, bytes);
+    }
+
+    void resetMeasuresTable() {
+        mobileRateEstimator.resetMeasuresTable();
+    }
+
+    int getAverageValueFromTable(){
+       return mobileRateEstimator.getRateKbps();
     }
 };
 

--- a/srtcore/stats.h
+++ b/srtcore/stats.h
@@ -145,7 +145,7 @@ struct Sender
     Metric<Packets> recvdAck; // The number of ACK packets received by the sender.
     Metric<Packets> recvdNak; // The number of ACK packets received by the sender.
 
-    CMovingRateEstimator mobileRateEstimator; // The average Mbps over last second
+    CMovingRateEstimator mavgRateEstimator; // The average Mbps over last second
 
     void reset()
     {
@@ -171,11 +171,11 @@ struct Sender
         sentFilterExtra.resetTrace();
     }
 
-    void updateRate(int pkts, double bytes) { mobileRateEstimator.addSample(pkts, bytes); }
+    void updateRate(int pkts, double bytes) { mavgRateEstimator.addSample(pkts, bytes); }
 
-    void resetRate() { mobileRateEstimator.resetRate(); }
+    void resetRate() { mavgRateEstimator.resetRate(); }
 
-    int getAverageValue() { return mobileRateEstimator.getRate(); }
+    int getAverageValue() { return mavgRateEstimator.getRate(); }
 };
 
 /// Receiver-side statistics.
@@ -196,7 +196,7 @@ struct Receiver
     Metric<Packets> sentAck; // The number of ACK packets sent by the receiver.
     Metric<Packets> sentNak; // The number of NACK packets sent by the receiver.
 
-    CMovingRateEstimator mobileRateEstimator; // The average Mbps over last second
+    CMovingRateEstimator mavgRateEstimator; // The average Mbps over last second
 
     void reset()
     {
@@ -230,11 +230,11 @@ struct Receiver
         sentNak.resetTrace();
     }
 
-    void updateRate(int pkts, double bytes) { mobileRateEstimator.addSample(pkts, bytes); }
+    void updateRate(int pkts, double bytes) { mavgRateEstimator.addSample(pkts, bytes); }
 
-    void resetRate() { mobileRateEstimator.resetRate(); }
+    void resetRate() { mavgRateEstimator.resetRate(); }
 
-    int getAverageValue() { return mobileRateEstimator.getRate(); }
+    int getAverageValue() { return mavgRateEstimator.getRate(); }
 };
 
 } // namespace stats


### PR DESCRIPTION
fixes #1812  - A new class was created to compute received and sent average rates for last second, independent of the call interval.