### PR TITLE
[MAINT][core] Fixed data race in CTimer

### DIFF
--- a/srtcore/sync.cpp
+++ b/srtcore/sync.cpp
@@ -239,6 +239,7 @@ bool srt::sync::CTimer::sleep_until(TimePoint<steady_clock> tp)
 #if USE_BUSY_WAITING
         while (cur_tp < m_tsSchedTime)
         {
+            InvertedLock ulk (m_event.mutex());
 #ifdef IA32
             __asm__ volatile ("pause; rep; nop; nop; nop; nop; nop;");
 #elif IA64

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -750,6 +750,8 @@ public:
     ///         false on timeout
     bool wait_for(UniqueLock& lk, const steady_clock::duration& rel_time);
 
+    bool wait_until(UniqueLock& lk, const steady_clock::time_point& tp);
+
     void lock_wait();
 
     void wait(UniqueLock& lk);


### PR DESCRIPTION
The `m_tsSchedTime` field should be protected by a mutex, and this is so applied in all other places.

Changed lock to the whole loop with unlocking for the wait call only.

Implemented forwarder for `wait_until` in `CEvent` that was missing.

For the use-busy-waiting version the mutex is lifted for the series of nop calls, otherwise simultaneous interrupt() would be impossible.