### PR TITLE
[core] Unify unix macro

### DIFF
--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -905,7 +905,7 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
     FD_SET(m_iSocket, &set);
     tv.tv_sec            = 0;
     tv.tv_usec           = 10000;
-    const int select_ret = ::select((int)m_iSocket + 1, &set, NULL, &set, &tv);
+    const int select_ret = ::select((int)m_iSocket + 1, &set, NULL, NULL, &tv);
 #else
     const int select_ret = 1; // the socket is expected to be in the blocking mode itself
 #endif

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -529,7 +529,7 @@ void srt::CChannel::setUDPSockOpt()
     }
 #endif
 
-#ifdef UNIX
+#ifdef unix
     // Set non-blocking I/O
     // UNIX does not support SO_RCVTIMEO
     int opts = ::fcntl(m_iSocket, F_GETFL);
@@ -898,7 +898,7 @@ srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet
     int         msg_flags = 0;
     int         recv_size = -1;
 
-#if defined(UNIX) || defined(_WIN32)
+#if defined(unix) || defined(_WIN32)
     fd_set  set;
     timeval tv;
     FD_ZERO(&set);


### PR DESCRIPTION
In Ubuntu 20.04, gcc/clang has only lowercase `unix` macro, no `UNIX` macro.
And in channel.cpp, there are both `unix` and `UNIX` macro, unify to `unix`
```
➜  ~ echo | clang-11 -dM -E - | grep -i unix                                    
#define __unix 1
#define __unix__ 1
#define unix 1
➜  ~ echo | g++-14 -dM -E - | grep -i unix
#define __unix 1
#define __unix__ 1
#define unix 1
```