### PR TITLE
[apps] FIX srt-live-transmit stops listening after SRT disconnect #2997...

### DIFF
--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -790,11 +790,13 @@ int main(int argc, char** argv)
                         if (sock != SRT_INVALID_SOCK)
                         {
                             for (int n = 0; n < srtrfdslen; n ++)
+                            {
                                 if (sock == srtrwfds[n])
                                 {
                                     srcReady = true;
                                     break;
                                 }
+                            }
 
                         }
                     }

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -487,7 +487,6 @@ int main(int argc, char** argv)
     bool srcConnected = false;
     unique_ptr<Target> tar;
     bool tarConnected = false;
-    bool srcMayBlock = false;
 
     int pollid = srt_epoll_create();
     if (pollid < 0)
@@ -542,7 +541,6 @@ int main(int argc, char** argv)
                     {
                         const int con = src->GetSysSocket();
                         // try to make the standard input non blocking
-                        srcMayBlock = fcntl(con, F_SETFL, fcntl(con, F_GETFL) | O_NONBLOCK) < 0;
                         if (srt_epoll_add_ssock(pollid, con, &events))
                         {
                             cerr << "Failed to add FILE source to poll, "
@@ -806,6 +804,7 @@ int main(int argc, char** argv)
                         if (sock != -1)
                         {
                             for (int n = 0; n < sysrfdslen; n++)
+                            {
                                 if (sock == sysrfds[n])
                                 {
                                     srcReady = true;
@@ -844,7 +843,7 @@ int main(int argc, char** argv)
 
                         dataqueue.push_back(pkt);
                         receivedBytes += pkt->payload.size();
-                        if (srcMayBlock) 
+                        if (src->MayBlock())
                             break;
                     }
                 }

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -780,7 +780,7 @@ int main(int argc, char** argv)
 
                 bool srcReady = false;
 
-                if (src.get() && src->IsOpen())
+                if (src.get() && src->IsOpen() && !src->End())
                 {
                     if (srtrfdslen > 0)
                     {

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -811,7 +811,7 @@ int main(int argc, char** argv)
                                     srcReady = true;
                                     break;
                                 }
-
+                            }
                         }
                     } 
                 }

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -487,6 +487,7 @@ int main(int argc, char** argv)
     bool srcConnected = false;
     unique_ptr<Target> tar;
     bool tarConnected = false;
+    bool srcMayBlock = false;
 
     int pollid = srt_epoll_create();
     if (pollid < 0)
@@ -514,6 +515,7 @@ int main(int argc, char** argv)
                     return 1;
                 }
                 int events = SRT_EPOLL_IN | SRT_EPOLL_ERR;
+
                 switch (src->uri.type())
                 {
                 case UriParser::SRT:
@@ -537,14 +539,19 @@ int main(int argc, char** argv)
                     }
                     break;
                 case UriParser::FILE:
-                    if (srt_epoll_add_ssock(pollid,
-                        src->GetSysSocket(), &events))
                     {
-                        cerr << "Failed to add FILE source to poll, "
-                            << src->GetSysSocket() << endl;
-                        return 1;
+                        int con = src->GetSysSocket();
+                        // try to make the standard input non blocking
+                        srcMayBlock = fcntl(con, F_SETFL, fcntl(con, F_GETFL) | O_NONBLOCK) < 0;
+                        if (srt_epoll_add_ssock(pollid, con, &events))
+                        {
+                            cerr << "Failed to add FILE source to poll, "
+                                << src->GetSysSocket() << endl;
+                            return 1;
+                        }
+                        break;
+
                     }
-                    break;
                 default:
                     break;
                 }
@@ -589,6 +596,7 @@ int main(int argc, char** argv)
             SRTSOCKET srtrwfds[4] = {SRT_INVALID_SOCK, SRT_INVALID_SOCK , SRT_INVALID_SOCK , SRT_INVALID_SOCK };
             int sysrfdslen = 2;
             SYSSOCKET sysrfds[2];
+
             if (srt_epoll_wait(pollid,
                 &srtrwfds[0], &srtrfdslen, &srtrwfds[2], &srtwfdslen,
                 100,
@@ -771,12 +779,46 @@ int main(int argc, char** argv)
                     break;
                 }
 
+
+                bool srcReady = false;
+
+                if (src.get() && src->IsOpen())
+                {
+                    if (srtrfdslen > 0)
+                    {
+                        SRTSOCKET sock = src->GetSRTSocket();
+                        if (sock != SRT_INVALID_SOCK)
+                        {
+                            for (int n = 0; n < srtrfdslen; n ++)
+                                if (sock == srtrwfds[n])
+                                {
+                                    srcReady = true;
+                                    break;
+                                }
+
+                        }
+                    }
+                    if (!srcReady && sysrfdslen > 0)
+                    {
+                        int sock = src->GetSysSocket();
+                        if (sock != -1)
+                        {
+                            for (int n = 0; n < sysrfdslen; n++)
+                                if (sock == sysrfds[n])
+                                {
+                                    srcReady = true;
+                                    break;
+                                }
+
+                        }
+                    } 
+                }
                 // read a few chunks at a time in attempt to deplete
                 // read buffers as much as possible on each read event
                 // note that this implies live streams and does not
                 // work for cached/file sources
                 std::list<std::shared_ptr<MediaPacket>> dataqueue;
-                if (src.get() && src->IsOpen() && (srtrfdslen || sysrfdslen))
+                if (srcReady)
                 {
                     while (dataqueue.size() < cfg.buffering)
                     {
@@ -800,9 +842,10 @@ int main(int argc, char** argv)
 
                         dataqueue.push_back(pkt);
                         receivedBytes += pkt->payload.size();
+                        if (srcMayBlock) 
+                            break;
                     }
                 }
-
                 // if there is no target, let the received data be lost
                 while (!dataqueue.empty())
                 {

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -540,7 +540,7 @@ int main(int argc, char** argv)
                     break;
                 case UriParser::FILE:
                     {
-                        int con = src->GetSysSocket();
+                        const int con = src->GetSysSocket();
                         // try to make the standard input non blocking
                         srcMayBlock = fcntl(con, F_SETFL, fcntl(con, F_GETFL) | O_NONBLOCK) < 0;
                         if (srt_epoll_add_ssock(pollid, con, &events))

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -787,15 +787,7 @@ int main(int argc, char** argv)
                         SRTSOCKET sock = src->GetSRTSocket();
                         if (sock != SRT_INVALID_SOCK)
                         {
-                            for (int n = 0; n < srtrfdslen; n ++)
-                            {
-                                if (sock == srtrwfds[n])
-                                {
-                                    srcReady = true;
-                                    break;
-                                }
-                            }
-
+                            for (int n = 0; n < srtrfdslen && !(srcReady = (sock == srtrwfds[n])); n ++);
                         }
                     }
                     if (!srcReady && sysrfdslen > 0)
@@ -803,14 +795,7 @@ int main(int argc, char** argv)
                         int sock = src->GetSysSocket();
                         if (sock != -1)
                         {
-                            for (int n = 0; n < sysrfdslen; n++)
-                            {
-                                if (sock == sysrfds[n])
-                                {
-                                    srcReady = true;
-                                    break;
-                                }
-                            }
+                            for (int n = 0; n < sysrfdslen && !(srcReady = (sock == sysrfds[n])); n++);
                         }
                     } 
                 }

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -71,6 +71,7 @@ public:
 
     virtual SRTSOCKET GetSRTSocket() const { return SRT_INVALID_SOCK; }
     virtual int GetSysSocket() const { return -1; }
+    virtual bool MayBlock() { return false; }
     virtual bool AcceptNewClient() { return false; }
 };
 

--- a/apps/transmitbase.hpp
+++ b/apps/transmitbase.hpp
@@ -71,7 +71,7 @@ public:
 
     virtual SRTSOCKET GetSRTSocket() const { return SRT_INVALID_SOCK; }
     virtual int GetSysSocket() const { return -1; }
-    virtual bool MayBlock() { return false; }
+    virtual bool MayBlock() const { return false; }
     virtual bool AcceptNewClient() { return false; }
 };
 

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -704,6 +704,7 @@ Iface* CreateSrt(const string& host, int port, const map<string,string>& par) { 
 
 class ConsoleSource: public Source
 {
+    bool may_block = false;
 public:
 
     ConsoleSource()
@@ -713,6 +714,8 @@ public:
         // We have to set it to the binary mode
         _setmode(_fileno(stdin), _O_BINARY);
 #endif
+        const int fd = fileno(stdin);
+        may_block = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) < 0;
     }
 
     int Read(size_t chunk, MediaPacket& pkt, ostream & ignored SRT_ATR_UNUSED = cout) override
@@ -736,6 +739,7 @@ public:
     }
 
     bool IsOpen() override { return !cin.eof(); }
+    bool MayBlock() override { return may_block; }
     bool End() override { return cin.eof(); }
     int GetSysSocket() const override { return fileno(stdin); };
 };

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -704,7 +704,7 @@ Iface* CreateSrt(const string& host, int port, const map<string,string>& par) { 
 
 class ConsoleSource: public Source
 {
-    bool may_block = false;
+    bool may_block = true;
 public:
 
     ConsoleSource()
@@ -713,9 +713,10 @@ public:
         // The default stdin mode on windows is text.
         // We have to set it to the binary mode
         _setmode(_fileno(stdin), _O_BINARY);
-#endif
+#else
         const int fd = fileno(stdin);
         may_block = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) < 0;
+#endif
     }
 
     int Read(size_t chunk, MediaPacket& pkt, ostream & ignored SRT_ATR_UNUSED = cout) override

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -720,9 +720,8 @@ public:
         if (pkt.payload.size() < chunk)
             pkt.payload.resize(chunk);
 
-        bool st = cin.read(pkt.payload.data(), chunk).good();
-        chunk = cin.gcount();
-        if (chunk == 0 || !st)
+        int ret = ::read(GetSysSocket(), pkt.payload.data(), chunk);
+        if (ret <= 0)
         {
             pkt.payload.clear();
             return 0;
@@ -731,14 +730,14 @@ public:
         // Save this time to potentially use it for SRT target.
         pkt.time = srt_time_now();
         if (chunk < pkt.payload.size())
-            pkt.payload.resize(chunk);
+            pkt.payload.resize(ret);
 
-        return (int) chunk;
+        return ret;
     }
 
-    bool IsOpen() override { return cin.good(); }
+    bool IsOpen() override { return !cin.eof(); }
     bool End() override { return cin.eof(); }
-    int GetSysSocket() const override { return 0; };
+    int GetSysSocket() const override { return fileno(stdin); };
 };
 
 class ConsoleTarget: public Target
@@ -767,7 +766,7 @@ public:
 
     bool IsOpen() override { return cout.good(); }
     bool Broken() override { return cout.eof(); }
-    int GetSysSocket() const override { return 0; };
+    int GetSysSocket() const override { return fileno(stdout); };
 };
 
 template <class Iface> struct Console;

--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -741,7 +741,7 @@ public:
         return ret;
     }
 
-    bool IsOpen() override { return !cin.eof(); }
+    bool IsOpen() override { return cin.good(); }
     bool MayBlock() const final { return may_block; }
     bool End() override { return cin.eof(); }
     int GetSysSocket() const override { return fileno(stdin); };


### PR DESCRIPTION
... during no active input (FIX #2997)

There are two primary reasons for this issue:

1. The main loop assumes that each time srt_epoll_wait returns, there is data available to read from the source. However, this assumption is incorrect when an SRT socket is in listener mode and on the "target" side. In this mode, srt_epoll_wait can return simply to provide an opportunity to accept a new connection, even if no data is ready to be read. As a result, the process becomes stuck while waiting to read from the source.
2. The ConsoleSource operates in blocking mode by default. Even worse, its Read() method blocks execution until a full packet (1456 bytes) is received.

