### PR TITLE
[apps] Added setopt utility for easily setting socket options

### DIFF
--- a/apps/apputil.hpp
+++ b/apps/apputil.hpp
@@ -20,6 +20,7 @@
 
 #include "netinet_any.h"
 #include "utilities.h"
+#include "srt.h"
 
 #if _WIN32
 
@@ -336,4 +337,60 @@ std::string OptionHelpItem(const OptionName& o);
 const char* SRTClockTypeStr();
 void PrintLibVersion();
 
+
+namespace srt
+{
+
+struct OptionSetterProxy
+{
+    SRTSOCKET s;
+    int result = -1;
+
+    OptionSetterProxy(SRTSOCKET ss): s(ss) {}
+
+    struct OptionProxy
+    {
+        OptionSetterProxy& parent;
+        SRT_SOCKOPT opt;
+
+#define SPEC(type) \
+        OptionProxy& operator=(const type& val)\
+        {\
+            parent.result = srt_setsockflag(parent.s, opt, &val, sizeof val);\
+            return *this;\
+        }
+
+        SPEC(int32_t);
+        SPEC(int64_t);
+        SPEC(bool);
+#undef SPEC
+
+        template<size_t N>
+        OptionProxy& operator=(const char (&val)[N])
+        {
+            parent.result = srt_setsockflag(parent.s, opt, val, N-1);
+            return *this;
+        }
+
+        OptionProxy& operator=(const std::string& val)
+        {
+            parent.result = srt_setsockflag(parent.s, opt, val.c_str(), val.size());
+            return *this;
+        }
+    };
+
+    OptionProxy operator[](SRT_SOCKOPT opt)
+    {
+        return OptionProxy {*this, opt};
+    }
+
+    operator int() { return result; }
+};
+
+inline OptionSetterProxy setopt(SRTSOCKET socket)
+{
+    return OptionSetterProxy(socket);
+}
+
+}
 #endif // INC_SRT_APPCOMMON_H

--- a/testing/srt-test-mpbond.cpp
+++ b/testing/srt-test-mpbond.cpp
@@ -189,10 +189,7 @@ int main( int argc, char** argv )
 
         SRTSOCKET s = srt_create_socket();
 
-        //SRT_GROUPCONNTYPE gcon = SRTGC_GROUPONLY;
-        int gcon = 1;
-        srt_setsockflag(s, SRTO_GROUPCONNECT, &gcon, sizeof gcon);
-
+        srt::setopt(s)[SRTO_GROUPCONNECT] = 1;
         srt_bind(s, sa.get(), sizeof sa);
         srt_listen(s, 5);
 


### PR DESCRIPTION
This adds a friendly C++ wrapper over the `srt_setsockflag` call:

```
srt::setopt(sock)[OPTION] = value;
```
instead of
```
type value = something;
srt_setsockflag(sock, OPTION, &value, sizeof value);
```

Also an example usage was added to `srt-test-mpbond` app.