### PR TITLE
Added support for Windows on Arm64

### DIFF
--- a/scripts/win-installer/README.md
+++ b/scripts/win-installer/README.md
@@ -7,12 +7,19 @@ libsrt on Windows systems for Visual Studio applications using SRT.
 
 ### Prerequisites
 
-These first two steps need to be executed once only.
+These initial steps need to be executed once only.
 
-- Prerequisite 1: Install OpenSSL for Windows, both 64 and 32 bits.
+- Prerequisite 1: Install Visual Studio. The free Community Edition is recommended
+  for open-source software. See https://visualstudio.microsoft.com/. Be sure to
+  install the compilation tools for the all target architectures, including 64-bit Arm.
+  In the Visual Studio Installer program, select "Modify" -> "Individual Components".
+  In section "Compilers, build tools, and runtimes", select "MSVC v143 - VS2022 C++
+  ARM64/ARM64EC build tools (latest)" (the exact version may vary).
+
+- Prerequisite 2: Install OpenSSL for Windows, 64-bit Intel, 32-bit Intel, 64-bit Arm.
   This can be done automatically by running the PowerShell script `install-openssl.ps1`.
 
-- Prerequisite 2: Install NSIS, the NullSoft Installation Scripting system.
+- Prerequisite 3: Install NSIS, the NullSoft Installation Scripting system.
   This can be done automatically by running the PowerShell script `install-nsis.ps1`.
 
 ### Building the libsrt installer

--- a/scripts/win-installer/install-openssl.ps1
+++ b/scripts/win-installer/install-openssl.ps1
@@ -101,19 +101,19 @@ if ($status -ne 1 -and $status -ne 2) {
 }
 $config = ConvertFrom-Json $Response.Content
 
-# Download and install MSI packages for 32 and 64 bit.
-foreach ($bits in @(32, 64)) {
+# Download and install MSI packages for 32 and 64-bit Intel, 64-bit Arm.
+foreach ($conf in @(@{arch="intel"; bits=32}, @{arch="intel"; bits=64}, @{arch="arm"; bits=64})) {
 
     # Get the URL of the MSI installer from the JSON config.
     $Url = $config.files | Get-Member | ForEach-Object {
         $name = $_.name
         $info = $config.files.$($_.name)
-        if (-not $info.light -and $info.installer -like "msi" -and $info.bits -eq $bits -and $info.arch -like "intel") {
+        if (-not $info.light -and $info.installer -like "msi" -and $info.bits -eq $conf.bits -and $info.arch -like $conf.arch) {
             $info.url
         }
     } | Select-Object -Last 1
     if (-not $Url) {
-        Exit-Script "#### No MSI installer found for Win${bits}"
+        Exit-Script "#### No MSI installer found for $($conf.bits)-bit $($conf.arch)"
     }
 
     $MsiName = (Split-Path -Leaf $Url)

--- a/scripts/win-installer/libsrt.nsi
+++ b/scripts/win-installer/libsrt.nsi
@@ -28,9 +28,10 @@ Caption "SRT Libraries Installer"
 !include "x64.nsh"
 !verbose pop
 
-!define ProductName "libsrt"
-!define Build32Dir  "${BuildRoot}\build.Win32"
-!define Build64Dir  "${BuildRoot}\build.x64"
+!define ProductName   "libsrt"
+!define BuildWin32Dir "${BuildRoot}\build.Win32"
+!define BuildWin64Dir "${BuildRoot}\build.x64"
+!define BuildArm64Dir "${BuildRoot}\build.ARM64"
 
 ; Installer file information.
 VIProductVersion ${VersionInfo}
@@ -93,6 +94,7 @@ functionEnd
 function un.onInit
     ; In 64-bit installers, don't use registry redirection.
     ${If} ${RunningX64}
+    ${OrIf} ${IsNativeARM64}
         SetRegView 64
     ${EndIf}
 functionEnd
@@ -128,7 +130,7 @@ Section "Install"
     File "${RepoDir}\srtcore\platform_sys.h"
     File "${RepoDir}\srtcore\srt.h"
     File "${RepoDir}\srtcore\udt.h"
-    File "${Build64Dir}\version.h"
+    File "${BuildWin64Dir}\version.h"
 
     CreateDirectory "$INSTDIR\include\win"
     SetOutPath "$INSTDIR\include\win"
@@ -139,27 +141,39 @@ Section "Install"
     
     CreateDirectory "$INSTDIR\lib\Release-x64"
     SetOutPath "$INSTDIR\lib\Release-x64"
-    File /oname=srt.lib       "${Build64Dir}\Release\srt_static.lib"
-    File /oname=libcrypto.lib "${libcrypto64MD}"
-    File /oname=libssl.lib    "${libssl64MD}"
+    File /oname=srt.lib       "${BuildWin64Dir}\Release\srt_static.lib"
+    File /oname=libcrypto.lib "${libcryptoWin64MD}"
+    File /oname=libssl.lib    "${libsslWin64MD}"
 
     CreateDirectory "$INSTDIR\lib\Debug-x64"
     SetOutPath "$INSTDIR\lib\Debug-x64"
-    File /oname=srt.lib       "${Build64Dir}\Debug\srt_static.lib"
-    File /oname=libcrypto.lib "${libcrypto64MDd}"
-    File /oname=libssl.lib    "${libssl64MDd}"
+    File /oname=srt.lib       "${BuildWin64Dir}\Debug\srt_static.lib"
+    File /oname=libcrypto.lib "${libcryptoWin64MDd}"
+    File /oname=libssl.lib    "${libsslWin64MDd}"
 
     CreateDirectory "$INSTDIR\lib\Release-Win32"
     SetOutPath "$INSTDIR\lib\Release-Win32"
-    File /oname=srt.lib       "${Build32Dir}\Release\srt_static.lib"
-    File /oname=libcrypto.lib "${libcrypto32MD}"
-    File /oname=libssl.lib    "${libssl32MD}"
+    File /oname=srt.lib       "${BuildWin32Dir}\Release\srt_static.lib"
+    File /oname=libcrypto.lib "${libcryptoWin32MD}"
+    File /oname=libssl.lib    "${libsslWin32MD}"
 
     CreateDirectory "$INSTDIR\lib\Debug-Win32"
     SetOutPath "$INSTDIR\lib\Debug-Win32"
-    File /oname=srt.lib       "${Build32Dir}\Debug\srt_static.lib"
-    File /oname=libcrypto.lib "${libcrypto32MDd}"
-    File /oname=libssl.lib    "${libssl32MDd}"
+    File /oname=srt.lib       "${BuildWin32Dir}\Debug\srt_static.lib"
+    File /oname=libcrypto.lib "${libcryptoWin32MDd}"
+    File /oname=libssl.lib    "${libsslWin32MDd}"
+
+    CreateDirectory "$INSTDIR\lib\Release-Arm64"
+    SetOutPath "$INSTDIR\lib\Release-Arm64"
+    File /oname=srt.lib       "${BuildArm64Dir}\Release\srt_static.lib"
+    File /oname=libcrypto.lib "${libcryptoArm64MD}"
+    File /oname=libssl.lib    "${libsslArm64MD}"
+
+    CreateDirectory "$INSTDIR\lib\Debug-Arm64"
+    SetOutPath "$INSTDIR\lib\Debug-Arm64"
+    File /oname=srt.lib       "${BuildArm64Dir}\Debug\srt_static.lib"
+    File /oname=libcrypto.lib "${libcryptoArm64MDd}"
+    File /oname=libssl.lib    "${libsslArm64MDd}"
 
     ; Add an environment variable to installation root.
     WriteRegStr HKLM ${EnvironmentKey} "LIBSRT" "$INSTDIR"

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -154,13 +154,13 @@ void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_p
       r_probeWindow[k] = 1000;    //1 msec -> 1000 pkts/sec
 
    for (size_t i = 0; i < asize; ++ i)
-      r_bytesWindow[i] = max_payload_size; //based on 1 pkt/sec set in r_pktWindow[i]
+      r_bytesWindow[i] = int(max_payload_size); //based on 1 pkt/sec set in r_pktWindow[i]
 }
 
 int srt::CPktTimeWindowTools::ceilPerMega(double value, double count)
 {
     static const double MEGA = 1000.0 * 1000.0;
-    return ::ceil(MEGA / (value / count));
+    return int(::ceil(MEGA / (value / count)));
 }
 
 int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, size_t hdr_size, int& w_bytesps)
@@ -183,7 +183,7 @@ int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica,
         return 0;
     }
 
-    bytes += (hdr_size * count); //Add protocol headers to bytes received
+    bytes += (unsigned long)(hdr_size * count); //Add protocol headers to bytes received
     w_bytesps = ceilPerMega(sum, bytes);
     return ceilPerMega(sum, count);
 }


### PR DESCRIPTION
When building the libsrt binary installer for Windows, also build the libraries for Arm64 target, in addition to Win32 and Win64. The build can be performed anywhere, Visual Studio can build for distinct targets. 

**Before the build on an Intel machine, make sure that your VS installation includes the build tools for Arm64. See `scripts/win-installer/README.md` for more details.**

On existing build systems, be sure to run `install-openssl.ps1` again once to make sure that the Arm64 libraries for OpenSSL are installed.

Also fixed a few harmless warnings.

The resulting libsrt Windows installer has been successfully tested using TSDuck `srt` plugin (input and output) on a Windows Arm64 virtual machine on a Mac with "Apple Silicon" CPU (ie. Arm64).
