### PR TITLE
[maint] Moved debug-related functions to common

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -461,6 +461,54 @@ bool SrtParseConfig(const string& s, SrtConfig& w_config)
 
     return true;
 }
+
+std::string FormatLossArray(const std::vector< std::pair<int32_t, int32_t> >& lra)
+{
+    std::ostringstream os;
+
+    os << "[ ";
+    for (std::vector< std::pair<int32_t, int32_t> >::const_iterator i = lra.begin(); i != lra.end(); ++i)
+    {
+        int len = CSeqNo::seqoff(i->first, i->second);
+        os << "%" << i->first;
+        if (len > 1)
+            os << "+" << len;
+        os << " ";
+    }
+
+    os << "]";
+    return os.str();
+}
+
+ostream& PrintEpollEvent(ostream& os, int events, int et_events)
+{
+    static pair<int, const char*> const namemap [] = {
+        make_pair(SRT_EPOLL_IN, "R"),
+        make_pair(SRT_EPOLL_OUT, "W"),
+        make_pair(SRT_EPOLL_ERR, "E"),
+        make_pair(SRT_EPOLL_UPDATE, "U")
+    };
+    bool any = false;
+
+    const int N = (int)Size(namemap);
+
+    for (int i = 0; i < N; ++i)
+    {
+        if (events & namemap[i].first)
+        {
+            os << "[";
+            if (et_events & namemap[i].first)
+                os << "^";
+            os << namemap[i].second << "]";
+            any = true;
+        }
+    }
+
+    if (!any)
+        os << "[]";
+
+    return os;
+}
 } // namespace srt
 
 namespace srt_logging

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -1435,23 +1435,8 @@ inline bool checkMappedIPv4(const sockaddr_in6& sa)
     return checkMappedIPv4(addr);
 }
 
-inline std::string FormatLossArray(const std::vector< std::pair<int32_t, int32_t> >& lra)
-{
-    std::ostringstream os;
-
-    os << "[ ";
-    for (std::vector< std::pair<int32_t, int32_t> >::const_iterator i = lra.begin(); i != lra.end(); ++i)
-    {
-        int len = CSeqNo::seqoff(i->first, i->second);
-        os << "%" << i->first;
-        if (len > 1)
-            os << "+" << len;
-        os << " ";
-    }
-
-    os << "]";
-    return os.str();
-}
+std::string FormatLossArray(const std::vector< std::pair<int32_t, int32_t> >& lra);
+std::ostream& PrintEpollEvent(std::ostream& os, int events, int et_events = 0);
 
 } // namespace srt
 

--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -71,12 +71,6 @@ modified by
 using namespace std;
 using namespace srt::sync;
 
-#if ENABLE_HEAVY_LOGGING
-namespace srt {
-static ostream& PrintEpollEvent(ostream& os, int events, int et_events = 0);
-}
-#endif
-
 namespace srt_logging
 {
     extern Logger eilog, ealog;
@@ -955,31 +949,6 @@ int srt::CEPoll::update_events(const SRTSOCKET& uid, std::set<int>& eids, const 
 #if ENABLE_HEAVY_LOGGING
 namespace srt
 {
-
-static ostream& PrintEpollEvent(ostream& os, int events, int et_events)
-{
-    static pair<int, const char*> const namemap [] = {
-        make_pair(SRT_EPOLL_IN, "R"),
-        make_pair(SRT_EPOLL_OUT, "W"),
-        make_pair(SRT_EPOLL_ERR, "E"),
-        make_pair(SRT_EPOLL_UPDATE, "U")
-    };
-
-    const int N = (int)Size(namemap);
-
-    for (int i = 0; i < N; ++i)
-    {
-        if (events & namemap[i].first)
-        {
-            os << "[";
-            if (et_events & namemap[i].first)
-                os << "^";
-            os << namemap[i].second << "]";
-        }
-    }
-
-    return os;
-}
 
 string DisplayEpollResults(const std::map<SRTSOCKET, int>& sockset)
 {


### PR DESCRIPTION
`FormatLossArray` and `PrintEpollEvent` have been moved bodies to common.cpp.