### PR TITLE
[TEST] Fixed a test that reuses connection-failed socket

### DIFF
--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -170,20 +170,22 @@ TEST_F(TestConnectionTimeout, Nonblocking) {
 */
 TEST_F(TestConnectionTimeout, BlockingLoop)
 {
-    const SRTSOCKET client_sock = srt_create_socket();
-    ASSERT_GT(client_sock, 0);    // socket_id should be > 0
-
-    // Set connection timeout to 999 ms to reduce the test execution time.
-    // Also need to hit a time point between two threads:
-    // srt_connect will check TTL every second,
-    // CRcvQueue::worker will wait on a socket for 10 ms.
-    // Need to have a condition, when srt_connect will process the timeout.
-    const int connection_timeout_ms = 999;
-    EXPECT_EQ(srt_setsockopt(client_sock, 0, SRTO_CONNTIMEO, &connection_timeout_ms, sizeof connection_timeout_ms), SRT_SUCCESS);
-
     const sockaddr* psa = reinterpret_cast<const sockaddr*>(&m_sa);
+    const int connection_timeout_ms = 999;
     for (int i = 0; i < 10; ++i)
     {
+        const SRTSOCKET client_sock = srt_create_socket();
+        EXPECT_GT(client_sock, 0);    // socket_id should be > 0
+        if (client_sock <= 0)
+            break;
+
+        // Set connection timeout to 999 ms to reduce the test execution time.
+        // Also need to hit a time point between two threads:
+        // srt_connect will check TTL every second,
+        // CRcvQueue::worker will wait on a socket for 10 ms.
+        // Need to have a condition, when srt_connect will process the timeout.
+        EXPECT_EQ(srt_setsockopt(client_sock, 0, SRTO_CONNTIMEO, &connection_timeout_ms, sizeof connection_timeout_ms), SRT_SUCCESS);
+
         const chrono::steady_clock::time_point chrono_ts_start = chrono::steady_clock::now();
         EXPECT_EQ(srt_connect(client_sock, psa, sizeof m_sa), SRT_ERROR);
 
@@ -200,9 +202,9 @@ TEST_F(TestConnectionTimeout, BlockingLoop)
                 << error_code << " " << srt_getlasterror_str() << "\n";
             break;
         }
-    }
 
-    EXPECT_EQ(srt_close(client_sock), SRT_SUCCESS);
+        EXPECT_EQ(srt_close(client_sock), SRT_SUCCESS);
+    }
 }
 
 


### PR DESCRIPTION
In this test there's a change: instead of reusing the once created socket, which is expected to fail on timeout, the socket is closed in every iteration and created anew.