### PR TITLE
[core] Fixed static variable usage in the crypto module.

### DIFF
--- a/haicrypt/hcrypt.h
+++ b/haicrypt/hcrypt.h
@@ -77,7 +77,7 @@ typedef struct hcrypt_Session_str {
         size_t              inbuf_siz;
 
         int                 se;             /* Stream Encapsulation (HCRYPT_SE_xxx) */
-        hcrypt_MsgInfo *    msg_info;
+        const hcrypt_MsgInfo * msg_info;
 
         struct {
             size_t          data_max_len;

--- a/haicrypt/hcrypt_ctx.h
+++ b/haicrypt/hcrypt_ctx.h
@@ -84,7 +84,7 @@ typedef struct tag_hcrypt_Ctx {
         size_t           sek_len;
         unsigned char    sek[HAICRYPT_KEY_MAX_SZ];
 
-        hcrypt_MsgInfo * msg_info;  /* Transport message handler */
+        const hcrypt_MsgInfo * msg_info;  /* Transport message handler */
         unsigned         pkt_cnt;   /* Key usage counter */
 
 #define HCRYPT_CTX_MAX_KM_PFX_SZ   16

--- a/haicrypt/hcrypt_msg.h
+++ b/haicrypt/hcrypt_msg.h
@@ -57,7 +57,6 @@ typedef struct {
         void        (*setPki)(unsigned char *msg, hcrypt_Pki);
         void        (*resetCache)(unsigned char *pfx_cache, unsigned pkt_type, unsigned flags);
         void        (*indexMsg)(unsigned char *msg, unsigned char *pfx_cache);
-        int         (*parseMsg)(unsigned char *msg);
 }hcrypt_MsgInfo;
 
 
@@ -72,6 +71,7 @@ typedef struct {
 
 #define hcryptMsg_PaddedLen(len, fact)  ((((len)+(fact)-1)/(fact))*(fact))
 
+int hcryptMsg_SRT_ParseMsg(unsigned char* msg);
 
 /*
  *  HaiCrypt KMmsg (Keying Material):

--- a/haicrypt/hcrypt_msg.h
+++ b/haicrypt/hcrypt_msg.h
@@ -128,9 +128,8 @@ int hcryptMsg_SRT_ParseMsg(unsigned char* msg);
 #define HCRYPT_AUTH_AES_GCM     1
 
 #define HCRYPT_SE_TSUDP         1
-        hcrypt_MsgInfo *        hcryptMsg_STA_MsgInfo(void);
 #define HCRYPT_SE_TSSRT         2
-        hcrypt_MsgInfo *        hcryptMsg_SRT_MsgInfo(void);
+  const hcrypt_MsgInfo *        hcryptMsg_SRT_MsgInfo(void);
 
 #define hcryptMsg_KM_GetVersion(msg)    (((msg)[HCRYPT_MSG_KM_OFS_VERSION]>>4)& 0xF)
 #define hcryptMsg_KM_GetPktType(msg)    (((msg)[HCRYPT_MSG_KM_OFS_PT]) & 0xF)

--- a/haicrypt/hcrypt_msg.h
+++ b/haicrypt/hcrypt_msg.h
@@ -71,7 +71,7 @@ typedef struct {
 
 #define hcryptMsg_PaddedLen(len, fact)  ((((len)+(fact)-1)/(fact))*(fact))
 
-int hcryptMsg_SRT_ParseMsg(unsigned char* msg);
+int hcryptMsg_SRT_ParseMsg(const hcrypt_MsgInfo* mi, unsigned char* msg);
 
 /*
  *  HaiCrypt KMmsg (Keying Material):

--- a/haicrypt/hcrypt_rx.c
+++ b/haicrypt/hcrypt_rx.c
@@ -78,7 +78,7 @@ int HaiCrypt_Rx_Process(HaiCrypt_Handle hhc,
 	}
 
 	/* Validate HaiCrypt message */
-	if (0 > (msg_type = crypto->msg_info->parseMsg(in_msg))) {
+	if (0 > (msg_type = hcryptMsg_SRT_ParseMsg(in_msg))) {
 		return(-1);
 	}
 

--- a/haicrypt/hcrypt_rx.c
+++ b/haicrypt/hcrypt_rx.c
@@ -78,7 +78,7 @@ int HaiCrypt_Rx_Process(HaiCrypt_Handle hhc,
 	}
 
 	/* Validate HaiCrypt message */
-	if (0 > (msg_type = hcryptMsg_SRT_ParseMsg(in_msg))) {
+	if (0 > (msg_type = hcryptMsg_SRT_ParseMsg(crypto->msg_info, in_msg))) {
 		return(-1);
 	}
 

--- a/haicrypt/hcrypt_xpt_srt.c
+++ b/haicrypt/hcrypt_xpt_srt.c
@@ -119,7 +119,7 @@ static const hcrypt_MsgInfo _hcMsg_SRT_MsgInfo = {
 	.indexMsg    = hcryptMsg_SRT_IndexMsg
 };
 
-const hcrypt_MsgInfo* hcryptMsg_SRT_InitMsgInfo(void)
+const hcrypt_MsgInfo* hcryptMsg_SRT_MsgInfo(void)
 {
 	return (&_hcMsg_SRT_MsgInfo);
 }

--- a/haicrypt/hcrypt_xpt_srt.c
+++ b/haicrypt/hcrypt_xpt_srt.c
@@ -124,7 +124,7 @@ const hcrypt_MsgInfo* hcryptMsg_SRT_MsgInfo(void)
 	return (&_hcMsg_SRT_MsgInfo);
 }
 
-int hcryptMsg_SRT_ParseMsg(unsigned char *msg)
+int hcryptMsg_SRT_ParseMsg(const hcrypt_MsgInfo* mi, unsigned char *msg)
 {
 	int rc;
 
@@ -140,10 +140,10 @@ int hcryptMsg_SRT_ParseMsg(unsigned char *msg)
 
 	switch(rc) {
 	case HCRYPT_MSG_PT_MS:
-		if (hcryptMsg_HasNoSek(&_hcMsg_SRT_MsgInfo, msg)
-		||  hcryptMsg_HasBothSek(&_hcMsg_SRT_MsgInfo, msg)) {
+		if (hcryptMsg_HasNoSek(mi, msg)
+		||  hcryptMsg_HasBothSek(mi, msg)) {
 			HCRYPT_LOG(LOG_ERR, "invalid MS msg flgs: %02x\n", 
-				hcryptMsg_GetKeyIndex(&_hcMsg_SRT_MsgInfo, msg));
+				hcryptMsg_GetKeyIndex(mi, msg));
 			return(-1);
 		}
 		break;

--- a/haicrypt/hcrypt_xpt_srt.c
+++ b/haicrypt/hcrypt_xpt_srt.c
@@ -65,7 +65,6 @@ written by
 #define HCRYPT_MSG_SRT_OFS_MSGNO	4
 #define HCRYPT_MSG_SRT_SHF_KFLGS	27   //shift
 
-static hcrypt_MsgInfo _hcMsg_SRT_MsgInfo;
 
 static unsigned hcryptMsg_SRT_GetKeyFlags(unsigned char *msg)
 {
@@ -110,7 +109,22 @@ static void hcryptMsg_SRT_IndexMsg(unsigned char *msg, unsigned char *pfx_cache)
 	return; //nothing to do, header and index maintained by SRT
 }
 
-static int hcryptMsg_SRT_ParseMsg(unsigned char *msg)
+static const hcrypt_MsgInfo _hcMsg_SRT_MsgInfo = {
+	.hdr_len     = HCRYPT_MSG_SRT_HDR_SZ,
+	.pfx_len     = HCRYPT_MSG_SRT_PFX_SZ,
+	.getKeyFlags = hcryptMsg_SRT_GetKeyFlags,
+	.getPki      = hcryptMsg_SRT_GetPki,
+	.setPki      = hcryptMsg_SRT_SetPki,
+	.resetCache  = hcryptMsg_SRT_ResetCache,
+	.indexMsg    = hcryptMsg_SRT_IndexMsg
+};
+
+const hcrypt_MsgInfo* hcryptMsg_SRT_InitMsgInfo(void)
+{
+	return (&_hcMsg_SRT_MsgInfo);
+}
+
+int hcryptMsg_SRT_ParseMsg(unsigned char *msg)
 {
 	int rc;
 
@@ -153,19 +167,4 @@ static int hcryptMsg_SRT_ParseMsg(unsigned char *msg)
 	return(rc);	/* -1: error, 0: unknown: >0: PT */
 }	
 
-static hcrypt_MsgInfo _hcMsg_SRT_MsgInfo;
-
-hcrypt_MsgInfo *hcryptMsg_SRT_MsgInfo(void)
-{
-	_hcMsg_SRT_MsgInfo.hdr_len      = HCRYPT_MSG_SRT_HDR_SZ;
-	_hcMsg_SRT_MsgInfo.pfx_len      = HCRYPT_MSG_SRT_PFX_SZ;
-	_hcMsg_SRT_MsgInfo.getKeyFlags  = hcryptMsg_SRT_GetKeyFlags;
-	_hcMsg_SRT_MsgInfo.getPki       = hcryptMsg_SRT_GetPki;
-	_hcMsg_SRT_MsgInfo.setPki       = hcryptMsg_SRT_SetPki;
-	_hcMsg_SRT_MsgInfo.resetCache   = hcryptMsg_SRT_ResetCache;
-	_hcMsg_SRT_MsgInfo.indexMsg     = hcryptMsg_SRT_IndexMsg;
-	_hcMsg_SRT_MsgInfo.parseMsg     = hcryptMsg_SRT_ParseMsg;
-
-	return(&_hcMsg_SRT_MsgInfo);
-}
 


### PR DESCRIPTION
As reported in #3035, `srt/haicrypt/hcrypt_xpt_srt.c` has two definitions of the static variable `_hcMsg_SRT_MsgInfo`:

```c
// Line: 68
static hcrypt_MsgInfo _hcMsg_SRT_MsgInfo;
// Line: 156
static hcrypt_MsgInfo _hcMsg_SRT_MsgInfo;
```

One more problem is the `.parseMsg` field off the structure that is initialized with a pointer to `hcryptMsg_SRT_ParseMsg` function. The `hcryptMsg_SRT_ParseMsg` function in its turn uses the static _hcMsg_SRT_MsgInfo internally.

To resolve this interdependency the `hcryptMsg_SRT_ParseMsg` function is made visible and now requires a pointer to a `hcrypt_MsgInfo`  structure instead of using the static variable implicitly.
The `_hcMsg_SRT_MsgInfo` can now be const and initialized once the following way:

```c
static const hcrypt_MsgInfo _hcMsg_SRT_MsgInfo = {
	.hdr_len     = HCRYPT_MSG_SRT_HDR_SZ,
	.pfx_len     = HCRYPT_MSG_SRT_PFX_SZ,
	.getKeyFlags = hcryptMsg_SRT_GetKeyFlags,
	.getPki      = hcryptMsg_SRT_GetPki,
	.setPki      = hcryptMsg_SRT_SetPki,
	.resetCache  = hcryptMsg_SRT_ResetCache,
	.indexMsg    = hcryptMsg_SRT_IndexMsg,
};
```


Fixes #3035.