### PR TITLE
[build] - Extend cmake_minimum_required for compatibility with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 
-cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5..4.0 FATAL_ERROR)
 set (SRT_VERSION 1.5.4)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/scripts")


### PR DESCRIPTION
I am not sure this will work for older cmakes,  but lets try the CI

see https://fedoraproject.org/wiki/Changes/CMake4.0