### PR TITLE
Address Sanitizer Issue, Fix Stack buffer reference after it has gone…

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -864,6 +864,12 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
 #ifndef _WIN32
     msghdr mh; // will not be used on failure
 
+#ifdef SRT_ENABLE_PKTINFO
+   // ASAN, Data in this buffer is referenced by mh and needs to remain in
+   //  scope while it is being used. It needs to stay in scope because it is
+   //  later referenced below via getTargetAddress(mh).
+   char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
+#endif
     if (select_ret > 0)
     {
         mh.msg_name       = (w_addr.get());
@@ -878,7 +884,9 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
 #ifdef SRT_ENABLE_PKTINFO
         // Without m_bBindMasked, we don't need ancillary data - the source
         // address will always be the bound address.
-        char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
+
+        // ASAN: Moved outside of this block scope, see above.
+        //char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
         if (m_bBindMasked)
         {
             // Extract the destination IP address from the ancillary

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -865,9 +865,7 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
     msghdr mh; // will not be used on failure
 
 #ifdef SRT_ENABLE_PKTINFO
-   // ASAN, Data in this buffer is referenced by mh and needs to remain in
-   //  scope while it is being used. It needs to stay in scope because it is
-   //  later referenced below via getTargetAddress(mh).
+   // This buffer is mounted inside mh so it must stay in the same scope
    char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
 #endif
     if (select_ret > 0)

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -884,9 +884,6 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
 #ifdef SRT_ENABLE_PKTINFO
         // Without m_bBindMasked, we don't need ancillary data - the source
         // address will always be the bound address.
-
-        // ASAN: Moved outside of this block scope, see above.
-        //char mh_crtl_buf[sizeof(CMSGNodeIPv4) + sizeof(CMSGNodeIPv6)];
         if (m_bBindMasked)
         {
             // Extract the destination IP address from the ancillary


### PR DESCRIPTION
Address Sanitizer Issue, Fix Stack buffer reference after it has gone out of scope.


```

==1873251==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fe0a779a88c at pc 0x000001c942ad bp 0x7fe0a876c9c0 sp 0x7fe0a876c9b8
READ of size 4 at 0x7fe0a779a88c thread T17
    #0 0x1c942ac in srt::CChannel::getTargetAddress(msghdr const&) const /mnt/jlsws2/dev/orthrus/master/src/vendor/utils/haisrt/srt-1.5.4-rc.1/srtcore/channel.h:218:57
    #1 0x1c9384a in srt::CChannel::recvfrom(srt::sockaddr_any&, srt::CPacket&) const /mnt/jlsws2/dev/orthrus/master/src/vendor/utils/haisrt/srt-1.5.4-rc.1/srtcore/channel.cpp:944:31
    #2 0x1dd9c3d in srt::CRcvQueue::worker_RetrieveUnit(int&, srt::CUnit*&, srt::sockaddr_any&) /mnt/jlsws2/dev/orthrus/master/src/vendor/utils/haisrt/srt-1.5.4-rc.1/srtcore/queue.cpp:1407:35
    #3 0x1dd8817 in srt::CRcvQueue::worker(void*) /mnt/jlsws2/dev/orthrus/master/src/vendor/utils/haisrt/srt-1.5.4-rc.1/srtcore/queue.cpp:1246:43
    #4 0x7fe0d5fbc668 in asan_thread_start(void*) ../../../llvm-project-llvmorg-18.1.8/compiler-rt/lib/asan/asan_interceptors.cpp:239:28
    #5 0x7fe0c36a339c in start_thread /usr/src/debug/glibc/glibc/nptl/pthread_create.c:447:8
    #6 0x7fe0c372849b in __GI___clone3 /usr/src/debug/glibc/glibc/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

Address 0x7fe0a779a88c is located in stack of thread T17 at offset 140 in frame
    #0 0x1c9357f in srt::CChannel::recvfrom(srt::sockaddr_any&, srt::CPacket&) const /mnt/jlsws2/dev/orthrus/master/src/vendor/utils/haisrt/srt-1.5.4-rc.1/srtcore/channel.cpp:841

  This frame has 3 object(s):
    [32, 88) 'mh' (line 865)
    [128, 216) 'mh_crtl_buf' (line 881) <== Memory access at offset 140 is inside this variable
    [256, 288) 'ref.tmp' (line 944)
```

The stack variable object `mh` after call to `recvmsg` will reference data contained in the stack buffer `mh_crtl_buf` . This data is then referenced by a later call to `getTargetAddress(mh)`, but the stack buffer has already gone out of scope. This PR moves the stack variable outside of the conditional block scope so that it is still in scope while it is being referenced later on in this method.

Issue uncovered by using the CLANG Address Sanitizer.