### PR TITLE
[MAINT] Apply conditional to setting a macro for IPv6 on Mac

### DIFF
--- a/srtcore/platform_sys.h
+++ b/srtcore/platform_sys.h
@@ -68,7 +68,9 @@
 // also other macros, like TARGET_OS_IOS etc.
 
 #include "TargetConditionals.h"
+#ifndef __APPLE_USE_RFC_3542
 #define __APPLE_USE_RFC_3542 /* IPV6_PKTINFO */
+#endif
 
 #ifdef SRT_IMPORT_TIME
       #include <mach/mach_time.h>


### PR DESCRIPTION
Fixes #3081 