### PR TITLE
[test] Added option handling also to non-fixture-based tests

### DIFF
--- a/test/test_env.h
+++ b/test/test_env.h
@@ -53,7 +53,11 @@ public:
     static void start(int& w_retstatus);
     static void stop();
 
-    TestInit() { start((ninst)); }
+    TestInit()
+    {
+        start((ninst));
+        HandlePerTestOptions();
+    }
     ~TestInit() { stop(); }
 
     void HandlePerTestOptions();
@@ -115,7 +119,6 @@ public:
     void SetUp() override final
     {
         init_holder.reset(new TestInit);
-        init_holder->HandlePerTestOptions();
         setup();
     }
 


### PR DESCRIPTION
This fixes a bug in test_env.h, which made options available only for fixture-based tests.

With this fix, options are available for all tests.

Extracted from #2444 