### PR TITLE
[core] Fixed problems found by thread and memory sanitizers

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -318,6 +318,13 @@ void srt::CUDTUnited::closeAllSockets()
         {
             j->second->m_tsClosureTimeStamp = steady_clock::time_point();
         }
+
+        for (groups_t::iterator j = m_Groups.begin(); j != m_Groups.end(); ++j)
+        {
+            SRTSOCKET id = j->second->m_GroupID;
+            m_ClosedGroups[id] = j->second;
+        }
+        m_Groups.clear();
     }
 
     HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all CLOSED sockets.");

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -319,12 +319,14 @@ void srt::CUDTUnited::closeAllSockets()
             j->second->m_tsClosureTimeStamp = steady_clock::time_point();
         }
 
+#if ENABLE_BONDING
         for (groups_t::iterator j = m_Groups.begin(); j != m_Groups.end(); ++j)
         {
             SRTSOCKET id = j->second->m_GroupID;
             m_ClosedGroups[id] = j->second;
         }
         m_Groups.clear();
+#endif
     }
 
     HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all CLOSED sockets.");

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -591,7 +591,11 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
     }
 
     // exceeding backlog, refuse the connection request
-    if (ls->m_QueuedSockets.size() >= ls->m_uiBackLog)
+
+    enterCS(ls->m_AcceptLock);
+    size_t backlog = ls->m_QueuedSockets.size();
+    leaveCS(ls->m_AcceptLock);
+    if (backlog >= ls->m_uiBackLog)
     {
         w_error = SRT_REJ_BACKLOG;
         LOGC(cnlog.Note, log << "newConnection: listen backlog=" << ls->m_uiBackLog << " EXCEEDED");

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -11924,7 +11924,7 @@ int64_t srt::CUDT::socketStartTime(SRTSOCKET u)
     if (!s)
         return APIError(MJ_NOTSUP, MN_SIDINVAL);
 
-    return count_microseconds(s->core().m_stats.tsStartTime.time_since_epoch());
+    return count_microseconds(s->core().socketStartTime().time_since_epoch());
 }
 
 bool srt::CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -747,6 +747,7 @@ private:
 
     time_point socketStartTime()
     {
+        sync::ScopedLock lk (m_StatsLock);
         return m_stats.tsStartTime;
     }
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -869,7 +869,7 @@ void CUDTGroup::getOpt(SRT_SOCKOPT optname, void* pw_optval, int& w_optlen)
             firstsocket = gi->ps->core().id();
         leaveCS(m_GroupLock);
         // CUDTUnited::m_GlobControlLock can't be acquired with m_GroupLock either.
-        // We have also no guarantee that after leacing m_GroupLock the socket isn't
+        // We have also no guarantee that after leaving m_GroupLock the socket isn't
         // going to be deleted. Hence use the safest method by extracting through the id.
         if (firstsocket != SRT_INVALID_SOCK)
         {

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -1284,7 +1284,7 @@ TEST(Bonding, BackupPrioritySelection)
 
     g_nconnected = 0;
     g_nfailed = 0;
-    volatile bool recvd = false;
+    sync::atomic<bool> recvd { false };
 
     // 1.
     sockaddr_in bind_sa;


### PR DESCRIPTION
Changes:

1. Fixed removal of all groups in the procedure of total removal (called from `CUDTUnited::cleanup`). That was reported as a leak.
2. Fixed access of m_QueuedSockets without m_AcceptLock.
3. Fixed usage of `CUDT::m_stats.tsStartTime` without m_StatsLock.
4. Getting option by asking the first socket: untangled the lock order of m_GroupLock and m_GlobControlLock; changed the order by attempting to extract the socket by ID after taking it from the group member container.
5. test: change variable to atomic to avoid data race.