### PR TITLE
[build] Update Ubuntu runners to 22.04.

### DIFF
--- a/.github/workflows/abi.yml
+++ b/.github/workflows/abi.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     name: ABI checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: NDK-R23
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Setup Android NDK R23

--- a/.github/workflows/cxx11-ubuntu.yaml
+++ b/.github/workflows/cxx11-ubuntu.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUILD_WRAPPER_OUT_DIR: sonar-output # Directory where build-wrapper output will be placed
     steps:


### PR DESCRIPTION
Ubuntu runner version 20.04 is not supported any more. See https://github.com/actions/runner-images/issues/11101