### PR TITLE
[core] Fixed group lock-order-inversion.

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -485,6 +485,8 @@ public:
         // This is only for a use together with an empty constructor.
         bool acquire(CUDTUnited& glob, CUDTSocket* s)
         {
+            if (s == NULL)
+                return false;
             const bool caught = glob.acquireSocket(s);
             socket = caught ? s : NULL;
             return caught;

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -784,12 +784,14 @@ void CUDTGroup::getOpt(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
         // because the call will acquire m_ControlLock leading to a lock-order-inversion.
         enterCS(m_GroupLock);
         gli_t gi = m_Group.begin();
+        CUDTSocket* const ps = (gi != m_Group.end()) ? gi->ps : NULL;
         leaveCS(m_GroupLock);
-        if (gi != m_Group.end())
+        if (ps)
         {
+            CUDTUnited::SocketKeeper sk(CUDT::uglobal(), ps);
             // Return the value from the first member socket, if any is present
             // Note: Will throw exception if the request is wrong.
-            gi->ps->core().getOpt(optname, (pw_optval), (w_optlen));
+            ps->core().getOpt(optname, (pw_optval), (w_optlen));
             is_set_on_socket = true;
         }
     }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -785,13 +785,13 @@ void CUDTGroup::getOpt(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
         enterCS(m_GroupLock);
         gli_t gi = m_Group.begin();
         CUDTSocket* const ps = (gi != m_Group.end()) ? gi->ps : NULL;
+        CUDTUnited::SocketKeeper sk(CUDT::uglobal(), ps);
         leaveCS(m_GroupLock);
-        if (ps)
+        if (sk.socket)
         {
-            CUDTUnited::SocketKeeper sk(CUDT::uglobal(), ps);
             // Return the value from the first member socket, if any is present
             // Note: Will throw exception if the request is wrong.
-            ps->core().getOpt(optname, (pw_optval), (w_optlen));
+            sk.socket->core().getOpt(optname, (pw_optval), (w_optlen));
             is_set_on_socket = true;
         }
     }

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -780,8 +780,11 @@ void CUDTGroup::getOpt(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
 
     bool is_set_on_socket = false;
     {
-        ScopedLock cg(m_GroupLock);
+        // Can't have m_GroupLock locked while calling getOpt on a member socket
+        // because the call will acquire m_ControlLock leading to a lock-order-inversion.
+        enterCS(m_GroupLock);
         gli_t gi = m_Group.begin();
+        leaveCS(m_GroupLock);
         if (gi != m_Group.end())
         {
             // Return the value from the first member socket, if any is present


### PR DESCRIPTION
Fixes #3010 by not holding the m_GroupLock wile calling getOpt on a member socket.