### PR TITLE
[TEST] Fixed tests to avoid mistakes in CI

### DIFF
--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -726,13 +726,10 @@ TEST(Bonding, ConnectNonBlocking)
     for (const auto GTYPE: types)
     {
         g_listen_socket = srt_create_socket();
-        sockaddr_in bind_sa;
-        memset(&bind_sa, 0, sizeof bind_sa);
-        bind_sa.sin_family = AF_INET;
-        EXPECT_EQ(inet_pton(AF_INET, ADDR.c_str(), &bind_sa.sin_addr), 1);
-        bind_sa.sin_port = htons(PORT);
 
-        EXPECT_NE(srt_bind(g_listen_socket, (sockaddr*)&bind_sa, sizeof bind_sa), -1);
+        sockaddr_any sa = srt::CreateAddr(ADDR, PORT, AF_INET);
+
+        EXPECT_NE(srt_bind(g_listen_socket, sa.get(), sa.size()), -1);
         const int yes = 1;
         srt_setsockflag(g_listen_socket, SRTO_GROUPCONNECT, &yes, sizeof yes);
         EXPECT_NE(srt_listen(g_listen_socket, 5), -1);
@@ -758,14 +755,17 @@ TEST(Bonding, ConnectNonBlocking)
 
         srt_connect_callback(ss, &ConnectCallback, this);
 
-        sockaddr_in sa;
-        sa.sin_family = AF_INET;
-        sa.sin_port = htons(PORT);
-        EXPECT_EQ(inet_pton(AF_INET, "127.0.0.1", &sa.sin_addr), 1);
+        cout << "TEST: Group type: " << GTYPE << endl;
+
+        // synchronizers
+        std::promise<void>
+            connect_passed,
+            accept_passed,
+            checks_done;
 
         //srt_setloglevel(LOG_DEBUG);
 
-        auto acthr = std::thread([&lsn_eid]() {
+        auto acthr = std::thread([&lsn_eid, &connect_passed, &accept_passed, &checks_done]() {
                 SRT_EPOLL_EVENT ev[3];
 
                 ThreadName::set("TEST_A");
@@ -782,8 +782,15 @@ TEST(Bonding, ConnectNonBlocking)
                 EXPECT_NE(ev[0].events & ev_in_bit, 0);
                 bool have_also_update = ev[0].events & SRT_EPOLL_UPDATE;
 
+                cout << "[A] Accept delay until connect done...\n";
+                // Delay with executing accept to keep the peer in "in progress"
+                // connection state.
+                connect_passed.get_future().get();
+
+                cout << "[A] Accept: go on\n";
+
                 sockaddr_any adr;
-                int accept_id = srt_accept(g_listen_socket, adr.get(), &adr.len);
+                SRTSOCKET accept_id = srt_accept(g_listen_socket, adr.get(), &adr.len);
 
                 // Expected: group reporting
                 EXPECT_NE(accept_id & SRTGROUP_MASK, 0);
@@ -803,19 +810,35 @@ TEST(Bonding, ConnectNonBlocking)
                     EXPECT_EQ(ev[0].events, (int)SRT_EPOLL_UPDATE);
                 }
 
-                cout << "[A] Waitig for close (up to 5s)\n";
+                // As accept is expected to be finished and two connections were
+                // established, make sure that both connections are established.
+                // Wait until you have at least two members
+                SRT_SOCKGROUPDATA members[3];
+                size_t grouplen = 3;
+                cout << "[A] Waiting until having 2 members in the group\n";
+                while (srt_group_data(accept_id, members, &grouplen) != SRT_ERROR
+                        && grouplen < 2)
+                {
+                    grouplen = 3;
+                    this_thread::sleep_for(milliseconds(250));
+                }
+                accept_passed.set_value();
+
+
+                cout << "[A] Waitig on epoll for close (up to 5s)\n";
                 // Wait up to 5s for an error
                 srt_epoll_uwait(lsn_eid, ev, 3, 5000);
-
                 srt_close(accept_id);
+                checks_done.set_value();
+
                 cout << "[A] thread finished\n";
         });
 
         cout << "Connecting two sockets\n";
 
         SRT_SOCKGROUPCONFIG cc[2];
-        cc[0] = srt_prepare_endpoint(NULL, (sockaddr*)&sa, sizeof sa);
-        cc[1] = srt_prepare_endpoint(NULL, (sockaddr*)&sa, sizeof sa);
+        cc[0] = srt_prepare_endpoint(NULL, sa.get(), sa.size());
+        cc[1] = srt_prepare_endpoint(NULL, sa.get(), sa.size());
 
         EXPECT_NE(srt_epoll_add_usock(poll_id, ss, &epoll_out), SRT_ERROR);
 
@@ -824,21 +847,28 @@ TEST(Bonding, ConnectNonBlocking)
         char data[4] = { 1, 2, 3, 4};
         cout << "Sending...\n";
         int wrong_send = srt_send(ss, data, sizeof data);
+
+        // Only now we allow the other thread to go on with accept
+        connect_passed.set_value();
         cout << "Getting error...\n";
         int errorcode = srt_getlasterror(NULL);
         EXPECT_EQ(wrong_send, -1);
         EXPECT_EQ(errorcode, SRT_EASYNCSND) << "REAL ERROR: " << srt_getlasterror_str();
 
+        // Wait to make sure that both links are connected.
+        accept_passed.get_future().get();
+
         // Wait up to 2s
         SRT_EPOLL_EVENT ev[3];
         const int uwait_result = srt_epoll_uwait(poll_id, ev, 3, 2000);
-        std::cout << "Returned from connecting two sockets " << std::endl;
+        std::cout << "Returned from connecting two sockets, waiting for all checks from [A]" << std::endl;
+
+        checks_done.get_future().get();
 
         EXPECT_EQ(uwait_result, 1);  // Expect the group reported
         EXPECT_EQ(ev[0].fd, ss);
 
-        // One second to make sure that both links are connected.
-        this_thread::sleep_for(seconds(1));
+        std::cout << "Closing group and releasing resources\n";
 
         EXPECT_EQ(srt_close(ss), 0);
         acthr.join();

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -170,20 +170,22 @@ TEST_F(TestConnectionTimeout, Nonblocking) {
 */
 TEST_F(TestConnectionTimeout, BlockingLoop)
 {
-    const SRTSOCKET client_sock = srt_create_socket();
-    ASSERT_GT(client_sock, 0);    // socket_id should be > 0
-
-    // Set connection timeout to 999 ms to reduce the test execution time.
-    // Also need to hit a time point between two threads:
-    // srt_connect will check TTL every second,
-    // CRcvQueue::worker will wait on a socket for 10 ms.
-    // Need to have a condition, when srt_connect will process the timeout.
-    const int connection_timeout_ms = 999;
-    EXPECT_EQ(srt_setsockopt(client_sock, 0, SRTO_CONNTIMEO, &connection_timeout_ms, sizeof connection_timeout_ms), SRT_SUCCESS);
-
     const sockaddr* psa = reinterpret_cast<const sockaddr*>(&m_sa);
+    const int connection_timeout_ms = 999;
     for (int i = 0; i < 10; ++i)
     {
+        const SRTSOCKET client_sock = srt_create_socket();
+        EXPECT_GT(client_sock, 0);    // socket_id should be > 0
+        if (client_sock <= 0)
+            break;
+
+        // Set connection timeout to 999 ms to reduce the test execution time.
+        // Also need to hit a time point between two threads:
+        // srt_connect will check TTL every second,
+        // CRcvQueue::worker will wait on a socket for 10 ms.
+        // Need to have a condition, when srt_connect will process the timeout.
+        EXPECT_EQ(srt_setsockopt(client_sock, 0, SRTO_CONNTIMEO, &connection_timeout_ms, sizeof connection_timeout_ms), SRT_SUCCESS);
+
         const chrono::steady_clock::time_point chrono_ts_start = chrono::steady_clock::now();
         EXPECT_EQ(srt_connect(client_sock, psa, sizeof m_sa), SRT_ERROR);
 
@@ -200,9 +202,9 @@ TEST_F(TestConnectionTimeout, BlockingLoop)
                 << error_code << " " << srt_getlasterror_str() << "\n";
             break;
         }
-    }
 
-    EXPECT_EQ(srt_close(client_sock), SRT_SUCCESS);
+        EXPECT_EQ(srt_close(client_sock), SRT_SUCCESS);
+    }
 }
 
 


### PR DESCRIPTION
Fixed tests:

1. TestConnectionTimeout.BlockingLoop

This test was incorrectly reusing once created socket to do connection failure tests. This test didn't work correctly in case when connection somehow succeeded, and it breaks the rule that a socket should be used for connection, and then whether it succeeds or not, it should be used for connection possibly, and then closed - not connected multiple times after a failure.

2. Bonding.ConnectNonBlocking

This test was often failing in Travis because it relies too much on timing: connection is expected to return an error code if it is in progress, but for this the peer (running in a thread here) should not accept the connection until this check was done. Therefore there are needed synchronization points in the form of the promise. This prevents from both premature closing and getting things in the state that was not yet the expected one.