### PR TITLE
Fixed initialization problem in SocketKeeper version with acquire

### DIFF
--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -486,7 +486,11 @@ public:
         bool acquire(CUDTUnited& glob, CUDTSocket* s)
         {
             if (s == NULL)
+            {
+                socket = NULL;
                 return false;
+            }
+
             const bool caught = glob.acquireSocket(s);
             socket = caught ? s : NULL;
             return caught;

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -547,14 +547,17 @@ TEST(Bonding, InitialFailure)
     char outbuf[1316];
     SRT_MSGCTRL mc = srt_msgctrl_default;
     int recvlen = srt_recvmsg2(gs, outbuf, 1316, &mc);
-    EXPECT_EQ(recvlen, packet_data.size());
-    outbuf[recvlen] = 0;
+    EXPECT_EQ(recvlen, int(packet_data.size()));
 
-    EXPECT_EQ(outbuf, packet_data);
+    if (recvlen > 0)
+    {
+        outbuf[recvlen] = 0;
+        EXPECT_EQ(outbuf, packet_data);
+    }
     EXPECT_EQ(mc.pktseq, lsn_isn);
 
     recvlen = srt_recv(gs, outbuf, 80);
-    EXPECT_EQ(recvlen, SRT_ERROR);
+    EXPECT_EQ(recvlen, int(SRT_ERROR));
 
     srt_close(gs);
     srt_close(grp);


### PR DESCRIPTION
Problem: `SocketKeeper::socket` field could remain undefined in case when `acquire()` was called with `s == NULL`.