### PR TITLE
Fix Build GCC>13 and C++>=20.

### DIFF
--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -572,7 +572,7 @@ template <class T>
 class CSharedObjectPtr : public SharedMutex
 {
 public:
-    CSharedObjectPtr<T>()
+    CSharedObjectPtr()
         : m_pObj(NULL)
     {
     }


### PR DESCRIPTION
C++20: template ID is not allowed in constructor and build fails for GCC>13 and/or c++>=20.

```
/home/jsantiago/tt09/srt/srtcore/sync.h:575:24: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  575 |     CSharedObjectPtr<T>()
      |                        ^
/home/jsantiago/tt09/srt/srtcore/sync.h:575:24: note: remove the ?< >?
```