### PR TITLE
Fix Windows installers

### DIFF
--- a/scripts/win-installer/README.md
+++ b/scripts/win-installer/README.md
@@ -18,6 +18,8 @@ These initial steps need to be executed once only.
 
 - Prerequisite 2: Install OpenSSL for Windows, 64-bit Intel, 32-bit Intel, 64-bit Arm.
   This can be done automatically by running the PowerShell script `install-openssl.ps1`.
+  If you are interested in more information about OpenSSL for Windows, scroll to the
+  appendix at the end of this page.
 
 - Prerequisite 3: Install NSIS, the NullSoft Installation Scripting system.
   This can be done automatically by running the PowerShell script `install-nsis.ps1`.
@@ -128,3 +130,80 @@ This directory contains the following files:
 | libsrt.nsi              | NSIS installation script (used to build the installer).
 | libsrt.props            | Visual Studio property files to use libsrt (embedded in the installer).
 | README.md               | This text file.
+
+## Appendix: Using OpenSSL on Windows
+
+The SRT protocol uses encryption. Internally, `libsrt` can use multiple cryptographic
+libraries but OpenSSL is the default choice on all platforms, including Windows.
+
+OpenSSL is not part of the base installation of a Windows platform and should be
+separately installed. OpenSSL is neither "Windows-friendly" and the OpenSSL team
+does not provide Windows binaries.
+
+The production of OpenSSL binaries for Windows is delegated to Shining Light
+Productions (http://slproweb.com/). Binaries for all architectures are available
+here: http://slproweb.com/products/Win32OpenSSL.html
+
+### How to grab OpenSSL installers for Windows
+
+This is automatically done by the PowerShell script `install-openssl.ps1` in
+this directory. Let's see what's behind the scene.
+
+First, the script determines which installers should be downloaded and where
+to get them from.
+
+Initially, the HTML for the [slproweb](http://slproweb.com/products/Win32OpenSSL.html)
+page was built on server-side. Our script grabbed the URL content, parsed the HTML
+and extracted the URL of the binaries for the latest OpenSSL packages from the
+"href" of the links.
+
+At some point in 2024, the site changed policy. The Web page was no longer
+built on server-side, but on client-side. The downloaded HTML contains some
+JavaScript which dynamically builds the URL of the binaries for the latest
+OpenSSL binaries. The previous method now finds no valid package URL from
+the downloaded page (a full browser is needed to execute the JavaScript).
+The JavaScript downloads a JSON file which contains all references to
+the OpenSSL binaries.
+
+Therefore, the script `install-openssl.ps1` now uses the same method:
+download that JSON file and parse it.
+
+### Multi-architecture builds
+
+The `libsrt` installer contains static libraries for all three architectures
+which are supported by Windows: x86, x64, Arm64. The corresponding static
+libraries for OpenSSL are also needed and included in the installer.
+
+Because Visual Studio can build libraries and executables for all three
+architectures, on any build system, we need to install the OpenSSL headers
+and libraries for all three architectures, on the build system.
+
+This is what the script `install-openssl.ps1` does. However, the way to
+do this has changed over time.
+
+As a starting point, there are three installers, one per architecture.
+All installers are x86 executables which can be run on any Windows system
+(Arm64 Windows emulates x86 and x64 when necessary). Additionally, the
+three sets of files are installed side by side, without overlap.
+
+- x86: `C:\Program Files (x86)\OpenSSL-Win32`
+- x64: `C:\Program Files\OpenSSL-Win64`
+- Arm64: `C:\Program Files\OpenSSL-Win64-ARM`
+
+So, the script `install-openssl.ps1` installed them all and `libsrt` could
+be built for all architecture.
+
+However, it works only on Arm64 systems. On x86 and x64 system, the OpenSSL
+installer for Arm64 fails. The installer executable can run but there is an
+explicit check in the installation process to abort when running on Intel
+systems.
+
+Since most Windows build servers are Intel systems, this approach was no
+longer appropriate.
+
+At some point, the producers of the OpenSSL binaries acknowledged the problem
+and they created an additional form of installer: the "universal" one. This
+package can be installed on any system and the binaries and headers are installed
+for all architectures, in one single location.
+
+- Universal: `C:\Program Files (x86)\OpenSSL-WinUniversal`

--- a/scripts/win-installer/build-win-installer.ps1
+++ b/scripts/win-installer/build-win-installer.ps1
@@ -95,74 +95,33 @@ Write-Output "Windows version info: $VersionInfo"
 #-----------------------------------------------------------------------------
 
 # Locate OpenSSL root from local installation.
-# After version 3.something, OpenSSL has changed its installation layout.
-# We have to look for OpenSSL libraries in various locations.
-$SSL = @{
-    "x64" = @{
-        "available" = $true;
-        "alt" = "Win64";
-        "bits" = 64;
-        "root" = "C:\Program Files\OpenSSL-Win64"
-    };
-    "Win32" = @{
-        "available" = $true;
-        "alt" = "x86";
-        "bits" = 32;
-        "root" = "C:\Program Files (x86)\OpenSSL-Win32"
-    }
-    "ARM64" = @{
-        "available" = $true;
-        "alt" = "arm64";
-        "bits" = 64;
-        "root" = "C:\Program Files\OpenSSL-Win64-ARM"
-    };
-}
+# We now requires the "universal" OpenSSL installer (see README.md).
+# The universal OpenSSL installer is installed in $SSL.
+# $ARCH translates between VC "platform" names to subdirectory names inside $SSL.
+# $LIBDIR translates between VC "configuration" names to library subdirectory names.
 
-# Currently, on Intel systems, we are not able to install ARM64 versions of
-# the OpenSSL libraries. This is a limitation of the OpenSSL packaging for
-# Windows.
-if (-not ($env:PROCESSOR_ARCHITECTURE -like "ARM64") -and -not (Test-Path $SSL.ARM64.root)) {
-    $SSL.ARM64.available = $false
-    Write-Output "Warning: OpenSSL libraries for ARM64 not found."
-    Write-Output "This is a $($env:PROCESSOR_ARCHITECTURE) system."
-    Write-Output "Currently, you need an ARM64 system to build libsrt for all three architectures."
-}
+$SSL = "C:\Program Files (x86)\OpenSSL-WinUniversal"
+$ARCH = @{x64 = "x64"; Win32 = "x86"; ARM64 = "arm64"}
+$LIBDIR = @{Release = "MD"; Debug = "MDd"}
+$LIBFILE = @{crypto = "libcrypto_static.lib"; ssl = "libssl_static.lib"}
+
+function ssl-include($pf) { return "$SSL\include\$($ARCH.$pf)" }
+function ssl-libdir($pf, $conf) { return "$SSL\lib\VC\$($ARCH.$pf)\$($LIBDIR.$conf)" }
+function ssl-lib($pf, $conf, $lib) { return "$(ssl-libdir $pf $conf)\$($LIBFILE.$lib)" }
 
 # Verify OpenSSL directories and static libraries.
 Write-Output "Searching OpenSSL libraries ..."
 $Missing = 0
-foreach ($arch in $SSL.Keys) {
-    $root = $SSL.$arch.root
-    $bits = $SSL.$arch.bits
-    $alt = $SSL.$arch.alt
-    if (-not $SSL.$arch.available) {
-        # No build on this architecture
-        $SSL.$arch.libsslMD = ""
-        $SSL.$arch.libsslMDd = ""
-        $SSL.$arch.libcryptoMD = ""
-        $SSL.$arch.libcryptoMDd = ""
-    }
-    elseif (-not (Test-Path $root)) {
-        Write-Output "**** Missing $root"
+foreach ($Platform in $SSL.Keys) {
+    if (-not (Test-Path -PathType Container $(ssl-include $Platform))) {
+        Write-Output "**** Missing $(ssl-include $Platform)"
         $Missing = $Missing + 1
     }
-    else {
-        foreach ($lib in @("ssl", "crypto")) {
-            foreach ($conf in @("MD", "MDd")) {
-                $name = "lib${lib}${conf}"
-                $SSL.$arch.$name = ""
-                foreach ($try in @("$root\lib\VC\static\lib${lib}${bits}${conf}.lib",
-                                   "$root\lib\VC\${arch}\${conf}\lib${lib}_static.lib",
-                                   "$root\lib\VC\${alt}\${conf}\lib${lib}_static.lib")) {
-                    if (Test-Path $try) {
-                        $SSL.$arch.$name = $try
-                        break
-                    }
-                }
-                if (-not $SSL.$arch.$name) {
-                    Write-Output "**** OpenSSL static library for $name not found"
-                    $Missing = $Missing + 1
-                }
+    foreach ($lib in $LIBFILE.Keys) {
+        foreach ($conf in $LIBDIR.Keys) {
+            if (-not (Test-Path $(ssl-lib $Platform $conf $lib))) {
+                Write-Output "**** Missing $(ssl-lib $Platform $conf $lib)"
+                $Missing = $Missing + 1
             }
         }
     }
@@ -214,40 +173,31 @@ Write-Output "NSIS: $NSIS"
 #-----------------------------------------------------------------------------
 
 if (-not $NoBuild) {
-    foreach ($Platform in $SSL.Keys) {
-        if ($SSL.$Platform.available) {
-            # Build directory. Cleanup to force a fresh cmake config.
-            $BuildDir = "$TmpDir\build.$Platform"
-            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $BuildDir
-            [void](New-Item -Path $BuildDir -ItemType Directory -Force)
+    foreach ($Platform in $ARCH.Keys) {
+        # Build directory. Cleanup to force a fresh cmake config.
+        $BuildDir = "$TmpDir\build.$Platform"
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $BuildDir
+        [void](New-Item -Path $BuildDir -ItemType Directory -Force)
 
-            # Run CMake.
-            # Note: In previous versions of CMake, it was necessary to specify where
-            # OpenSSL was located using OPENSSL_ROOT_DIR, OPENSSL_LIBRARIES, and
-            # OPENSSL_INCLUDE_DIR. Starting with CMake 3.29.0, this is no longer
-            # necessary because CMake knows where to find the OpenSSL binaries from
-            # slproweb. Additionally, for some unkown reason, defining the OPENSSL_xxx
-            # variables no longer works with Arm64 libraries, even though the path to
-            # that version is correct. So, it's better to let CMake find OpenSSL by itself.
-            Write-Output "Configuring build for platform $Platform ..."
-            $SRoot = $SSL[$Platform]["root"]
-            $LibSSL = $SSL[$Platform]["libsslMD"]
-            $LibCrypto = $SSL[$Platform]["libcryptoMD"]
-            & $CMake -S $RepoDir -B $BuildDir -A $Platform -DENABLE_STDCXX_SYNC=ON
+        # Run CMake.
+        Write-Output "Configuring build for platform $Platform ..."
+        & $CMake -S $RepoDir -B $BuildDir -A $Platform `
+            -DENABLE_STDCXX_SYNC=ON `
+            -DOPENSSL_INCLUDE_DIR="$(ssl-include $Platform)" `
+            -DOPENSSL_ROOT_DIR="$(ssl-libdir $Platform Release)"
 
-            # Patch version string in version.h
-            Get-Content "$BuildDir\version.h" |
-                ForEach-Object {
-                    $_ -replace "#define *SRT_VERSION_STRING .*","#define SRT_VERSION_STRING `"$Version`""
-                } |
-                Out-File "$BuildDir\version.new" -Encoding ascii
-            Move-Item "$BuildDir\version.new" "$BuildDir\version.h" -Force
+        # Patch version string in version.h
+        Get-Content "$BuildDir\version.h" |
+            ForEach-Object {
+                $_ -replace "#define *SRT_VERSION_STRING .*","#define SRT_VERSION_STRING `"$Version`""
+            } |
+            Out-File "$BuildDir\version.new" -Encoding ascii
+        Move-Item "$BuildDir\version.new" "$BuildDir\version.h" -Force
 
-            # Compile SRT.
-            Write-Output "Building for platform $Platform ..."
-            foreach ($Conf in @("Release", "Debug")) {
-                & $MSBuild "$BuildDir\SRT.sln" /nologo /maxcpucount /property:Configuration=$Conf /property:Platform=$Platform /target:srt_static
-            }
+        # Compile SRT.
+        Write-Output "Building for platform $Platform ..."
+        foreach ($Conf in $LIBDIR.Keys) {
+            & $MSBuild "$BuildDir\SRT.sln" /nologo /maxcpucount /property:Configuration=$Conf /property:Platform=$Platform /target:srt_static
         }
     }
 }
@@ -255,14 +205,12 @@ if (-not $NoBuild) {
 # Verify the presence of compiled libraries.
 Write-Output "Checking compiled libraries ..."
 $Missing = 0
-foreach ($Conf in @("Release", "Debug")) {
+foreach ($Conf in $LIBDIR.Keys) {
     foreach ($Platform in $SSL.Keys) {
-        if ($SSL.$Platform.available) {
-            $Path = "$TmpDir\build.$Platform\$Conf\srt_static.lib"
-            if (-not (Test-Path $Path)) {
-                Write-Output "**** Missing $Path"
-                $Missing = $Missing + 1
-            }
+        $Path = "$TmpDir\build.$Platform\$Conf\srt_static.lib"
+        if (-not (Test-Path $Path)) {
+            Write-Output "**** Missing $Path"
+            $Missing = $Missing + 1
         }
     }
 }
@@ -285,21 +233,18 @@ Write-Output "Building installer ..."
     /DOutDir="$OutDir" `
     /DBuildRoot="$TmpDir" `
     /DRepoDir="$RepoDir" `
-    /DhasWin32="$(if ($SSL.Win32.available) {'true'} else {''})" `
-    /DlibsslWin32MD="$($SSL.Win32.libsslMD)" `
-    /DlibsslWin32MDd="$($SSL.Win32.libsslMDd)" `
-    /DlibcryptoWin32MD="$($SSL.Win32.libcryptoMD)" `
-    /DlibcryptoWin32MDd="$($SSL.Win32.libcryptoMDd)" `
-    /DhasWin64="$(if ($SSL.x64.available) {'true'} else {''})" `
-    /DlibsslWin64MD="$($SSL.x64.libsslMD)" `
-    /DlibsslWin64MDd="$($SSL.x64.libsslMDd)" `
-    /DlibcryptoWin64MD="$($SSL.x64.libcryptoMD)" `
-    /DlibcryptoWin64MDd="$($SSL.x64.libcryptoMDd)" `
-    /DhasArm64="$(if ($SSL.ARM64.available) {'true'} else {''})" `
-    /DlibsslArm64MD="$($SSL.ARM64.libsslMD)" `
-    /DlibsslArm64MDd="$($SSL.ARM64.libsslMDd)" `
-    /DlibcryptoArm64MD="$($SSL.ARM64.libcryptoMD)" `
-    /DlibcryptoArm64MDd="$($SSL.ARM64.libcryptoMDd)" `
+    /DlibsslWin32Release="$(ssl-lib Win32 Release ssl)" `
+    /DlibsslWin32Debug="$(ssl-lib Win32 Debug ssl)" `
+    /DlibcryptoWin32Release="$(ssl-lib Win32 Release crypto)" `
+    /DlibcryptoWin32Debug="$(ssl-lib Win32 Debug crypto)" `
+    /DlibsslWin64Release="$(ssl-lib x64 Release ssl)" `
+    /DlibsslWin64Debug="$(ssl-lib x64 Debug ssl)" `
+    /DlibcryptoWin64Release="$(ssl-lib x64 Release crypto)" `
+    /DlibcryptoWin64Debug="$(ssl-lib x64 Debug crypto)" `
+    /DlibsslArm64Release="$(ssl-lib Arm64 Release ssl)" `
+    /DlibsslArm64Debug="$(ssl-lib Arm64 Debug ssl)" `
+    /DlibcryptoArm64Release="$(ssl-lib Arm64 Release crypto)" `
+    /DlibcryptoArm64Debug="$(ssl-lib Arm64 Debug crypto)" `
     "$ScriptDir\libsrt.nsi" 
 
 if (-not (Test-Path $InstallExe)) {

--- a/scripts/win-installer/install-openssl.ps1
+++ b/scripts/win-installer/install-openssl.ps1
@@ -37,24 +37,7 @@ param(
 
 Write-Output "OpenSSL download and installation procedure"
 
-# A bit of history: Where to load OpenSSL binaries from?
-#
-# The packages are built by "slproweb". The binaries are downloadable from
-# their Web page at: http://slproweb.com/products/Win32OpenSSL.html
-#
-# Initially, the HTML for this page was built on server-side. This script
-# grabbed the URL content, parse the HTML and extracted the URL of the
-# binaries for the latest OpenSSL packages from the "href" of the links.
-#
-# At some point in 2024, the site changed policy. The Web page is no longer
-# built on server-side, but on client-side. The downloaded HTML contains some
-# JavaScript which dynamically builds the URL of the binaries for the latest
-# OpenSSL binaries. The previous method now finds no valid package URL from
-# the downloaded page (a full browser is needed to execute the JavaScript).
-# The JavaScript downloads a JSON file which contains all references to
-# the OpenSSL binaries. This script now uses the same method: download that
-# JSON file and parse it.
-
+# The list of OpenSSL packages is available in a JSON file. See more details in README.md.
 $PackageList = "https://github.com/slproweb/opensslhashes/raw/master/win32_openssl_hashes.json"
 
 # A function to exit this script.
@@ -101,50 +84,36 @@ if ($status -ne 1 -and $status -ne 2) {
 }
 $config = ConvertFrom-Json $Response.Content
 
-# List of packages to install.
-$Packs = @(@{arch="intel"; bits=32}, @{arch="intel"; bits=64})
-if ($env:PROCESSOR_ARCHITECTURE -like "arm*") {
-    $Packs += @(@{arch="arm"; bits=64})
+# Find the URL of the latest "universal" installer in the JSON config file.
+$Url = $config.files | Get-Member | ForEach-Object {
+    $name = $_.name
+    $info = $config.files.$($_.name)
+    if (-not $info.light -and $info.installer -like "exe" -and $info.arch -like "universal") {
+        $info.url
+    }
+} | Select-Object -Last 1
+if (-not $Url) {
+    Exit-Script "#### No universal installer found"
+}
+
+$ExeName = (Split-Path -Leaf $Url)
+$ExePath = "$TmpDir\$ExeName"
+
+if (-not $ForceDownload -and (Test-Path $ExePath)) {
+    Write-Output "$ExeName already downloaded, use -ForceDownload to download again"
 }
 else {
-    Write-Output "Cannot install the ARM64 OpenSSL libraries on a $($env:PROCESSOR_ARCHITECTURE) system."
-    Write-Output "This is a limitation of the current packaging of OpenSSL for Windows."
+    Write-Output "Downloading $Url ..."
+    Invoke-WebRequest -UseBasicParsing -UserAgent Download -Uri $Url -OutFile $ExePath
 }
 
-# Download and install all MSI packages.
-foreach ($conf in $Packs) {
+if (-not (Test-Path $ExePath)) {
+    Exit-Script "$Url download failed"
+}
 
-    # Get the URL of the MSI installer from the JSON config.
-    $Url = $config.files | Get-Member | ForEach-Object {
-        $name = $_.name
-        $info = $config.files.$($_.name)
-        if (-not $info.light -and $info.installer -like "msi" -and $info.bits -eq $conf.bits -and $info.arch -like $conf.arch) {
-            $info.url
-        }
-    } | Select-Object -Last 1
-    if (-not $Url) {
-        Exit-Script "#### No MSI installer found for $($conf.bits)-bit $($conf.arch)"
-    }
-
-    $MsiName = (Split-Path -Leaf $Url)
-    $MsiPath = "$TmpDir\$MsiName"
-
-    if (-not $ForceDownload -and (Test-Path $MsiPath)) {
-        Write-Output "$MsiName already downloaded, use -ForceDownload to download again"
-    }
-    else {
-        Write-Output "Downloading $Url ..."
-        Invoke-WebRequest -UseBasicParsing -UserAgent Download -Uri $Url -OutFile $MsiPath
-    }
-
-    if (-not (Test-Path $MsiPath)) {
-        Exit-Script "$Url download failed"
-    }
-
-    if (-not $NoInstall) {
-        Write-Output "Installing $MsiName"
-        Start-Process msiexec.exe -ArgumentList @("/i", $MsiPath, "/qn", "/norestart") -Wait
-    }
+if (-not $NoInstall) {
+    Write-Output "Installing $ExeName"
+    Start-Process -FilePath $ExePath -ArgumentList @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/ALLUSERS") -Wait
 }
 
 Exit-Script

--- a/scripts/win-installer/install-openssl.ps1
+++ b/scripts/win-installer/install-openssl.ps1
@@ -101,8 +101,18 @@ if ($status -ne 1 -and $status -ne 2) {
 }
 $config = ConvertFrom-Json $Response.Content
 
-# Download and install MSI packages for 32 and 64-bit Intel, 64-bit Arm.
-foreach ($conf in @(@{arch="intel"; bits=32}, @{arch="intel"; bits=64}, @{arch="arm"; bits=64})) {
+# List of packages to install.
+$Packs = @(@{arch="intel"; bits=32}, @{arch="intel"; bits=64})
+if ($env:PROCESSOR_ARCHITECTURE -like "arm*") {
+    $Packs += @(@{arch="arm"; bits=64})
+}
+else {
+    Write-Output "Cannot install the ARM64 OpenSSL libraries on a $($env:PROCESSOR_ARCHITECTURE) system."
+    Write-Output "This is a limitation of the current packaging of OpenSSL for Windows."
+}
+
+# Download and install all MSI packages.
+foreach ($conf in $Packs) {
 
     # Get the URL of the MSI installer from the JSON config.
     $Url = $config.files | Get-Member | ForEach-Object {

--- a/scripts/win-installer/libsrt.nsi
+++ b/scripts/win-installer/libsrt.nsi
@@ -139,6 +139,8 @@ Section "Install"
     ; Libraries.
     CreateDirectory "$INSTDIR\lib"
     
+!if "${hasWin64}" != ""
+
     CreateDirectory "$INSTDIR\lib\Release-x64"
     SetOutPath "$INSTDIR\lib\Release-x64"
     File /oname=srt.lib       "${BuildWin64Dir}\Release\srt_static.lib"
@@ -150,6 +152,9 @@ Section "Install"
     File /oname=srt.lib       "${BuildWin64Dir}\Debug\srt_static.lib"
     File /oname=libcrypto.lib "${libcryptoWin64MDd}"
     File /oname=libssl.lib    "${libsslWin64MDd}"
+
+!endif
+!if "${hasWin32}" != ""
 
     CreateDirectory "$INSTDIR\lib\Release-Win32"
     SetOutPath "$INSTDIR\lib\Release-Win32"
@@ -163,6 +168,9 @@ Section "Install"
     File /oname=libcrypto.lib "${libcryptoWin32MDd}"
     File /oname=libssl.lib    "${libsslWin32MDd}"
 
+!endif
+!if "${hasArm64}" != ""
+
     CreateDirectory "$INSTDIR\lib\Release-Arm64"
     SetOutPath "$INSTDIR\lib\Release-Arm64"
     File /oname=srt.lib       "${BuildArm64Dir}\Release\srt_static.lib"
@@ -174,6 +182,8 @@ Section "Install"
     File /oname=srt.lib       "${BuildArm64Dir}\Debug\srt_static.lib"
     File /oname=libcrypto.lib "${libcryptoArm64MDd}"
     File /oname=libssl.lib    "${libsslArm64MDd}"
+
+!endif
 
     ; Add an environment variable to installation root.
     WriteRegStr HKLM ${EnvironmentKey} "LIBSRT" "$INSTDIR"

--- a/scripts/win-installer/libsrt.nsi
+++ b/scripts/win-installer/libsrt.nsi
@@ -139,51 +139,41 @@ Section "Install"
     ; Libraries.
     CreateDirectory "$INSTDIR\lib"
     
-!if "${hasWin64}" != ""
-
     CreateDirectory "$INSTDIR\lib\Release-x64"
     SetOutPath "$INSTDIR\lib\Release-x64"
     File /oname=srt.lib       "${BuildWin64Dir}\Release\srt_static.lib"
-    File /oname=libcrypto.lib "${libcryptoWin64MD}"
-    File /oname=libssl.lib    "${libsslWin64MD}"
+    File /oname=libcrypto.lib "${libcryptoWin64Release}"
+    File /oname=libssl.lib    "${libsslWin64Release}"
 
     CreateDirectory "$INSTDIR\lib\Debug-x64"
     SetOutPath "$INSTDIR\lib\Debug-x64"
     File /oname=srt.lib       "${BuildWin64Dir}\Debug\srt_static.lib"
-    File /oname=libcrypto.lib "${libcryptoWin64MDd}"
-    File /oname=libssl.lib    "${libsslWin64MDd}"
-
-!endif
-!if "${hasWin32}" != ""
+    File /oname=libcrypto.lib "${libcryptoWin64Debug}"
+    File /oname=libssl.lib    "${libsslWin64Debug}"
 
     CreateDirectory "$INSTDIR\lib\Release-Win32"
     SetOutPath "$INSTDIR\lib\Release-Win32"
     File /oname=srt.lib       "${BuildWin32Dir}\Release\srt_static.lib"
-    File /oname=libcrypto.lib "${libcryptoWin32MD}"
-    File /oname=libssl.lib    "${libsslWin32MD}"
+    File /oname=libcrypto.lib "${libcryptoWin32Release}"
+    File /oname=libssl.lib    "${libsslWin32Release}"
 
     CreateDirectory "$INSTDIR\lib\Debug-Win32"
     SetOutPath "$INSTDIR\lib\Debug-Win32"
     File /oname=srt.lib       "${BuildWin32Dir}\Debug\srt_static.lib"
-    File /oname=libcrypto.lib "${libcryptoWin32MDd}"
-    File /oname=libssl.lib    "${libsslWin32MDd}"
-
-!endif
-!if "${hasArm64}" != ""
+    File /oname=libcrypto.lib "${libcryptoWin32Debug}"
+    File /oname=libssl.lib    "${libsslWin32Debug}"
 
     CreateDirectory "$INSTDIR\lib\Release-Arm64"
     SetOutPath "$INSTDIR\lib\Release-Arm64"
     File /oname=srt.lib       "${BuildArm64Dir}\Release\srt_static.lib"
-    File /oname=libcrypto.lib "${libcryptoArm64MD}"
-    File /oname=libssl.lib    "${libsslArm64MD}"
+    File /oname=libcrypto.lib "${libcryptoArm64Release}"
+    File /oname=libssl.lib    "${libsslArm64Release}"
 
     CreateDirectory "$INSTDIR\lib\Debug-Arm64"
     SetOutPath "$INSTDIR\lib\Debug-Arm64"
     File /oname=srt.lib       "${BuildArm64Dir}\Debug\srt_static.lib"
-    File /oname=libcrypto.lib "${libcryptoArm64MDd}"
-    File /oname=libssl.lib    "${libsslArm64MDd}"
-
-!endif
+    File /oname=libcrypto.lib "${libcryptoArm64Debug}"
+    File /oname=libssl.lib    "${libsslArm64Debug}"
 
     ; Add an environment variable to installation root.
     WriteRegStr HKLM ${EnvironmentKey} "LIBSRT" "$INSTDIR"


### PR DESCRIPTION
The Windows installer provides the SRT libraries for all possible architectures. However, SRT needs OpenSSL and OpenSSL for Windows cannot install its Arm64 libraries on Intel systems. More precisely, on Arm64 systems, we may install OpenSSL libraries for x86, x64 and Arm64. However, on Intel systems, OpenSSL libraries can be installed for x86, x64 only. This is an unfortunate limitation of the OpenSSL installer for Windows.

As a consequence, when building the libsrt installer in a Windows Intel system, the installer now contains the x86 and x64 libraries only. To build a libsrt installer with the binaries for the three architectures, the build must be performed on a Windows Arm64 system.

This is not easy to achieve on automated CI systems where Windows systems are usually Intel only. Manually, the easiest way to get a Windows Arm64 is to install a virtual machine on a recent Mac.

PS: Sorry for pushing a second PR on the topic in a couple of days. All my tests were done on a Windows Arm64 system. All went fine. The installer contained the libsrt binaries for the three architectures. I realized the problem when repeating the build on a Windows x64 system. The most frustrating part is that the only reason is the impossibility to get the OpenSSL libraries for Arm64 in binary form on Intel systems. I will check with the guys at Shining Light Productions if they can amend their delivery of OpenSSL on Windows.