### PR TITLE
[core] Fix incorrectly updated epoll flags in case of group accept

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -707,7 +707,7 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listener,
             throw false; // let it jump directly into the omni exception handler
         }
 
-        ns->core().acceptAndRespond(ls->m_SelfAddr, peer, hspkt, (w_hs));
+        ns->core().acceptAndRespond(ls, peer, hspkt, (w_hs));
     }
     catch (...)
     {
@@ -770,7 +770,7 @@ int srt::CUDTUnited::newConnection(const SRTSOCKET     listener,
             // But then, acceptance of a group may happen only once, so if any
             // sockets of the same group were submitted to accept, they must
             // be removed from the accept queue at this time.
-            should_submit_to_accept = g->groupPending();
+            should_submit_to_accept = g->groupPending_LOCKED();
 
             // Update the status in the group so that the next
             // operation can include the socket in the group operation.
@@ -1334,11 +1334,18 @@ SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int
             // when the group ID is returned to the app caller
             g->m_stats.tsLastSampleTime = steady_clock::now();
 
+            // Ok, now that we have to get the group:
+            // 1. Get all listeners that have so far reported any pending connection
+            //    for this group.
+            // 2. THE VERY LISTENER that provided this connection should be only
+            //    checked if it contains ANY FURTHER queued sockets than this.
+
             HLOGC(cnlog.Debug, log << "accept: reporting group $" << g->m_GroupID << " instead of member socket @" << u);
             u                                = g->m_GroupID;
             s->core().m_config.iGroupConnect = 1; // should be derived from ls, but make sure
-            g->m_bPending = false;
-            CUDT::uglobal().removePendingForGroup(g);
+
+            vector<SRTSOCKET> listeners = g->clearPendingListeners();
+            CUDT::uglobal().removePendingForGroup(g, listeners, s->m_SocketID);
         }
         else
         {
@@ -1361,72 +1368,95 @@ SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int
 #if ENABLE_BONDING
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::removePendingForGroup(const CUDTGroup* g)
+void srt::CUDTUnited::removePendingForGroup(const CUDTGroup* g, const vector<SRTSOCKET>& listeners, SRTSOCKET this_socket)
 {
-    // We don't have a list of listener sockets that have ever
-    // reported a pending connection for a group, so the only
-    // way to find them is to ride over the list of all sockets...
-
-    list<SRTSOCKET> members;
+    set<SRTSOCKET> members;
     g->getMemberSockets((members));
 
-    for (sockets_t::iterator i = m_Sockets.begin(); i != m_Sockets.end(); ++i)
+    IF_HEAVY_LOGGING(ostringstream outl);
+    IF_HEAVY_LOGGING(for (vector<SRTSOCKET>::const_iterator lp = listeners.begin(); lp != listeners.end(); ++lp) { outl << " @" << (*lp); });
+
+    HLOGC(cnlog.Debug, log << "removePendingForGroup: " << listeners.size() << " listeners collected: " << outl.str());
+
+    // What we need to do is:
+    // 1. Walk through the listener sockets and check their accept queue.
+    // 2. Skip a socket that:
+    //    - Is equal to this_socket (was removed from the queue already and triggered group accept)
+    //    - Does not belong to group members (should remain there for other purposes)
+    // 3. Any member socket found in that listener:
+    //    - this socket must be removed from the queue
+    //    - the listener containing this socket must be added UPDATE event.
+
+    map<CUDTSocket*, int> listeners_to_update;
+
+    for (vector<SRTSOCKET>::const_iterator i = listeners.begin(); i != listeners.end(); ++i)
     {
-        CUDTSocket* s = i->second;
-        // Check if any of them is a listener socket...
-
-        /* XXX This is left for information only that we are only
-           interested with listener sockets - with the current
-           implementation checking it is pointless because the
-           m_QueuedSockets structure is present in every socket
-           anyway even if it's not a listener, and only listener
-           sockets may have this container nonempty. So checking
-           the container should suffice.
-
-        if (!s->core().m_bListening)
-            continue;
-            */
-
-        if (s->m_QueuedSockets.empty())
-            continue;
-
-        // Somehow fortunate for us that it's a set, so we
-        // can simply check if this allegedly listener socket
-        // contains any of them.
-        for (list<SRTSOCKET>::iterator m = members.begin(), mx = m; m != members.end(); m = mx)
+        CUDTSocket* ls = locateSocket_LOCKED(*i);
+        if (!ls)
         {
-            ++mx;
-            std::map<SRTSOCKET, sockaddr_any>::iterator q = s->m_QueuedSockets.find(*m);
-            if (q != s->m_QueuedSockets.end())
+            HLOGC(cnlog.Debug, log << "Group-pending lsn @" << (*i) << " deleted in the meantime");
+            continue;
+        }
+        vector<SRTSOCKET> swipe_members;
+
+        for (map<SRTSOCKET, sockaddr_any>::const_iterator q = ls->m_QueuedSockets.begin(); q != ls->m_QueuedSockets.end(); ++q)
+        {
+            HLOGC(cnlog.Debug, log << "Group-pending lsn @" << (*i) << " queued socket @" << q->first << ":");
+            // 1. Check if it was the accept-triggering socket
+            if (q->first == this_socket)
             {
-                HLOGC(cnlog.Debug, log << "accept: listener @" << s->m_SocketID
-                        << " had ququed member @" << *m << " -- removed");
-                // Found an intersection socket.
-                // Remove it from the listener queue
-                s->m_QueuedSockets.erase(q);
-
-                // NOTE ALSO that after this removal the queue may be EMPTY,
-                // and if so, the listener socket should be no longer ready for accept.
-                if (s->m_QueuedSockets.empty())
-                {
-                    m_EPoll.update_events(s->m_SocketID, s->core().m_sPollID, SRT_EPOLL_ACCEPT, false);
-                }
-
-                // and remove it also from the members list.
-                // This can be done safely because we use a SAFE LOOP.
-                // We can also do it safely because a socket may be
-                // present in only one listener socket in the whole app.
-                members.erase(m);
+                listeners_to_update[ls] += 0;
+                HLOGC(cnlog.Debug, log << "... is the accept-trigger; will only possibly silence the listener");
+                continue;
             }
+
+            // 2. Check if it was this group's member socket
+            if (members.find(q->first) == members.end())
+            {
+                // Increase the number of not-member-related sockets to know if
+                // the read-ready status from the listener should be cleared.
+                listeners_to_update[ls]++;
+                HLOGC(cnlog.Debug, log << "... is not a member of $" << g->id() << "; skipping");
+                continue;
+            }
+
+            // 3. Found at least one socket that is this group's member
+            //    and is not the socket that triggered accept.
+            swipe_members.push_back(q->first);
+            listeners_to_update[ls] += 0;
+            HLOGC(cnlog.Debug, log << "... is to be unqueued");
+        }
+        if (ls->m_QueuedSockets.empty())
+            HLOGC(cnlog.Debug, log << "Group-pending lsn @" << (*i) << ": NO QUEUED SOCKETS");
+
+        for (vector<SRTSOCKET>::iterator is = swipe_members.begin(); is != swipe_members.end(); ++is)
+        {
+            ls->m_QueuedSockets.erase(*is);
+        }
+    }
+
+    // Now; for every listener, which contained at least one socket that is
+    // this group's member:
+    // - ADD UPDATE event
+    // - REMOVE ACCEPT event, if the number of "other sockets" is zero.
+
+    // NOTE: "map" container is used because we need to have unique listener container,
+    // while the listener may potentially be added multiple times in the loop of queued sockets.
+    for (map<CUDTSocket*, int>::iterator mi = listeners_to_update.begin(); mi != listeners_to_update.end(); ++mi)
+    {
+        CUDTSocket* s;
+        int nothers;
+        Tie(s, nothers) = *mi;
+
+        HLOGC(cnlog.Debug, log << "Group-pending lsn @" << s->m_SocketID << " had in-group accepted sockets and " << nothers << " other sockets");
+        if (nothers == 0)
+        {
+            m_EPoll.update_events(s->m_SocketID, s->core().m_sPollID, SRT_EPOLL_ACCEPT, false);
         }
 
-        // It may happen that the list of members can be
-        // eventually purged even if we haven't checked every socket.
-        // If it happens so, quit immediately because there's nothing
-        // left to do.
-        if (members.empty())
-            return;
+        m_EPoll.update_events(s->m_SocketID, s->core().m_sPollID, SRT_EPOLL_UPDATE, true);
     }
+
 }
 
 #endif

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -306,7 +306,7 @@ public:
 #if ENABLE_BONDING
     SRT_ATTR_REQUIRES(m_GlobControlLock)
     int checkQueuedSocketsEvents(const std::map<SRTSOCKET, sockaddr_any>& sockets);
-    void removePendingForGroup(const CUDTGroup* g);
+    void removePendingForGroup(const CUDTGroup* g, const std::vector<SRTSOCKET>& listeners, SRTSOCKET this_socket);
 #endif
 
     SRTSTATUS installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq);

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -570,15 +570,15 @@ private:
     SRT_ATR_NODISCARD bool processSrtMsg(const CPacket *ctrlpkt);
     SRT_ATR_NODISCARD int processSrtMsg_HSREQ(const uint32_t* srtdata, size_t bytelen, uint32_t ts, int hsv);
     SRT_ATR_NODISCARD int processSrtMsg_HSRSP(const uint32_t* srtdata, size_t bytelen, uint32_t ts, int hsv);
-    SRT_ATR_NODISCARD bool interpretSrtHandshake(const CHandShake& hs, const CPacket& hspkt, uint32_t* out_data, size_t* out_len);
+    SRT_ATR_NODISCARD bool interpretSrtHandshake(CUDTSocket* lsn, const CHandShake& hs, const CPacket& hspkt, uint32_t* out_data, size_t* out_len);
     SRT_ATR_NODISCARD bool checkApplyFilterConfig(const std::string& cs);
 
 #if ENABLE_BONDING
     static CUDTGroup& newGroup(const int); // defined EXCEPTIONALLY in api.cpp for convenience reasons
     // Note: This is an "interpret" function, which should treat the tp as
     // "possibly group type" that might be out of the existing values.
-    SRT_ATR_NODISCARD bool interpretGroup(const int32_t grpdata[], size_t data_size, int hsreq_type_cmd);
-    SRT_ATR_NODISCARD SRTSOCKET makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE tp, uint32_t link_flags);
+    SRT_ATR_NODISCARD bool interpretGroup(CUDTSocket* listener, const int32_t grpdata[], size_t data_size, int hsreq_type_cmd);
+    SRT_ATR_NODISCARD SRTSOCKET makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE tp, uint32_t link_flags, SRTSOCKET listener);
     void synchronizeWithGroup(CUDTGroup* grp);
 #endif
 
@@ -607,7 +607,8 @@ private:
     /// @param peer [in] The address of the listening UDT entity.
     /// @param hspkt [in] The original packet that brought the handshake.
     /// @param hs [in/out] The handshake information sent by the peer side (in), negotiated value (out).
-    void acceptAndRespond(const sockaddr_any& agent, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& hs);
+    void acceptAndRespond(CUDTSocket* lsn, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& hs);
+
     bool createSendHSResponse(uint32_t* kmdata, size_t kmdatasize, const CNetworkInterface& hsaddr, CHandShake& w_hs) ATR_NOTHROW;
 
     /// Write back to the hs structure the data after they have been

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -273,7 +273,6 @@ CUDTGroup::CUDTGroup(SRT_GROUP_TYPE gtype)
     , m_RcvBaseSeqNo(SRT_SEQNO_NONE)
     , m_bOpened(false)
     , m_bConnected(false)
-    , m_bPending(false)
     , m_bClosing(false)
     , m_iLastSchedSeqNo(SRT_SEQNO_NONE)
     , m_iLastSchedMsgNo(SRT_MSGNO_NONE)
@@ -4222,7 +4221,7 @@ void CUDTGroup::setGroupConnected()
 {
     if (!m_bConnected)
     {
-        HLOGC(cnlog.Debug, log << "GROUP: First socket connected, SETTING GROUP CONNECTED");
+        HLOGC(cnlog.Debug, log << "GROUP: First socket connected, SETTING GROUP CONNECTED (" << m_Group.size() << " members now)");
         // Switch to connected state and give appropriate signal
         m_Global.m_EPoll.update_events(id(), m_sPollID, SRT_EPOLL_CONNECT, true);
         m_bConnected = true;
@@ -4295,13 +4294,13 @@ void CUDTGroup::updateLatestRcv(CUDTSocket* s)
     }
 }
 
-void CUDTGroup::getMemberSockets(std::list<SRTSOCKET>& w_ids) const
+void CUDTGroup::getMemberSockets(std::set<SRTSOCKET>& w_ids) const
 {
     ScopedLock gl (m_GroupLock);
 
     for (cgli_t gi = m_Group.begin(); gi != m_Group.end(); ++gi)
     {
-        w_ids.push_back(gi->id);
+        w_ids.insert(gi->id);
     }
 }
 

--- a/srtcore/group.h
+++ b/srtcore/group.h
@@ -206,7 +206,21 @@ public:
 
     bool groupPending()
     {
-        return m_bPending;
+        srt::sync::ScopedLock g(m_GroupLock);
+        return groupPending_LOCKED();
+    }
+
+    bool groupPending_LOCKED()
+    {
+        return !m_PendingListeners.empty();
+    }
+
+    std::vector<SRTSOCKET> clearPendingListeners()
+    {
+        srt::sync::ScopedLock g(m_GroupLock);
+        std::vector<SRTSOCKET> pending;
+        std::swap(m_PendingListeners, pending);
+        return pending;
     }
 
     void setGroupConnected();
@@ -674,13 +688,20 @@ private:
     /// True: at least one socket is connected, even if pending from the listener
     bool m_bConnected;
 
-    /// True: this group was created on the listner side for the first socket
-    /// that is pending connection, so the group is about to be reported for the
-    /// srt_accept() call, but the application hasn't retrieved the group yet.
-    /// Not in use in case of caller-side groups.
-    // NOTE: using atomic in otder to allow this variable to be changed independently
-    // on any mutex locks.
-    sync::atomic<bool> m_bPending;
+    // Added with every listener at the moment when a new
+    // connection reports in and the first socket comes in from
+    // the listener. This listener must stay in this list as long
+    // as the group is in the "pending mode", that is, waiting for
+    // being accepted by srt_accept() call. After getting accepted
+    // this list is clear. The purpose of this list is that after
+    // doing srt_accept(), every listener in this list must be checked
+    // if it still has queued sockets that are members of this group.
+    // NOTE:
+    // - BEFORE srt_accept() is called, EVERY member socket of this
+    //   group must remain among queued sockets.
+    // - AFTER srt_accept() is called (the group may be accepted off
+    //   any listener that gets a pending socket connection), 
+    std::vector<SRTSOCKET> m_PendingListeners;
 
     /// True: the group was requested to close and it should not allow any operations.
     bool m_bClosing;
@@ -759,10 +780,32 @@ public:
     // However, after creation it will be still waiting for being
     // extracted by the application in `srt_accept`, and until then
     // it stays as pending.
-    void setOpenPending()
+    void setOpenPending(SRTSOCKET lsn)
     {
+        sync::ScopedLock lk (m_GroupLock);
         m_bOpened = true;
-        m_bPending = true;
+        m_PendingListeners.push_back(lsn);
+    }
+
+    void updatePending(SRTSOCKET lsn)
+    {
+        sync::ScopedLock lk (m_GroupLock);
+
+        // This is called when the group has been already created at
+        // the listener side as mirror, and now whether it's still in
+        // the pending mode or it's already accepted, is recognized
+        // by that there is anything in the pending list.
+        //
+        // When this group is first created, it gets called setOpenPending,
+        // which always adds at least one listener to the list. This here
+        // is called either after the first setOpenPending for any next
+        // pending socket, while the group wasn't yet accepted, or after
+        // the group was accepted, in which case this list is empty.
+
+        if (!m_PendingListeners.empty())
+        {
+            m_PendingListeners.push_back(lsn);
+        }
     }
 
     std::string CONID() const
@@ -823,7 +866,7 @@ public:
 
     void updateLatestRcv(srt::CUDTSocket*);
 
-    void getMemberSockets(std::list<SRTSOCKET>&) const;
+    void getMemberSockets(std::set<SRTSOCKET>&) const;
 
     // Property accessors
     SRTU_PROPERTY_RW_CHAIN(CUDTGroup, SRTSOCKET, id, m_GroupID);


### PR DESCRIPTION
The previous fix for the pending groups was done incorrectly. The problem is that even if the group is pending, it should still keep the UPDATE state on every listener that provided FURTHER group member sockets.

Instead of the `m_bPending` flag, now it's providing the group with the list of listener sockets which at the moment have any pending member sockets that are members of this group. This way every single listener socket is set the UPDATE flag if it contained any second and next sockets pending for this group.

The situation is happening in case when you have multiple connections reporting at once and all of them for a moment remain the pending sockets. In this case every single listener socket that provided the socket for this group should keep it queued and report read-ready state (no matter that only one of them can effectively deliver the group). Once the `srt_accept` is called for any of the listeners that reported it, the first found group member socket is extracted from the queue, but the reported socket is replaced with the group ID. This time however all listener sockets are reviewed to check if any of them have more queued sockets and:
* If there are any queued sockets that are members of the same group, this listener socket should be set UPDATE flag
* If there are any queued sockets that are not members of this group, the listener socket should remain readable, otherwise the IN flag is cleared.

IMPORTANT: The very first listener that gets the reported-in connection for a group, as it CREATES the mirror group at the listener side, adds this listener to the pending listeners in the group. Any next such connection request adds the listener to this list ONLY IF AT LEAST ONE SOCKET IS THERE ALREADY (otherwise it means that the group wasn't pending and the socket is not queued). After the call to accept, this list is cleared.