### PR TITLE
[core] Fixed getting SRTO_RCVBUF and SRTO_SNDBUF on a group.

### DIFF
--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -472,7 +472,7 @@ template <size_t N>
 static void importStringOption(vector<CUDTGroup::ConfigItem>& storage, SRT_SOCKOPT optname, const StringStorage<N>& optval)
 {
     if (optval.empty())
-		return;
+        return;
 
     // Store the option when:
     // - option has a value (default is empty).
@@ -615,9 +615,11 @@ bool CUDTGroup::applyFlags(uint32_t flags, HandshakeSide)
 template <class Type>
 struct Value
 {
-    static int fill(void* optval, int, const Type& value)
+    static int fill(void* optval, int len, const Type& value)
     {
-        // XXX assert size >= sizeof(Type) ?
+        if (size_t(len) < sizeof(Type))
+            return 0;
+
         *(Type*)optval = value;
         return sizeof(Type);
     }
@@ -671,7 +673,7 @@ static bool getOptDefault(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
 
     case SRTO_SNDBUF:
     case SRTO_RCVBUF:
-        w_optlen = fillValue((pw_optval), w_optlen, CSrtConfig::DEF_BUFFER_SIZE * (CSrtConfig::DEF_MSS - CPacket::UDP_HDR_SIZE));
+        w_optlen = fillValue<int>((pw_optval), w_optlen, CSrtConfig::DEF_BUFFER_SIZE * (CSrtConfig::DEF_MSS - CPacket::UDP_HDR_SIZE));
         break;
 
     case SRTO_LINGER:


### PR DESCRIPTION
The documented length of `SRTO_RCVBUF` and `SRTO_SNDBUF` socket options is 4 bytes, the code was setting 8 bytes without checking `optlen`. Hence producing an out-of-bound memory write.


Introduced since the start by PR #1109.
Affected SRT versions: v1.4.2+.

Work within issue #3074.