### PR TITLE
Update cxx11-macos.yaml

### DIFF
--- a/.github/workflows/cxx11-macos.yaml
+++ b/.github/workflows/cxx11-macos.yaml
@@ -13,7 +13,10 @@ jobs:
 
     steps:
     - name: GoogleTest
-      run: brew install googletest
+      run: |
+        brew tap homebrew/core --force
+        brew extract --version=1.16.0 googletest $USER/oldstuff
+        brew install $USER/oldstuff/googletest@1.16.0
     - uses: actions/checkout@v3
     - name: configure
       run: |


### PR DESCRIPTION
Downgrade googletest to 1.16.x as latest one requires C++ 17