### PR TITLE
Fix bind to local interface when sending to udp ep

### DIFF
--- a/apps/transmitmedia.cpp
+++ b/apps/transmitmedia.cpp
@@ -895,10 +895,10 @@ protected:
             else
             {
                 opt_name = IP_ADD_MEMBERSHIP;
-                mreq_arg_size = sizeof(mreq);
-                mreq_arg_ptr = &mreq;
                 mreq.imr_multiaddr.s_addr = target_addr.sin.sin_addr.s_addr;
                 mreq.imr_interface.s_addr = interface_addr.sin.sin_addr.s_addr;
+                mreq_arg_size = sizeof(mreq);
+                mreq_arg_ptr = &mreq;
             }
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes #3121

Tested in 1.5.4 release, but it doesn't look like UDP has changed since then.

I've tested Windows output (srt-live-transmit.exe srt://XXX.XXX.XXX.XXX udp://239.XXX.XXX.XXX) but not UDP input or on Linux

E: There's a bunch of renaming that might not conform to the repo's style, but the most important change is the remove of line 914, and the new binding logic used in line 1003 and 1058