### PR TITLE
[core] Fix accepted sockets by srt_listen_callback adding to queue backlog, but not removing

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -668,6 +668,9 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listen,
 
         if (ls->core().m_cbAcceptHook)
         {
+            // Since we have a custom accept hook, avoid adding to m_QueuedSockets
+            // used by the accept() call
+            should_submit_to_accept = false;
             if (!ls->core().runAcceptHook(&ns->core(), peer.get(), w_hs, hspkt))
             {
                 w_error = ns->core().m_RejectReason;


### PR DESCRIPTION
When using srt_listen_callback to accept sockets and closing them with srt_close, m_QueuedSockets will be added to, but never removed from.

This PR fixes this by modifying the newConnection method such that if we have an accept hook on that listener socket, by utilizing the existing should_submit_to_accept we do not execute the block that adds the socket to m_QueuedSockets and notify the accept method.

The unwanted behavior here is that the backlog size becomes a number of lifetime maximum socket connection a listener socket can have.

How to recreate:
1. Register a callback with srt_listen_callback that always returns 1 and saves the sockets to a list
2. When calling srt_listen use a backlog of 1
3. Monitor the list of sockets that have connected for status and call srt_close if they are broken
4. Connect one client, then disconnect it after establishing connection
5. Connect one client and observe that it cannot connect because of backlog exceeded