### PR TITLE
[build] Update for compatibility with CMake 4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 set (SRT_VERSION 1.5.4)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")


### PR DESCRIPTION
As of CMake 4.0, backward compatibility with versions of CMake older than 3.5 is removed.

This change is inspired/informed by similar changes in other projects:

- https://github.com/GrokImageCompression/grok/commit/40af3b5f2b9343d162a829e91868976ed2bbf563#diff-ddbe22569a7b36432ac7278e7a656e3e16f1e8fccbd848a5f35957affb1a90c8R13-R16
- https://gitlab.winehq.org/mono/mono/-/commit/831415edd2a578a2b4851996ca796f47dbc3f2f3#69a14f67200ae7e0007a07b7ca8633d08f812b4a_2_1