### PR TITLE
[tests] Fixed unit tests compiler warnings AppleClang 15.

### DIFF
--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -429,14 +429,14 @@ TEST(Bonding, Options)
     int revlat = -1;
     int optsize = sizeof revlat;
     EXPECT_NE(srt_getsockflag(grp, SRTO_RCVLATENCY, &revlat, &optsize), SRT_ERROR);
-    EXPECT_EQ(optsize, sizeof revlat);
+    EXPECT_EQ(optsize, (int) sizeof revlat);
     EXPECT_EQ(revlat, 500);
 
     revlat = -1;
     optsize = sizeof revlat;
     // Expect the same value set on the member socket
     EXPECT_NE(srt_getsockflag(member, SRTO_RCVLATENCY, &revlat, &optsize), SRT_ERROR);
-    EXPECT_EQ(optsize, sizeof revlat);
+    EXPECT_EQ(optsize, (int) sizeof revlat);
     EXPECT_EQ(revlat, 500);
 
     // Individual socket option modified on group
@@ -451,7 +451,7 @@ TEST(Bonding, Options)
 
     // But getting the option value should be equal to the group setting
     EXPECT_NE(srt_getsockflag(grp, SRTO_OHEADBW, &ohead, &optsize), SRT_ERROR);
-    EXPECT_EQ(optsize, sizeof ohead);
+    EXPECT_EQ(optsize, (int) sizeof ohead);
     EXPECT_EQ(ohead, 12);
 
 #if SRT_ENABLE_ENCRYPTION
@@ -459,11 +459,11 @@ TEST(Bonding, Options)
     uint32_t kms = -1;
 
     EXPECT_NE(srt_getsockflag(grp, SRTO_KMSTATE, &kms, &optsize), SRT_ERROR);
-    EXPECT_EQ(optsize, sizeof kms);
+    EXPECT_EQ(optsize, (int) sizeof kms);
     EXPECT_EQ(kms, int(SRT_KM_S_SECURED));
 
     EXPECT_NE(srt_getsockflag(grp, SRTO_PBKEYLEN, &kms, &optsize), SRT_ERROR);
-    EXPECT_EQ(optsize, sizeof kms);
+    EXPECT_EQ(optsize, (int) sizeof kms);
     EXPECT_EQ(kms, 16);
 
 #ifdef ENABLE_AEAD_API_PREVIEW

--- a/test/test_buffer_rcv.cpp
+++ b/test/test_buffer_rcv.cpp
@@ -236,7 +236,7 @@ TEST_F(CRcvBufferReadMsg, OnePacketGap)
     {
         const size_t msg_bytelen = m_payload_sz;
         EXPECT_TRUE(rcv_buffer.isRcvDataReady());
-        EXPECT_EQ(readMessage(buff.data(), buff.size()), msg_bytelen);
+        EXPECT_EQ(readMessage(buff.data(), buff.size()), (int) msg_bytelen);
         EXPECT_TRUE(verifyPayload(buff.data(), msg_bytelen, CSeqNo::incseq(m_init_seqno, pktno)));
     }
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
@@ -317,7 +317,7 @@ TEST_F(CRcvBufferReadMsg, PacketDropByMsgNoSeqNo)
 
     // Let's say SND does not have the very first packet of the message,
     // therefore seqnolo of the msg drop request starts with the second packet of the message.
-    EXPECT_EQ(rcv_buffer.dropMessage(CSeqNo::incseq(m_init_seqno), CSeqNo::incseq(m_init_seqno, msg_len_pkts - 1), msgno, CRcvBuffer::KEEP_EXISTING), msg_len_pkts);
+    EXPECT_EQ(rcv_buffer.dropMessage(CSeqNo::incseq(m_init_seqno), CSeqNo::incseq(m_init_seqno, msg_len_pkts - 1), msgno, CRcvBuffer::KEEP_EXISTING), (int) msg_len_pkts);
     EXPECT_FALSE(hasAvailablePackets());
     EXPECT_FALSE(rcv_buffer.isRcvDataReady());
 
@@ -343,7 +343,7 @@ TEST_F(CRcvBufferReadMsg, OnePacket)
     EXPECT_TRUE(hasAvailablePackets());
 
     const int res2 = readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res2, msg_bytelen);
+    EXPECT_EQ(res2, (int) msg_bytelen);
     EXPECT_TRUE(verifyPayload(buff.data(), res2, m_init_seqno));
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
 }
@@ -419,7 +419,7 @@ TEST_F(CRcvBufferReadMsg, MsgAcked)
     EXPECT_TRUE(hasAvailablePackets());
 
     const int res = readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res, msg_bytelen);
+    EXPECT_EQ(res, (int) msg_bytelen);
     for (size_t i = 0; i < msg_pkts; ++i)
     {
         const ptrdiff_t offset = i * m_payload_sz;
@@ -478,7 +478,7 @@ TEST_F(CRcvBufferReadMsg, MsgHalfAck)
     EXPECT_TRUE(hasAvailablePackets());
 
     const int res = readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res, msg_bytelen);
+    EXPECT_EQ(res, (int) msg_bytelen);
     for (size_t i = 0; i < msg_pkts; ++i)
     {
         const ptrdiff_t offset = i * m_payload_sz;
@@ -502,7 +502,7 @@ TEST_F(CRcvBufferReadMsg, OutOfOrderMsgNoACK)
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
     const int res = readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res, msg_bytelen);
+    EXPECT_EQ(res, (int) msg_bytelen);
     for (size_t i = 0; i < msg_pkts; ++i)
     {
         const ptrdiff_t offset = i * m_payload_sz;
@@ -529,7 +529,7 @@ TEST_F(CRcvBufferReadMsg, OutOfOrderMsgGap)
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
     const int res = readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res, msg_bytelen);
+    EXPECT_EQ(res, (int) msg_bytelen);
     for (size_t i = 0; i < msg_pkts; ++i)
     {
         const ptrdiff_t offset = i * m_payload_sz;
@@ -598,7 +598,7 @@ TEST_F(CRcvBufferReadMsg, LongMsgReadReady)
     EXPECT_TRUE(hasAvailablePackets());
 
     const int res = readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res, msg_bytelen);
+    EXPECT_EQ(res, (int) msg_bytelen);
     for (size_t i = 0; i < msg_pkts; ++i)
     {
         const ptrdiff_t offset = i * m_payload_sz;
@@ -621,7 +621,7 @@ TEST_F(CRcvBufferReadMsg, MsgOutOfOrderDrop)
     const size_t msg_bytelen = msg_pkts * m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
     int res = m_rcv_buffer->readMessage(buff.data(), buff.size());
-    EXPECT_EQ(res, msg_bytelen);
+    EXPECT_EQ(res, (int) msg_bytelen);
     for (size_t i = 0; i < msg_pkts; ++i)
     {
         EXPECT_TRUE(verifyPayload(buff.data() + i * m_payload_sz, m_payload_sz, msg_seqno + int(i)));
@@ -660,7 +660,7 @@ TEST_F(CRcvBufferReadMsg, MsgOutOfOrderAfterInOrder)
     for (int msg_i = 0; msg_i < 3; ++msg_i)
     {
         EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
-        EXPECT_EQ(m_rcv_buffer->readMessage(buff.data(), buff.size()), msg_bytelen);
+        EXPECT_EQ(m_rcv_buffer->readMessage(buff.data(), buff.size()), (int) msg_bytelen);
         for (size_t i = 0; i < msg_pkts; ++i)
         {
             EXPECT_TRUE(verifyPayload(buff.data() + i * m_payload_sz, m_payload_sz, int(m_init_seqno + msg_i * msg_pkts + i)));
@@ -706,7 +706,7 @@ TEST_F(CRcvBufferReadMsg, OnePacketTSBPD)
 
     // Read out the first message
     const int read_len = m_rcv_buffer->readMessage(buff.data(), buff.size());
-    EXPECT_EQ(read_len, msg_bytelen);
+    EXPECT_EQ(read_len, (int) msg_bytelen);
     EXPECT_TRUE(verifyPayload(buff.data(), read_len, m_init_seqno));
 
     // Check the state after a packet was read
@@ -768,7 +768,7 @@ TEST_F(CRcvBufferReadMsg, TSBPDGapBeforeValid)
 
     const size_t msg_bytelen = m_payload_sz;
     array<char, 2 * msg_bytelen> buff;
-    EXPECT_EQ(readMessage(buff.data(), buff.size()), msg_bytelen);
+    EXPECT_EQ(readMessage(buff.data(), buff.size()), (int) msg_bytelen);
     EXPECT_TRUE(verifyPayload(buff.data(), m_payload_sz, seqno));
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
 }

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -262,7 +262,7 @@ TEST(TestConnectionAPI, Accept)
     {
         // Do extra checks only if you know that this was returned.
         EXPECT_EQ(ready[0].fd, caller_sock);
-        EXPECT_EQ(ready[0].events & SRT_EPOLL_ERR, 0);
+        EXPECT_EQ(ready[0].events & SRT_EPOLL_ERR, 0u);
     }
     srt_close(caller_sock);
     srt_close(listener_sock);

--- a/test/test_losslist_rcv.cpp
+++ b/test/test_losslist_rcv.cpp
@@ -81,7 +81,7 @@ TEST(CRcvFreshLossListTest, CheckFreshLossList)
         CRcvFreshLoss (45, 80, 100)
     };
 
-    EXPECT_EQ(floss.size(), 4);
+    EXPECT_EQ(floss.size(), 4u);
 
     // Ok, now let's do element removal
 
@@ -90,7 +90,7 @@ TEST(CRcvFreshLossListTest, CheckFreshLossList)
 
     EXPECT_EQ(rm, true);
     EXPECT_EQ(had_ttl, 10);
-    EXPECT_EQ(floss.size(), 5);
+    EXPECT_EQ(floss.size(), 5u);
 
     // Now we expect to have [10-15] [25-25] [27-35]...
     // After revoking 25 it should have removed it.
@@ -99,41 +99,41 @@ TEST(CRcvFreshLossListTest, CheckFreshLossList)
     rm = CRcvFreshLoss::removeOne((floss), 27, &had_ttl);
     EXPECT_EQ(rm, true);
     EXPECT_EQ(had_ttl, 10);
-    EXPECT_EQ(floss.size(), 5);
+    EXPECT_EQ(floss.size(), 5u);
 
     // STRIP
     rm = CRcvFreshLoss::removeOne((floss), 28, &had_ttl);
     EXPECT_EQ(rm, true);
     EXPECT_EQ(had_ttl, 10);
-    EXPECT_EQ(floss.size(), 5);
+    EXPECT_EQ(floss.size(), 5u);
 
     // DELETE
     rm = CRcvFreshLoss::removeOne((floss), 25, &had_ttl);
     EXPECT_EQ(rm, true);
     EXPECT_EQ(had_ttl, 10);
-    EXPECT_EQ(floss.size(), 4);
+    EXPECT_EQ(floss.size(), 4u);
 
     // SPLIT
     rm = CRcvFreshLoss::removeOne((floss), 50, &had_ttl);
     EXPECT_EQ(rm, true);
     EXPECT_EQ(had_ttl, 100);
-    EXPECT_EQ(floss.size(), 5);
+    EXPECT_EQ(floss.size(), 5u);
 
     // DELETE
     rm = CRcvFreshLoss::removeOne((floss), 30, &had_ttl);
     EXPECT_EQ(rm, true);
     EXPECT_EQ(had_ttl, 3);
-    EXPECT_EQ(floss.size(), 4);
+    EXPECT_EQ(floss.size(), 4u);
 
     // Remove nonexistent sequence, but existing before.
     rm = CRcvFreshLoss::removeOne((floss), 25, NULL);
     EXPECT_EQ(rm, false);
-    EXPECT_EQ(floss.size(), 4);
+    EXPECT_EQ(floss.size(), 4u);
 
     // Remove nonexistent sequence that didn't exist before.
     rm = CRcvFreshLoss::removeOne((floss), 31, &had_ttl);
     EXPECT_EQ(rm, false);
     EXPECT_EQ(had_ttl, 0);
-    EXPECT_EQ(floss.size(), 4);
+    EXPECT_EQ(floss.size(), 4u);
 
 }

--- a/test/test_socket_options.cpp
+++ b/test/test_socket_options.cpp
@@ -245,7 +245,7 @@ void CheckGetSockOpt(const OptionTestEntry& entry, SRTSOCKET sock, const ValueTy
         << "Getting " << entry.optname << " returned error: " << srt_getlasterror_str();
 
     EXPECT_EQ(opt_val, value) << desc << ": Wrong " << entry.optname << " value " << opt_val;
-    EXPECT_EQ(opt_len, entry.opt_len) << desc << "Wrong " << entry.optname << " value length";
+    EXPECT_EQ(opt_len, (int) entry.opt_len) << desc << "Wrong " << entry.optname << " value length";
 }
 
 typedef char const* strptr;
@@ -258,7 +258,7 @@ void CheckGetSockOpt<strptr>(const OptionTestEntry& entry, SRTSOCKET sock, const
         << "Getting " << entry.optname << " returned error: " << srt_getlasterror_str();
 
     EXPECT_EQ(strncmp(opt_val, value, min(opt_len, (int)entry.opt_len)), 0) << desc << ": Wrong " << entry.optname << " value " << opt_val;
-    EXPECT_EQ(opt_len, entry.opt_len) << desc << "Wrong " << entry.optname << " value length";
+    EXPECT_EQ(opt_len, (int) entry.opt_len) << desc << "Wrong " << entry.optname << " value length";
 }
 
 template<class ValueType>

--- a/test/test_sync.cpp
+++ b/test/test_sync.cpp
@@ -159,7 +159,7 @@ TEST(SyncRandom, GenRandomInt)
     {
         const int rand_val = genRandomInt(0, int(mn.size()) - 1);
         ASSERT_GE(rand_val, 0);
-        ASSERT_LT(rand_val, mn.size());
+        ASSERT_LT(rand_val, (int) mn.size());
         ++mn[rand_val];
     }
 
@@ -445,7 +445,7 @@ TEST(SyncEvent, WaitForTwoNotifyOne)
 
     using future_t = decltype(async(launch::async, wait_async, &cond, &mutex, timeout, 0));
 
-    future_t future_result[2] = {
+    std::array<future_t, 2> future_result = {
         async(launch::async, wait_async, &cond, &mutex, timeout, 0),
         async(launch::async, wait_async, &cond, &mutex, timeout, 1)
     };
@@ -462,9 +462,9 @@ TEST(SyncEvent, WaitForTwoNotifyOne)
 
     using wait_t = decltype(future_t().wait_for(chrono::microseconds(0)));
 
-    wait_t wait_state[2] = {
-        move(future_result[0].wait_for(chrono::microseconds(500))),
-        move(future_result[1].wait_for(chrono::microseconds(500)))
+    std::array<wait_t, 2> wait_state = {
+        future_result[0].wait_for(chrono::microseconds(500)),
+        future_result[1].wait_for(chrono::microseconds(500))
     };
 
     cerr << "SyncEvent::WaitForTwoNotifyOne: NOTIFICATION came from " << notified_clients.size()

--- a/test/test_utilities.cpp
+++ b/test/test_utilities.cpp
@@ -160,11 +160,11 @@ TEST(CircularBuffer, Overall)
     ASSERT_EQ(output.d, 22.1);
 
     IF_HEAVY_LOGGING(cerr << "Pushing 1 aslong there is capacity:\n");
-    int i = 0;
+    IF_HEAVY_LOGGING(int i = 0);
     while (buf.push(1) != -1)
     {
         IF_HEAVY_LOGGING(cerr << "Pushed, begin=" << buf.m_xBegin << " end=" << buf.m_xEnd << endl);
-        ++i;
+        IF_HEAVY_LOGGING(++i);
     }
     IF_HEAVY_LOGGING(cerr << "Done " << i << " operations, buffer:\n");
     IF_HEAVY_LOGGING(ShowCircularBuffer(buf));

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -209,7 +209,6 @@ int main( int argc, char** argv )
         return 1;
     }
 
-    auto s = new SrtSource;
     unique_ptr<Source> src;
     unique_ptr<Target> tar;
 
@@ -222,6 +221,7 @@ int main( int argc, char** argv )
             Verb() << "SRT -> " << outspec;
             tar = Target::Create(outspec);
 
+            auto s = new SrtSource;
             s->Acquire(conngrp);
             src.reset(s);
         }

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -1059,8 +1059,8 @@ void SrtCommon::OpenGroupClient()
         if (!extras.empty())
         {
             Verb() << "?" << extras[0] << VerbNoEOL;
-            for (size_t i = 1; i < extras.size(); ++i)
-                Verb() << "&" << extras[i] << VerbNoEOL;
+            for (size_t ii = 1; ii < extras.size(); ++ii)
+                Verb() << "&" << extras[ii] << VerbNoEOL;
         }
 
         Verb();
@@ -1194,11 +1194,11 @@ Connect_Again:
                     NULL, NULL) != -1)
         {
             Verb() << "[C]" << VerbNoEOL;
-            for (int i = 0; i < len1; ++i)
-                Verb() << " " << ready_conn[i] << VerbNoEOL;
+            for (int ii = 0; ii < len1; ++ii)
+                Verb() << " " << ready_conn[ii] << VerbNoEOL;
             Verb() << "[E]" << VerbNoEOL;
-            for (int i = 0; i < len2; ++i)
-                Verb() << " " << ready_err[i] << VerbNoEOL;
+            for (int ii = 0; ii < len2; ++ii)
+                Verb() << " " << ready_err[ii] << VerbNoEOL;
 
             Verb() << "";
 


### PR DESCRIPTION
<details><summary>AppleClang 15 Warnings</summary>

```shell
[ 66%] Building CXX object CMakeFiles/test-srt.dir/test/test_buffer_rcv.cpp.o
In file included from /Users/runner/work/srt/srt/test/test_buffer_rcv.cpp:3:
/opt/homebrew/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const int' and 'const unsigned long' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/opt/homebrew/include/gtest/gtest.h:1413:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<int, unsigned long>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
/Users/runner/work/srt/srt/test/test_buffer_rcv.cpp:239:9: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<int, unsigned long, nullptr>' requested here
        EXPECT_EQ(readMessage(buff.data(), buff.size()), msg_bytelen);
        ^
/opt/homebrew/include/gtest/gtest.h:1885:54: note: expanded from macro 'EXPECT_EQ'
  EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
                                                     ^
1 warning generated.
[ 67%] Building CXX object CMakeFiles/test-srt.dir/test/test_common.cpp.o
[ 69%] Building CXX object CMakeFiles/test-srt.dir/test/test_connection_timeout.cpp.o
In file included from /Users/runner/work/srt/srt/test/test_connection_timeout.cpp:3:
/opt/homebrew/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const unsigned int' and 'const int' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/opt/homebrew/include/gtest/gtest.h:1413:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned int, int>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
/Users/runner/work/srt/srt/test/test_connection_timeout.cpp:265:9: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<unsigned int, int, nullptr>' requested here
        EXPECT_EQ(ready[0].events & SRT_EPOLL_ERR, 0);
        ^
/opt/homebrew/include/gtest/gtest.h:1885:54: note: expanded from macro 'EXPECT_EQ'
  EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
                                                     ^
1 warning generated.
[ 70%] Building CXX object CMakeFiles/test-srt.dir/test/test_crypto.cpp.o
[ 71%] Building CXX object CMakeFiles/test-srt.dir/test/test_cryspr.cpp.o
[ 73%] Building CXX object CMakeFiles/test-srt.dir/test/test_enforced_encryption.cpp.o
[ 74%] Building CXX object CMakeFiles/test-srt.dir/test/test_epoll.cpp.o
[ 75%] Building CXX object CMakeFiles/test-srt.dir/test/test_fec_rebuilding.cpp.o
[ 76%] Building CXX object CMakeFiles/test-srt.dir/test/test_file_transmission.cpp.o
[ 78%] Building CXX object CMakeFiles/test-srt.dir/test/test_ipv6.cpp.o
[ 79%] Building CXX object CMakeFiles/test-srt.dir/test/test_listen_callback.cpp.o
[ 80%] Building CXX object CMakeFiles/test-srt.dir/test/test_losslist_rcv.cpp.o
In file included from /Users/runner/work/srt/srt/test/test_losslist_rcv.cpp:2:
/opt/homebrew/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const unsigned long' and 'const int' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/opt/homebrew/include/gtest/gtest.h:1413:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<unsigned long, int>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
/Users/runner/work/srt/srt/test/test_losslist_rcv.cpp:84:5: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<unsigned long, int, nullptr>' requested here
    EXPECT_EQ(floss.size(), 4);
    ^
/opt/homebrew/include/gtest/gtest.h:1885:54: note: expanded from macro 'EXPECT_EQ'
  EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
                                                     ^
1 warning generated.
[ 82%] Building CXX object CMakeFiles/test-srt.dir/test/test_losslist_snd.cpp.o
[ 83%] Building CXX object CMakeFiles/test-srt.dir/test/test_many_connections.cpp.o
[ 84%] Building CXX object CMakeFiles/test-srt.dir/test/test_muxer.cpp.o
[ 85%] Building CXX object CMakeFiles/test-srt.dir/test/test_seqno.cpp.o
[ 87%] Building CXX object CMakeFiles/test-srt.dir/test/test_socket_options.cpp.o
In file included from /Users/runner/work/srt/srt/test/test_socket_options.cpp:16:
/opt/homebrew/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const int' and 'const unsigned long' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/opt/homebrew/include/gtest/gtest.h:1413:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<int, unsigned long>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
/Users/runner/work/srt/srt/test/test_socket_options.cpp:261:5: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<int, unsigned long, nullptr>' requested here
    EXPECT_EQ(opt_len, entry.opt_len) << desc << "Wrong " << entry.optname << " value length";
    ^
/opt/homebrew/include/gtest/gtest.h:1885:54: note: expanded from macro 'EXPECT_EQ'
  EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
                                                     ^
1 warning generated.
[ 88%] Building CXX object CMakeFiles/test-srt.dir/test/test_sync.cpp.o
/Users/runner/work/srt/srt/test/test_sync.cpp:466:9: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
        move(future_result[0].wait_for(chrono::microseconds(500))),
        ^
        std::
/Users/runner/work/srt/srt/test/test_sync.cpp:467:9: warning: unqualified call to 'std::move' [-Wunqualified-std-cast-call]
        move(future_result[1].wait_for(chrono::microseconds(500)))
        ^
        std::
In file included from /Users/runner/work/srt/srt/test/test_sync.cpp:1:
/opt/homebrew/include/gtest/gtest.h:1476:28: warning: comparison of integers of different signs: 'const int' and 'const unsigned long' [-Wsign-compare]
GTEST_IMPL_CMP_HELPER_(LT, <)
~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/opt/homebrew/include/gtest/gtest.h:1462:14: note: expanded from macro 'GTEST_IMPL_CMP_HELPER_'
    if (val1 op val2) {                                                    \
        ~~~~ ^  ~~~~
/Users/runner/work/srt/srt/test/test_sync.cpp:162:9: note: in instantiation of function template specialization 'testing::internal::CmpHelperLT<int, unsigned long>' requested here
        ASSERT_LT(rand_val, mn.size());
        ^
/opt/homebrew/include/gtest/gtest.h:1926:31: note: expanded from macro 'ASSERT_LT'
#define ASSERT_LT(val1, val2) GTEST_ASSERT_LT(val1, val2)
                              ^
/opt/homebrew/include/gtest/gtest.h:1904:44: note: expanded from macro 'GTEST_ASSERT_LT'
  ASSERT_PRED_FORMAT2(::testing::internal::CmpHelperLT, val1, val2)
                                           ^
3 warnings generated.
[ 89%] Building CXX object CMakeFiles/test-srt.dir/test/test_threadname.cpp.o
[ 91%] Building CXX object CMakeFiles/test-srt.dir/test/test_timer.cpp.o
[ 92%] Building CXX object CMakeFiles/test-srt.dir/test/test_unitqueue.cpp.o
[ 93%] Building CXX object CMakeFiles/test-srt.dir/test/test_utilities.cpp.o
/Users/runner/work/srt/srt/test/test_utilities.cpp:163:9: warning: variable 'i' set but not used [-Wunused-but-set-variable]
    int i = 0;
        ^
1 warning generated.
[ 94%] Building CXX object CMakeFiles/test-srt.dir/test/test_reuseaddr.cpp.o
[ 96%] Building CXX object CMakeFiles/test-srt.dir/test/test_socketdata.cpp.o
[ 97%] Building CXX object CMakeFiles/test-srt.dir/test/test_snd_rate_estimator.cpp.o
[ 98%] Building CXX object CMakeFiles/test-srt.dir/test/test_bonding.cpp.o
In file included from /Users/runner/work/srt/srt/test/test_bonding.cpp:7:
/opt/homebrew/include/gtest/gtest.h:1394:11: warning: comparison of integers of different signs: 'const int' and 'const unsigned long' [-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/opt/homebrew/include/gtest/gtest.h:1413:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<int, unsigned long>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
/Users/runner/work/srt/srt/test/test_bonding.cpp:432:5: note: in instantiation of function template specialization 'testing::internal::EqHelper::Compare<int, unsigned long, nullptr>' requested here
    EXPECT_EQ(optsize, sizeof revlat);
    ^
/opt/homebrew/include/gtest/gtest.h:1885:54: note: expanded from macro 'EXPECT_EQ'
  EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
                                                     ^
1 warning generated.
```
</details>