### PR TITLE
[DEV] Updated ABI checker to use correct version ABI checks.

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -35,9 +35,9 @@ jobs:
         SRT_BASE=v$(../scripts/get-build-version.tcl base)
         echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
         if [[ $SRT_TAG == $SRT_BASE ]]; then
-			echo "NOT CHECKING ABI: base version is being built: $SRT_TAG"
-			exit 0
-		fi
+            echo "NOT CHECKING ABI: base version is being built: $SRT_TAG"
+            exit 0
+        fi
     - uses: actions/checkout@v3
       with:
         path: gitview_base

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -67,13 +67,6 @@ jobs:
                exit $RES
             fi
         fi
-  show-results:
-    name: ABI checks - report
-    runs-on: ubuntu-20.04
-    needs: build
-
-    steps:
-     - name: Download report
-       uses: actions/download-artifact@v3
-       with:
-         name: compat_reports
+    - uses: actions/download-artifact@v3
+      with:
+        name: compat_reports

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -56,10 +56,10 @@ jobs:
            echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
         else
             #git clone https://github.com/lvc/abi-compliance-checker.git
-			cd gitview_pr/submodules
-			git submodule update --init abi-compliance-checker
+            cd gitview_pr/submodules
+            git submodule update --init abi-compliance-checker
             cd abi-compliance-checker && sudo make install && cd ../
-			cd ../..
+            cd ../..
             abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
             RES=$?
             if (( $RES != 0 )); then

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -34,7 +34,7 @@ jobs:
         abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG
         SRT_BASE=v$(../scripts/get-build-version.tcl base)
         echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
-        if [[ $SRT_TAG == $SRT_BASE ]]; then
+        if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
             echo "NOT CHECKING ABI: base version is being built: $SRT_TAG"
             exit 0
         fi
@@ -56,7 +56,7 @@ jobs:
         abi-dumper libsrt.so -o libsrt-base.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_BASE
     - name: abi-check
       run: |
-        if [[ $SRT_TAG == $SRT_BASE ]]; then
+        if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
            echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
         else
             #git clone https://github.com/lvc/abi-compliance-checker.git

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -34,6 +34,10 @@ jobs:
         abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG
         SRT_BASE=v$(../scripts/get-build-version.tcl base)
         echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
+        if [[ $SRT_TAG == $SRT_BASE ]]; then
+			echo "NOT CHECKING ABI: base version is being built: $SRT_TAG"
+			exit 0
+		fi
     - uses: actions/checkout@v3
       with:
         path: gitview_base

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -56,8 +56,10 @@ jobs:
            echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
         else
             #git clone https://github.com/lvc/abi-compliance-checker.git
-            git submodule update --init submodules/abi-compliance-checker
-            cd submodules/abi-compliance-checker && sudo make install && cd ../
+			cd gitview_pr/submodules
+			git submodule update --init abi-compliance-checker
+            cd abi-compliance-checker && sudo make install && cd ../
+			cd ../..
             abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
             RES=$?
             if (( $RES != 0 )); then

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -67,6 +67,7 @@ jobs:
                exit $RES
             fi
         fi
-    - uses: actions/download-artifact@v3
+    - name: Download report
+      uses: actions/download-artifact@v4
       with:
-        name: compat_reports
+        path: compat_reports

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -56,7 +56,7 @@ jobs:
            echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
         else
             #git clone https://github.com/lvc/abi-compliance-checker.git
-            cd submodules/abi-compliance-checker && sudo make install && cd ../
+            cd submodules/abi-compliance-checker && git submodule update --init . && sudo make install && cd ../
             abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
             RES=$?
             if (( $RES != 0 )); then

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -56,7 +56,8 @@ jobs:
            echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
         else
             #git clone https://github.com/lvc/abi-compliance-checker.git
-            cd submodules/abi-compliance-checker && git submodule update --init . && sudo make install && cd ../
+            git submodule update --init submodules/abi-compliance-checker
+            cd submodules/abi-compliance-checker && sudo make install && cd ../
             abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
             RES=$?
             if (( $RES != 0 )); then

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -29,8 +29,8 @@ jobs:
         sudo apt install -y tcl
         cd gitview_pr/_build && cmake --build ./
         make install DESTDIR=./installdir
-        SRT_TAG=v$(../scripts/get-build-version.tcl full)
-        SRT_TAG_VERSION=$(../scripts/get-build-version.tcl base minor)
+        SRT_TAG_VERSION=v$(../scripts/get-build-version.tcl full)
+        SRT_TAG=${SRT_TAG_VERSION}dev-$(git rev-parse --short HEAD)
         abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG
         SRT_BASE=v$(../scripts/get-build-version.tcl base)
         echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
@@ -52,7 +52,7 @@ jobs:
         abi-dumper libsrt.so -o libsrt-base.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_BASE
     - name: abi-check
       run: |
-        if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
+        if [[ $SRT_TAG == $SRT_BASE ]]; then
            echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
         else
             #git clone https://github.com/lvc/abi-compliance-checker.git
@@ -67,3 +67,13 @@ jobs:
                exit $RES
             fi
         fi
+  show-results:
+    name: ABI checks - report
+    runs-on: ubuntu-20.04
+    needs: build
+
+    steps:
+     - name: Download report
+       uses: actions/download-artifact@v3
+       with:
+         name: compat_reports

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -5,7 +5,6 @@ on:
     branches: [ "master", "dev" ]
   pull_request:
     branches: [ "master", "dev" ]
-  workflow_dispatch:
 
 env:
   SRT_BASE: v1.5.0
@@ -26,12 +25,14 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_UNITTESTS=ON ../
     - name: build
       run: |
-        sudo apt install -y abi-dumper tcl
+        sudo apt install -y abi-dumper
+        sudo apt install -y tcl
         cd gitview_pr/_build && cmake --build ./
         make install DESTDIR=./installdir
-        SRT_TAG_VERSION=v$(../scripts/get-build-version.tcl full)
-		SRT_BASE=v$(../scripts/get-build-version.tcl base)
-        abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG_VERSION
+        SRT_TAG=v$(../scripts/get-build-version.tcl full)
+        SRT_TAG_VERSION=$(../scripts/get-build-version.tcl base minor)
+        abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG
+        SRT_BASE=v$(../scripts/get-build-version.tcl base)
         echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
     - uses: actions/checkout@v3
       with:
@@ -51,15 +52,15 @@ jobs:
         abi-dumper libsrt.so -o libsrt-base.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_BASE
     - name: abi-check
       run: |
-		 if [[$SRT_TAG_VERSION == $SRT_BASE]]; then
-			echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
-		 else
-			 #git clone https://github.com/lvc/abi-compliance-checker.git
-			 cd submodules/abi-compliance-checker && sudo make install && cd ../
-			 abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
-			 RES=$?
-			 if (( $RES != 0 )); then
-				echo "ABI/API Compatibility check failed with value $?"
-				exit $RES
-			 fi
-		 fi
+        if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
+           echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
+        else
+            #git clone https://github.com/lvc/abi-compliance-checker.git
+            cd submodules/abi-compliance-checker && sudo make install && cd ../
+            abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
+            RES=$?
+            if (( $RES != 0 )); then
+               echo "ABI/API Compatibility check failed with value $?"
+               exit $RES
+            fi
+        fi

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -17,45 +17,48 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        path: pull_request
+        path: gitview_pr
     - name: configure
       run: |
-        cd pull_request
+        cd gitview_pr
         mkdir _build && cd _build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_UNITTESTS=ON ../
     - name: build
       run: |
-        sudo apt install -y abi-dumper
-        cd pull_request/_build && cmake --build ./
+        sudo apt install -y abi-dumper tcl
+        cd gitview_pr/_build && cmake --build ./
         make install DESTDIR=./installdir
-        SRT_TAG_VERSION=$(cat version.h |grep SRT_VERSION_MINOR |head -n1 |awk {'print $3'})
-        abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver 0
-        SRT_BASE="v1.$SRT_TAG_VERSION.0"
+        SRT_TAG_VERSION=v$(../scripts/get-build-version.tcl full)
+		SRT_BASE=v$(../scripts/get-build-version.tcl base)
+        abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG_VERSION
         echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
     - uses: actions/checkout@v3
       with:
-        path: tag
+        path: gitview_base
         ref: ${{ env.SRT_BASE }}
     - name: configure_tag
       run: |
         echo $SRT_TAG_VERSION
-        cd tag
+        cd gitview_base
         mkdir _build && cd _build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_UNITTESTS=ON ../
     - name: build_tag
       run: |
-        cd tag      
+        cd gitview_base      
         cd _build && cmake --build ./
         make install DESTDIR=./installdir
-        abi-dumper libsrt.so -o libsrt-tag.dump -public-headers installdir/usr/local/include/srt/ -lver 1
+        abi-dumper libsrt.so -o libsrt-base.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_BASE
     - name: abi-check
       run: |
-         git clone https://github.com/lvc/abi-compliance-checker.git
-         cd abi-compliance-checker && sudo make install && cd ../
-         abi-compliance-checker -l libsrt -old tag/_build/libsrt-tag.dump -new pull_request/_build/libsrt-pr.dump
-         RES=$?
-         if (( $RES != 0 ))
-          then
-            echo "ABI/API Compatibility check failed with value $?"
-            exit $RES
-          fi
+		 if [[$SRT_TAG_VERSION == $SRT_BASE]]; then
+			echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
+		 else
+			 #git clone https://github.com/lvc/abi-compliance-checker.git
+			 cd submodules/abi-compliance-checker && sudo make install && cd ../
+			 abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
+			 RES=$?
+			 if (( $RES != 0 )); then
+				echo "ABI/API Compatibility check failed with value $?"
+				exit $RES
+			 fi
+		 fi

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -14,6 +14,8 @@ jobs:
     name: Build current version
     runs-on: ubuntu-20.04
 
+    outputs:
+       SRT_BASE: ${{ steps.commands.outputs.SRT_BASE }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -35,17 +37,19 @@ jobs:
         SRT_BASE=v$(../scripts/get-build-version.tcl base)
         if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
             echo "NOT CHECKING ABI: base version is being built: $SRT_TAG"
-            echo "SRT_BASE=''" >> "$GITHUB_ENV"
+            echo "SRT_BASE=''" >> "$GITHUB_OUTPUT"
             exit 0
         fi
-        echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
+        echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_OUTPUT"
 
   build_base:
     name: Build base version
     runs-on: ubuntu-20.04
     needs: build_pr
-    if: ${{ env.SRT_BASE != '' }}
+    if: ${{ needs.build_pr.outputs.SRT_BASE != '' }}
 
+    env:
+       SRT_BASE: ${{ needs.build_pr.outputs.SRT_BASE }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -67,25 +71,23 @@ jobs:
   check_abi:
     name: Compare ABI
     runs-on: ubuntu-20.04
-    needs: build_base
+    needs: [build_pr, build_base]
+    env:
+       SRT_BASE: ${{ needs.build_pr.outputs.SRT_BASE }}
 
     steps:
     - name: abi-check
       run: |
-        if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
-           echo "NO CHECKS DONE: PR is still the base version $SRT_BASE"
-        else
-            #git clone https://github.com/lvc/abi-compliance-checker.git
-            cd gitview_pr/submodules
-            git submodule update --init abi-compliance-checker
-            cd abi-compliance-checker && sudo make install && cd ../
-            cd ../..
-            abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
-            RES=$?
-            if (( $RES != 0 )); then
-               echo "ABI/API Compatibility check failed with value $?"
-               exit $RES
-            fi
+        #git clone https://github.com/lvc/abi-compliance-checker.git
+        cd gitview_pr/submodules
+        git submodule update --init abi-compliance-checker
+        cd abi-compliance-checker && sudo make install && cd ../
+        cd ../..
+        abi-compliance-checker -l libsrt -old gitview_base/_build/libsrt-base.dump -new gitview_pr/_build/libsrt-pr.dump
+        RES=$?
+        if (( $RES != 0 )); then
+           echo "ABI/API Compatibility check failed with value $?"
+           exit $RES
         fi
     - name: Download report
       uses: actions/download-artifact@v4

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master", "dev" ]
   pull_request:
     branches: [ "master", "dev" ]
+  workflow_dispatch:
 
 env:
   SRT_BASE: v1.5.0

--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -10,8 +10,8 @@ env:
   SRT_BASE: v1.5.0
 
 jobs:
-  build:
-    name: ABI checks
+  build_pr:
+    name: Build current version
     runs-on: ubuntu-20.04
 
     steps:
@@ -33,11 +33,20 @@ jobs:
         SRT_TAG=${SRT_TAG_VERSION}dev-$(git rev-parse --short HEAD)
         abi-dumper libsrt.so -o libsrt-pr.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_TAG
         SRT_BASE=v$(../scripts/get-build-version.tcl base)
-        echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
         if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then
             echo "NOT CHECKING ABI: base version is being built: $SRT_TAG"
+            echo "SRT_BASE=''" >> "$GITHUB_ENV"
             exit 0
         fi
+        echo "SRT_BASE=$SRT_BASE" >> "$GITHUB_ENV"
+
+  build_base:
+    name: Build base version
+    runs-on: ubuntu-20.04
+    needs: build_pr
+    if: ${{ env.SRT_BASE != '' }}
+
+    steps:
     - uses: actions/checkout@v3
       with:
         path: gitview_base
@@ -54,6 +63,13 @@ jobs:
         cd _build && cmake --build ./
         make install DESTDIR=./installdir
         abi-dumper libsrt.so -o libsrt-base.dump -public-headers installdir/usr/local/include/srt/ -lver $SRT_BASE
+
+  check_abi:
+    name: Compare ABI
+    runs-on: ubuntu-20.04
+    needs: build_base
+
+    steps:
     - name: abi-check
       run: |
         if [[ $SRT_TAG_VERSION == $SRT_BASE ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 
 cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
-set (SRT_VERSION 1.5.4)
+set (SRT_VERSION 1.6.0)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
 include(haiUtil) # needed for set_version_variables

--- a/scripts/abi-check.tcl
+++ b/scripts/abi-check.tcl
@@ -56,8 +56,16 @@ if {![file isdirectory $olddir] || ![file isdirectory $newdir]} {
 	exit 1
 }
 
-generate-abi-dump $olddir 1
-generate-abi-dump $newdir 0
+set wd [pwd]
+cd $olddir
+set base_ver [exec $top/scripts/get-build-version.tcl]
+cd $wd
+cd $newdir
+set new_ver [exec $top/scripts/get-build-version.tcl]
+cd $wd
+
+generate-abi-dump $olddir $base_ver
+generate-abi-dump $newdir $new_ver
 
 set res [catch {exec >@stdout 2>@stderr $abichecker -l libsrt -old $olddir/libsrt-abi.dump -new $newdir/libsrt-abi.dump} out]
 

--- a/scripts/get-build-version.tcl
+++ b/scripts/get-build-version.tcl
@@ -1,0 +1,47 @@
+#!/usr/bin/tclsh
+
+if {![file exists version.h]} {
+	puts stderr "No version.h file found - run this in the build directory!"
+	exit 1
+}
+
+set fd [open version.h r]
+
+set version ""
+set line ""
+while {[gets $fd line] != -1} {
+	# Use regexp because this is safer to avoid
+	# unexpected list interpretation mistakes
+	if {[regexp {#define SRT_VERSION_STRING} $line]} {
+		# Once matched this way, we can safely use tcl-list-like access
+		set version [lindex $line 2 0]
+		break
+	}
+}
+close $fd
+
+if {$version == ""} {
+	puts stderr "No version extracted (no SRT_VERSION_STRING found)"
+	exit 1
+}
+
+lassign $argv model part
+
+if {$model == ""} {
+	set model current
+}
+
+lassign [split $version .] major minor patch
+
+if {$part == "minor"} {
+	set prefix "$minor"
+} else {
+	set prefix "$major.$minor"
+}
+
+if {$model == "base"} {
+	puts "$prefix.0"
+} else {
+	puts "$prefix.$patch"
+}
+


### PR DESCRIPTION
This refactors the ABI checker CI entry in order to do the following:

1. Checks are done first on the current version. If the current version has patch version 0, meaning it's first in the line, the base version isn't installed and compiled and no ABI checks are done.
2. Building the base version and performing the checks are done in separate jobs so that they can be conditionally avoided.
3. (Pending) The resulting build artifacts - the report html file - should be made available.