### PR TITLE
[apps] Use sync.h instead of atomic.h in the verbose module.

### DIFF
--- a/apps/verbose.hpp
+++ b/apps/verbose.hpp
@@ -12,7 +12,7 @@
 #define INC_SRT_VERBOSE_HPP
 
 #include <iostream>
-#include "atomic.h"
+#include "sync.h"
 
 namespace Verbose
 {


### PR DESCRIPTION
The `atomic.h` header of the SRT project can include `sync.h` header in the following case:

```c++
#if defined(ATOMIC_USE_SRT_SYNC_MUTEX) && (ATOMIC_USE_SRT_SYNC_MUTEX == 1)
   #include "sync.h"
#endif
```

It leads to the compilation error because `sync.h` includes `atomic.h` and later `atomic_clock.h`:

```shell
[ 60%] Building CXX object /apps/socketoptions.cpp.o
In file included from /srtcore/sync.h:1069,
                 from /srt/srtcore/atomic.h:104,
                 from /srt/apps/verbose.hpp:15,
                 from /srt/apps/socketoptions.cpp:12:
/srt/srtcore/atomic_clock.h:25:5: error: 'atomic' does not name a type; did you mean 'atoi'?
     atomic<int64_t> dur;
     ^~~~~~
     atoi
/srt/srtcore/atomic_clock.h: In constructor 'srt::sync::AtomicDuration<Clock>::AtomicDuration()':
/srt/srtcore/atomic_clock.h:30:37: error: class 'srt::sync::AtomicDuration<Clock>' does not have any field named 'dur'
     AtomicDuration() ATR_NOEXCEPT : dur(0) {}
                                     ^~~
/submodule/srt/srtcore/atomic_clock.h: In member function 'srt::sync::AtomicDuration<Clock>::duration_type srt::sync::AtomicDuration<Clock>::load()':
/srt/srtcore/atomic_clock.h:34:23: error: 'dur' was not declared in this scope
         int64_t val = dur.load();
                       ^~~
/srt/srtcore/atomic_clock.h:34:23: note: suggested alternative: 'dup'
         int64_t val = dur.load();
                       ^~~
                       dup
```

The verbose module uses `srt::sync::atomic<bool> lockline`, so makes sense to include `sync.h` straight away.



**Affected SRT versions:** 1.5.4 RC.0, RC.1 (after PR #3004).