### PR TITLE
[core] Fixed accidental blocking on sendmsg call

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -552,6 +552,10 @@ void srt::CChannel::setUDPSockOpt()
     // Set receiving time-out value
     if (-1 == ::setsockopt(m_iSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof(timeval)))
         throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
+    // Set sending time-out, too; O_NONBLOCK sets it in both directions,
+    // so both should be also set here for consistency.
+    if (-1 == ::setsockopt(m_iSocket, SOL_SOCKET, SO_SNDTIMEO, (char*)&tv, sizeof(timeval)))
+        throw CUDTException(MJ_SETUP, MN_NORES, NET_ERROR);
 #endif
 
 #ifdef SRT_ENABLE_PKTINFO

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8313,6 +8313,7 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
         {
             ctrlpkt.pack(UMSG_ACK, &m_iAckSeqNo, data, ACKD_FIELD_SIZE * ACKD_TOTAL_SIZE_SMALL);
         }
+        bufflock.unlock();
 
         ctrlpkt.set_id(m_PeerID);
         setPacketTS(ctrlpkt, steady_clock::now());


### PR DESCRIPTION
Fixes #3137.

Changes:

1. Unlock the mutex of m_RcvBufLock, which should guard the ACK sequence recorded by another thread. The lock is not necessary at the moment when the prepared packet is about to be sent.
2. As the nonblocking mode was set using either `O_NONBLOCK` flag (by `fcntl`) or short timeout on the socket, depending on the system, for consistency the non-blocking mode should be set in both directions. Therefore added setting also `SO_SNDTIMEO` flag with the same value.