### PR TITLE
[core] Resolved GCC13 build warning regarding std::copy of a bool.

### DIFF
--- a/scripts/release-notes/generate_release_notes.py
+++ b/scripts/release-notes/generate_release_notes.py
@@ -21,7 +21,7 @@ def define_area(msg):
         if msg.startswith(f'[{area}] '):
             return area
 
-    return np.NaN
+    return np.nan
 
 
 def delete_prefix(msg):

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -447,11 +447,13 @@ static bool operator!=(const struct linger& l1, const struct linger& l2)
 template <class ValueType>
 static void importOption(vector<CUDTGroup::ConfigItem>& storage, SRT_SOCKOPT optname, const ValueType& field)
 {
-    ValueType default_opt      = ValueType();
-    int       default_opt_size = sizeof(ValueType);
-    ValueType opt              = field;
-    if (!getOptDefault(optname, (&default_opt), (default_opt_size)) || default_opt != opt)
+    ValueType default_opt             = ValueType();
+    static const int default_opt_size = sizeof(ValueType);
+    ValueType opt                     = field;
+    int opt_size                      = default_opt_size;
+    if (!getOptDefault(optname, (&default_opt), (opt_size)) || default_opt != opt)
     {
+        SRT_ASSERT(opt_size == default_opt_size);
         // Store the option when:
         // - no default for this option is found
         // - the option value retrieved from the field is different than default


### PR DESCRIPTION
The GCC 13 compiler produces a warning complaining that the length used for `std::copy` is out of bounds of an integer (or any other 1-byte type).
The source of this complaint was that the length was set in the `getOptDefault`, instead of a direct `sizeof` value. Even though the length returned for a Boolean is anyway determined via `sizeof(Type)` called from a template function, it is probably not that safe anyway.
Therefore just assert (in a debug build configuration) that the size returned is similar to the `sizeof` call used in the `importOption` function.

Fixes #3064.