### PR TITLE
[MAINT] Refax namespace usage and removed deprecated API

### DIFF
--- a/apps/logsupport.cpp
+++ b/apps/logsupport.cpp
@@ -19,6 +19,7 @@
 #include "../srtcore/utilities.h"
 
 using namespace std;
+using namespace srt;
 
 // This is based on codes taken from <sys/syslog.h>
 // This is POSIX standard, so it's not going to change.

--- a/apps/srt-file-transmit.cpp
+++ b/apps/srt-file-transmit.cpp
@@ -16,6 +16,7 @@ written by
 #include <direct.h>
 #endif
 #include <iostream>
+#include <fstream>
 #include <iterator>
 #include <vector>
 #include <map>
@@ -27,7 +28,6 @@ written by
 #include <cassert>
 #include <sys/stat.h>
 #include <srt.h>
-#include <udt.h>
 #include <common.h>
 
 #include "apputil.hpp"
@@ -44,6 +44,7 @@ written by
 
 
 using namespace std;
+using namespace srt;
 
 static bool interrupt = false;
 void OnINT_ForceExit(int)

--- a/apps/srt-live-transmit.cpp
+++ b/apps/srt-live-transmit.cpp
@@ -77,7 +77,6 @@
 // to the library. Application using the "installed" library should
 // use <srt/srt.h>
 #include <srt.h>
-#include <udt.h> // This TEMPORARILY contains extra C++-only SRT API.
 #include <logging.h>
 
 using namespace std;

--- a/apps/srt-tunnel.cpp
+++ b/apps/srt-tunnel.cpp
@@ -39,7 +39,6 @@
 // to the library. Application using the "installed" library should
 // use <srt/srt.h>
 #include <srt.h>
-#include <udt.h> // This TEMPORARILY contains extra C++-only SRT API.
 #include <logging.h>
 #include <api.h>
 #include <utilities.h>
@@ -215,7 +214,6 @@ class Engine
 
     int status = 0;
     Medium::ReadStatus rdst = Medium::RD_ERROR;
-    UDT::ERRORINFO srtx;
 
 public:
     enum Dir { DIR_IN, DIR_OUT };
@@ -470,9 +468,18 @@ protected:
 
     using Medium::Error;
 
-    static void Error(UDT::ERRORINFO& ri, const string& text)
+    static void Error(int srterror, int errnov, const string& text)
     {
-        throw TransmissionError("ERROR: " + text + ": " + ri.getErrorMessage());
+        string message = srt_strerror(srterror, errnov);
+
+        string hm = srt::Sprint("ERROR #", srterror, ": ", text, ": ", message);
+        if (errnov == 0)
+            throw TransmissionError(hm);
+        else
+        {
+            char buf[180];
+            throw TransmissionError(srt::Sprint(hm, ": #", errnov, ": ", SysStrError(errnov, buf, 179)));
+        }
     }
 
     ~SrtMedium() override
@@ -629,15 +636,19 @@ void SrtMedium::CreateListener()
 
     if (stat == SRT_ERROR)
     {
+        int errnov = 0;
+        int result = srt_getlasterror(&errnov);
         srt_close(m_socket);
-        Error(UDT::getlasterror(), "srt_bind");
+        Error(result, errnov, "srt_bind");
     }
 
     stat = srt_listen(m_socket, backlog);
     if (stat == SRT_ERROR)
     {
+        int errnov = 0;
+        int result = srt_getlasterror(&errnov);
         srt_close(m_socket);
-        Error(UDT::getlasterror(), "srt_listen");
+        Error(result, errnov, "srt_listen");
     }
 
     m_listener = true;
@@ -677,7 +688,9 @@ unique_ptr<Medium> SrtMedium::Accept()
     SRTSOCKET s = srt_accept(m_socket, (sa.get()), (&sa.len));
     if (s == SRT_INVALID_SOCK)
     {
-        Error(UDT::getlasterror(), "srt_accept");
+        int errnov = 0;
+        int result = srt_getlasterror(&errnov);
+        Error(result, errnov, "srt_accept");
     }
 
     ConfigurePost(s);
@@ -737,7 +750,11 @@ void SrtMedium::Connect()
 
     SRTSOCKET st = srt_connect(m_socket, sa.get(), sizeof sa);
     if (st == SRT_INVALID_SOCK)
-        Error(UDT::getlasterror(), "srt_connect");
+    {
+        int errnov = 0;
+        int result = srt_getlasterror(&errnov);
+        Error(result, errnov, "srt_connect");
+    }
 
     ConfigurePost(m_socket);
 
@@ -888,7 +905,9 @@ void SrtMedium::Write(bytevector& w_buffer)
     int st = srt_send(m_socket, w_buffer.data(), (int)w_buffer.size());
     if (st == int(SRT_ERROR))
     {
-        Error(UDT::getlasterror(), "srt_send");
+        int errnov = 0;
+        int result = srt_getlasterror(&errnov);
+        Error(result, errnov, "srt_send");
     }
 
     // This should be ==, whereas > is not possible, but

--- a/apps/statswriter.hpp
+++ b/apps/statswriter.hpp
@@ -85,7 +85,7 @@ public:
 
     bool Option(const std::string& key, std::string* rval = nullptr)
     {
-        const std::string* out = map_getp(options, key);
+        const std::string* out = srt::map_getp(options, key);
         if (!out)
             return false;
 

--- a/apps/transmitmedia.hpp
+++ b/apps/transmitmedia.hpp
@@ -16,7 +16,6 @@
 #include <stdexcept>
 
 #include "transmitbase.hpp"
-#include <udt.h> // Needs access to CUDTException
 
 using namespace std;
 

--- a/apps/uriparser.cpp
+++ b/apps/uriparser.cpp
@@ -422,7 +422,7 @@ int main( int argc, char** argv )
         for (string& s: args)
         {
             vector<string> keyval;
-            Split(s, '=', back_inserter(keyval));
+            srt::Split(s, '=', back_inserter(keyval));
             if (keyval.size() < 2)
                 keyval.push_back("");
             parser[keyval[0]] = keyval[1];

--- a/apps/uriparser.hpp
+++ b/apps/uriparser.hpp
@@ -39,7 +39,7 @@ public:
     // Some predefined types
     Type type() const;
 
-    typedef MapProxy<std::string, std::string> ParamProxy;
+    typedef srt::MapProxy<std::string, std::string> ParamProxy;
 
 // Operations
 public:

--- a/srtcore/ATTIC/udt.h
+++ b/srtcore/ATTIC/udt.h
@@ -64,6 +64,10 @@ modified by
  * file doesn't contain _FUNCTIONS_ predicted to be used in C - see udtc.h
  */
 
+// XXX NOTE XXX
+// This file remains for reference, but it has been removed from
+// public headers and it is not in use anymore.
+
 #ifndef INC_SRT_UDT_H
 #define INC_SRT_UDT_H
 
@@ -220,36 +224,9 @@ SRT_API SRT_SOCKSTATUS getsockstate(SRTSOCKET u);
 
 }  // namespace UDT
 
-// This is a log configuration used inside SRT.
-// Applications using SRT, if they want to use the logging mechanism
-// are free to create their own logger configuration objects for their
-// own logger FA objects, or create their own. The object of this type
-// is required to initialize the logger FA object.
-namespace srt_logging { struct LogConfig; }
-SRT_API extern srt_logging::LogConfig srt_logger_config;
-
-namespace srt
-{
-
-// This is a C++ SRT API extension. This is not a part of legacy UDT API.
-SRT_API void setloglevel(srt_logging::LogLevel::type ll);
-SRT_API void addlogfa(srt_logging::LogFA fa);
-SRT_API void dellogfa(srt_logging::LogFA fa);
-SRT_API void resetlogfa(std::set<srt_logging::LogFA> fas);
-SRT_API void resetlogfa(const int* fara, size_t fara_size);
-SRT_API void setlogstream(std::ostream& stream);
-SRT_API void setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler);
-SRT_API void setlogflags(int flags);
-
-SRT_API bool setstreamid(SRTSOCKET u, const std::string& sid);
-SRT_API std::string getstreamid(SRTSOCKET u);
-
-// Namespace alias
-namespace logging {
-    using namespace srt_logging;
-}
-
-} // namespace srt
+// XXX Here was the part with srt namespace and srt_logger_config file.
+// The latter was moved to common.h. The C++ SRT API parts have been moved
+// to srt.h file.
 
 // Planned deprecated removal: rel1.6.0
 // There's also no portable way possible to enforce a deprecation

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -67,7 +67,6 @@ modified by
 #include "logging.h"
 #include "threadname.h"
 #include "srt.h"
-#include "udt.h"
 
 #ifdef _WIN32
 #include <win/wintime.h>
@@ -81,7 +80,10 @@ using namespace std;
 using namespace srt_logging;
 using namespace srt::sync;
 
-void srt::CUDTSocket::construct()
+namespace srt
+{
+
+void CUDTSocket::construct()
 {
 #if ENABLE_BONDING
     m_GroupOf         = NULL;
@@ -92,7 +94,7 @@ void srt::CUDTSocket::construct()
     setupMutex(m_ControlLock, "Control");
 }
 
-srt::CUDTSocket::~CUDTSocket()
+CUDTSocket::~CUDTSocket()
 {
     releaseMutex(m_AcceptLock);
     releaseCond(m_AcceptCond);
@@ -100,7 +102,7 @@ srt::CUDTSocket::~CUDTSocket()
 }
 
 SRT_TSA_DISABLED // Uses m_Status that should be guarded, but for reading it is enough to be atomic
-SRT_SOCKSTATUS srt::CUDTSocket::getStatus()
+SRT_SOCKSTATUS CUDTSocket::getStatus()
 {
     // TTL in CRendezvousQueue::updateConnStatus() will set m_bConnecting to false.
     // Although m_Status is still SRTS_CONNECTING, the connection is in fact to be closed due to TTL expiry.
@@ -118,7 +120,7 @@ SRT_SOCKSTATUS srt::CUDTSocket::getStatus()
 }
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTSocket::breakSocket_LOCKED(int reason)
+void CUDTSocket::breakSocket_LOCKED(int reason)
 {
     // This function is intended to be called from GC,
     // under a lock of m_GlobControlLock.
@@ -130,7 +132,7 @@ void srt::CUDTSocket::breakSocket_LOCKED(int reason)
 }
 
 SRT_TSA_DISABLED // Uses m_Status that should be guarded, but for reading it is enough to be atomic
-void srt::CUDTSocket::setClosed()
+void CUDTSocket::setClosed()
 {
     m_Status = SRTS_CLOSED;
 
@@ -141,14 +143,14 @@ void srt::CUDTSocket::setClosed()
     m_tsClosureTimeStamp = steady_clock::now();
 }
 
-void srt::CUDTSocket::setBrokenClosed()
+void CUDTSocket::setBrokenClosed()
 {
     m_UDT.m_iBrokenCounter = 60;
     m_UDT.m_bBroken        = true;
     setClosed();
 }
 
-bool srt::CUDTSocket::readReady()
+bool CUDTSocket::readReady()
 {
     if (m_UDT.m_bConnected && m_UDT.isRcvBufferReady())
         return true;
@@ -159,19 +161,19 @@ bool srt::CUDTSocket::readReady()
     return broken();
 }
 
-bool srt::CUDTSocket::writeReady() const
+bool CUDTSocket::writeReady() const
 {
     return (m_UDT.m_bConnected && (m_UDT.m_pSndBuffer->getCurrBufSize() < m_UDT.m_config.iSndBufSize)) || broken();
 }
 
-bool srt::CUDTSocket::broken() const
+bool CUDTSocket::broken() const
 {
     return m_UDT.m_bBroken || !m_UDT.m_bConnected;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-srt::CUDTUnited::CUDTUnited()
+CUDTUnited::CUDTUnited()
     : m_Sockets()
     , m_GlobControlLock()
     , m_IDLock()
@@ -209,7 +211,7 @@ srt::CUDTUnited::CUDTUnited()
     HLOGC(inlog.Debug, log << "SRT Clock Type: " << SRT_SYNC_CLOCK_STR);
 }
 
-srt::CUDTUnited::~CUDTUnited()
+CUDTUnited::~CUDTUnited()
 {
     // Call it if it wasn't called already.
     // This will happen at the end of main() of the application,
@@ -238,7 +240,7 @@ srt::CUDTUnited::~CUDTUnited()
 #endif
 }
 
-string srt::CUDTUnited::CONID(SRTSOCKET sock)
+string CUDTUnited::CONID(SRTSOCKET sock)
 {
     if (int32_t(sock) <= 0) // embraces SRT_INVALID_SOCK, SRT_SOCKID_CONNREQ and illegal negative domain
         return "";
@@ -248,7 +250,7 @@ string srt::CUDTUnited::CONID(SRTSOCKET sock)
     return os.str();
 }
 
-bool srt::CUDTUnited::startGarbageCollector()
+bool CUDTUnited::startGarbageCollector()
 {
 
     ScopedLock guard(m_GCStartLock);
@@ -260,7 +262,7 @@ bool srt::CUDTUnited::startGarbageCollector()
     return m_bGCStatus;
 }
 
-void srt::CUDTUnited::stopGarbageCollector()
+void CUDTUnited::stopGarbageCollector()
 {
 
     ScopedLock guard(m_GCStartLock);
@@ -276,7 +278,7 @@ void srt::CUDTUnited::stopGarbageCollector()
     }
 }
 
-void srt::CUDTUnited::closeAllSockets()
+void CUDTUnited::closeAllSockets()
 {
     // remove all sockets and multiplexers
     HLOGC(inlog.Debug, log << "GC: GLOBAL EXIT - releasing all pending sockets. Acquring control lock...");
@@ -364,14 +366,14 @@ void srt::CUDTUnited::closeAllSockets()
             break;
 
         HLOGC(inlog.Debug, log << "GC: checkBrokenSockets didn't wipe all sockets, repeating after 1s sleep");
-        srt::sync::this_thread::sleep_for(milliseconds_from(1));
+        sync::this_thread::sleep_for(milliseconds_from(1));
     }
 
 
 }
 
 
-SRTRUNSTATUS srt::CUDTUnited::startup()
+SRTRUNSTATUS CUDTUnited::startup()
 {
     ScopedLock gcinit(m_InitLock);
     m_iInstanceCount++;
@@ -381,7 +383,7 @@ SRTRUNSTATUS srt::CUDTUnited::startup()
         return startGarbageCollector() ? SRT_RUN_OK : SRT_RUN_ERROR; 
 }
 
-SRTSTATUS srt::CUDTUnited::cleanup()
+SRTSTATUS CUDTUnited::cleanup()
 {
     // IMPORTANT!!!
     // In this function there must be NO LOGGING AT ALL.  This function may
@@ -401,7 +403,7 @@ SRTSTATUS srt::CUDTUnited::cleanup()
     return SRT_STATUS_OK;
 }
 
-SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
+SRTSOCKET CUDTUnited::generateSocketID(bool for_group)
 {
     ScopedLock guard(m_IDLock);
 
@@ -504,7 +506,7 @@ SRTSOCKET srt::CUDTUnited::generateSocketID(bool for_group)
     return SRTSOCKET(sockval);
 }
 
-SRTSOCKET srt::CUDTUnited::newSocket(CUDTSocket** pps, bool managed)
+SRTSOCKET CUDTUnited::newSocket(CUDTSocket** pps, bool managed)
 {
     // XXX consider using some replacement of std::unique_ptr
     // so that exceptions will clean up the object without the
@@ -563,7 +565,7 @@ SRTSOCKET srt::CUDTUnited::newSocket(CUDTSocket** pps, bool managed)
 }
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::swipeSocket_LOCKED(SRTSOCKET id, CUDTSocket* s, CUDTUnited::SwipeSocketTerm lateremove)
+void CUDTUnited::swipeSocket_LOCKED(SRTSOCKET id, CUDTSocket* s, CUDTUnited::SwipeSocketTerm lateremove)
 {
     m_ClosedSockets[id] = s;
     if (!lateremove)
@@ -578,7 +580,7 @@ void srt::CUDTUnited::swipeSocket_LOCKED(SRTSOCKET id, CUDTSocket* s, CUDTUnited
 // having applied a shared lock on CRcvQueue::m_pListener in
 // CRcvQueue::worker_ProcessConnectionRequest. As this thread
 // locks both mutexes as shared, it doesn't form a deadlock.
-int srt::CUDTUnited::newConnection(const SRTSOCKET     listener,
+int CUDTUnited::newConnection(const SRTSOCKET     listener,
                                    const sockaddr_any& peer,
                                    const CPacket&      hspkt,
                                    CHandShake&         w_hs,
@@ -939,7 +941,7 @@ ERR_ROLLBACK:
     return 1;
 }
 
-SRT_EPOLL_T srt::CUDTSocket::getListenerEvents()
+SRT_EPOLL_T CUDTSocket::getListenerEvents()
 {
     // You need to check EVERY socket that has been queued
     // and verify its internals. With independent socket the
@@ -967,7 +969,7 @@ SRT_EPOLL_T srt::CUDTSocket::getListenerEvents()
 }
 
 #if ENABLE_BONDING
-int srt::CUDTUnited::checkQueuedSocketsEvents(const map<SRTSOCKET, sockaddr_any>& sockets)
+int CUDTUnited::checkQueuedSocketsEvents(const map<SRTSOCKET, sockaddr_any>& sockets)
 {
     SRT_EPOLL_T flags = 0;
 
@@ -1002,12 +1004,12 @@ int srt::CUDTUnited::checkQueuedSocketsEvents(const map<SRTSOCKET, sockaddr_any>
 #endif
 
 // static forwarder
-SRTSTATUS srt::CUDT::installAcceptHook(SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
+SRTSTATUS CUDT::installAcceptHook(SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
 {
     return uglobal().installAcceptHook(lsn, hook, opaq);
 }
 
-SRTSTATUS srt::CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
+SRTSTATUS CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_callback_fn* hook, void* opaq)
 {
     try
     {
@@ -1023,12 +1025,12 @@ SRTSTATUS srt::CUDTUnited::installAcceptHook(const SRTSOCKET lsn, srt_listen_cal
     return SRT_STATUS_OK;
 }
 
-SRTSTATUS srt::CUDT::installConnectHook(SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq)
+SRTSTATUS CUDT::installConnectHook(SRTSOCKET lsn, srt_connect_callback_fn* hook, void* opaq)
 {
     return uglobal().installConnectHook(lsn, hook, opaq);
 }
 
-SRTSTATUS srt::CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_callback_fn* hook, void* opaq)
+SRTSTATUS CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_callback_fn* hook, void* opaq)
 {
     try
     {
@@ -1052,7 +1054,7 @@ SRTSTATUS srt::CUDTUnited::installConnectHook(const SRTSOCKET u, srt_connect_cal
     return SRT_STATUS_OK;
 }
 
-SRT_SOCKSTATUS srt::CUDTUnited::getStatus(const SRTSOCKET u)
+SRT_SOCKSTATUS CUDTUnited::getStatus(const SRTSOCKET u)
 {
     // protects the m_Sockets structure
     SharedLock cg(m_GlobControlLock);
@@ -1069,7 +1071,7 @@ SRT_SOCKSTATUS srt::CUDTUnited::getStatus(const SRTSOCKET u)
     return i->second->getStatus();
 }
 
-SRTSTATUS srt::CUDTUnited::getCloseReason(const SRTSOCKET u, SRT_CLOSE_INFO& info)
+SRTSTATUS CUDTUnited::getCloseReason(const SRTSOCKET u, SRT_CLOSE_INFO& info)
 {
     // protects the m_Sockets structure
     SharedLock cg(m_GlobControlLock);
@@ -1100,7 +1102,7 @@ SRTSTATUS srt::CUDTUnited::getCloseReason(const SRTSOCKET u, SRT_CLOSE_INFO& inf
     return SRT_STATUS_OK;
 }
 
-SRTSTATUS srt::CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
+SRTSTATUS CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
 {
     ScopedLock cg(s->m_ControlLock);
 
@@ -1127,7 +1129,7 @@ SRTSTATUS srt::CUDTUnited::bind(CUDTSocket* s, const sockaddr_any& name)
     return SRT_STATUS_OK;
 }
 
-SRTSTATUS srt::CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
+SRTSTATUS CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
 {
     ScopedLock cg(s->m_ControlLock);
 
@@ -1156,14 +1158,14 @@ SRTSTATUS srt::CUDTUnited::bind(CUDTSocket* s, UDPSOCKET udpsock)
     return SRT_STATUS_OK;
 }
 
-SRTSTATUS srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
+SRTSTATUS CUDTUnited::listen(const SRTSOCKET u, int backlog)
 {
     if (backlog <= 0)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
 
     // Don't search for the socket if it's already -1;
     // this never is a valid socket.
-    if (u == UDT::INVALID_SOCK)
+    if (u == SRT_INVALID_SOCK)
         throw CUDTException(MJ_NOTSUP, MN_SIDINVAL, 0);
 
     CUDTSocket* s = locateSocket(u);
@@ -1202,7 +1204,7 @@ SRTSTATUS srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
     return SRT_STATUS_OK;
 }
 
-SRTSOCKET srt::CUDTUnited::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut)
+SRTSOCKET CUDTUnited::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut)
 {
     CEPollDesc* ed  = 0;
     int         eid = m_EPoll.create(&ed);
@@ -1247,7 +1249,7 @@ SRTSOCKET srt::CUDTUnited::accept_bond(const SRTSOCKET listeners[], int lsize, i
     return accept(lsn, ((sockaddr*)&dummy), (&outlen));
 }
 
-SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_addrlen)
+SRTSOCKET CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int* pw_addrlen)
 {
     if (pw_addr && !pw_addrlen)
     {
@@ -1404,7 +1406,7 @@ SRTSOCKET srt::CUDTUnited::accept(const SRTSOCKET listen, sockaddr* pw_addr, int
 #if ENABLE_BONDING
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::removePendingForGroup(const CUDTGroup* g, const vector<SRTSOCKET>& listeners, SRTSOCKET this_socket)
+void CUDTUnited::removePendingForGroup(const CUDTGroup* g, const vector<SRTSOCKET>& listeners, SRTSOCKET this_socket)
 {
     set<SRTSOCKET> members;
     g->getMemberSockets((members));
@@ -1499,7 +1501,7 @@ void srt::CUDTUnited::removePendingForGroup(const CUDTGroup* g, const vector<SRT
 
 #endif
 
-SRTSOCKET srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int namelen)
+SRTSOCKET CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const sockaddr* tarname, int namelen)
 {
     // Here both srcname and tarname must be specified
     if (!srcname || !tarname || namelen < int(sizeof(sockaddr_in)))
@@ -1546,7 +1548,7 @@ SRTSOCKET srt::CUDTUnited::connect(SRTSOCKET u, const sockaddr* srcname, const s
     return SRT_SOCKID_CONNREQ;
 }
 
-SRTSOCKET srt::CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
+SRTSOCKET CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
     if (!name || namelen < int(sizeof(sockaddr_in)))
     {
@@ -1584,7 +1586,7 @@ SRTSOCKET srt::CUDTUnited::connect(const SRTSOCKET u, const sockaddr* name, int 
 }
 
 #if ENABLE_BONDING
-SRTSOCKET srt::CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* gd)
+SRTSOCKET CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* gd)
 {
     SRTSOCKET gstat = groupConnect(pg, gd, 1);
     if (gstat == SRT_INVALID_SOCK)
@@ -1601,7 +1603,7 @@ SRTSOCKET srt::CUDTUnited::singleMemberConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFI
 }
 
 // [[using assert(pg->m_iBusy > 0)]]
-SRTSOCKET srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int arraysize)
+SRTSOCKET CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targets, int arraysize)
 {
     CUDTGroup& g = *pg;
     SRT_ASSERT(g.m_iBusy > 0);
@@ -1734,7 +1736,7 @@ SRTSOCKET srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targ
         // Do it after setting all stored options, as some of them may
         // influence some group data.
 
-        srt::groups::SocketData data = srt::groups::prepareSocketData(ns);
+        groups::SocketData data = groups::prepareSocketData(ns);
         if (targets[tii].token != -1)
         {
             // Reuse the token, if specified by the caller
@@ -2139,7 +2141,7 @@ SRTSOCKET srt::CUDTUnited::groupConnect(CUDTGroup* pg, SRT_SOCKGROUPCONFIG* targ
 }
 #endif
 
-void srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_t forced_isn)
+void CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, int32_t forced_isn)
 {
     ScopedLock cg(s->m_ControlLock);
     // a socket can "connect" only if it is in the following states:
@@ -2203,7 +2205,7 @@ void srt::CUDTUnited::connectIn(CUDTSocket* s, const sockaddr_any& target_addr, 
     }
 }
 
-SRTSTATUS srt::CUDTUnited::close(const SRTSOCKET u, int reason)
+SRTSTATUS CUDTUnited::close(const SRTSOCKET u, int reason)
 {
 #if ENABLE_BONDING
     if (CUDT::isgroup(u))
@@ -2239,16 +2241,16 @@ SRTSTATUS srt::CUDTUnited::close(const SRTSOCKET u, int reason)
 }
 
 #if ENABLE_BONDING
-void srt::CUDTUnited::deleteGroup(CUDTGroup* g)
+void CUDTUnited::deleteGroup(CUDTGroup* g)
 {
     using srt_logging::gmlog;
 
-    srt::sync::ExclusiveLock cg(m_GlobControlLock);
+    sync::ExclusiveLock cg(m_GlobControlLock);
     return deleteGroup_LOCKED(g);
 }
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
+void CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
 {
     SRT_ASSERT(g->groupEmpty());
 
@@ -2287,7 +2289,7 @@ void srt::CUDTUnited::deleteGroup_LOCKED(CUDTGroup* g)
 #endif
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::recordCloseReason(CUDTSocket* s)
+void CUDTUnited::recordCloseReason(CUDTSocket* s)
 {
     CloseInfo ci;
     ci.info.agent = SRT_CLOSE_REASON(s->core().m_AgentCloseReason.load());
@@ -2333,7 +2335,7 @@ void srt::CUDTUnited::recordCloseReason(CUDTSocket* s)
     }
 }
 
-SRTSTATUS srt::CUDTUnited::close(CUDTSocket* s, int reason)
+SRTSTATUS CUDTUnited::close(CUDTSocket* s, int reason)
 {
     HLOGC(smlog.Debug, log << s->core().CONID() << "CLOSE. Acquiring control lock");
 
@@ -2549,7 +2551,7 @@ SRTSTATUS srt::CUDTUnited::close(CUDTSocket* s, int reason)
     return SRT_STATUS_OK;
 }
 
-void srt::CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
+void CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
 {
     if (!pw_name || !pw_namelen)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -2573,7 +2575,7 @@ void srt::CUDTUnited::getpeername(const SRTSOCKET u, sockaddr* pw_name, int* pw_
     *pw_namelen = len;
 }
 
-void srt::CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
+void CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_namelen)
 {
     if (!pw_name || !pw_namelen)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -2597,7 +2599,7 @@ void srt::CUDTUnited::getsockname(const SRTSOCKET u, sockaddr* pw_name, int* pw_
     *pw_namelen = len;
 }
 
-void srt::CUDTUnited::getsockdevname(const SRTSOCKET u, char* pw_name, size_t* pw_namelen)
+void CUDTUnited::getsockdevname(const SRTSOCKET u, char* pw_name, size_t* pw_namelen)
 {
     if (!pw_name || !pw_namelen)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -2630,7 +2632,7 @@ void srt::CUDTUnited::getsockdevname(const SRTSOCKET u, char* pw_name, size_t* p
     *pw_namelen = 0; // report empty one
 }
 
-int srt::CUDTUnited::select(UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout)
+int CUDTUnited::select(std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, std::set<SRTSOCKET>* exceptfds, const timeval* timeout)
 {
     const steady_clock::time_point entertime = steady_clock::now();
 
@@ -2734,7 +2736,7 @@ int srt::CUDTUnited::select(UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSE
     return count;
 }
 
-int srt::CUDTUnited::selectEx(const vector<SRTSOCKET>& fds,
+int CUDTUnited::selectEx(const vector<SRTSOCKET>& fds,
                               vector<SRTSOCKET>*       readfds,
                               vector<SRTSOCKET>*       writefds,
                               vector<SRTSOCKET>*       exceptfds,
@@ -2800,17 +2802,17 @@ int srt::CUDTUnited::selectEx(const vector<SRTSOCKET>& fds,
     return count;
 }
 
-int srt::CUDTUnited::epoll_create()
+int CUDTUnited::epoll_create()
 {
     return m_EPoll.create();
 }
 
-void srt::CUDTUnited::epoll_clear_usocks(int eid)
+void CUDTUnited::epoll_clear_usocks(int eid)
 {
     return m_EPoll.clear_usocks(eid);
 }
 
-void srt::CUDTUnited::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
+void CUDTUnited::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
 {
 #if ENABLE_BONDING
     if (CUDT::isgroup(u))
@@ -2841,24 +2843,24 @@ void srt::CUDTUnited::epoll_add_usock(const int eid, const SRTSOCKET u, const in
 // NOTE: WILL LOCK (serially):
 // - CEPoll::m_EPollLock
 // - CUDT::m_RecvLock
-void srt::CUDTUnited::epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, const int* events)
+void CUDTUnited::epoll_add_usock_INTERNAL(const int eid, CUDTSocket* s, const int* events)
 {
     m_EPoll.update_usock(eid, s->m_SocketID, events);
     s->core().addEPoll(eid);
 }
 
-void srt::CUDTUnited::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
+void CUDTUnited::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
     return m_EPoll.add_ssock(eid, s, events);
 }
 
-void srt::CUDTUnited::epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events)
+void CUDTUnited::epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
     return m_EPoll.update_ssock(eid, s, events);
 }
 
 template <class EntityType>
-void srt::CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
+void CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
 {
     // XXX Not sure if this is anyhow necessary because setting readiness
     // to false doesn't actually trigger any action. Further research needed.
@@ -2878,19 +2880,19 @@ void srt::CUDTUnited::epoll_remove_entity(const int eid, EntityType* ent)
 }
 
 // Needed internal access!
-void srt::CUDTUnited::epoll_remove_socket_INTERNAL(const int eid, CUDTSocket* s)
+void CUDTUnited::epoll_remove_socket_INTERNAL(const int eid, CUDTSocket* s)
 {
     return epoll_remove_entity(eid, &s->core());
 }
 
 #if ENABLE_BONDING
-void srt::CUDTUnited::epoll_remove_group_INTERNAL(const int eid, CUDTGroup* g)
+void CUDTUnited::epoll_remove_group_INTERNAL(const int eid, CUDTGroup* g)
 {
     return epoll_remove_entity(eid, g);
 }
 #endif
 
-void srt::CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
+void CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
 {
     CUDTSocket* s = 0;
 
@@ -2916,27 +2918,27 @@ void srt::CUDTUnited::epoll_remove_usock(const int eid, const SRTSOCKET u)
     return m_EPoll.update_usock(eid, u, &no_events);
 }
 
-void srt::CUDTUnited::epoll_remove_ssock(const int eid, const SYSSOCKET s)
+void CUDTUnited::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
     return m_EPoll.remove_ssock(eid, s);
 }
 
-int srt::CUDTUnited::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
+int CUDTUnited::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
     return m_EPoll.uwait(eid, fdsSet, fdsSize, msTimeOut);
 }
 
-int32_t srt::CUDTUnited::epoll_set(int eid, int32_t flags)
+int32_t CUDTUnited::epoll_set(int eid, int32_t flags)
 {
     return m_EPoll.setflags(eid, flags);
 }
 
-void srt::CUDTUnited::epoll_release(const int eid)
+void CUDTUnited::epoll_release(const int eid)
 {
     return m_EPoll.release(eid);
 }
 
-srt::CUDTSocket* srt::CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling erh)
+CUDTSocket* CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling erh)
 {
     SharedLock cg(m_GlobControlLock);
     CUDTSocket* s = locateSocket_LOCKED(u);
@@ -2951,7 +2953,7 @@ srt::CUDTSocket* srt::CUDTUnited::locateSocket(const SRTSOCKET u, ErrorHandling 
 }
 
 // [[using locked(m_GlobControlLock)]];
-srt::CUDTSocket* srt::CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
+CUDTSocket* CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
 {
     sockets_t::iterator i = m_Sockets.find(u);
 
@@ -2964,7 +2966,7 @@ srt::CUDTSocket* srt::CUDTUnited::locateSocket_LOCKED(SRTSOCKET u)
 }
 
 #if ENABLE_BONDING
-srt::CUDTGroup* srt::CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling erh)
+CUDTGroup* CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling erh)
 {
     SharedLock cg(m_GlobControlLock);
 
@@ -2981,7 +2983,7 @@ srt::CUDTGroup* srt::CUDTUnited::locateAcquireGroup(SRTSOCKET u, ErrorHandling e
     return i->second;
 }
 
-srt::CUDTGroup* srt::CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
+CUDTGroup* CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
 {
     SharedLock cg(m_GlobControlLock);
     CUDTGroup* g = s->m_GroupOf;
@@ -2995,7 +2997,7 @@ srt::CUDTGroup* srt::CUDTUnited::acquireSocketsGroup(CUDTSocket* s)
 }
 #endif
 
-srt::CUDTSocket* srt::CUDTUnited::locateAcquireSocket(SRTSOCKET u, ErrorHandling erh)
+CUDTSocket* CUDTUnited::locateAcquireSocket(SRTSOCKET u, ErrorHandling erh)
 {
     SharedLock cg(m_GlobControlLock);
 
@@ -3011,7 +3013,7 @@ srt::CUDTSocket* srt::CUDTUnited::locateAcquireSocket(SRTSOCKET u, ErrorHandling
     return s;
 }
 
-bool srt::CUDTUnited::acquireSocket(CUDTSocket* s)
+bool CUDTUnited::acquireSocket(CUDTSocket* s)
 {
     // Note that before using this function you must be certain
     // that the socket isn't broken already and it still has at least
@@ -3034,7 +3036,7 @@ bool srt::CUDTUnited::acquireSocket(CUDTSocket* s)
     return true;
 }
 
-srt::CUDTSocket* srt::CUDTUnited::locatePeer(const sockaddr_any& peer, const SRTSOCKET id, int32_t isn)
+CUDTSocket* CUDTUnited::locatePeer(const sockaddr_any& peer, const SRTSOCKET id, int32_t isn)
 {
     SharedLock cg(m_GlobControlLock);
 
@@ -3058,7 +3060,7 @@ srt::CUDTSocket* srt::CUDTUnited::locatePeer(const sockaddr_any& peer, const SRT
     return NULL;
 }
 
-void srt::CUDTUnited::checkBrokenSockets()
+void CUDTUnited::checkBrokenSockets()
 {
     ExclusiveLock cg(m_GlobControlLock);
 
@@ -3242,7 +3244,7 @@ void srt::CUDTUnited::checkBrokenSockets()
 }
 
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
+void CUDTUnited::removeSocket(const SRTSOCKET u)
 {
     sockets_t::iterator i = m_ClosedSockets.find(u);
 
@@ -3365,7 +3367,7 @@ void srt::CUDTUnited::removeSocket(const SRTSOCKET u)
 /// @param mid Muxer ID that identifies the multiplexer in the socket
 /// @param u Socket ID that was the last multiplexer's user (logging only)
 // [[using locked(m_GlobControlLock)]]
-void srt::CUDTUnited::removeMux(const int mid)
+void CUDTUnited::removeMux(const int mid)
 {
     // Ignore those never bound
     if (mid == -1)
@@ -3406,7 +3408,7 @@ void srt::CUDTUnited::removeMux(const int mid)
     }
 }
 
-void srt::CUDTUnited::checkTemporaryDatabases()
+void CUDTUnited::checkTemporaryDatabases()
 {
     ExclusiveLock cg(m_GlobControlLock);
 
@@ -3431,7 +3433,7 @@ void srt::CUDTUnited::checkTemporaryDatabases()
         m_ClosedDatabase.erase(*i);
 }
 
-void srt::CUDTUnited::configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int af)
+void CUDTUnited::configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int af)
 {
     w_m.m_mcfg       = s->core().m_config;
     w_m.m_iIPversion = af;
@@ -3439,7 +3441,7 @@ void srt::CUDTUnited::configureMuxer(CMultiplexer& w_m, const CUDTSocket* s, int
     w_m.m_iID        = int32_t(s->m_SocketID);
 }
 
-uint16_t srt::CUDTUnited::installMuxer(CUDTSocket* w_s, CMultiplexer& fw_sm)
+uint16_t CUDTUnited::installMuxer(CUDTSocket* w_s, CMultiplexer& fw_sm)
 {
     w_s->core().m_pSndQueue = fw_sm.m_pSndQueue;
     w_s->core().m_pRcvQueue = fw_sm.m_pRcvQueue;
@@ -3450,7 +3452,7 @@ uint16_t srt::CUDTUnited::installMuxer(CUDTSocket* w_s, CMultiplexer& fw_sm)
     return sa.hport();
 }
 
-bool srt::CUDTUnited::inet6SettingsCompat(const sockaddr_any& muxaddr, const CSrtMuxerConfig& cfgMuxer,
+bool CUDTUnited::inet6SettingsCompat(const sockaddr_any& muxaddr, const CSrtMuxerConfig& cfgMuxer,
         const sockaddr_any& reqaddr, const CSrtMuxerConfig& cfgSocket)
 {
     if (muxaddr.family() != AF_INET6)
@@ -3469,7 +3471,7 @@ bool srt::CUDTUnited::inet6SettingsCompat(const sockaddr_any& muxaddr, const CSr
     return true;
 }
 
-bool srt::CUDTUnited::channelSettingsMatch(const CSrtMuxerConfig& cfgMuxer, const CSrtConfig& cfgSocket)
+bool CUDTUnited::channelSettingsMatch(const CSrtMuxerConfig& cfgMuxer, const CSrtConfig& cfgSocket)
 {
     if (!cfgMuxer.bReuseAddr)
     {
@@ -3484,7 +3486,7 @@ bool srt::CUDTUnited::channelSettingsMatch(const CSrtMuxerConfig& cfgMuxer, cons
     return false;
 }
 
-void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& reqaddr, const UDPSOCKET* udpsock /*[[nullable]]*/)
+void CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& reqaddr, const UDPSOCKET* udpsock /*[[nullable]]*/)
 {
     ExclusiveLock cg(m_GlobControlLock);
 
@@ -3798,7 +3800,7 @@ void srt::CUDTUnited::updateMux(CUDTSocket* s, const sockaddr_any& reqaddr, cons
 // exists, otherwise the dispatching procedure wouldn't even call this
 // function. By historical reasons there's also a fallback for a case when the
 // multiplexer wasn't found by id, the search by port number continues.
-bool srt::CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
+bool CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
 {
     ExclusiveLock cg(m_GlobControlLock);
     const int  port = ls->m_SelfAddr.hport();
@@ -3885,7 +3887,7 @@ bool srt::CUDTUnited::updateListenerMux(CUDTSocket* s, const CUDTSocket* ls)
     return false;
 }
 
-void* srt::CUDTUnited::garbageCollect(void* p)
+void* CUDTUnited::garbageCollect(void* p)
 {
     CUDTUnited* self = (CUDTUnited*)p;
 
@@ -3911,17 +3913,17 @@ void* srt::CUDTUnited::garbageCollect(void* p)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-SRTRUNSTATUS srt::CUDT::startup()
+SRTRUNSTATUS CUDT::startup()
 {
     return uglobal().startup();
 }
 
-SRTSTATUS srt::CUDT::cleanup()
+SRTSTATUS CUDT::cleanup()
 {
     return uglobal().cleanup();
 }
 
-SRTSOCKET srt::CUDT::socket()
+SRTSOCKET CUDT::socket()
 {
     try
     {
@@ -3945,17 +3947,17 @@ SRTSOCKET srt::CUDT::socket()
     }
 }
 
-srt::CUDT::APIError::APIError(const CUDTException& e)
+CUDT::APIError::APIError(const CUDTException& e)
 {
     SetThreadLocalError(e);
 }
 
-srt::CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
+CUDT::APIError::APIError(CodeMajor mj, CodeMinor mn, int syserr)
 {
     SetThreadLocalError(CUDTException(mj, mn, syserr));
 }
 
-srt::CUDT::APIError::APIError(int errorcode)
+CUDT::APIError::APIError(int errorcode)
 {
     CodeMajor mj = CodeMajor(errorcode / 1000);
     CodeMinor mn = CodeMinor(errorcode % 1000);
@@ -3967,7 +3969,7 @@ srt::CUDT::APIError::APIError(int errorcode)
 // This doesn't have argument of GroupType due to header file conflicts.
 
 // [[using locked(s_UDTUnited.m_GlobControlLock)]]
-srt::CUDTGroup& srt::CUDTUnited::newGroup(const int type)
+CUDTGroup& CUDTUnited::newGroup(const int type)
 {
     const SRTSOCKET id = generateSocketID(true);
 
@@ -3975,11 +3977,11 @@ srt::CUDTGroup& srt::CUDTUnited::newGroup(const int type)
     return addGroup(id, SRT_GROUP_TYPE(type)).set_id(id);
 }
 
-SRTSOCKET srt::CUDT::createGroup(SRT_GROUP_TYPE gt)
+SRTSOCKET CUDT::createGroup(SRT_GROUP_TYPE gt)
 {
     try
     {
-        srt::sync::ExclusiveLock globlock(uglobal().m_GlobControlLock);
+        sync::ExclusiveLock globlock(uglobal().m_GlobControlLock);
         return uglobal().newGroup(gt).id();
         // Note: potentially, after this function exits, the group
         // could be deleted, immediately, from a separate thread (tho
@@ -3999,7 +4001,7 @@ SRTSOCKET srt::CUDT::createGroup(SRT_GROUP_TYPE gt)
 
 // [[using locked(m_ControlLock)]]
 // [[using locked(CUDT::s_UDTUnited.m_GlobControlLock)]]
-void srt::CUDTSocket::removeFromGroup(bool broken)
+void CUDTSocket::removeFromGroup(bool broken)
 {
     CUDTGroup* g = m_GroupOf;
     if (g)
@@ -4029,7 +4031,7 @@ void srt::CUDTSocket::removeFromGroup(bool broken)
     }
 }
 
-SRTSOCKET srt::CUDT::getGroupOfSocket(SRTSOCKET socket)
+SRTSOCKET CUDT::getGroupOfSocket(SRTSOCKET socket)
 {
     // Lock this for the whole function as we need the group
     // to persist the call.
@@ -4041,7 +4043,7 @@ SRTSOCKET srt::CUDT::getGroupOfSocket(SRTSOCKET socket)
     return s->m_GroupOf->id();
 }
 
-SRTSTATUS srt::CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize)
+SRTSTATUS CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, size_t* psize)
 {
     if (!CUDT::isgroup(groupid) || !psize)
     {
@@ -4059,7 +4061,7 @@ SRTSTATUS srt::CUDT::getGroupData(SRTSOCKET groupid, SRT_SOCKGROUPDATA* pdata, s
 }
 #endif
 
-SRTSTATUS srt::CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
+SRTSTATUS CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
 {
     try
     {
@@ -4093,7 +4095,7 @@ SRTSTATUS srt::CUDT::bind(SRTSOCKET u, const sockaddr* name, int namelen)
     }
 }
 
-SRTSTATUS srt::CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
+SRTSTATUS CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
 {
     try
     {
@@ -4118,7 +4120,7 @@ SRTSTATUS srt::CUDT::bind(SRTSOCKET u, UDPSOCKET udpsock)
     }
 }
 
-SRTSTATUS srt::CUDT::listen(SRTSOCKET u, int backlog)
+SRTSTATUS CUDT::listen(SRTSOCKET u, int backlog)
 {
     try
     {
@@ -4139,7 +4141,7 @@ SRTSTATUS srt::CUDT::listen(SRTSOCKET u, int backlog)
     }
 }
 
-SRTSOCKET srt::CUDT::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut)
+SRTSOCKET CUDT::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t msTimeOut)
 {
     try
     {
@@ -4163,7 +4165,7 @@ SRTSOCKET srt::CUDT::accept_bond(const SRTSOCKET listeners[], int lsize, int64_t
     }
 }
 
-SRTSOCKET srt::CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
+SRTSOCKET CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
 {
     try
     {
@@ -4187,7 +4189,7 @@ SRTSOCKET srt::CUDT::accept(SRTSOCKET u, sockaddr* addr, int* addrlen)
     }
 }
 
-SRTSOCKET srt::CUDT::connect(SRTSOCKET u, const sockaddr* name, const sockaddr* tname, int namelen)
+SRTSOCKET CUDT::connect(SRTSOCKET u, const sockaddr* name, const sockaddr* tname, int namelen)
 {
     try
     {
@@ -4209,7 +4211,7 @@ SRTSOCKET srt::CUDT::connect(SRTSOCKET u, const sockaddr* name, const sockaddr* 
 }
 
 #if ENABLE_BONDING
-SRTSOCKET srt::CUDT::connectLinks(SRTSOCKET grp, SRT_SOCKGROUPCONFIG targets[], int arraysize)
+SRTSOCKET CUDT::connectLinks(SRTSOCKET grp, SRT_SOCKGROUPCONFIG targets[], int arraysize)
 {
     if (arraysize <= 0)
         return APIError(MJ_NOTSUP, MN_INVAL, 0), SRT_INVALID_SOCK;
@@ -4241,7 +4243,7 @@ SRTSOCKET srt::CUDT::connectLinks(SRTSOCKET grp, SRT_SOCKGROUPCONFIG targets[], 
 }
 #endif
 
-SRTSOCKET srt::CUDT::connect(SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
+SRTSOCKET CUDT::connect(SRTSOCKET u, const sockaddr* name, int namelen, int32_t forced_isn)
 {
     try
     {
@@ -4262,7 +4264,7 @@ SRTSOCKET srt::CUDT::connect(SRTSOCKET u, const sockaddr* name, int namelen, int
     }
 }
 
-SRTSTATUS srt::CUDT::close(SRTSOCKET u, int reason)
+SRTSTATUS CUDT::close(SRTSOCKET u, int reason)
 {
     try
     {
@@ -4279,7 +4281,7 @@ SRTSTATUS srt::CUDT::close(SRTSOCKET u, int reason)
     }
 }
 
-SRTSTATUS srt::CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
+SRTSTATUS CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
 {
     try
     {
@@ -4297,7 +4299,7 @@ SRTSTATUS srt::CUDT::getpeername(SRTSOCKET u, sockaddr* name, int* namelen)
     }
 }
 
-SRTSTATUS srt::CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
+SRTSTATUS CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
 {
     try
     {
@@ -4315,7 +4317,7 @@ SRTSTATUS srt::CUDT::getsockname(SRTSOCKET u, sockaddr* name, int* namelen)
     }
 }
 
-SRTSTATUS srt::CUDT::getsockdevname(SRTSOCKET u, char* name, size_t* namelen)
+SRTSTATUS CUDT::getsockdevname(SRTSOCKET u, char* name, size_t* namelen)
 {
     try
     {
@@ -4333,7 +4335,7 @@ SRTSTATUS srt::CUDT::getsockdevname(SRTSOCKET u, char* name, size_t* namelen)
     }
 }
 
-SRTSTATUS srt::CUDT::getsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_optval, int* pw_optlen)
+SRTSTATUS CUDT::getsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_optval, int* pw_optlen)
 {
     if (!pw_optval || !pw_optlen)
     {
@@ -4366,7 +4368,7 @@ SRTSTATUS srt::CUDT::getsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, void* pw_
     }
 }
 
-SRTSTATUS srt::CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, int optlen)
+SRTSTATUS CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const void* optval, int optlen)
 {
     if (!optval || optlen < 0)
         return APIError(MJ_NOTSUP, MN_INVAL, 0);
@@ -4397,7 +4399,7 @@ SRTSTATUS srt::CUDT::setsockopt(SRTSOCKET u, int, SRT_SOCKOPT optname, const voi
     }
 }
 
-int srt::CUDT::send(SRTSOCKET u, const char* buf, int len, int)
+int CUDT::send(SRTSOCKET u, const char* buf, int len, int)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     return sendmsg2(u, buf, len, (mctrl));
@@ -4405,7 +4407,7 @@ int srt::CUDT::send(SRTSOCKET u, const char* buf, int len, int)
 
 // --> CUDT::recv moved down
 
-int srt::CUDT::sendmsg(SRTSOCKET u, const char* buf, int len, int ttl, bool inorder, int64_t srctime)
+int CUDT::sendmsg(SRTSOCKET u, const char* buf, int len, int ttl, bool inorder, int64_t srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     mctrl.msgttl      = ttl;
@@ -4414,7 +4416,7 @@ int srt::CUDT::sendmsg(SRTSOCKET u, const char* buf, int len, int ttl, bool inor
     return sendmsg2(u, buf, len, (mctrl));
 }
 
-int srt::CUDT::sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
+int CUDT::sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
 {
     try
     {
@@ -4443,14 +4445,14 @@ int srt::CUDT::sendmsg2(SRTSOCKET u, const char* buf, int len, SRT_MSGCTRL& w_m)
     }
 }
 
-int srt::CUDT::recv(SRTSOCKET u, char* buf, int len, int)
+int CUDT::recv(SRTSOCKET u, char* buf, int len, int)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     int         ret   = recvmsg2(u, buf, len, (mctrl));
     return ret;
 }
 
-int srt::CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
+int CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     int         ret   = recvmsg2(u, buf, len, (mctrl));
@@ -4458,7 +4460,7 @@ int srt::CUDT::recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
     return ret;
 }
 
-int srt::CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
+int CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
 {
     try
     {
@@ -4483,7 +4485,7 @@ int srt::CUDT::recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_m)
     }
 }
 
-int64_t srt::CUDT::sendfile(SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
+int64_t CUDT::sendfile(SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
 {
     try
     {
@@ -4505,7 +4507,7 @@ int64_t srt::CUDT::sendfile(SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t 
     }
 }
 
-int64_t srt::CUDT::recvfile(SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
+int64_t CUDT::recvfile(SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
 {
     try
     {
@@ -4522,7 +4524,7 @@ int64_t srt::CUDT::recvfile(SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t 
     }
 }
 
-int srt::CUDT::select(int, UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout)
+int CUDT::select(int, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, std::set<SRTSOCKET>* exceptfds, const timeval* timeout)
 {
     if ((!readfds) && (!writefds) && (!exceptfds))
     {
@@ -4548,7 +4550,7 @@ int srt::CUDT::select(int, UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET
     }
 }
 
-int srt::CUDT::selectEx(const vector<SRTSOCKET>& fds,
+int CUDT::selectEx(const vector<SRTSOCKET>& fds,
                         vector<SRTSOCKET>*       readfds,
                         vector<SRTSOCKET>*       writefds,
                         vector<SRTSOCKET>*       exceptfds,
@@ -4578,7 +4580,7 @@ int srt::CUDT::selectEx(const vector<SRTSOCKET>& fds,
     }
 }
 
-int srt::CUDT::epoll_create()
+int CUDT::epoll_create()
 {
     try
     {
@@ -4595,7 +4597,7 @@ int srt::CUDT::epoll_create()
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_clear_usocks(int eid)
+SRTSTATUS CUDT::epoll_clear_usocks(int eid)
 {
     try
     {
@@ -4614,7 +4616,7 @@ SRTSTATUS srt::CUDT::epoll_clear_usocks(int eid)
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
+SRTSTATUS CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int* events)
 {
     try
     {
@@ -4632,7 +4634,7 @@ SRTSTATUS srt::CUDT::epoll_add_usock(const int eid, const SRTSOCKET u, const int
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
+SRTSTATUS CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
     try
     {
@@ -4650,7 +4652,7 @@ SRTSTATUS srt::CUDT::epoll_add_ssock(const int eid, const SYSSOCKET s, const int
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_update_usock(const int eid, const SRTSOCKET u, const int* events)
+SRTSTATUS CUDT::epoll_update_usock(const int eid, const SRTSOCKET u, const int* events)
 {
     try
     {
@@ -4669,7 +4671,7 @@ SRTSTATUS srt::CUDT::epoll_update_usock(const int eid, const SRTSOCKET u, const 
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events)
+SRTSTATUS CUDT::epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events)
 {
     try
     {
@@ -4688,7 +4690,7 @@ SRTSTATUS srt::CUDT::epoll_update_ssock(const int eid, const SYSSOCKET s, const 
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
+SRTSTATUS CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
 {
     try
     {
@@ -4707,7 +4709,7 @@ SRTSTATUS srt::CUDT::epoll_remove_usock(const int eid, const SRTSOCKET u)
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
+SRTSTATUS CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
 {
     try
     {
@@ -4726,7 +4728,7 @@ SRTSTATUS srt::CUDT::epoll_remove_ssock(const int eid, const SYSSOCKET s)
     }
 }
 
-int srt::CUDT::epoll_wait(const int       eid,
+int CUDT::epoll_wait(const int       eid,
                           set<SRTSOCKET>* readfds,
                           set<SRTSOCKET>* writefds,
                           int64_t         msTimeOut,
@@ -4748,7 +4750,7 @@ int srt::CUDT::epoll_wait(const int       eid,
     }
 }
 
-int srt::CUDT::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
+int CUDT::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
     try
     {
@@ -4765,7 +4767,7 @@ int srt::CUDT::epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, 
     }
 }
 
-int32_t srt::CUDT::epoll_set(const int eid, int32_t flags)
+int32_t CUDT::epoll_set(const int eid, int32_t flags)
 {
     try
     {
@@ -4782,7 +4784,7 @@ int32_t srt::CUDT::epoll_set(const int eid, int32_t flags)
     }
 }
 
-SRTSTATUS srt::CUDT::epoll_release(const int eid)
+SRTSTATUS CUDT::epoll_release(const int eid)
 {
     try
     {
@@ -4800,12 +4802,12 @@ SRTSTATUS srt::CUDT::epoll_release(const int eid)
     }
 }
 
-srt::CUDTException& srt::CUDT::getlasterror()
+CUDTException& CUDT::getlasterror()
 {
     return GetThreadLocalError();
 }
 
-SRTSTATUS srt::CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
+SRTSTATUS CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool instantaneous)
 {
 #if ENABLE_BONDING
     if (CUDT::isgroup(u))
@@ -4830,7 +4832,7 @@ SRTSTATUS srt::CUDT::bstats(SRTSOCKET u, CBytePerfMon* perf, bool clear, bool in
 }
 
 #if ENABLE_BONDING
-SRTSTATUS srt::CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
+SRTSTATUS CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear)
 {
     try
     {
@@ -4852,7 +4854,7 @@ SRTSTATUS srt::CUDT::groupsockbstats(SRTSOCKET u, CBytePerfMon* perf, bool clear
 }
 #endif
 
-srt::CUDT* srt::CUDT::getUDTHandle(SRTSOCKET u)
+CUDT* CUDT::getUDTHandle(SRTSOCKET u)
 {
     try
     {
@@ -4871,7 +4873,7 @@ srt::CUDT* srt::CUDT::getUDTHandle(SRTSOCKET u)
     }
 }
 
-SRT_SOCKSTATUS srt::CUDT::getsockstate(SRTSOCKET u)
+SRT_SOCKSTATUS CUDT::getsockstate(SRTSOCKET u)
 {
     try
     {
@@ -4897,12 +4899,12 @@ SRT_SOCKSTATUS srt::CUDT::getsockstate(SRTSOCKET u)
     }
 }
 
-int srt::CUDT::getMaxPayloadSize(SRTSOCKET id)
+int CUDT::getMaxPayloadSize(SRTSOCKET id)
 {
     return uglobal().getMaxPayloadSize(id);
 }
 
-int srt::CUDTUnited::getMaxPayloadSize(SRTSOCKET id)
+int CUDTUnited::getMaxPayloadSize(SRTSOCKET id)
 {
     CUDTSocket* s = locateSocket(id);
     if (!s)
@@ -4938,194 +4940,6 @@ int srt::CUDTUnited::getMaxPayloadSize(SRTSOCKET id)
     return payload_size;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
-namespace UDT
-{
-
-SRTRUNSTATUS startup()
-{
-    return srt::CUDT::startup();
-}
-
-SRTSTATUS cleanup()
-{
-    return srt::CUDT::cleanup();
-}
-
-SRTSTATUS bind(SRTSOCKET u, const struct sockaddr* name, int namelen)
-{
-    return srt::CUDT::bind(u, name, namelen);
-}
-
-SRTSTATUS bind2(SRTSOCKET u, UDPSOCKET udpsock)
-{
-    return srt::CUDT::bind(u, udpsock);
-}
-
-SRTSTATUS listen(SRTSOCKET u, int backlog)
-{
-    return srt::CUDT::listen(u, backlog);
-}
-
-SRTSOCKET accept(SRTSOCKET u, struct sockaddr* addr, int* addrlen)
-{
-    return srt::CUDT::accept(u, addr, addrlen);
-}
-
-SRTSOCKET connect(SRTSOCKET u, const struct sockaddr* name, int namelen)
-{
-    return srt::CUDT::connect(u, name, namelen, SRT_SEQNO_NONE);
-}
-
-SRTSTATUS close(SRTSOCKET u)
-{
-    return srt::CUDT::close(u, SRT_CLS_API);
-}
-
-SRTSTATUS getpeername(SRTSOCKET u, struct sockaddr* name, int* namelen)
-{
-    return srt::CUDT::getpeername(u, name, namelen);
-}
-
-SRTSTATUS getsockname(SRTSOCKET u, struct sockaddr* name, int* namelen)
-{
-    return srt::CUDT::getsockname(u, name, namelen);
-}
-
-SRTSTATUS getsockopt(SRTSOCKET u, int level, SRT_SOCKOPT optname, void* optval, int* optlen)
-{
-    return srt::CUDT::getsockopt(u, level, optname, optval, optlen);
-}
-
-SRTSTATUS setsockopt(SRTSOCKET u, int level, SRT_SOCKOPT optname, const void* optval, int optlen)
-{
-    return srt::CUDT::setsockopt(u, level, optname, optval, optlen);
-}
-
-// DEVELOPER API
-
-SRTSOCKET connect_debug(SRTSOCKET u, const struct sockaddr* name, int namelen, int32_t forced_isn)
-{
-    return srt::CUDT::connect(u, name, namelen, forced_isn);
-}
-
-int send(SRTSOCKET u, const char* buf, int len, int flags)
-{
-    return srt::CUDT::send(u, buf, len, flags);
-}
-
-int recv(SRTSOCKET u, char* buf, int len, int flags)
-{
-    return srt::CUDT::recv(u, buf, len, flags);
-}
-
-int sendmsg(SRTSOCKET u, const char* buf, int len, int ttl, bool inorder, int64_t srctime)
-{
-    return srt::CUDT::sendmsg(u, buf, len, ttl, inorder, srctime);
-}
-
-int recvmsg(SRTSOCKET u, char* buf, int len, int64_t& srctime)
-{
-    return srt::CUDT::recvmsg(u, buf, len, srctime);
-}
-
-int recvmsg(SRTSOCKET u, char* buf, int len)
-{
-    int64_t srctime;
-    return srt::CUDT::recvmsg(u, buf, len, srctime);
-}
-
-int64_t sendfile(SRTSOCKET u, fstream& ifs, int64_t& offset, int64_t size, int block)
-{
-    return srt::CUDT::sendfile(u, ifs, offset, size, block);
-}
-
-int64_t recvfile(SRTSOCKET u, fstream& ofs, int64_t& offset, int64_t size, int block)
-{
-    return srt::CUDT::recvfile(u, ofs, offset, size, block);
-}
-
-int64_t sendfile2(SRTSOCKET u, const char* path, int64_t* offset, int64_t size, int block)
-{
-    fstream ifs(path, ios::binary | ios::in);
-    int64_t ret = srt::CUDT::sendfile(u, ifs, *offset, size, block);
-    ifs.close();
-    return ret;
-}
-
-int64_t recvfile2(SRTSOCKET u, const char* path, int64_t* offset, int64_t size, int block)
-{
-    fstream ofs(path, ios::binary | ios::out);
-    int64_t ret = srt::CUDT::recvfile(u, ofs, *offset, size, block);
-    ofs.close();
-    return ret;
-}
-
-int select(int nfds, UDSET* readfds, UDSET* writefds, UDSET* exceptfds, const struct timeval* timeout)
-{
-    return srt::CUDT::select(nfds, readfds, writefds, exceptfds, timeout);
-}
-
-int selectEx(const vector<SRTSOCKET>& fds,
-             vector<SRTSOCKET>*       readfds,
-             vector<SRTSOCKET>*       writefds,
-             vector<SRTSOCKET>*       exceptfds,
-             int64_t                  msTimeOut)
-{
-    return srt::CUDT::selectEx(fds, readfds, writefds, exceptfds, msTimeOut);
-}
-
-int epoll_create()
-{
-    return srt::CUDT::epoll_create();
-}
-
-SRTSTATUS epoll_clear_usocks(int eid)
-{
-    return srt::CUDT::epoll_clear_usocks(eid);
-}
-
-SRTSTATUS epoll_add_usock(int eid, SRTSOCKET u, const int* events)
-{
-    return srt::CUDT::epoll_add_usock(eid, u, events);
-}
-
-SRTSTATUS epoll_add_ssock(int eid, SYSSOCKET s, const int* events)
-{
-    return srt::CUDT::epoll_add_ssock(eid, s, events);
-}
-
-SRTSTATUS epoll_update_usock(int eid, SRTSOCKET u, const int* events)
-{
-    return srt::CUDT::epoll_update_usock(eid, u, events);
-}
-
-SRTSTATUS epoll_update_ssock(int eid, SYSSOCKET s, const int* events)
-{
-    return srt::CUDT::epoll_update_ssock(eid, s, events);
-}
-
-SRTSTATUS epoll_remove_usock(int eid, SRTSOCKET u)
-{
-    return srt::CUDT::epoll_remove_usock(eid, u);
-}
-
-SRTSTATUS epoll_remove_ssock(int eid, SYSSOCKET s)
-{
-    return srt::CUDT::epoll_remove_ssock(eid, s);
-}
-
-int epoll_wait(int             eid,
-               set<SRTSOCKET>* readfds,
-               set<SRTSOCKET>* writefds,
-               int64_t         msTimeOut,
-               set<SYSSOCKET>* lrfds,
-               set<SYSSOCKET>* lwfds)
-{
-    return srt::CUDT::epoll_wait(eid, readfds, writefds, msTimeOut, lrfds, lwfds);
-}
-
 template <class SOCKTYPE>
 inline void set_result(set<SOCKTYPE>* val, int* num, SOCKTYPE* fds)
 {
@@ -5145,7 +4959,7 @@ inline void set_result(set<SOCKTYPE>* val, int* num, SOCKTYPE* fds)
     }
 }
 
-int epoll_wait2(int        eid,
+int CUDT::epoll_wait2(int        eid,
                 SRTSOCKET* readfds,
                 int*       rnum,
                 SRTSOCKET* writefds,
@@ -5179,7 +4993,7 @@ int epoll_wait2(int        eid,
     if ((lwfds != NULL) && (lwnum != NULL))
         lwval = &lwset;
 
-    int ret = srt::CUDT::epoll_wait(eid, rval, wval, msTimeOut, lrval, lwval);
+    int ret = epoll_wait(eid, rval, wval, msTimeOut, lrval, lwval);
     if (ret > 0)
     {
         // set<SRTSOCKET>::const_iterator i;
@@ -5196,58 +5010,6 @@ int epoll_wait2(int        eid,
     }
     return ret;
 }
-
-int epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
-{
-    return srt::CUDT::epoll_uwait(eid, fdsSet, fdsSize, msTimeOut);
-}
-
-SRTSTATUS epoll_release(int eid)
-{
-    return srt::CUDT::epoll_release(eid);
-}
-
-ERRORINFO& getlasterror()
-{
-    return srt::CUDT::getlasterror();
-}
-
-int getlasterror_code()
-{
-    return srt::CUDT::getlasterror().getErrorCode();
-}
-
-const char* getlasterror_desc()
-{
-    return srt::CUDT::getlasterror().getErrorMessage();
-}
-
-int getlasterror_errno()
-{
-    return srt::CUDT::getlasterror().getErrno();
-}
-
-// Get error string of a given error code
-const char* geterror_desc(int code, int err)
-{
-    srt::CUDTException e(CodeMajor(code / 1000), CodeMinor(code % 1000), err);
-    return (e.getErrorMessage());
-}
-
-SRTSTATUS bstats(SRTSOCKET u, SRT_TRACEBSTATS* perf, bool clear)
-{
-    return srt::CUDT::bstats(u, perf, clear);
-}
-
-SRT_SOCKSTATUS getsockstate(SRTSOCKET u)
-{
-    return srt::CUDT::getsockstate(u);
-}
-
-} // namespace UDT
-
-namespace srt
-{
 
 void setloglevel(LogLevel::type ll)
 {

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -57,7 +57,6 @@ modified by
 #include <vector>
 #include <string>
 #include "netinet_any.h"
-#include "udt.h"
 #include "packet.h"
 #include "queue.h"
 #include "cache.h"
@@ -124,7 +123,7 @@ public:
     void construct();
 
 private:
-    srt::sync::atomic<int> m_iBusy;
+    sync::atomic<int> m_iBusy;
 public:
     void apiAcquire() { ++m_iBusy; }
     void apiRelease() { --m_iBusy; }
@@ -338,7 +337,7 @@ public:
     void getpeername(const SRTSOCKET u, sockaddr* name, int* namelen);
     void getsockname(const SRTSOCKET u, sockaddr* name, int* namelen);
     void getsockdevname(const SRTSOCKET u, char* name, size_t* namelen);
-    int  select(UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout);
+    int  select(std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, std::set<SRTSOCKET>* exceptfds, const timeval* timeout);
     int  selectEx(const std::vector<SRTSOCKET>& fds,
                   std::vector<SRTSOCKET>*       readfds,
                   std::vector<SRTSOCKET>*       writefds,
@@ -386,7 +385,7 @@ public:
     // This is an internal function; 'type' should be pre-checked if it has a correct value.
     // This doesn't have argument of GroupType due to cross-interface conflicts.
     SRT_TSA_NEEDS_LOCKED(m_GlobControlLock)
-    srt::CUDTGroup& newGroup(const int type);
+    CUDTGroup& newGroup(const int type);
 
     SRT_TSA_NEEDS_NONLOCKED(m_GlobControlLock)
     void deleteGroup(CUDTGroup* g);

--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -45,6 +45,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cmath>
 #include <limits>
+#include <fstream>
 #include "buffer_rcv.h"
 #include "logging.h"
 
@@ -890,7 +891,7 @@ int CRcvBuffer::readBufferTo(int len, copy_to_dst_f funcCopyToDst, void* arg)
             return -1;
         }
 
-        const srt::CPacket& pkt = packetAt(p);
+        const CPacket& pkt = packetAt(p);
 
         if (bTsbPdEnabled)
         {

--- a/srtcore/buffer_snd.cpp
+++ b/srtcore/buffer_snd.cpp
@@ -53,6 +53,7 @@ modified by
 #include "platform_sys.h"
 
 #include <cmath>
+#include <fstream> // for debug purposes
 #include "buffer_snd.h"
 #include "packet.h"
 #include "core.h" // provides some constants

--- a/srtcore/byte_order.h
+++ b/srtcore/byte_order.h
@@ -1,0 +1,193 @@
+
+// Copied from: https://gist.github.com/panzi/6856583
+// License: Public Domain.
+
+#ifndef INC_HVU_BYTE_ORDER_H
+#define INC_HVU_BYTE_ORDER_H
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+#	define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || defined(__GLIBC__)
+
+#	include <endian.h>
+
+// GLIBC-2.8 and earlier does not provide these macros.
+// See http://linux.die.net/man/3/endian
+// From https://gist.github.com/panzi/6856583
+#   if defined(__GLIBC__) \
+      && ( !defined(__GLIBC_MINOR__) \
+         || ((__GLIBC__ < 2) \
+         || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ < 9))) )
+#       include <arpa/inet.h>
+#       if defined(__BYTE_ORDER) && (__BYTE_ORDER == __LITTLE_ENDIAN)
+
+#           define htole32(x) (x)
+#           define le32toh(x) (x)
+
+#       elif defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)
+
+#           define htole16(x) ((((((uint16_t)(x)) >> 8))|((((uint16_t)(x)) << 8)))
+#           define le16toh(x) ((((((uint16_t)(x)) >> 8))|((((uint16_t)(x)) << 8)))
+
+#           define htole32(x) (((uint32_t)htole16(((uint16_t)(((uint32_t)(x)) >> 16)))) | (((uint32_t)htole16(((uint16_t)(x)))) << 16))
+#           define le32toh(x) (((uint32_t)le16toh(((uint16_t)(((uint32_t)(x)) >> 16)))) | (((uint32_t)le16toh(((uint16_t)(x)))) << 16))
+
+#       else
+#           error Byte Order not supported or not defined.
+#       endif
+#   endif
+
+#elif defined(__APPLE__)
+
+#	include <libkern/OSByteOrder.h>
+
+#	define htobe16(x) OSSwapHostToBigInt16(x)
+#	define htole16(x) OSSwapHostToLittleInt16(x)
+#	define be16toh(x) OSSwapBigToHostInt16(x)
+#	define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#	define htobe32(x) OSSwapHostToBigInt32(x)
+#	define htole32(x) OSSwapHostToLittleInt32(x)
+#	define be32toh(x) OSSwapBigToHostInt32(x)
+#	define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#	define htobe64(x) OSSwapHostToBigInt64(x)
+#	define htole64(x) OSSwapHostToLittleInt64(x)
+#	define be64toh(x) OSSwapBigToHostInt64(x)
+#	define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+#	include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
+
+#	include <sys/endian.h>
+
+#ifndef be16toh
+#	define be16toh(x) betoh16(x)
+#endif
+#ifndef le16toh
+#	define le16toh(x) letoh16(x)
+#endif
+
+#ifndef be32toh
+#	define be32toh(x) betoh32(x)
+#endif
+#ifndef le32toh
+#	define le32toh(x) letoh32(x)
+#endif
+
+#ifndef be64toh
+#	define be64toh(x) betoh64(x)
+#endif
+#ifndef le64toh
+#	define le64toh(x) letoh64(x)
+#endif
+
+#elif defined(SUNOS)
+
+   // SunOS/Solaris
+
+   #include <sys/byteorder.h>
+   #include <sys/isa_defs.h>
+
+   #define __LITTLE_ENDIAN 1234
+   #define __BIG_ENDIAN 4321
+
+   # if defined(_BIG_ENDIAN)
+   #define __BYTE_ORDER __BIG_ENDIAN
+   #define be64toh(x) (x)
+   #define be32toh(x) (x)
+   #define be16toh(x) (x)
+   #define le16toh(x) ((uint16_t)BSWAP_16(x))
+   #define le32toh(x) BSWAP_32(x)
+   #define le64toh(x) BSWAP_64(x)
+   #define htobe16(x) (x)
+   #define htole16(x) ((uint16_t)BSWAP_16(x))
+   #define htobe32(x) (x)
+   #define htole32(x) BSWAP_32(x)
+   #define htobe64(x) (x)
+   #define htole64(x) BSWAP_64(x)
+   # else
+   #define __BYTE_ORDER __LITTLE_ENDIAN
+   #define be64toh(x) BSWAP_64(x)
+   #define be32toh(x) ntohl(x)
+   #define be16toh(x) ntohs(x)
+   #define le16toh(x) (x)
+   #define le32toh(x) (x)
+   #define le64toh(x) (x)
+   #define htobe16(x) htons(x)
+   #define htole16(x) (x)
+   #define htobe32(x) htonl(x)
+   #define htole32(x) (x)
+   #define htobe64(x) BSWAP_64(x)
+   #define htole64(x) (x)
+   # endif
+
+#elif defined(__WINDOWS__)
+
+#	include <winsock2.h>
+
+#	if BYTE_ORDER == LITTLE_ENDIAN
+
+#		define htobe16(x) htons(x)
+#		define htole16(x) (x)
+#		define be16toh(x) ntohs(x)
+#		define le16toh(x) (x)
+ 
+#		define htobe32(x) htonl(x)
+#		define htole32(x) (x)
+#		define be32toh(x) ntohl(x)
+#		define le32toh(x) (x)
+ 
+#		define htobe64(x) htonll(x)
+#		define htole64(x) (x)
+#		define be64toh(x) ntohll(x)
+#		define le64toh(x) (x)
+
+#	elif BYTE_ORDER == BIG_ENDIAN
+
+		/* that would be xbox 360 */
+#		define htobe16(x) (x)
+#		define htole16(x) __builtin_bswap16(x)
+#		define be16toh(x) (x)
+#		define le16toh(x) __builtin_bswap16(x)
+ 
+#		define htobe32(x) (x)
+#		define htole32(x) __builtin_bswap32(x)
+#		define be32toh(x) (x)
+#		define le32toh(x) __builtin_bswap32(x)
+ 
+#		define htobe64(x) (x)
+#		define htole64(x) __builtin_bswap64(x)
+#		define be64toh(x) (x)
+#		define le64toh(x) __builtin_bswap64(x)
+
+#	else
+
+#		error byte order not supported
+
+#	endif // BYTE_ORDER
+
+#	define __BYTE_ORDER    BYTE_ORDER
+#	define __BIG_ENDIAN    BIG_ENDIAN
+#	define __LITTLE_ENDIAN LITTLE_ENDIAN
+#	define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+#	error Endian: platform not supported
+
+#endif // Platform-dependent macro
+
+#endif // INC_HVU_BYTE_ORDER_H

--- a/srtcore/cache.cpp
+++ b/srtcore/cache.cpp
@@ -46,7 +46,10 @@ written by
 
 using namespace std;
 
-srt::CInfoBlock& srt::CInfoBlock::copyFrom(const CInfoBlock& obj)
+namespace srt
+{
+
+CInfoBlock& CInfoBlock::copyFrom(const CInfoBlock& obj)
 {
     std::copy(obj.m_piIP, obj.m_piIP + 4, m_piIP);
     m_iIPversion       = obj.m_iIPversion;
@@ -61,7 +64,7 @@ srt::CInfoBlock& srt::CInfoBlock::copyFrom(const CInfoBlock& obj)
     return *this;
 }
 
-bool srt::CInfoBlock::operator==(const CInfoBlock& obj) const
+bool CInfoBlock::operator==(const CInfoBlock& obj) const
 {
     if (m_iIPversion != obj.m_iIPversion)
         return false;
@@ -78,7 +81,7 @@ bool srt::CInfoBlock::operator==(const CInfoBlock& obj) const
     return true;
 }
 
-srt::CInfoBlock* srt::CInfoBlock::clone()
+CInfoBlock* CInfoBlock::clone()
 {
     CInfoBlock* obj = new CInfoBlock;
 
@@ -95,7 +98,7 @@ srt::CInfoBlock* srt::CInfoBlock::clone()
     return obj;
 }
 
-int srt::CInfoBlock::getKey()
+int CInfoBlock::getKey()
 {
     if (m_iIPversion == AF_INET)
         return m_piIP[0];
@@ -103,7 +106,7 @@ int srt::CInfoBlock::getKey()
     return m_piIP[0] + m_piIP[1] + m_piIP[2] + m_piIP[3];
 }
 
-void srt::CInfoBlock::convert(const sockaddr_any& addr, uint32_t aw_ip[4])
+void CInfoBlock::convert(const sockaddr_any& addr, uint32_t aw_ip[4])
 {
     if (addr.family() == AF_INET)
     {
@@ -115,3 +118,5 @@ void srt::CInfoBlock::convert(const sockaddr_any& addr, uint32_t aw_ip[4])
         memcpy((aw_ip), addr.sin6.sin6_addr.s6_addr, sizeof addr.sin6.sin6_addr.s6_addr);
     }
 }
+
+} // END namespace srt

--- a/srtcore/cache.h
+++ b/srtcore/cache.h
@@ -46,7 +46,6 @@ written by
 
 #include "sync.h"
 #include "netinet_any.h"
-#include "udt.h"
 
 namespace srt
 {
@@ -88,7 +87,7 @@ public:
     {
         m_vHashPtr.resize(m_iHashSize);
         // Exception: -> CUDTUnited ctor
-        srt::sync::setupMutex(m_Lock, "Cache");
+        sync::setupMutex(m_Lock, "Cache");
     }
 
     ~CCache() { clear(); }
@@ -100,7 +99,7 @@ public:
 
     int lookup(T* data)
     {
-        srt::sync::ScopedLock cacheguard(m_Lock);
+        sync::ScopedLock cacheguard(m_Lock);
 
         int key = data->getKey();
         if (key < 0)
@@ -128,7 +127,7 @@ public:
 
     int update(T* data)
     {
-        srt::sync::ScopedLock cacheguard(m_Lock);
+        sync::ScopedLock cacheguard(m_Lock);
 
         int key = data->getKey();
         if (key < 0)
@@ -226,7 +225,7 @@ private:
     int m_iHashSize;
     int m_iCurrSize;
 
-    srt::sync::Mutex m_Lock;
+    sync::Mutex m_Lock;
 
 private:
     CCache(const CCache&);

--- a/srtcore/channel.cpp
+++ b/srtcore/channel.cpp
@@ -134,9 +134,8 @@ static int set_cloexec(int fd, int set)
 #endif // if defined(_AIX) ...
 #endif // ifndef _WIN32
 #endif // if ENABLE_CLOEXEC
-} // namespace srt
 
-srt::CChannel::CChannel()
+CChannel::CChannel()
     : m_iSocket(INVALID_SOCKET)
 #ifdef SRT_ENABLE_PKTINFO
     , m_bBindMasked(true)
@@ -157,9 +156,9 @@ srt::CChannel::CChannel()
 #endif
 }
 
-srt::CChannel::~CChannel() {}
+CChannel::~CChannel() {}
 
-void srt::CChannel::createSocket(int family)
+void CChannel::createSocket(int family)
 {
 #if ENABLE_SOCK_CLOEXEC
     bool cloexec_flag = false;
@@ -215,7 +214,7 @@ void srt::CChannel::createSocket(int family)
     }
 }
 
-void srt::CChannel::open(const sockaddr_any& addr)
+void CChannel::open(const sockaddr_any& addr)
 {
     createSocket(addr.family());
     socklen_t namelen = addr.size();
@@ -232,7 +231,7 @@ void srt::CChannel::open(const sockaddr_any& addr)
     setUDPSockOpt();
 }
 
-void srt::CChannel::open(int family)
+void CChannel::open(int family)
 {
     createSocket(family);
 
@@ -280,7 +279,7 @@ void srt::CChannel::open(int family)
     setUDPSockOpt();
 }
 
-void srt::CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
+void CChannel::attach(UDPSOCKET udpsock, const sockaddr_any& udpsocks_addr)
 {
     // The getsockname() call is done before calling it and the
     // result is placed into udpsocks_addr.
@@ -303,7 +302,7 @@ static inline string fmt_alt(bool value, const string& label, const string& unla
     return value ? label : unlabel;
 }
 
-void srt::CChannel::setUDPSockOpt()
+void CChannel::setUDPSockOpt()
 {
 #if defined(SUNOS)
     {
@@ -580,7 +579,7 @@ void srt::CChannel::setUDPSockOpt()
 #endif
 }
 
-void srt::CChannel::close() const
+void CChannel::close() const
 {
 #ifndef _WIN32
     ::close(m_iSocket);
@@ -589,31 +588,31 @@ void srt::CChannel::close() const
 #endif
 }
 
-int srt::CChannel::getSndBufSize()
+int CChannel::getSndBufSize()
 {
     socklen_t size = (socklen_t)sizeof m_mcfg.iUDPSndBufSize;
     ::getsockopt(m_iSocket, SOL_SOCKET, SO_SNDBUF, (char*)&m_mcfg.iUDPSndBufSize, &size);
     return m_mcfg.iUDPSndBufSize;
 }
 
-int srt::CChannel::getRcvBufSize()
+int CChannel::getRcvBufSize()
 {
     socklen_t size = (socklen_t)sizeof m_mcfg.iUDPRcvBufSize;
     ::getsockopt(m_iSocket, SOL_SOCKET, SO_RCVBUF, (char*)&m_mcfg.iUDPRcvBufSize, &size);
     return m_mcfg.iUDPRcvBufSize;
 }
 
-void srt::CChannel::setConfig(const CSrtMuxerConfig& config)
+void CChannel::setConfig(const CSrtMuxerConfig& config)
 {
     m_mcfg = config;
 }
 
-void srt::CChannel::getSocketOption(int level, int option, char* pw_dataptr, socklen_t& w_len, int& w_status)
+void CChannel::getSocketOption(int level, int option, char* pw_dataptr, socklen_t& w_len, int& w_status)
 {
     w_status = ::getsockopt(m_iSocket, level, option, (pw_dataptr), (&w_len));
 }
 
-int srt::CChannel::getIpTTL() const
+int CChannel::getIpTTL() const
 {
     if (m_iSocket == INVALID_SOCKET)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -636,7 +635,7 @@ int srt::CChannel::getIpTTL() const
     return m_mcfg.iIpTTL;
 }
 
-int srt::CChannel::getIpToS() const
+int CChannel::getIpToS() const
 {
     if (m_iSocket == INVALID_SOCKET)
         throw CUDTException(MJ_NOTSUP, MN_INVAL, 0);
@@ -662,7 +661,7 @@ int srt::CChannel::getIpToS() const
 }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-bool srt::CChannel::getBind(char* dst, size_t len)
+bool CChannel::getBind(char* dst, size_t len)
 {
     if (m_iSocket == INVALID_SOCKET)
         return false; // No socket to get data from
@@ -680,7 +679,7 @@ bool srt::CChannel::getBind(char* dst, size_t len)
 }
 #endif
 
-int srt::CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
+int CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
 {
 #if defined(unix) || defined(__APPLE__)
     int value = 0;
@@ -691,7 +690,7 @@ int srt::CChannel::ioctlQuery(int type SRT_ATR_UNUSED) const
     return -1;
 }
 
-int srt::CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNUSED) const
+int CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNUSED) const
 {
 #if defined(unix) || defined(__APPLE__)
     int       value = 0;
@@ -703,7 +702,7 @@ int srt::CChannel::sockoptQuery(int level SRT_ATR_UNUSED, int option SRT_ATR_UNU
     return -1;
 }
 
-void srt::CChannel::getSockAddr(sockaddr_any& w_addr) const
+void CChannel::getSockAddr(sockaddr_any& w_addr) const
 {
     // The getsockname function requires only to have enough target
     // space to copy the socket name, it doesn't have to be correlated
@@ -714,14 +713,14 @@ void srt::CChannel::getSockAddr(sockaddr_any& w_addr) const
     w_addr.len = namelen;
 }
 
-void srt::CChannel::getPeerAddr(sockaddr_any& w_addr) const
+void CChannel::getPeerAddr(sockaddr_any& w_addr) const
 {
     socklen_t namelen = (socklen_t)w_addr.storage_size();
     ::getpeername(m_iSocket, (w_addr.get()), (&namelen));
     w_addr.len = namelen;
 }
 
-int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const CNetworkInterface& source_ni SRT_ATR_UNUSED) const
+int CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const CNetworkInterface& source_ni SRT_ATR_UNUSED) const
 {
 #if ENABLE_HEAVY_LOGGING
     ostringstream dsrc;
@@ -784,7 +783,7 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const CNetw
         if (dcounter > 8)
         {
             // Make a random number in the range between 8 and 24
-            const int rnd = srt::sync::genRandomInt(8, 24);
+            const int rnd = sync::genRandomInt(8, 24);
 
             if (dcounter > rnd)
             {
@@ -903,7 +902,7 @@ int srt::CChannel::sendto(const sockaddr_any& addr, CPacket& packet, const CNetw
     return res;
 }
 
-srt::EReadStatus srt::CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
+EReadStatus CChannel::recvfrom(sockaddr_any& w_addr, CPacket& w_packet) const
 {
     EReadStatus status    = RST_OK;
     int         msg_flags = 0;
@@ -1158,3 +1157,5 @@ Return_error:
     w_packet.setLength(-1);
     return status;
 }
+
+} // namespace srt

--- a/srtcore/channel.h
+++ b/srtcore/channel.h
@@ -53,7 +53,6 @@ modified by
 #define INC_SRT_CHANNEL_H
 
 #include "platform_sys.h"
-#include "udt.h"
 #include "packet.h"
 #include "socketconfig.h"
 #include "netinet_any.h"
@@ -117,14 +116,14 @@ public:
     /// @param [in] src source address to sent on an outgoing packet (if not ANY)
     /// @return Actual size of data sent.
 
-    int sendto(const sockaddr_any& addr, srt::CPacket& packet, const CNetworkInterface& src) const;
+    int sendto(const sockaddr_any& addr, CPacket& packet, const CNetworkInterface& src) const;
 
     /// Receive a packet from the channel and record the source address.
     /// @param [in] addr pointer to the source address.
     /// @param [in] packet reference to a CPacket entity.
     /// @return Actual size of data received.
 
-    EReadStatus recvfrom(sockaddr_any& addr, srt::CPacket& packet) const;
+    EReadStatus recvfrom(sockaddr_any& addr, CPacket& packet) const;
 
     void setConfig(const CSrtMuxerConfig& config);
 

--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -69,7 +69,6 @@ modified by
  #include <ifaddrs.h>
 #endif
 
-#include "udt.h"
 #include "md5.h"
 #include "common.h"
 #include "netinet_any.h"
@@ -90,10 +89,9 @@ namespace srt
 {
 
 const char* strerror_get_message(size_t major, size_t minor);
-} // namespace srt
 
 
-srt::CUDTException::CUDTException(CodeMajor major, CodeMinor minor, int err):
+CUDTException::CUDTException(CodeMajor major, CodeMinor minor, int err):
 m_iMajor(major),
 m_iMinor(minor)
 {
@@ -103,30 +101,30 @@ m_iMinor(minor)
       m_iErrno = err;
 }
 
-const char* srt::CUDTException::getErrorMessage() const ATR_NOTHROW
+const char* CUDTException::getErrorMessage() const ATR_NOTHROW
 {
     return strerror_get_message(m_iMajor, m_iMinor);
 }
 
-std::string srt::CUDTException::getErrorString() const
+string CUDTException::getErrorString() const
 {
     return getErrorMessage();
 }
 
 #define UDT_XCODE(mj, mn) (int(mj)*1000)+int(mn)
 
-int srt::CUDTException::getErrorCode() const
+int CUDTException::getErrorCode() const
 {
     return UDT_XCODE(m_iMajor, m_iMinor);
 }
 
-int srt::CUDTException::getErrno() const
+int CUDTException::getErrno() const
 {
    return m_iErrno;
 }
 
 
-void srt::CUDTException::clear()
+void CUDTException::clear()
 {
    m_iMajor = MJ_SUCCESS;
    m_iMinor = MN_NONE;
@@ -136,7 +134,7 @@ void srt::CUDTException::clear()
 #undef UDT_XCODE
 
 //
-bool srt::CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver)
+bool CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ver)
 {
    if (AF_INET == ver)
    {
@@ -164,7 +162,7 @@ bool srt::CIPAddress::ipcmp(const sockaddr* addr1, const sockaddr* addr2, int ve
    return false;
 }
 
-void srt::CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
+void CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
 {
     if (addr.family() == AF_INET)
     {
@@ -179,7 +177,6 @@ void srt::CIPAddress::ntop(const sockaddr_any& addr, uint32_t ip[4])
     }
 }
 
-namespace srt {
 bool checkMappedIPv4(const uint16_t* addr)
 {
     static const uint16_t ipv4on6_model [8] =
@@ -194,11 +191,10 @@ bool checkMappedIPv4(const uint16_t* addr)
 
     return std::equal(mbegin, mend, addr);
 }
-}
 
 // XXX This has void return and the first argument is passed by reference.
 // Consider simply returning sockaddr_any by value.
-void srt::CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const sockaddr_any& peer)
+void CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const sockaddr_any& peer)
 {
     //using ::srt_logging::inlog;
     uint32_t* target_ipv4_addr = NULL;
@@ -306,8 +302,6 @@ void srt::CIPAddress::pton(sockaddr_any& w_addr, const uint32_t ip[4], const soc
     }
 }
 
-
-namespace srt {
 static string ShowIP4(const sockaddr_in* sin)
 {
     ostringstream os;
@@ -359,10 +353,9 @@ string CIPAddress::show(const sockaddr* adr)
     else
         return "(unsupported sockaddr type)";
 }
-} // namespace srt
 
 //
-void srt::CMD5::compute(const char* input, unsigned char result[16])
+void CMD5::compute(const char* input, unsigned char result[16])
 {
    md5_state_t state;
 
@@ -371,11 +364,8 @@ void srt::CMD5::compute(const char* input, unsigned char result[16])
    md5_finish(&state, result);
 }
 
-namespace srt {
-std::string MessageTypeStr(UDTMessageType mt, uint32_t extt)
+string MessageTypeStr(UDTMessageType mt, uint32_t extt)
 {
-    using std::string;
-
     static const char* const udt_types [] = {
         "handshake",
         "keepalive",
@@ -415,7 +405,7 @@ std::string MessageTypeStr(UDTMessageType mt, uint32_t extt)
     return udt_types[mt];
 }
 
-std::string ConnectStatusStr(EConnectStatus cst)
+string ConnectStatusStr(EConnectStatus cst)
 {
     return
           cst == CONN_CONTINUE ? "INDUCED/CONCLUDING"
@@ -427,7 +417,7 @@ std::string ConnectStatusStr(EConnectStatus cst)
         : "REJECTED";
 }
 
-std::string TransmissionEventStr(ETransmissionEvent ev)
+string TransmissionEventStr(ETransmissionEvent ev)
 {
     static const char* const vals [] =
     {
@@ -473,7 +463,7 @@ bool SrtParseConfig(const string& s, SrtConfig& w_config)
     return true;
 }
 
-std::string FormatLossArray(const std::vector< std::pair<int32_t, int32_t> >& lra)
+string FormatLossArray(const std::vector< std::pair<int32_t, int32_t> >& lra)
 {
     std::ostringstream os;
 
@@ -547,7 +537,7 @@ vector<LocalInterface> GetLocalInterfaces()
     {
         for (PIP_ADAPTER_ADDRESSES i = pAddresses; i; i = pAddresses->Next)
         {
-            std::string name = i->AdapterName;
+            string name = i->AdapterName;
             PIP_ADAPTER_UNICAST_ADDRESS pUnicast = pAddresses->FirstUnicastAddress;
             while (pUnicast)
             {
@@ -604,7 +594,7 @@ namespace srt_logging
 // Value display utilities
 // (also useful for applications)
 
-std::string SockStatusStr(SRT_SOCKSTATUS s)
+string SockStatusStr(SRT_SOCKSTATUS s)
 {
     if (int(s) < int(SRTS_INIT) || int(s) > int(SRTS_NONEXIST))
         return "???";
@@ -612,7 +602,7 @@ std::string SockStatusStr(SRT_SOCKSTATUS s)
     static struct AutoMap
     {
         // Values start from 1, so do -1 to avoid empty cell
-        std::string names[int(SRTS_NONEXIST)-1+1];
+        string names[int(SRTS_NONEXIST)-1+1];
 
         AutoMap()
         {
@@ -633,14 +623,14 @@ std::string SockStatusStr(SRT_SOCKSTATUS s)
     return names.names[int(s)-1];
 }
 
-std::string MemberStatusStr(SRT_MEMBERSTATUS s)
+string MemberStatusStr(SRT_MEMBERSTATUS s)
 {
     if (int(s) < int(SRT_GST_PENDING) || int(s) > int(SRT_GST_BROKEN))
         return "???";
 
     static struct AutoMap
     {
-        std::string names[int(SRT_GST_BROKEN)+1];
+        string names[int(SRT_GST_BROKEN)+1];
 
         AutoMap()
         {

--- a/srtcore/congctl.cpp
+++ b/srtcore/congctl.cpp
@@ -60,8 +60,8 @@ void SrtCongestion::Check()
 
 class LiveCC: public SrtCongestionControlBase
 {
-    srt::sync::atomic<int64_t>  m_llSndMaxBW;          //Max bandwidth (bytes/sec)
-    srt::sync::atomic<size_t>   m_zSndAvgPayloadSize;  //Average Payload Size of packets to xmit
+    sync::atomic<int64_t>  m_llSndMaxBW;          //Max bandwidth (bytes/sec)
+    sync::atomic<size_t>   m_zSndAvgPayloadSize;  //Average Payload Size of packets to xmit
     size_t   m_zMaxPayloadSize;
     size_t   m_zHeaderSize;
 

--- a/srtcore/congctl.h
+++ b/srtcore/congctl.h
@@ -20,7 +20,7 @@ namespace srt {
 
 class CUDT;
 class SrtCongestionControlBase;
-typedef SrtCongestionControlBase* srtcc_create_t(srt::CUDT* parent);
+typedef SrtCongestionControlBase* srtcc_create_t(CUDT* parent);
 
 class SrtCongestion
 {
@@ -98,7 +98,7 @@ public:
     // in appropriate time. It should select appropriate
     // congctl basing on the value in selector, then
     // pin oneself in into CUDT for receiving event signals.
-    bool configure(srt::CUDT* parent);
+    bool configure(CUDT* parent);
 
     // This function will intentionally delete the contained object.
     // This makes future calls to ready() return false. Calling
@@ -136,7 +136,7 @@ class SrtCongestionControlBase
 {
 protected:
     // Here can be some common fields
-    srt::CUDT* m_parent;
+    CUDT* m_parent;
 
     double m_dPktSndPeriod;
     double m_dCWndSize;
@@ -151,7 +151,7 @@ protected:
     //char* m_pcParam;         // Used to access m_llMaxBw. Use m_parent->maxBandwidth() instead.
 
     // Constructor in protected section so that this class is semi-abstract.
-    SrtCongestionControlBase(srt::CUDT* parent);
+    SrtCongestionControlBase(CUDT* parent);
 public:
 
     // This could be also made abstract, but this causes a linkage
@@ -193,7 +193,7 @@ public:
     // Arg 2: value calculated out of CUDT's m_config.llInputBW and m_config.iOverheadBW.
     virtual void updateBandwidth(int64_t, int64_t) {}
 
-    virtual bool needsQuickACK(const srt::CPacket&)
+    virtual bool needsQuickACK(const CPacket&)
     {
         return false;
     }

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -60,20 +60,6 @@ modified by
 #include <linux/if.h>
 #endif
 
-#include <cmath>
-#include <sstream>
-#include <algorithm>
-#include <iterator>
-#include "srt.h"
-#include "access_control.h" // Required for SRT_REJX_FALLBACK
-#include "queue.h"
-#include "api.h"
-#include "core.h"
-#include "logging.h"
-#include "crypto.h"
-#include "logging_api.h" // Required due to containing extern srt_logger_config
-#include "logger_defs.h"
-
 #if !HAVE_CXX11
 // for pthread_once
 #include <pthread.h>
@@ -87,40 +73,53 @@ modified by
 #undef max
 #endif
 
+#include <cmath>
+#include <sstream>
+#include <fstream>
+#include <algorithm>
+#include <iterator>
+#include "srt.h"
+#include "access_control.h" // Required for SRT_REJX_FALLBACK
+#include "queue.h"
+#include "api.h"
+#include "core.h"
+#include "logging.h"
+#include "crypto.h"
+#include "logging_api.h" // Required due to containing extern srt_logger_config
+#include "logger_defs.h"
+
 using namespace std;
-using namespace srt;
 using namespace srt::sync;
 using namespace srt_logging;
 
-const SRTSOCKET UDT::INVALID_SOCK = SRT_INVALID_SOCK;
-const SRTSTATUS UDT::ERROR        = SRT_ERROR;
+namespace srt
+{
 
-//#define SRT_CMD_HSREQ       1           /* SRT Handshake Request (sender) */
-#define SRT_CMD_HSREQ_MINSZ 8 /* Minumum Compatible (1.x.x) packet size (bytes) */
-#define SRT_CMD_HSREQ_SZ 12   /* Current version packet size */
-#if SRT_CMD_HSREQ_SZ > SRT_CMD_MAXSZ
-#error SRT_CMD_MAXSZ too small
-#endif
-/*      Handshake Request (Network Order)
-        0[31..0]:   SRT version     SRT_DEF_VERSION
-        1[31..0]:   Options         0 [ | SRT_OPT_TSBPDSND ][ | SRT_OPT_HAICRYPT ]
-        2[31..16]:  TsbPD resv      0
-        2[15..0]:   TsbPD delay     [0..60000] msec
-*/
+const size_t SRT_CMD_HSREQ_MINSZ = 8;  // Minumum Compatible (1.x.x) packet size (bytes) 
+const size_t SRT_CMD_HSREQ_SZ = 12;  // Current version packet size
+
+SRT_STATIC_ASSERT(SRT_CMD_HSREQ_SZ <= SRT_CMD_MAXSZ, "error: SRT_CMD_MAXSZ too small");
+
+//      Handshake Request (Network Order)
+//      0[31..0]:   SRT version     SRT_DEF_VERSION
+//      1[31..0]:   Options         0 [ | SRT_OPT_TSBPDSND ][ | SRT_OPT_HAICRYPT ]
+//      2[31..16]:  TsbPD resv      0
+//      2[15..0]:   TsbPD delay     [0..60000] msec
+//
 
 //#define SRT_CMD_HSRSP       2           /* SRT Handshake Response (receiver) */
-#define SRT_CMD_HSRSP_MINSZ 8 /* Minumum Compatible (1.x.x) packet size (bytes) */
-#define SRT_CMD_HSRSP_SZ 12   /* Current version packet size */
-#if SRT_CMD_HSRSP_SZ > SRT_CMD_MAXSZ
-#error SRT_CMD_MAXSZ too small
-#endif
-/*      Handshake Response (Network Order)
-        0[31..0]:   SRT version     SRT_DEF_VERSION
-        1[31..0]:   Options         0 [ | SRT_OPT_TSBPDRCV [| SRT_OPT_TLPKTDROP ]][ | SRT_OPT_HAICRYPT]
-                                      [ | SRT_OPT_NAKREPORT ] [ | SRT_OPT_REXMITFLG ]
-        2[31..16]:  TsbPD resv      0
-        2[15..0]:   TsbPD delay     [0..60000] msec
-*/
+const size_t SRT_CMD_HSRSP_MINSZ = 8;  // Minumum Compatible (1.x.x) packet size (bytes) */
+const size_t SRT_CMD_HSRSP_SZ = 12;  // Current version packet size */
+
+SRT_STATIC_ASSERT(SRT_CMD_HSRSP_SZ <= SRT_CMD_MAXSZ, " error: SRT_CMD_MAXSZ too small");
+
+//      Handshake Response (Network Order)
+//      0[31..0]:   SRT version     SRT_DEF_VERSION
+//      1[31..0]:   Options         0 [ | SRT_OPT_TSBPDRCV [| SRT_OPT_TLPKTDROP ]][ | SRT_OPT_HAICRYPT]
+//                                    [ | SRT_OPT_NAKREPORT ] [ | SRT_OPT_REXMITFLG ]
+//      2[31..16]:  TsbPD resv      0
+//      2[15..0]:   TsbPD delay     [0..60000] msec
+//
 
 // IMPORTANT!!! This array must be ordered by value, because std::binary_search is performed on it!
 extern const SRT_SOCKOPT srt_post_opt_list [SRT_SOCKOPT_NPOST] = {
@@ -146,9 +145,6 @@ const int32_t
     SRTO_R_PRE = BIT(1),     //< cannot be modified after connection is established
     SRTO_POST_SPEC = BIT(2); //< executes some action after setting the option
 
-
-namespace srt
-{
 
 struct SrtOptionAction
 {
@@ -233,11 +229,9 @@ struct SrtOptionAction
 
 const SrtOptionAction s_sockopt_action;
 
-} // namespace srt
-
 #if HAVE_CXX11
 
-CUDTUnited& srt::CUDT::uglobal()
+CUDTUnited& CUDT::uglobal()
 {
     static CUDTUnited instance;
     return instance;
@@ -253,7 +247,7 @@ static CUDTUnited *getInstance()
     return &instance;
 }
 
-CUDTUnited& srt::CUDT::uglobal()
+CUDTUnited& CUDT::uglobal()
 {
     // We don't want lock each time, pthread_once can be faster than mutex.
     pthread_once(&s_UDTUnitedOnce, reinterpret_cast<void (*)()>(getInstance));
@@ -263,7 +257,7 @@ CUDTUnited& srt::CUDT::uglobal()
 #endif
 
 SRT_TSA_DISABLED
-void srt::CUDT::construct()
+void CUDT::construct()
 {
     m_pSndBuffer           = NULL;
     m_pRcvBuffer           = NULL;
@@ -316,7 +310,7 @@ void srt::CUDT::construct()
     // m_cbPacketArrival.set(this, &CUDT::defaultPacketArrival);
 }
 
-srt::CUDT::CUDT(CUDTSocket* parent)
+CUDT::CUDT(CUDTSocket* parent)
     : m_parent(parent)
 #ifdef ENABLE_MAXREXMITBW
     , m_SndRexmitRate(sync::steady_clock::now())
@@ -345,7 +339,7 @@ srt::CUDT::CUDT(CUDTSocket* parent)
 
 }
 
-srt::CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor)
+CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor)
     : m_parent(parent)
 #ifdef ENABLE_MAXREXMITBW
     , m_SndRexmitRate(sync::steady_clock::now())
@@ -387,7 +381,7 @@ srt::CUDT::CUDT(CUDTSocket* parent, const CUDT& ancestor)
     m_pCache = ancestor.m_pCache;
 }
 
-srt::CUDT::~CUDT()
+CUDT::~CUDT()
 {
     // release mutex/condtion variables
     destroySynch();
@@ -401,7 +395,7 @@ srt::CUDT::~CUDT()
     delete m_pRNode;
 }
 
-void srt::CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
+void CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
 {
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -460,7 +454,7 @@ void srt::CUDT::setOpt(SRT_SOCKOPT optName, const void* optval, int optlen)
     }
 }
 
-void srt::CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
+void CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 {
     ScopedLock cg(m_ConnectionLock);
 
@@ -865,7 +859,7 @@ void srt::CUDT::getOpt(SRT_SOCKOPT optName, void *optval, int &optlen)
 
 
 #if ENABLE_BONDING
-SRT_ERRNO srt::CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
+SRT_ERRNO CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
 {
     SRT_SOCKOPT this_opt = SRTO_VERSION;
     for (size_t i = 0; i < opt.options.size(); ++i)
@@ -879,7 +873,7 @@ SRT_ERRNO srt::CUDT::applyMemberConfigObject(const SRT_SocketOptionObject& opt)
 }
 #endif
 
-bool srt::CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
+bool CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
 {
     CUDT *that = getUDTHandle(u);
     if (!that)
@@ -895,7 +889,7 @@ bool srt::CUDT::setstreamid(SRTSOCKET u, const std::string &sid)
     return true;
 }
 
-string srt::CUDT::getstreamid(SRTSOCKET u)
+string CUDT::getstreamid(SRTSOCKET u)
 {
     CUDT *that = getUDTHandle(u);
     if (!that)
@@ -907,7 +901,7 @@ string srt::CUDT::getstreamid(SRTSOCKET u)
 // XXX REFACTOR: Make common code for CUDT constructor and clearData,
 // possibly using CUDT::construct.
 // Initial sequence number, loss, acknowledgement, etc.
-void srt::CUDT::clearData()
+void CUDT::clearData()
 {
     const size_t full_hdr_size = CPacket::udpHeaderSize(AF_INET) + CPacket::HDR_SIZE;
     m_iMaxSRTPayloadSize = m_config.iMSS - full_hdr_size;
@@ -964,7 +958,7 @@ void srt::CUDT::clearData()
 // Hence thread checking is disabled.
 
 SRT_TSA_DISABLED
-void srt::CUDT::open()
+void CUDT::open()
 {
     ScopedLock cg(m_ConnectionLock);
 
@@ -1021,7 +1015,7 @@ void srt::CUDT::open()
     m_bOpened = true;
 }
 
-void srt::CUDT::setListenState()
+void CUDT::setListenState()
 {
     if (!m_bOpened)
         throw CUDTException(MJ_NOTSUP, MN_NONE, 0);
@@ -1068,7 +1062,7 @@ void srt::CUDT::setListenState()
     }
 }
 
-size_t srt::CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, int hs_version)
+size_t CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgtype, int hs_version)
 {
     if (srtlen < SRT_HS_E_SIZE)
     {
@@ -1096,7 +1090,7 @@ size_t srt::CUDT::fillSrtHandshake(uint32_t *aw_srtdata, size_t srtlen, int msgt
     }
 }
 
-size_t srt::CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
+size_t CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
 {
     // INITIATOR sends HSREQ.
 
@@ -1159,7 +1153,7 @@ size_t srt::CUDT::fillSrtHandshake_HSREQ(uint32_t *aw_srtdata, size_t /* srtlen 
     return 3;
 }
 
-size_t srt::CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
+size_t CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen - unused */, int hs_version)
 {
     // Setting m_tsRcvPeerStartTime is done in processSrtMsg_HSREQ(), so
     // this condition will be skipped only if this function is called without
@@ -1269,7 +1263,7 @@ size_t srt::CUDT::fillSrtHandshake_HSRSP(uint32_t *aw_srtdata, size_t /* srtlen 
     return 3;
 }
 
-size_t srt::CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
+size_t CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
 {
     size_t srtlen = fillSrtHandshake(srtdata, size, cmd, handshakeVersion());
     HLOGC(cnlog.Debug, log << "CMD:" << MessageTypeStr(UMSG_EXT, cmd) << "(" << cmd << ") Len:"
@@ -1282,7 +1276,7 @@ size_t srt::CUDT::prepareSrtHsMsg(int cmd, uint32_t *srtdata, size_t size)
     return srtlen;
 }
 
-void srt::CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
+void CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
 {
     CPacket srtpkt;
     int32_t srtcmd = (int32_t)cmd;
@@ -1333,7 +1327,7 @@ void srt::CUDT::sendSrtMsg(int cmd, uint32_t *srtdata_in, size_t srtlen_in)
     }
 }
 
-size_t srt::CUDT::fillHsExtConfigString(uint32_t* pcmdspec, int cmd, const string& str)
+size_t CUDT::fillHsExtConfigString(uint32_t* pcmdspec, int cmd, const string& str)
 {
     uint32_t* space = pcmdspec + 1;
     size_t wordsize         = (str.size() + 3) / 4;
@@ -1352,7 +1346,7 @@ size_t srt::CUDT::fillHsExtConfigString(uint32_t* pcmdspec, int cmd, const strin
 #if ENABLE_BONDING
 // [[using locked(m_parent->m_ControlLock)]]
 // [[using locked(s_UDTUnited.m_GlobControlLock)]]
-size_t srt::CUDT::fillHsExtGroup(uint32_t* pcmdspec)
+size_t CUDT::fillHsExtGroup(uint32_t* pcmdspec)
 {
     SRT_ASSERT(m_parent->m_GroupOf != NULL);
     uint32_t* space = pcmdspec + 1;
@@ -1388,7 +1382,7 @@ size_t srt::CUDT::fillHsExtGroup(uint32_t* pcmdspec)
 }
 #endif
 
-size_t srt::CUDT::fillHsExtKMREQ(uint32_t* pcmdspec, size_t ki)
+size_t CUDT::fillHsExtKMREQ(uint32_t* pcmdspec, size_t ki)
 {
     uint32_t* space = pcmdspec + 1;
 
@@ -1417,7 +1411,7 @@ size_t srt::CUDT::fillHsExtKMREQ(uint32_t* pcmdspec, size_t ki)
     return ra_size;
 }
 
-size_t srt::CUDT::fillHsExtKMRSP(uint32_t* pcmdspec, const uint32_t* kmdata, size_t kmdata_wordsize)
+size_t CUDT::fillHsExtKMRSP(uint32_t* pcmdspec, const uint32_t* kmdata, size_t kmdata_wordsize)
 {
     uint32_t* space = pcmdspec + 1;
     const uint32_t failure_kmrsp[] = {SRT_KM_S_UNSECURED};
@@ -1468,7 +1462,7 @@ size_t srt::CUDT::fillHsExtKMRSP(uint32_t* pcmdspec, const uint32_t* kmdata, siz
 // PREREQUISITE:
 // pkt must be set the buffer and configured for UMSG_HANDSHAKE.
 // Note that this function replaces also serialization for the HSv4.
-bool srt::CUDT::createSrtHandshake(
+bool CUDT::createSrtHandshake(
         int             srths_cmd,
         int             srtkm_cmd,
         const uint32_t* kmdata,
@@ -1971,20 +1965,20 @@ public:
 
     ~RttTracer()
     {
-        srt::sync::ScopedLock lck(m_mtx);
+        sync::ScopedLock lck(m_mtx);
         m_fout.close();
     }
 
-    void trace(const srt::sync::steady_clock::time_point& currtime,
+    void trace(const sync::steady_clock::time_point& currtime,
                const std::string& event, int rtt_sample, int rttvar_sample,
                bool is_smoothed_rtt_reset, int64_t recvTotal,
                int smoothed_rtt, int rttvar)
     {
-        srt::sync::ScopedLock lck(m_mtx);
+        sync::ScopedLock lck(m_mtx);
         create_file();
         
-        m_fout << srt::sync::FormatTimeSys(currtime) << ",";
-        m_fout << srt::sync::FormatTime(currtime) << ",";
+        m_fout << sync::FormatTimeSys(currtime) << ",";
+        m_fout << sync::FormatTime(currtime) << ",";
         m_fout << event << ",";
         m_fout << rtt_sample << ",";
         m_fout << rttvar_sample << ",";
@@ -2008,7 +2002,7 @@ private:
         if (m_fout.is_open())
             return;
 
-        std::string str_tnow = srt::sync::FormatTimeSys(srt::sync::steady_clock::now());
+        std::string str_tnow = sync::FormatTimeSys(sync::steady_clock::now());
         str_tnow.resize(str_tnow.size() - 7); // remove trailing ' [SYST]' part
         while (str_tnow.find(':') != std::string::npos) {
             str_tnow.replace(str_tnow.find(':'), 1, 1, '_');
@@ -2022,7 +2016,7 @@ private:
     }
 
 private:
-    srt::sync::Mutex m_mtx;
+    sync::Mutex m_mtx;
     std::ofstream m_fout;
 };
 
@@ -2030,7 +2024,7 @@ RttTracer s_rtt_trace;
 #endif
 
 
-bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
+bool CUDT::processSrtMsg(const CPacket *ctrlpkt)
 {
     // XXX ScopedLock clok (m_ConnectionLock); ???
 
@@ -2116,7 +2110,7 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
     return true;
 }
 
-int srt::CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
+int CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
 {
     // Set this start time in the beginning, regardless as to whether TSBPD is being
     // used or not. This must be done in the Initiator as well as Responder.
@@ -2331,7 +2325,7 @@ int srt::CUDT::processSrtMsg_HSREQ(const uint32_t *srtdata, size_t bytelen, uint
     return SRT_CMD_HSRSP;
 }
 
-int srt::CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
+int CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint32_t ts, int hsv)
 {
     // XXX Check for mis-version
     // With HSv4 we accept only version less than 1.3.0
@@ -2479,7 +2473,7 @@ int srt::CUDT::processSrtMsg_HSRSP(const uint32_t *srtdata, size_t bytelen, uint
 }
 
 // This function is called only when the URQ_CONCLUSION handshake has been received from the peer.
-bool srt::CUDT::interpretSrtHandshake(CUDTSocket* lsn, const CHandShake& hs,
+bool CUDT::interpretSrtHandshake(CUDTSocket* lsn, const CHandShake& hs,
                                  const CPacket&    hspkt,
                                  uint32_t*         out_data SRT_ATR_UNUSED,
                                  size_t*           pw_len)
@@ -3084,7 +3078,7 @@ bool srt::CUDT::interpretSrtHandshake(CUDTSocket* lsn, const CHandShake& hs,
     return true;
 }
 
-bool srt::CUDT::checkApplyFilterConfig(const std::string &confstr)
+bool CUDT::checkApplyFilterConfig(const std::string &confstr)
 {
     SrtFilterConfig cfg;
     if (!ParseFilterConfig(confstr, (cfg)))
@@ -3168,7 +3162,7 @@ bool srt::CUDT::checkApplyFilterConfig(const std::string &confstr)
 }
 
 #if ENABLE_BONDING
-bool srt::CUDT::interpretGroup(CUDTSocket* lsn, const int32_t groupdata[], size_t data_size SRT_ATR_UNUSED, int hsreq_type_cmd SRT_ATR_UNUSED)
+bool CUDT::interpretGroup(CUDTSocket* lsn, const int32_t groupdata[], size_t data_size SRT_ATR_UNUSED, int hsreq_type_cmd SRT_ATR_UNUSED)
 {
     // `data_size` isn't checked because we believe it's checked earlier.
     // Also this code doesn't predict to get any other format than the official one,
@@ -3355,7 +3349,7 @@ bool srt::CUDT::interpretGroup(CUDTSocket* lsn, const int32_t groupdata[], size_
 //     SRT_TSA_NEEDS_LOCKED(CUDTUnited::m_GlobControlLock)
 // Can't be set because clang-tsa doesn't honor friend declarations
 // Alternatively you can move it to CUDTSocket class.
-SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t link_flags, SRTSOCKET listener)
+SRTSOCKET CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint32_t link_flags, SRTSOCKET listener)
 {
     // Note: This function will lock pg->m_GroupLock!
 
@@ -3459,7 +3453,7 @@ SRTSOCKET srt::CUDT::makeMePeerOf(SRTSOCKET peergroup, SRT_GROUP_TYPE gtp, uint3
     return gp->id();
 }
 
-void srt::CUDT::synchronizeWithGroup(CUDTGroup* gp)
+void CUDT::synchronizeWithGroup(CUDTGroup* gp)
 {
     ScopedLock gl (*gp->exp_groupLock());
 
@@ -3552,7 +3546,7 @@ void srt::CUDT::synchronizeWithGroup(CUDTGroup* gp)
 }
 #endif
 
-void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
+void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 {
     ScopedLock cg (m_ConnectionLock);
 
@@ -3970,7 +3964,7 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 }
 
 // Asynchronous connection
-EConnectStatus srt::CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEPT
+EConnectStatus CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NOEXCEPT
 {
     EConnectStatus cst = CONN_CONTINUE;
     CUDTException  e;
@@ -3987,7 +3981,7 @@ EConnectStatus srt::CUDT::processAsyncConnectResponse(const CPacket &pkt) ATR_NO
     return cst;
 }
 
-bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
+bool CUDT::processAsyncConnectRequest(EReadStatus         rst,
                                       EConnectStatus      cst,
                                       const CPacket*      pResponse /*[[nullable]]*/,
                                       const sockaddr_any& serv_addr)
@@ -4093,7 +4087,7 @@ bool srt::CUDT::processAsyncConnectRequest(EReadStatus         rst,
     return status;
 }
 
-void srt::CUDT::sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& r_rsppkt)
+void CUDT::sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& r_rsppkt)
 {
     // We can reuse m_ConnReq because we are about to abandon the connection process.
     m_ConnReq.m_iReqType = URQFailure(m_RejectReason);
@@ -4111,7 +4105,7 @@ void srt::CUDT::sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& 
     m_pSndQueue->sendto(serv_addr, r_rsppkt, m_SourceAddr);
 }
 
-void srt::CUDT::cookieContest()
+void CUDT::cookieContest()
 {
     if (m_SrtHsSide != HSD_DRAW)
         return;
@@ -4177,7 +4171,7 @@ void srt::CUDT::cookieContest()
 // - There's no KMX (including first responder's handshake in rendezvous). This writes 0 to w_kmdatasize.
 // - The encryption status is failure. Respond with fail code and w_kmdatasize = 1.
 // - The last KMX was successful. Respond with the original kmdata and their size in w_kmdatasize.
-EConnectStatus srt::CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatasize)
+EConnectStatus CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatasize)
 {
     // If the last CONCLUSION message didn't contain the KMX extension, there's
     // no key recorded yet, so it can't be extracted. Mark this w_kmdatasize empty though.
@@ -4261,7 +4255,7 @@ EConnectStatus srt::CUDT::craftKmResponse(uint32_t* aw_kmdata, size_t& w_kmdatas
     return CONN_ACCEPT;
 }
 
-EConnectStatus srt::CUDT::processRendezvous(
+EConnectStatus CUDT::processRendezvous(
     const CPacket* pResponse /*[[nullable]]*/, const sockaddr_any& serv_addr,
     EReadStatus rst, CPacket& w_reqpkt)
 {
@@ -4538,7 +4532,7 @@ EConnectStatus srt::CUDT::processRendezvous(
 }
 
 // [[using locked(m_ConnectionLock)]];
-EConnectStatus srt::CUDT::processConnectResponse(const CPacket& response, CUDTException* eout) ATR_NOEXCEPT
+EConnectStatus CUDT::processConnectResponse(const CPacket& response, CUDTException* eout) ATR_NOEXCEPT
 {
     // NOTE: ASSUMED LOCK ON: m_ConnectionLock.
 
@@ -4799,7 +4793,7 @@ EConnectStatus srt::CUDT::processConnectResponse(const CPacket& response, CUDTEx
     return postConnect(&response, false, eout);
 }
 
-bool srt::CUDT::applyResponseSettings(const CPacket* pHspkt /*[[nullable]]*/) ATR_NOEXCEPT
+bool CUDT::applyResponseSettings(const CPacket* pHspkt /*[[nullable]]*/) ATR_NOEXCEPT
 {
     if (!m_ConnRes.valid())
     {
@@ -4856,7 +4850,7 @@ bool srt::CUDT::applyResponseSettings(const CPacket* pHspkt /*[[nullable]]*/) AT
     return true;
 }
 
-EConnectStatus srt::CUDT::postConnect(const CPacket* pResponse, bool rendezvous, CUDTException *eout) ATR_NOEXCEPT
+EConnectStatus CUDT::postConnect(const CPacket* pResponse, bool rendezvous, CUDTException *eout) ATR_NOEXCEPT
 {
     if (m_ConnRes.m_iVersion < HS_VERSION_SRT1)
         m_tsRcvPeerStartTime = steady_clock::time_point(); // will be set correctly in SRT HS.
@@ -5099,7 +5093,7 @@ EConnectStatus srt::CUDT::postConnect(const CPacket* pResponse, bool rendezvous,
     return CONN_ACCEPT;
 }
 
-void srt::CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t typefield)
+void CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32_t typefield)
 {
     int enc_flags = SrtHSRequest::SRT_HSTYPE_ENCFLAGS::unwrap(typefield);
 
@@ -5146,7 +5140,7 @@ void srt::CUDT::checkUpdateCryptoKeyLen(const char *loghdr SRT_ATR_UNUSED, int32
 }
 
 // Rendezvous
-void srt::CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_extension, bool& w_needs_hsrsp)
+void CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_extension, bool& w_needs_hsrsp)
 {
     UDTRequestType req           = m_ConnRes.m_iReqType;
     int            hs_flags      = SrtHSRequest::SRT_HSTYPE_HSFLAGS::unwrap(m_ConnRes.m_iType);
@@ -5512,7 +5506,7 @@ void srt::CUDT::rendezvousSwitchState(UDTRequestType& w_rsptype, bool& w_needs_e
  * This thread runs only if TsbPd mode is enabled
  * Hold received packets until its time to 'play' them, at PktTimeStamp + TsbPdDelay.
  */
-void * srt::CUDT::tsbpd(void* param)
+void * CUDT::tsbpd(void* param)
 {
     CUDT* self = (CUDT*)param;
 
@@ -5544,7 +5538,7 @@ void * srt::CUDT::tsbpd(void* param)
         const steady_clock::time_point tnow = steady_clock::now();
 
         self->m_pRcvBuffer->updRcvAvgDataSize(tnow);
-        const srt::CRcvBuffer::PacketInfo info = self->m_pRcvBuffer->getFirstValidPacketInfo();
+        const CRcvBuffer::PacketInfo info = self->m_pRcvBuffer->getFirstValidPacketInfo();
 
         const bool is_time_to_deliver = !is_zero(info.tsbpd_time) && (tnow >= info.tsbpd_time);
         tsNextDelivery = info.tsbpd_time;
@@ -5729,7 +5723,7 @@ void * srt::CUDT::tsbpd(void* param)
     return NULL;
 }
 
-int srt::CUDT::rcvDropTooLateUpTo(int seqno, DropReason reason)
+int CUDT::rcvDropTooLateUpTo(int seqno, DropReason reason)
 {
     // Make sure that it would not drop over m_iRcvCurrSeqNo, which may break senders.
     if (CSeqNo::seqcmp(seqno, CSeqNo::incseq(m_iRcvCurrSeqNo)) > 0)
@@ -5755,7 +5749,7 @@ int srt::CUDT::rcvDropTooLateUpTo(int seqno, DropReason reason)
     return iDropCntTotal;
 }
 
-void srt::CUDT::setInitialRcvSeq(int32_t isn)
+void CUDT::setInitialRcvSeq(int32_t isn)
 {
     m_iRcvLastAck = isn;
 #ifdef ENABLE_LOGGING
@@ -5780,7 +5774,7 @@ void srt::CUDT::setInitialRcvSeq(int32_t isn)
     }
 }
 
-bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout)
+bool CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd, CUDTException *eout)
 {
     // This will be lazily created due to being the common
     // code with HSv5 rendezvous, in which this will be run
@@ -5822,7 +5816,7 @@ bool srt::CUDT::prepareConnectionObjects(const CHandShake &hs, HandshakeSide hsd
     return true;
 }
 
-int srt::CUDT::getAuthTagSize() const
+int CUDT::getAuthTagSize() const
 {
     if (m_pCryptoControl && m_pCryptoControl->getCryptoMode() == CSrtConfig::CIPHER_MODE_AES_GCM)
         return HAICRYPT_AUTHTAG_MAX;
@@ -5830,7 +5824,7 @@ int srt::CUDT::getAuthTagSize() const
     return 0;
 }
 
-bool srt::CUDT::prepareBuffers(CUDTException* eout)
+bool CUDT::prepareBuffers(CUDTException* eout)
 {
     if (m_pSndBuffer)
     {
@@ -5866,7 +5860,7 @@ bool srt::CUDT::prepareBuffers(CUDTException* eout)
 
         m_pSndBuffer = new CSndBuffer(m_TransferIPVersion, 32, snd_payload_size, authtag);
         SRT_ASSERT(m_iPeerISN != -1);
-        m_pRcvBuffer = new srt::CRcvBuffer(m_iPeerISN, m_config.iRcvBufSize, m_pRcvQueue->m_pUnitQueue, m_config.bMessageAPI);
+        m_pRcvBuffer = new CRcvBuffer(m_iPeerISN, m_config.iRcvBufSize, m_pRcvQueue->m_pUnitQueue, m_config.bMessageAPI);
         // After introducing lite ACK, the sndlosslist may not be cleared in time, so it requires twice a space.
         m_pSndLossList = new CSndLossList(m_iFlowWindowSize * 2);
         m_pRcvLossList = new CRcvLossList(m_config.iFlightFlagSize);
@@ -5882,7 +5876,7 @@ bool srt::CUDT::prepareBuffers(CUDTException* eout)
     return true;
 }
 
-void srt::CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
+void CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
 {
     // this is a response handshake
     w_hs.m_iReqType        = URQ_CONCLUSION;
@@ -5901,7 +5895,7 @@ void srt::CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
     CIPAddress::ntop(peer, (w_hs.m_piPeerIP));
 }
 
-void srt::CUDT::acceptAndRespond(CUDTSocket* lsn, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& w_hs)
+void CUDT::acceptAndRespond(CUDTSocket* lsn, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& w_hs)
 {
     HLOGC(cnlog.Debug, log << CONID() << "acceptAndRespond: setting up data according to handshake");
     const sockaddr_any& agent = lsn->m_SelfAddr;
@@ -6141,7 +6135,7 @@ bool CUDT::createSendHSResponse(uint32_t* kmdata, size_t kmdatasize, const CNetw
     return true;
 }
 
-bool srt::CUDT::frequentLogAllowed(size_t logid, const time_point& tnow, std::string& w_why)
+bool CUDT::frequentLogAllowed(size_t logid, const time_point& tnow, std::string& w_why)
 {
 #ifndef SRT_LOG_SLOWDOWN_FREQ_MS
 #define SRT_LOG_SLOWDOWN_FREQ_MS 1000
@@ -6189,7 +6183,7 @@ bool srt::CUDT::frequentLogAllowed(size_t logid, const time_point& tnow, std::st
 // be created, as this happens before the completion of the connection (and
 // therefore configuration of the crypter object), which can only take place upon
 // reception of CONCLUSION response from the listener.
-bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
+bool CUDT::createCrypter(HandshakeSide side, bool bidirectional)
 {
     // Lazy initialization
     if (m_pCryptoControl)
@@ -6217,7 +6211,7 @@ bool srt::CUDT::createCrypter(HandshakeSide side, bool bidirectional)
     return m_pCryptoControl->init(side, m_config, bidirectional, useGcm153);
 }
 
-SRT_REJECT_REASON srt::CUDT::setupCC()
+SRT_REJECT_REASON CUDT::setupCC()
 {
     // Prepare configuration object,
     // Create the CCC object and configure it.
@@ -6300,7 +6294,7 @@ SRT_REJECT_REASON srt::CUDT::setupCC()
     return SRT_REJ_UNKNOWN;
 }
 
-void srt::CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timebase)
+void CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timebase)
 {
     // Do a fast pre-check first - this simply declares that agent uses HSv5
     // and the legacy SRT Handshake is not to be done. Second check is whether
@@ -6352,7 +6346,7 @@ void srt::CUDT::considerLegacySrtHandshake(const steady_clock::time_point &timeb
     sendSrtMsg(SRT_CMD_HSREQ);
 }
 
-void srt::CUDT::checkSndTimers()
+void CUDT::checkSndTimers()
 {
     if (m_SrtHsSide == HSD_INITIATOR)
     {
@@ -6376,7 +6370,7 @@ void srt::CUDT::checkSndTimers()
         m_pCryptoControl->sendKeysToPeer(this, SRTT());
 }
 
-void srt::CUDT::checkSndKMRefresh()
+void CUDT::checkSndKMRefresh()
 {
     // Do not apply the regenerated key to the to the receiver context.
     const bool bidir = false;
@@ -6384,7 +6378,7 @@ void srt::CUDT::checkSndKMRefresh()
         m_pCryptoControl->regenCryptoKm(this, bidir);
 }
 
-void srt::CUDT::addressAndSend(CPacket& w_pkt)
+void CUDT::addressAndSend(CPacket& w_pkt)
 {
     w_pkt.set_id(m_PeerID);
     setPacketTS(w_pkt, steady_clock::now());
@@ -6399,7 +6393,7 @@ void srt::CUDT::addressAndSend(CPacket& w_pkt)
 
 // [[using maybe_locked(m_GlobControlLock, if called from breakSocket_LOCKED, usually from GC)]]
 // [[using maybe_locked(m_parent->m_ControlLock, if called from srt_close())]]
-bool srt::CUDT::closeInternal(int reason) ATR_NOEXCEPT
+bool CUDT::closeInternal(int reason) ATR_NOEXCEPT
 {
     // NOTE: this function is called from within the garbage collector thread.
 
@@ -6553,7 +6547,7 @@ bool srt::CUDT::closeInternal(int reason) ATR_NOEXCEPT
     return true;
 }
 
-int srt::CUDT::receiveBuffer(char *data, int len)
+int CUDT::receiveBuffer(char *data, int len)
 {
     if (!m_CongCtl->checkTransArgs(SrtCongestion::STA_BUFFER, SrtCongestion::STAD_RECV, data, len, SRT_MSGTTL_INF, false))
         throw CUDTException(MJ_NOTSUP, MN_INVALBUFFERAPI, 0);
@@ -6678,7 +6672,7 @@ int srt::CUDT::receiveBuffer(char *data, int len)
 
 // [[using maybe_locked(CUDTGroup::m_GroupLock, m_parent->m_GroupOf != NULL)]];
 // [[using locked(m_SendLock)]];
-int srt::CUDT::sndDropTooLate()
+int CUDT::sndDropTooLate()
 {
     if (!m_bPeerTLPktDrop)
         return 0;
@@ -6766,7 +6760,7 @@ int srt::CUDT::sndDropTooLate()
     return dpkts;
 }
 
-int srt::CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, int64_t srctime)
+int CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, int64_t srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     mctrl.msgttl      = msttl;
@@ -6778,7 +6772,7 @@ int srt::CUDT::sendmsg(const char *data, int len, int msttl, bool inorder, int64
 // [[using maybe_locked(CUDTGroup::m_GroupLock, m_parent->m_GroupOf != NULL)]]
 // GroupLock is applied when this function is called from inside CUDTGroup::send,
 // which is the only case when the m_parent->m_GroupOf is not NULL.
-int srt::CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
+int CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
 {
     // throw an exception if not connected
     if (m_bBroken || m_bClosing)
@@ -7075,13 +7069,13 @@ int srt::CUDT::sendmsg2(const char *data, int len, SRT_MSGCTRL& w_mctrl)
     return size;
 }
 
-int srt::CUDT::recv(char* data, int len)
+int CUDT::recv(char* data, int len)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     return recvmsg2(data, len, (mctrl));
 }
 
-int srt::CUDT::recvmsg(char* data, int len, int64_t& srctime)
+int CUDT::recvmsg(char* data, int len, int64_t& srctime)
 {
     SRT_MSGCTRL mctrl = srt_msgctrl_default;
     int res = recvmsg2(data, len, (mctrl));
@@ -7092,7 +7086,7 @@ int srt::CUDT::recvmsg(char* data, int len, int64_t& srctime)
 // [[using maybe_locked(CUDTGroup::m_GroupLock, m_parent->m_GroupOf != NULL)]]
 // GroupLock is applied when this function is called from inside CUDTGroup::recv,
 // which is the only case when the m_parent->m_GroupOf is not NULL.
-int srt::CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
+int CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
 {
     // Check if the socket is a member of a receiver group.
     // If so, then reading by receiveMessage is disallowed.
@@ -7121,23 +7115,23 @@ int srt::CUDT::recvmsg2(char* data, int len, SRT_MSGCTRL& w_mctrl)
 }
 
 // [[using locked(m_RcvBufferLock)]]
-size_t srt::CUDT::getAvailRcvBufferSizeNoLock() const
+size_t CUDT::getAvailRcvBufferSizeNoLock() const
 {
     return m_pRcvBuffer->getAvailSize(m_iRcvLastAck);
 }
 
-bool srt::CUDT::isRcvBufferReady() const
+bool CUDT::isRcvBufferReady() const
 {
     ScopedLock lck(m_RcvBufferLock);
     return m_pRcvBuffer->isRcvDataReady(steady_clock::now());
 }
 
-bool srt::CUDT::isRcvBufferReadyNoLock() const
+bool CUDT::isRcvBufferReadyNoLock() const
 {
     return m_pRcvBuffer->isRcvDataReady(steady_clock::now());
 }
 
-bool srt::CUDT::isRcvBufferFull() const
+bool CUDT::isRcvBufferFull() const
 {
     ScopedLock lck(m_RcvBufferLock);
     return m_pRcvBuffer->full();
@@ -7147,7 +7141,7 @@ bool srt::CUDT::isRcvBufferFull() const
 // - 0 - by return value
 // - 1 - by exception
 // - 2 - by abort (unused)
-int srt::CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_exception)
+int CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_exception)
 {
     // Recvmsg isn't restricted to the congctl type, it's the most
     // basic method of passing the data. You can retrieve data as
@@ -7398,7 +7392,7 @@ int srt::CUDT::receiveMessage(char* data, int len, SRT_MSGCTRL& w_mctrl, int by_
     return res;
 }
 
-int64_t srt::CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int block)
+int64_t CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int block)
 {
     if (m_bBroken || m_bClosing)
         throw CUDTException(MJ_CONNECTION, MN_CONNLOST, 0);
@@ -7522,7 +7516,7 @@ int64_t srt::CUDT::sendfile(fstream &ifs, int64_t &offset, int64_t size, int blo
     return size - tosend;
 }
 
-int64_t srt::CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
+int64_t CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int block)
 {
     if (!m_bConnected || !m_CongCtl.ready())
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -7644,7 +7638,7 @@ int64_t srt::CUDT::recvfile(fstream &ofs, int64_t &offset, int64_t size, int blo
     return size - torecv;
 }
 
-void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
+void CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
 {
     if (!m_bConnected)
         throw CUDTException(MJ_CONNECTION, MN_NOCONN, 0);
@@ -7825,7 +7819,7 @@ void srt::CUDT::bstats(CBytePerfMon *perf, bool clear, bool instantaneous)
     }
 }
 
-bool srt::CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
+bool CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
 {
     // Special things that must be done HERE, not in SrtCongestion,
     // because it involves the input buffer in CUDT. It would be
@@ -7944,7 +7938,7 @@ bool srt::CUDT::updateCC(ETransmissionEvent evt, const EventVariant arg)
     return true;
 }
 
-void srt::CUDT::initSynch()
+void CUDT::initSynch()
 {
     setupMutex(m_SendBlockLock, "SendBlock");
     setupCond(m_SendBlockCond, "SendBlock");
@@ -7959,7 +7953,7 @@ void srt::CUDT::initSynch()
     setupCond(m_RcvTsbPdCond, "RcvTsbPd");
 }
 
-void srt::CUDT::destroySynch()
+void CUDT::destroySynch()
 {
     releaseMutex(m_SendBlockLock);
 
@@ -7984,7 +7978,7 @@ void srt::CUDT::destroySynch()
     releaseCond(m_RcvTsbPdCond);
 }
 
-void srt::CUDT::releaseSynch()
+void CUDT::releaseSynch()
 {
     SRT_ASSERT(m_bClosing);
     if (!m_bClosing)
@@ -8018,7 +8012,6 @@ void srt::CUDT::releaseSynch()
     leaveCS(m_RecvLock);
 }
 
-namespace srt {
 #if ENABLE_HEAVY_LOGGING
 static void DebugAck(string hdr, int prev, int ack)
 {
@@ -8049,9 +8042,8 @@ static void DebugAck(string hdr, int prev, int ack)
 #else
 static inline void DebugAck(string, int, int) {}
 #endif
-}
 
-void srt::CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam, int size)
+void CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rparam, int size)
 {
     CPacket ctrlpkt;
     setPacketTS(ctrlpkt, steady_clock::now());
@@ -8190,7 +8182,7 @@ void srt::CUDT::sendCtrl(UDTMessageType pkttype, const int32_t* lparam, void* rp
         m_tsLastSndTime.store(steady_clock::now());
 }
 
-bool srt::CUDT::getFirstNoncontSequence(int32_t& w_seq, string& w_log_reason)
+bool CUDT::getFirstNoncontSequence(int32_t& w_seq, string& w_log_reason)
 {
     if (!m_pRcvBuffer)
     {
@@ -8231,7 +8223,7 @@ bool srt::CUDT::getFirstNoncontSequence(int32_t& w_seq, string& w_log_reason)
     return true;
 }
 
-int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
+int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
 {
     int nbsent = 0;
     int local_prevack = 0;
@@ -8505,7 +8497,7 @@ int srt::CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
     return nbsent;
 }
 
-void srt::CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
+void CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
 {
 #if ENABLE_BONDING
     // This is for the call of CSndBuffer::getMsgNoAt that returns
@@ -8592,7 +8584,7 @@ void srt::CUDT::updateSndLossListOnACK(int32_t ackdata_seqno)
     leaveCS(m_StatsLock);
 }
 
-void srt::CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point& currtime)
+void CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_point& currtime)
 {
     const int32_t* ackdata       = (const int32_t*)ctrlpkt.m_pcData;
     const int32_t  ackdata_seqno = ackdata[ACKD_RCVLASTACK];
@@ -8856,7 +8848,7 @@ void srt::CUDT::processCtrlAck(const CPacket &ctrlpkt, const steady_clock::time_
     leaveCS(m_StatsLock);
 }
 
-void srt::CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival)
+void CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsArrival)
 {
     int32_t ack = 0;
 
@@ -8954,7 +8946,7 @@ void srt::CUDT::processCtrlAckAck(const CPacket& ctrlpkt, const time_point& tsAr
         m_iRcvLastAckAck = ack;
 }
 
-void srt::CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
+void CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
 {
     const int32_t* losslist = (int32_t*)(ctrlpkt.m_pcData);
     const size_t   losslist_len = ctrlpkt.getLength() / 4;
@@ -9116,7 +9108,7 @@ void srt::CUDT::processCtrlLossReport(const CPacket& ctrlpkt)
     leaveCS(m_StatsLock);
 }
 
-void srt::CUDT::processCtrlHS(const CPacket& ctrlpkt)
+void CUDT::processCtrlHS(const CPacket& ctrlpkt)
 {
     CHandShake req;
     req.load_from(ctrlpkt.m_pcData, ctrlpkt.getLength());
@@ -9229,7 +9221,7 @@ void srt::CUDT::processCtrlHS(const CPacket& ctrlpkt)
     }
 }
 
-void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
+void CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
 {
     typedef int32_t expected_t[2];
     if (ctrlpkt.getLength() < sizeof (expected_t))
@@ -9329,7 +9321,7 @@ void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
     }
 }
 
-void srt::CUDT::processCtrlShutdown(const CPacket& ctrlpkt)
+void CUDT::processCtrlShutdown(const CPacket& ctrlpkt)
 {
     const uint32_t* data = (const uint32_t*) ctrlpkt.m_pcData;
     const size_t   data_len = ctrlpkt.getLength() / 4;
@@ -9365,7 +9357,7 @@ void srt::CUDT::processCtrlShutdown(const CPacket& ctrlpkt)
     completeBrokenConnectionDependencies(SRT_ECONNLOST); // LOCKS!
 }
 
-void srt::CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
+void CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
 {
     HLOGC(inlog.Debug, log << CONID() << "CONTROL EXT MSG RECEIVED:"
         << MessageTypeStr(ctrlpkt.getType(), ctrlpkt.getExtendedType())
@@ -9395,7 +9387,7 @@ void srt::CUDT::processCtrlUserDefined(const CPacket& ctrlpkt)
     }
 }
 
-void srt::CUDT::processCtrl(const CPacket &ctrlpkt)
+void CUDT::processCtrl(const CPacket &ctrlpkt)
 {
     // Just heard from the peer, reset the expiration count.
     m_iEXPCount = 1;
@@ -9465,7 +9457,7 @@ void srt::CUDT::processCtrl(const CPacket &ctrlpkt)
     }
 }
 
-void srt::CUDT::updateSrtRcvSettings()
+void CUDT::updateSrtRcvSettings()
 {
     // CHANGED: we need to apply the tsbpd delay only for socket TSBPD.
     // For Group TSBPD the buffer will have to deliver packets always on request
@@ -9496,7 +9488,7 @@ void srt::CUDT::updateSrtRcvSettings()
     }
 }
 
-void srt::CUDT::updateSrtSndSettings()
+void CUDT::updateSrtSndSettings()
 {
     if (m_bPeerTsbPd)
     {
@@ -9518,7 +9510,7 @@ void srt::CUDT::updateSrtSndSettings()
     }
 }
 
-void srt::CUDT::updateAfterSrtHandshake(int hsv)
+void CUDT::updateAfterSrtHandshake(int hsv)
 {
     HLOGC(cnlog.Debug, log << CONID() << "updateAfterSrtHandshake: HS version " << hsv);
     // This is blocked from being run in the "app reader" version because here
@@ -9573,7 +9565,7 @@ void srt::CUDT::updateAfterSrtHandshake(int hsv)
     }
 }
 
-int srt::CUDT::packLostData(CPacket& w_packet)
+int CUDT::packLostData(CPacket& w_packet)
 {
     // protect m_iSndLastDataAck from updating by ACK processing
     UniqueLock ackguard(m_RecvAckLock);
@@ -9696,7 +9688,7 @@ int srt::CUDT::packLostData(CPacket& w_packet)
 #if SRT_DEBUG_TRACE_SND
 class snd_logger
 {
-    typedef srt::sync::steady_clock steady_clock;
+    typedef sync::steady_clock steady_clock;
 
 public:
     snd_logger() {}
@@ -9709,7 +9701,7 @@ public:
 
     struct
     {
-        typedef srt::sync::steady_clock steady_clock;
+        typedef sync::steady_clock steady_clock;
         long long usElapsed;
         steady_clock::time_point tsNow;
         int usSRTT;
@@ -9725,7 +9717,7 @@ public:
 
     void trace()
     {
-        using namespace srt::sync;
+        using namespace sync;
         ScopedLock lck(m_mtx);
         create_file();
 
@@ -9755,8 +9747,8 @@ private:
         if (m_fout.is_open())
             return;
 
-        m_start_time = srt::sync::steady_clock::now();
-        std::string str_tnow = srt::sync::FormatTimeSys(m_start_time);
+        m_start_time = sync::steady_clock::now();
+        std::string str_tnow = sync::FormatTimeSys(m_start_time);
         str_tnow.resize(str_tnow.size() - 7); // remove trailing ' [SYST]' part
         while (str_tnow.find(':') != std::string::npos)
         {
@@ -9771,15 +9763,15 @@ private:
     }
 
 private:
-    srt::sync::Mutex                    m_mtx;
+    sync::Mutex                    m_mtx;
     std::ofstream                       m_fout;
-    srt::sync::steady_clock::time_point m_start_time;
+    sync::steady_clock::time_point m_start_time;
 };
 
 snd_logger g_snd_logger;
 #endif // SRT_DEBUG_TRACE_SND
 
-void srt::CUDT::setPacketTS(CPacket& p, const time_point& ts)
+void CUDT::setPacketTS(CPacket& p, const time_point& ts)
 {
     enterCS(m_StatsLock);
     const time_point tsStart = m_stats.tsStartTime;
@@ -9787,7 +9779,7 @@ void srt::CUDT::setPacketTS(CPacket& p, const time_point& ts)
     p.set_timestamp(makeTS(ts, tsStart));
 }
 
-void srt::CUDT::setDataPacketTS(CPacket& p, const time_point& ts)
+void CUDT::setDataPacketTS(CPacket& p, const time_point& ts)
 {
     enterCS(m_StatsLock);
     const time_point tsStart = m_stats.tsStartTime;
@@ -9815,7 +9807,7 @@ void srt::CUDT::setDataPacketTS(CPacket& p, const time_point& ts)
     p.set_timestamp(makeTS(ts, tsStart));
 }
 
-bool srt::CUDT::isRetransmissionAllowed(const time_point& tnow SRT_ATR_UNUSED)
+bool CUDT::isRetransmissionAllowed(const time_point& tnow SRT_ATR_UNUSED)
 {
     // Prioritization of original packets only applies to Live CC.
     if (!m_bPeerTLPktDrop || !m_config.bMessageAPI)
@@ -9867,7 +9859,7 @@ bool srt::CUDT::isRetransmissionAllowed(const time_point& tnow SRT_ATR_UNUSED)
     return true;
 }
 
-bool srt::CUDT::packData(CPacket& w_packet, steady_clock::time_point& w_nexttime, CNetworkInterface& w_src_addr)
+bool CUDT::packData(CPacket& w_packet, steady_clock::time_point& w_nexttime, CNetworkInterface& w_src_addr)
 {
     int payload = 0;
     bool probe = false;
@@ -10007,7 +9999,7 @@ bool srt::CUDT::packData(CPacket& w_packet, steady_clock::time_point& w_nexttime
     return payload >= 0; // XXX shouldn't be > 0 ? == 0 is only when buffer range exceeded.
 }
 
-bool srt::CUDT::packUniqueData(CPacket& w_packet)
+bool CUDT::packUniqueData(CPacket& w_packet)
 {
     int current_sequence_number; // reflexing variable
     int kflg;
@@ -10162,7 +10154,7 @@ bool srt::CUDT::packUniqueData(CPacket& w_packet)
 
 // This is a close request, but called from the handler of the
 // buffer overflow in live mode.
-void srt::CUDT::processClose()
+void CUDT::processClose()
 {
     uint32_t res[1] = { SRT_CLS_OVERFLOW };
     sendCtrl(UMSG_SHUTDOWN, NULL, res, sizeof res);
@@ -10189,7 +10181,7 @@ void srt::CUDT::processClose()
     CGlobEvent::triggerEvent();
 }
 
-void srt::CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
+void CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &loss_seqs)
 {
     vector<int32_t> seqbuffer;
     seqbuffer.reserve(2 * loss_seqs.size()); // pessimistic
@@ -10216,7 +10208,7 @@ void srt::CUDT::sendLossReport(const std::vector<std::pair<int32_t, int32_t> > &
 }
 
 
-bool srt::CUDT::overrideSndSeqNo(int32_t seq)
+bool CUDT::overrideSndSeqNo(int32_t seq)
 {
     // This function is intended to be called from the socket
     // group management functions to synchronize the sequnece in
@@ -10275,7 +10267,7 @@ bool srt::CUDT::overrideSndSeqNo(int32_t seq)
     return true;
 }
 
-int srt::CUDT::checkLazySpawnTsbPdThread()
+int CUDT::checkLazySpawnTsbPdThread()
 {
     const bool need_tsbpd = m_bTsbPd || m_bGroupTsbPd;
     if (!need_tsbpd)
@@ -10305,7 +10297,7 @@ int srt::CUDT::checkLazySpawnTsbPdThread()
     return 0;
 }
 
-CUDT::time_point srt::CUDT::getPktTsbPdTime(void*, const CPacket& packet)
+CUDT::time_point CUDT::getPktTsbPdTime(void*, const CPacket& packet)
 {
     return m_pRcvBuffer->getPktTsbPdTime(packet.getMsgTimeStamp());
 }
@@ -10313,7 +10305,7 @@ CUDT::time_point srt::CUDT::getPktTsbPdTime(void*, const CPacket& packet)
 SRT_ATR_UNUSED static const char *const s_rexmitstat_str[] = {"ORIGINAL", "REXMITTED", "RXS-UNKNOWN"};
 
 // [[using locked(m_RcvBufferLock)]]
-int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool& w_new_inserted, time_point& w_next_tsbpd, bool& w_was_sent_in_order, CUDT::loss_seqs_t& w_srt_loss_seqs)
+int CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool& w_new_inserted, time_point& w_next_tsbpd, bool& w_was_sent_in_order, CUDT::loss_seqs_t& w_srt_loss_seqs)
 {
     bool excessive SRT_ATR_UNUSED = true; // stays true unless it was successfully added
 
@@ -10580,7 +10572,7 @@ int srt::CUDT::handleSocketPacketReception(const vector<CUnit*>& incoming, bool&
     return 0;
 }
 
-int srt::CUDT::processData(CUnit* in_unit)
+int CUDT::processData(CUnit* in_unit)
 {
     if (m_bClosing)
         return -1;
@@ -11021,7 +11013,7 @@ int srt::CUDT::processData(CUnit* in_unit)
 // if the transmission was already torn in the previously active link
 // this shouldn't be a problem that these packets won't be recovered
 // after activating the second link, although will be retried this way.
-void srt::CUDT::updateIdleLinkFrom(CUDT* source)
+void CUDT::updateIdleLinkFrom(CUDT* source)
 {
     int bufseq;
     {
@@ -11079,7 +11071,7 @@ void srt::CUDT::updateIdleLinkFrom(CUDT* source)
 /// do not include the lacking packet.
 /// The tolerance is not increased infinitely - it's bordered by iMaxReorderTolerance.
 /// This value can be set in options - SRT_LOSSMAXTTL.
-void srt::CUDT::unlose(const CPacket &packet)
+void CUDT::unlose(const CPacket &packet)
 {
     ScopedLock lg(m_RcvLossLock);
     int32_t sequence = packet.seqno();
@@ -11174,7 +11166,7 @@ void srt::CUDT::unlose(const CPacket &packet)
     }
 }
 
-void srt::CUDT::dropFromLossLists(int32_t from, int32_t to)
+void CUDT::dropFromLossLists(int32_t from, int32_t to)
 {
     ScopedLock lg(m_RcvLossLock);
 
@@ -11255,7 +11247,7 @@ void srt::CUDT::dropFromLossLists(int32_t from, int32_t to)
 }
 
 // This function, as the name states, should bake a new cookie.
-int32_t srt::CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int correction)
+int32_t CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int correction)
 {
     static unsigned int distractor = 0;
     unsigned int        rollover   = distractor + 10;
@@ -11315,7 +11307,7 @@ int32_t srt::CUDT::bake(const sockaddr_any& addr, int32_t current_cookie, int co
 // and this will be directly passed to the caller.
 
 // [[using locked(m_pRcvQueue->m_LSLock)]];
-int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
+int CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
 {
     // XXX ASSUMPTIONS:
     // [[using assert(packet.id() == 0)]]
@@ -11650,7 +11642,7 @@ int srt::CUDT::processConnectRequest(const sockaddr_any& addr, CPacket& packet)
     return RejectReasonForURQ(hs.m_iReqType);
 }
 
-void srt::CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
+void CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
 {
     if (lo == hi)
         lr.push_back(lo);
@@ -11661,7 +11653,7 @@ void srt::CUDT::addLossRecord(std::vector<int32_t> &lr, int32_t lo, int32_t hi)
     }
 }
 
-int srt::CUDT::checkACKTimer(const steady_clock::time_point &currtime)
+int CUDT::checkACKTimer(const steady_clock::time_point &currtime)
 {
     int because_decision = BECAUSE_NO_REASON;
     if (currtime > m_tsNextACKTime.load()  // ACK time has come
@@ -11700,7 +11692,7 @@ int srt::CUDT::checkACKTimer(const steady_clock::time_point &currtime)
     return because_decision;
 }
 
-int srt::CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
+int CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
 {
     // XXX The problem with working NAKREPORT with SRT_ARQ_ONREQ
     // is not that it would be inappropriate, but because it's not
@@ -11742,7 +11734,7 @@ int srt::CUDT::checkNAKTimer(const steady_clock::time_point& currtime)
     return debug_decision;
 }
 
-bool srt::CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_reason SRT_ATR_UNUSED)
+bool CUDT::checkExpTimer(const steady_clock::time_point& currtime, int check_reason SRT_ATR_UNUSED)
 {
     // VERY HEAVY LOGGING
 #if ENABLE_HEAVY_LOGGING & 1
@@ -11841,7 +11833,7 @@ bool srt::CUDT::checkExpTimer(const steady_clock::time_point& currtime, int chec
     return false;
 }
 
-void srt::CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
+void CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
 {
     // Check if HSv4 should be retransmitted, and if KM_REQ should be resent if the side is INITIATOR.
     checkSndTimers();
@@ -11926,7 +11918,7 @@ void srt::CUDT::checkRexmitTimer(const steady_clock::time_point& currtime)
     m_pSndQueue->m_pSndUList->update(this, CSndUList::DONT_RESCHEDULE);
 }
 
-void srt::CUDT::checkTimers()
+void CUDT::checkTimers()
 {
     // update CC parameters
     updateCC(TEV_CHECKTIMER, EventVariant(TEV_CHT_INIT));
@@ -11975,7 +11967,7 @@ void srt::CUDT::checkTimers()
     }
 }
 
-void srt::CUDT::updateBrokenConnection()
+void CUDT::updateBrokenConnection()
 {
     HLOGC(smlog.Debug, log << "updateBrokenConnection: setting closing=true and taking out epoll events");
     m_bClosing = true;
@@ -11985,7 +11977,7 @@ void srt::CUDT::updateBrokenConnection()
     CGlobEvent::triggerEvent();
 }
 
-void srt::CUDT::completeBrokenConnectionDependencies(int errorcode)
+void CUDT::completeBrokenConnectionDependencies(int errorcode)
 {
     int token = -1;
 
@@ -12053,7 +12045,7 @@ void srt::CUDT::completeBrokenConnectionDependencies(int errorcode)
 #endif
 }
 
-void srt::CUDT::addEPoll(const int eid)
+void CUDT::addEPoll(const int eid)
 {
     enterCS(uglobal().m_EPoll.m_EPollLock);
     m_sPollID.insert(eid);
@@ -12093,7 +12085,7 @@ void srt::CUDT::addEPoll(const int eid)
     }
 }
 
-void srt::CUDT::removeEPollEvents(const int eid)
+void CUDT::removeEPollEvents(const int eid)
 {
     // clear IO events notifications;
     // since this happens after the epoll ID has been removed, they cannot be set again
@@ -12102,14 +12094,14 @@ void srt::CUDT::removeEPollEvents(const int eid)
     uglobal().m_EPoll.update_events(m_SocketID, remove, SRT_EPOLL_IN | SRT_EPOLL_OUT, false);
 }
 
-void srt::CUDT::removeEPollID(const int eid)
+void CUDT::removeEPollID(const int eid)
 {
     enterCS(uglobal().m_EPoll.m_EPollLock);
     m_sPollID.erase(eid);
     leaveCS(uglobal().m_EPoll.m_EPollLock);
 }
 
-void srt::CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
+void CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
 {
     if (evt >= TEV_E_SIZE)
         return; // sanity check
@@ -12117,7 +12109,7 @@ void srt::CUDT::ConnectSignal(ETransmissionEvent evt, EventSlot sl)
     m_Slots[evt].push_back(sl);
 }
 
-void srt::CUDT::DisconnectSignal(ETransmissionEvent evt)
+void CUDT::DisconnectSignal(ETransmissionEvent evt)
 {
     if (evt >= TEV_E_SIZE)
         return; // sanity check
@@ -12125,7 +12117,7 @@ void srt::CUDT::DisconnectSignal(ETransmissionEvent evt)
     m_Slots[evt].clear();
 }
 
-void srt::CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
+void CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
 {
     for (std::vector<EventSlot>::iterator i = m_Slots[tev].begin(); i != m_Slots[tev].end(); ++i)
     {
@@ -12133,7 +12125,7 @@ void srt::CUDT::EmitSignal(ETransmissionEvent tev, EventVariant var)
     }
 }
 
-int srt::CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
+int CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
 {
     CUDTSocket *s = uglobal().locateSocket(u);
     if (!s)
@@ -12156,7 +12148,7 @@ int srt::CUDT::getsndbuffer(SRTSOCKET u, size_t *blocks, size_t *bytes)
     return std::abs(timespan);
 }
 
-int srt::CUDT::rejectReason(SRTSOCKET u)
+int CUDT::rejectReason(SRTSOCKET u)
 {
     CUDTSocket* s = uglobal().locateSocket(u);
     if (!s)
@@ -12165,7 +12157,7 @@ int srt::CUDT::rejectReason(SRTSOCKET u)
     return s->core().m_RejectReason;
 }
 
-SRTSTATUS srt::CUDT::rejectReason(SRTSOCKET u, int value)
+SRTSTATUS CUDT::rejectReason(SRTSOCKET u, int value)
 {
     CUDTSocket* s = uglobal().locateSocket(u);
     if (!s)
@@ -12178,7 +12170,7 @@ SRTSTATUS srt::CUDT::rejectReason(SRTSOCKET u, int value)
     return SRT_STATUS_OK;
 }
 
-int64_t srt::CUDT::socketStartTime(SRTSOCKET u)
+int64_t CUDT::socketStartTime(SRTSOCKET u)
 {
     CUDTSocket* s = uglobal().locateSocket(u);
     if (!s)
@@ -12188,7 +12180,7 @@ int64_t srt::CUDT::socketStartTime(SRTSOCKET u)
     return count_microseconds(start_time.time_since_epoch());
 }
 
-bool srt::CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)
+bool CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShake& hs, const CPacket& hspkt)
 {
     // Prepare the information for the hook.
 
@@ -12293,7 +12285,7 @@ bool srt::CUDT::runAcceptHook(CUDT *acore, const sockaddr* peer, const CHandShak
     return true;
 }
 
-void srt::CUDT::processKeepalive(const CPacket& ctrlpkt, const time_point& tsArrival)
+void CUDT::processKeepalive(const CPacket& ctrlpkt, const time_point& tsArrival)
 {
     // Here can be handled some protocol definition
     // for extra data sent through keepalive.
@@ -12325,7 +12317,7 @@ void srt::CUDT::processKeepalive(const CPacket& ctrlpkt, const time_point& tsArr
 }
 
 // This function should be called when closing the socket internally.
-void srt::CUDT::setAgentCloseReason(int reason)
+void CUDT::setAgentCloseReason(int reason)
 {
     m_AgentCloseReason.compare_exchange(SRT_CLS_UNKNOWN, reason);
 
@@ -12337,7 +12329,7 @@ void srt::CUDT::setAgentCloseReason(int reason)
 }
 
 // This function should be called in a handler of UMSG_SHUTDOWN.
-void srt::CUDT::setPeerCloseReason(int reason)
+void CUDT::setPeerCloseReason(int reason)
 {
     m_AgentCloseReason.compare_exchange(SRT_CLS_UNKNOWN, SRT_CLS_PEER);
     if (m_AgentCloseReason == SRT_CLS_PEER)
@@ -12348,9 +12340,11 @@ void srt::CUDT::setPeerCloseReason(int reason)
     }
 }
 
-void srt::CUDT::copyCloseInfo(SRT_CLOSE_INFO& info)
+void CUDT::copyCloseInfo(SRT_CLOSE_INFO& info)
 {
     info.agent = SRT_CLOSE_REASON(m_AgentCloseReason.load());
     info.peer = SRT_CLOSE_REASON(m_PeerCloseReason.load());
     info.time = m_CloseTimeStamp.load().time_since_epoch().count();
 }
+
+} // END namespace srt

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -54,6 +54,7 @@ modified by
 #define SRT_ENABLE_FAKE_LOSS_HS 0
 
 #include "platform_sys.h"
+#include "srt_attr_defs.h"
 
 // Linux specific
 #ifdef SRT_ENABLE_BINDTODEVICE

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -81,17 +81,7 @@ modified by
 #define SRT_ENABLE_FREQUENT_LOG_TRACE 0
 #endif
 
-
-// TODO: Utility function - to be moved to utilities.h?
-template <class T>
-inline T CountIIR(T base, T newval, double factor)
-{
-    if ( base == 0.0 )
-        return newval;
-
-    T diff = newval - base;
-    return base+T(diff*factor);
-}
+namespace srt {
 
 // TODO: Probably a better rework for that can be done - this can be
 // turned into a serializable structure, just like it's done for CHandShake.
@@ -152,7 +142,6 @@ enum SeqPairItems
 // Extended SRT Congestion control class - only an incomplete definition required
 class CCryptoControl;
 
-namespace srt {
 class CUDTUnited;
 class CUDTSocket;
 #if ENABLE_BONDING
@@ -228,7 +217,7 @@ public: //API
     static int recvmsg2(SRTSOCKET u, char* buf, int len, SRT_MSGCTRL& w_mctrl);
     static int64_t sendfile(SRTSOCKET u, std::fstream& ifs, int64_t& offset, int64_t size, int block = SRT_DEFAULT_SENDFILE_BLOCK);
     static int64_t recvfile(SRTSOCKET u, std::fstream& ofs, int64_t& offset, int64_t size, int block = SRT_DEFAULT_RECVFILE_BLOCK);
-    static int select(int nfds, UDT::UDSET* readfds, UDT::UDSET* writefds, UDT::UDSET* exceptfds, const timeval* timeout);
+    static int select(int nfds, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds, std::set<SRTSOCKET>* exceptfds, const timeval* timeout);
     static int selectEx(const std::vector<SRTSOCKET>& fds, std::vector<SRTSOCKET>* readfds, std::vector<SRTSOCKET>* writefds, std::vector<SRTSOCKET>* exceptfds, int64_t msTimeOut);
     static int epoll_create();
     static SRTSTATUS epoll_clear_usocks(int eid);
@@ -240,6 +229,9 @@ public: //API
     static SRTSTATUS epoll_update_ssock(const int eid, const SYSSOCKET s, const int* events = NULL);
     static int epoll_wait(const int eid, std::set<SRTSOCKET>* readfds, std::set<SRTSOCKET>* writefds,
             int64_t msTimeOut, std::set<SYSSOCKET>* lrfds = NULL, std::set<SYSSOCKET>* wrfds = NULL);
+    static int epoll_wait2(int eid, SRTSOCKET* readfds, int* rnum, SRTSOCKET* writefds, int* wnum,
+            int64_t    msTimeOut,
+            SYSSOCKET* lrfds, int* lrnum, SYSSOCKET* lwfds, int* lwnum);
     static int epoll_uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut);
     static int32_t epoll_set(const int eid, int32_t flags);
     static SRTSTATUS epoll_release(const int eid);
@@ -463,7 +455,7 @@ public: // internal API
 
     SRTU_PROPERTY_RO(SRTSOCKET, id, m_SocketID);
     SRTU_PROPERTY_RO(bool, isClosing, m_bClosing);
-    SRTU_PROPERTY_RO(srt::CRcvBuffer*, rcvBuffer, m_pRcvBuffer);
+    SRTU_PROPERTY_RO(CRcvBuffer*, rcvBuffer, m_pRcvBuffer);
     SRTU_PROPERTY_RO(bool, isTLPktDrop, m_bTLPktDrop);
     SRTU_PROPERTY_RO(bool, isSynReceiving, m_config.bSynRecving);
     SRTU_PROPERTY_RR(sync::Condition*, recvDataCond, &m_RecvDataCond);

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -33,7 +33,7 @@ using namespace srt_logging;
 namespace srt
 {
 
-const size_t SRT_MAX_KMRETRY = 10;
+const size_t SRT_MAX_KMRETRY SRT_ATR_UNUSED = 10;
 
 const size_t SRT_CMD_KMREQ_SZ = HCRYPT_MSG_KM_MAX_SZ;
 SRT_STATIC_ASSERT(SRT_CMD_KMREQ_SZ <= SRT_CMD_MAXSZ, "error: SRT_CMD_MAXSZ too small");

--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -13,6 +13,8 @@ written by
    Haivision Systems Inc.
  *****************************************************************************/
 
+#include "crypto.h"
+
 #include "platform_sys.h"
 
 #include <cstring>
@@ -20,30 +22,30 @@ written by
 #include <sstream>
 #include <iterator>
 
-#include "udt.h"
 #include "utilities.h"
 #include <haicrypt.h>
-#include "crypto.h"
 #include "logging.h"
 #include "core.h"
 #include "api.h"
 
 using namespace srt_logging;
 
-#define SRT_MAX_KMRETRY     10
- 
-//#define SRT_CMD_KMREQ       3           /* HaiCryptTP SRT Keying Material */
-//#define SRT_CMD_KMRSP       4           /* HaiCryptTP SRT Keying Material ACK */
-#define SRT_CMD_KMREQ_SZ    HCRYPT_MSG_KM_MAX_SZ          /* */
-#if     SRT_CMD_KMREQ_SZ > SRT_CMD_MAXSZ
-#error  SRT_CMD_MAXSZ too small
-#endif
+namespace srt
+{
+
+const size_t SRT_MAX_KMRETRY = 10;
+
+const size_t SRT_CMD_KMREQ_SZ = HCRYPT_MSG_KM_MAX_SZ;
+SRT_STATIC_ASSERT(SRT_CMD_KMREQ_SZ <= SRT_CMD_MAXSZ, "error: SRT_CMD_MAXSZ too small");
+
 /*      Key Material Request (Network Order)
         See HaiCryptTP SRT (hcrypt_xpt_srt.c)
 */
 
 // 10* HAICRYPT_DEF_KM_PRE_ANNOUNCE
 const int SRT_CRYPT_KM_PRE_ANNOUNCE SRT_ATR_UNUSED = 0x10000;
+
+}
 
 namespace srt_logging
 {
@@ -77,7 +79,10 @@ std::string KmStateStr(SRT_KM_STATE state)
 
 using srt_logging::KmStateStr;
 
-void srt::CCryptoControl::globalInit()
+namespace srt
+{
+
+void CCryptoControl::globalInit()
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     // We need to force the Cryspr to be initialized during startup to avoid the
@@ -86,7 +91,7 @@ void srt::CCryptoControl::globalInit()
 #endif
 }
 
-bool srt::CCryptoControl::isAESGCMSupported()
+bool CCryptoControl::isAESGCMSupported()
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     return HaiCrypt_IsAESGCM_Supported() != 0;
@@ -96,7 +101,7 @@ bool srt::CCryptoControl::isAESGCMSupported()
 }
 
 #if ENABLE_LOGGING
-std::string srt::CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srtlen)
+std::string CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_t srtlen)
 {
     std::ostringstream os;
     os << hdr << ": cmd=" << cmd << "(" << (cmd == SRT_CMD_KMREQ ? "KMREQ":"KMRSP") <<") len="
@@ -107,7 +112,7 @@ std::string srt::CCryptoControl::FormatKmMessage(std::string hdr, int cmd, size_
 }
 #endif
 
-void srt::CCryptoControl::updateKmState(int cmd, size_t srtlen SRT_ATR_UNUSED)
+void CCryptoControl::updateKmState(int cmd, size_t srtlen SRT_ATR_UNUSED)
 {
     if (cmd == SRT_CMD_KMREQ)
     {
@@ -123,7 +128,7 @@ void srt::CCryptoControl::updateKmState(int cmd, size_t srtlen SRT_ATR_UNUSED)
     }
 }
 
-void srt::CCryptoControl::createFakeSndContext()
+void CCryptoControl::createFakeSndContext()
 {
     if (!m_iSndKmKeyLen)
         m_iSndKmKeyLen = 16;
@@ -135,7 +140,7 @@ void srt::CCryptoControl::createFakeSndContext()
     }
 }
 
-int srt::CCryptoControl::processSrtMsg_KMREQ(
+int CCryptoControl::processSrtMsg_KMREQ(
         const uint32_t* srtdata SRT_ATR_UNUSED,
         size_t bytelen SRT_ATR_UNUSED,
         int hsv SRT_ATR_UNUSED, unsigned srtv SRT_ATR_UNUSED,
@@ -368,7 +373,7 @@ HSv4_ErrorReport:
     return SRT_CMD_KMRSP;
 }
 
-int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, unsigned srtv)
+int CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, unsigned srtv)
 {
     /* All 32-bit msg fields (if present) swapped on reception
      * But HaiCrypt expect network order message
@@ -480,7 +485,7 @@ int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len
     return retstatus;
 }
 
-void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SRT_ATR_UNUSED)
+void CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SRT_ATR_UNUSED)
 {
     sync::ScopedLock lck(m_mtxLock);
     if (!m_hSndCrypto || m_SndKmState == SRT_KM_S_UNSECURED)
@@ -490,7 +495,7 @@ void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SR
         return;
     }
 #ifdef SRT_ENABLE_ENCRYPTION
-    srt::sync::steady_clock::time_point now = srt::sync::steady_clock::now();
+    sync::steady_clock::time_point now = sync::steady_clock::now();
     /*
      * Crypto Key Distribution to peer:
      * If...
@@ -501,7 +506,7 @@ void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SR
      * then (re-)send handshake request.
      */
     if (((m_SndKmMsg[0].iPeerRetry > 0) || (m_SndKmMsg[1].iPeerRetry > 0))
-        && ((m_SndKmLastTime + srt::sync::microseconds_from((iSRTT * 3)/2)) <= now))
+        && ((m_SndKmLastTime + sync::microseconds_from((iSRTT * 3)/2)) <= now))
     {
         for (int ki = 0; ki < 2; ki++)
         {
@@ -518,7 +523,7 @@ void srt::CCryptoControl::sendKeysToPeer(CUDT* sock SRT_ATR_UNUSED, int iSRTT SR
 #endif
 }
 
-void srt::CCryptoControl::regenCryptoKm(CUDT* sock SRT_ATR_UNUSED, bool bidirectional SRT_ATR_UNUSED)
+void CCryptoControl::regenCryptoKm(CUDT* sock SRT_ATR_UNUSED, bool bidirectional SRT_ATR_UNUSED)
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     sync::ScopedLock lck(m_mtxLock);
@@ -594,11 +599,11 @@ void srt::CCryptoControl::regenCryptoKm(CUDT* sock SRT_ATR_UNUSED, bool bidirect
             << "; key[1]: len=" << m_SndKmMsg[1].MsgLen << " retry=" << m_SndKmMsg[1].iPeerRetry);
 
     if (sent)
-        m_SndKmLastTime = srt::sync::steady_clock::now();
+        m_SndKmLastTime = sync::steady_clock::now();
 #endif
 }
 
-srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
+CCryptoControl::CCryptoControl(SRTSOCKET id)
     : m_SocketID(id)
     , m_iSndKmKeyLen(0)
     , m_iRcvKmKeyLen(0)
@@ -621,7 +626,7 @@ srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     m_hRcvCrypto = NULL;
 }
 
-bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool bidirectional SRT_ATR_UNUSED, bool bUseGcm153 SRT_ATR_UNUSED)
+bool CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool bidirectional SRT_ATR_UNUSED, bool bUseGcm153 SRT_ATR_UNUSED)
 {
     // NOTE: initiator creates m_hSndCrypto. When bidirectional,
     // it creates also m_hRcvCrypto with the same key length.
@@ -714,14 +719,14 @@ bool srt::CCryptoControl::init(HandshakeSide side, const CSrtConfig& cfg, bool b
     return true;
 }
 
-void srt::CCryptoControl::close() 
+void CCryptoControl::close() 
 {
     /* Wipeout secrets */
     sync::ScopedLock lck(m_mtxLock);
     memset(&m_KmSecret, 0, sizeof(m_KmSecret));
 }
 
-std::string srt::CCryptoControl::CONID() const
+std::string CCryptoControl::CONID() const
 {
     if (int32_t(m_SocketID) <= 0)
         return "";
@@ -735,7 +740,6 @@ std::string srt::CCryptoControl::CONID() const
 #ifdef SRT_ENABLE_ENCRYPTION
 
 #if ENABLE_HEAVY_LOGGING
-namespace srt {
 static std::string CryptoFlags(int flg)
 {
     using namespace std;
@@ -752,10 +756,9 @@ static std::string CryptoFlags(int flg)
     copy(f.begin(), f.end(), ostream_iterator<string>(os, "|"));
     return os.str();
 }
-} // namespace srt
 #endif // ENABLE_HEAVY_LOGGING
 
-bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t keylen, HaiCrypt_CryptoDir cdir, bool bAESGCM)
+bool CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t keylen, HaiCrypt_CryptoDir cdir, bool bAESGCM)
 {
     if (w_hCrypto)
     {
@@ -802,14 +805,14 @@ bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle& w_hCrypto, size_t key
     return true;
 }
 #else
-bool srt::CCryptoControl::createCryptoCtx(HaiCrypt_Handle&, size_t, HaiCrypt_CryptoDir, bool)
+bool CCryptoControl::createCryptoCtx(HaiCrypt_Handle&, size_t, HaiCrypt_CryptoDir, bool)
 {
     return false;
 }
 #endif // SRT_ENABLE_ENCRYPTION
 
 
-srt::EncryptionStatus srt::CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNUSED)
+EncryptionStatus CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNUSED)
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     // Encryption not enabled - do nothing.
@@ -836,7 +839,7 @@ srt::EncryptionStatus srt::CCryptoControl::encrypt(CPacket& w_packet SRT_ATR_UNU
 #endif
 }
 
-srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNUSED)
+EncryptionStatus CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNUSED)
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     if (w_packet.getMsgCryptoFlags() == EK_NOENC)
@@ -912,7 +915,7 @@ srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNU
 }
 
 
-srt::CCryptoControl::~CCryptoControl()
+CCryptoControl::~CCryptoControl()
 {
 #ifdef SRT_ENABLE_ENCRYPTION
     close();
@@ -926,4 +929,6 @@ srt::CCryptoControl::~CCryptoControl()
         HaiCrypt_Close(m_hRcvCrypto);
     }
 #endif
+}
+
 }

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -20,7 +20,6 @@ written by
 #include <string>
 
 // UDT
-#include "udt.h"
 #include "packet.h"
 #include "utilities.h"
 #include "logging.h"
@@ -47,7 +46,7 @@ struct CSrtConfig;
 // For KMREQ/KMRSP. Only one field is used.
 const size_t SRT_KMR_KMSTATE = 0;
 
-#define SRT_CMD_MAXSZ       HCRYPT_MSG_KM_MAX_SZ  /* Maximum SRT custom messages payload size (bytes) */
+const size_t SRT_CMD_MAXSZ = HCRYPT_MSG_KM_MAX_SZ;  // Maximum SRT custom messages payload size (bytes)
 const size_t SRTDATA_MAXSIZE = SRT_CMD_MAXSZ/sizeof(uint32_t);
 
 class CCryptoControl

--- a/srtcore/epoll.h
+++ b/srtcore/epoll.h
@@ -57,7 +57,6 @@ modified by
 #include <map>
 #include <set>
 #include <list>
-#include "udt.h"
 
 namespace srt
 {
@@ -486,10 +485,10 @@ public: // for CUDT to acknowledge IO status
 
 private:
    int m_iIDSeed;                            // seed to generate a new ID
-   srt::sync::Mutex m_SeedLock;
+   sync::Mutex m_SeedLock;
 
    std::map<int, CEPollDesc> m_mPolls;       // all epolls
-   mutable srt::sync::Mutex m_EPollLock;
+   mutable sync::Mutex m_EPollLock;
 };
 
 #if ENABLE_HEAVY_LOGGING

--- a/srtcore/filelist.maf
+++ b/srtcore/filelist.maf
@@ -48,10 +48,10 @@ PUBLIC HEADERS
 srt.h
 logging_api.h
 access_control.h
+# version.h - NOTE: generated in the build and added to installation
 
 PROTECTED HEADERS
 platform_sys.h
-udt.h
 
 PRIVATE HEADERS
 api.h

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2609,7 +2609,7 @@ const char* CUDTGroup::StateStr(CUDTGroup::GroupState st)
     return unknown;
 }
 
-void CUDTGroup::synchronizeDrift(const srt::CUDT* srcMember)
+void CUDTGroup::synchronizeDrift(const CUDT* srcMember)
 {
     SRT_ASSERT(srcMember != NULL);
     ScopedLock glock(m_GroupLock);
@@ -2765,17 +2765,17 @@ public:
 
     ~StabilityTracer()
     {
-        srt::sync::ScopedLock lck(m_mtx);
+        ScopedLock lck(m_mtx);
         m_fout.close();
     }
 
-    void trace(const CUDT& u, const srt::sync::steady_clock::time_point& currtime, uint32_t activation_period_us,
+    void trace(const CUDT& u, const steady_clock::time_point& currtime, uint32_t activation_period_us,
         int64_t stability_tmo_us, const std::string& state, uint16_t weight)
     {
-        srt::sync::ScopedLock lck(m_mtx);
+        ScopedLock lck(m_mtx);
         create_file();
 
-        m_fout << srt::sync::FormatTime(currtime) << ",";
+        m_fout << FormatTime(currtime) << ",";
         m_fout << u.id() << ",";
         m_fout << weight << ",";
         m_fout << u.peerLatency_us() << ",";
@@ -2784,7 +2784,7 @@ public:
         m_fout << stability_tmo_us << ",";
         m_fout << count_microseconds(currtime - u.lastRspTime()) << ",";
         m_fout << state << ",";
-        m_fout << (srt::sync::is_zero(u.freshActivationStart()) ? -1 : (count_microseconds(currtime - u.freshActivationStart()))) << ",";
+        m_fout << (is_zero(u.freshActivationStart()) ? -1 : (count_microseconds(currtime - u.freshActivationStart()))) << ",";
         m_fout << activation_period_us << "\n";
         m_fout.flush();
     }
@@ -2792,7 +2792,7 @@ public:
 private:
     void print_header()
     {
-        //srt::sync::ScopedLock lck(m_mtx);
+        //ScopedLock lck(m_mtx);
         m_fout << "Timepoint,SocketID,weight,usLatency,usRTT,usRTTVar,usStabilityTimeout,usSinceLastResp,State,usSinceActivation,usActivationPeriod\n";
     }
 
@@ -2801,7 +2801,7 @@ private:
         if (m_fout.is_open())
             return;
 
-        std::string str_tnow = srt::sync::FormatTimeSys(srt::sync::steady_clock::now());
+        std::string str_tnow = FormatTimeSys(steady_clock::now());
         str_tnow.resize(str_tnow.size() - 7); // remove trailing ' [SYST]' part
         while (str_tnow.find(':') != std::string::npos) {
             str_tnow.replace(str_tnow.find(':'), 1, 1, '_');
@@ -2815,7 +2815,7 @@ private:
     }
 
 private:
-    srt::sync::Mutex m_mtx;
+    Mutex m_mtx;
     std::ofstream m_fout;
 };
 

--- a/srtcore/group.cpp
+++ b/srtcore/group.cpp
@@ -2792,7 +2792,6 @@ public:
 private:
     void print_header()
     {
-        //ScopedLock lck(m_mtx);
         m_fout << "Timepoint,SocketID,weight,usLatency,usRTT,usRTTVar,usStabilityTimeout,usSinceLastResp,State,usSinceActivation,usActivationPeriod\n";
     }
 

--- a/srtcore/handshake.cpp
+++ b/srtcore/handshake.cpp
@@ -51,17 +51,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iterator>
 #include <algorithm>
 
-#include "udt.h"
 #include "api.h"
 #include "core.h"
 #include "handshake.h"
 #include "utilities.h"
 
 using namespace std;
-using namespace srt;
 
+namespace srt
+{
 
-srt::CHandShake::CHandShake()
+CHandShake::CHandShake()
     : m_iVersion(0)
     , m_iType(0) // Universal: UDT_UNDEFINED or no flags
     , m_iISN(0)
@@ -76,7 +76,7 @@ srt::CHandShake::CHandShake()
       m_piPeerIP[i] = 0;
 }
 
-int srt::CHandShake::store_to(char* buf, size_t& w_size)
+int CHandShake::store_to(char* buf, size_t& w_size)
 {
    if (w_size < m_iContentSize)
       return -1;
@@ -98,7 +98,7 @@ int srt::CHandShake::store_to(char* buf, size_t& w_size)
    return 0;
 }
 
-int srt::CHandShake::load_from(const char* buf, size_t size)
+int CHandShake::load_from(const char* buf, size_t size)
 {
    if (size < m_iContentSize)
       return -1;
@@ -121,8 +121,6 @@ int srt::CHandShake::load_from(const char* buf, size_t size)
 
 #ifdef ENABLE_LOGGING
 
-namespace srt
-{
 const char* srt_rejectreason_name [] = {
     "UNKNOWN",
     "SYSTEM",
@@ -143,9 +141,8 @@ const char* srt_rejectreason_name [] = {
     "TIMEOUT",
     "CRYPTO"
 };
-}
 
-std::string srt::RequestTypeStr(UDTRequestType rq)
+std::string RequestTypeStr(UDTRequestType rq)
 {
     if (rq >= URQ_FAILURE_TYPES)
     {
@@ -178,7 +175,7 @@ std::string srt::RequestTypeStr(UDTRequestType rq)
     }
 }
 
-string srt::CHandShake::RdvStateStr(CHandShake::RendezvousState s)
+string CHandShake::RdvStateStr(CHandShake::RendezvousState s)
 {
     switch (s)
     {
@@ -194,7 +191,7 @@ string srt::CHandShake::RdvStateStr(CHandShake::RendezvousState s)
 }
 #endif
 
-bool srt::CHandShake::valid()
+bool CHandShake::valid()
 {
     if (m_iVersion < CUDT::HS_VERSION_UDT4
             || m_iISN < 0 || m_iISN >= CSeqNo::m_iMaxSeqNo
@@ -205,7 +202,7 @@ bool srt::CHandShake::valid()
     return true;
 }
 
-string srt::CHandShake::show()
+string CHandShake::show()
 {
     ostringstream so;
 
@@ -237,7 +234,7 @@ string srt::CHandShake::show()
     return so.str();
 }
 
-string srt::CHandShake::ExtensionFlagStr(int32_t fl)
+string CHandShake::ExtensionFlagStr(int32_t fl)
 {
     std::ostringstream out;
     if ( fl & HS_EXT_HSREQ )
@@ -264,7 +261,7 @@ string srt::CHandShake::ExtensionFlagStr(int32_t fl)
 // XXX This code isn't currently used. Left here because it can
 // be used in future, should any refactoring for the "manual word placement"
 // code be done.
-bool srt::SrtHSRequest::serialize(char* buf, size_t size) const
+bool SrtHSRequest::serialize(char* buf, size_t size) const
 {
     if (size < SRT_HS_SIZE)
         return false;
@@ -279,7 +276,7 @@ bool srt::SrtHSRequest::serialize(char* buf, size_t size) const
 }
 
 
-bool srt::SrtHSRequest::deserialize(const char* buf, size_t size)
+bool SrtHSRequest::deserialize(const char* buf, size_t size)
 {
     m_iSrtVersion = 0; // just to let users recognize if it succeeded or not.
 
@@ -295,7 +292,7 @@ bool srt::SrtHSRequest::deserialize(const char* buf, size_t size)
     return true;
 }
 
-std::string srt::SrtFlagString(int32_t flags)
+string SrtFlagString(int32_t flags)
 {
 #define LEN(arr) (sizeof (arr)/(sizeof ((arr)[0])))
 
@@ -325,4 +322,6 @@ std::string srt::SrtFlagString(int32_t flags)
     }
 
     return output;
+}
+
 }

--- a/srtcore/list.cpp
+++ b/srtcore/list.cpp
@@ -70,7 +70,10 @@ using srt_logging::tslog;
 
 using namespace srt::sync;
 
-srt::CSndLossList::CSndLossList(int size)
+namespace srt
+{
+
+CSndLossList::CSndLossList(int size)
     : m_caSeq()
     , m_iHead(-1)
     , m_iLength(0)
@@ -91,18 +94,18 @@ srt::CSndLossList::CSndLossList(int size)
     setupMutex(m_ListLock, "LossList");
 }
 
-srt::CSndLossList::~CSndLossList()
+CSndLossList::~CSndLossList()
 {
     delete[] m_caSeq;
     releaseMutex(m_ListLock);
 }
 
-void srt::CSndLossList::traceState() const
+void CSndLossList::traceState() const
 {
     traceState(std::cout) << "\n";
 }
 
-int srt::CSndLossList::insert(int32_t seqno1, int32_t seqno2)
+int CSndLossList::insert(int32_t seqno1, int32_t seqno2)
 {
     if (seqno1 < 0 || seqno2 < 0 ) {
         LOGC(qslog.Error, log << "IPE: Tried to insert negative seqno " << seqno1 << ":" << seqno2
@@ -219,7 +222,7 @@ int srt::CSndLossList::insert(int32_t seqno1, int32_t seqno2)
     return m_iLength - origlen;
 }
 
-void srt::CSndLossList::removeUpTo(int32_t seqno)
+void CSndLossList::removeUpTo(int32_t seqno)
 {
     ScopedLock listguard(m_ListLock);
 
@@ -331,14 +334,14 @@ void srt::CSndLossList::removeUpTo(int32_t seqno)
     }
 }
 
-int srt::CSndLossList::getLossLength() const
+int CSndLossList::getLossLength() const
 {
     ScopedLock listguard(m_ListLock);
 
     return m_iLength;
 }
 
-int32_t srt::CSndLossList::popLostSeq()
+int32_t CSndLossList::popLostSeq()
 {
     ScopedLock listguard(m_ListLock);
 
@@ -382,7 +385,7 @@ int32_t srt::CSndLossList::popLostSeq()
     return seqno;
 }
 
-void srt::CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
+void CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
 {
     SRT_ASSERT(pos >= 0);
     m_caSeq[pos].seqstart = seqno1;
@@ -398,7 +401,7 @@ void srt::CSndLossList::insertHead(int pos, int32_t seqno1, int32_t seqno2)
     m_iLength += CSeqNo::seqlen(seqno1, seqno2);
 }
 
-void srt::CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2)
+void CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int32_t seqno2)
 {
     m_caSeq[pos].seqstart = seqno1;
     SRT_ASSERT(m_caSeq[pos].seqend == SRT_SEQNO_NONE);
@@ -412,7 +415,7 @@ void srt::CSndLossList::insertAfter(int pos, int pos_after, int32_t seqno1, int3
     m_iLength += CSeqNo::seqlen(seqno1, seqno2);
 }
 
-void srt::CSndLossList::coalesce(int loc)
+void CSndLossList::coalesce(int loc)
 {
     // coalesce with next node. E.g., [3, 7], ..., [6, 9] becomes [3, 9]
     while ((m_caSeq[loc].inext != -1) && (m_caSeq[loc].seqend != SRT_SEQNO_NONE))
@@ -448,7 +451,7 @@ void srt::CSndLossList::coalesce(int loc)
     }
 }
 
-bool srt::CSndLossList::updateElement(int pos, int32_t seqno1, int32_t seqno2)
+bool CSndLossList::updateElement(int pos, int32_t seqno1, int32_t seqno2)
 {
     m_iLastInsertPos = pos;
 
@@ -474,7 +477,7 @@ bool srt::CSndLossList::updateElement(int pos, int32_t seqno1, int32_t seqno2)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-srt::CRcvLossList::CRcvLossList(int size)
+CRcvLossList::CRcvLossList(int size)
     : m_caSeq()
     , m_iHead(-1)
     , m_iTail(-1)
@@ -492,12 +495,12 @@ srt::CRcvLossList::CRcvLossList(int size)
     }
 }
 
-srt::CRcvLossList::~CRcvLossList()
+CRcvLossList::~CRcvLossList()
 {
     delete[] m_caSeq;
 }
 
-int srt::CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
+int CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
 {
     SRT_ASSERT(seqno1 != SRT_SEQNO_NONE && seqno2 != SRT_SEQNO_NONE);
     // Make sure that seqno2 isn't earlier than seqno1.
@@ -577,7 +580,7 @@ int srt::CRcvLossList::insert(int32_t seqno1, int32_t seqno2)
     return n;
 }
 
-bool srt::CRcvLossList::remove(int32_t seqno)
+bool CRcvLossList::remove(int32_t seqno)
 {
     if (m_iLargestSeq == SRT_SEQNO_NONE || CSeqNo::seqcmp(seqno, m_iLargestSeq) > 0)
         m_iLargestSeq = seqno;
@@ -716,7 +719,7 @@ bool srt::CRcvLossList::remove(int32_t seqno)
     return true;
 }
 
-bool srt::CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
+bool CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
 {
     if (CSeqNo::seqcmp(seqno1, seqno2) > 0)
     {
@@ -729,7 +732,7 @@ bool srt::CRcvLossList::remove(int32_t seqno1, int32_t seqno2)
     return true;
 }
 
-int32_t srt::CRcvLossList::removeUpTo(int32_t seqno_last)
+int32_t CRcvLossList::removeUpTo(int32_t seqno_last)
 {
     int32_t first = getFirstLostSeq();
     if (first == SRT_SEQNO_NONE)
@@ -757,7 +760,7 @@ int32_t srt::CRcvLossList::removeUpTo(int32_t seqno_last)
     return first;
 }
 
-bool srt::CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
+bool CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
 {
     if (0 == m_iLength)
         return false;
@@ -778,12 +781,12 @@ bool srt::CRcvLossList::find(int32_t seqno1, int32_t seqno2) const
     return false;
 }
 
-int srt::CRcvLossList::getLossLength() const
+int CRcvLossList::getLossLength() const
 {
     return m_iLength;
 }
 
-int32_t srt::CRcvLossList::getFirstLostSeq() const
+int32_t CRcvLossList::getFirstLostSeq() const
 {
     if (0 == m_iLength)
         return SRT_SEQNO_NONE;
@@ -791,7 +794,7 @@ int32_t srt::CRcvLossList::getFirstLostSeq() const
     return m_caSeq[m_iHead].seqstart;
 }
 
-void srt::CRcvLossList::getLossArray(int32_t* array, int& len, int limit)
+void CRcvLossList::getLossArray(int32_t* array, int& len, int limit)
 {
     len = 0;
 
@@ -814,7 +817,7 @@ void srt::CRcvLossList::getLossArray(int32_t* array, int& len, int limit)
     }
 }
 
-srt::CRcvFreshLoss::CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_age)
+CRcvFreshLoss::CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_age)
     : ttl(initial_age)
     , timestamp(steady_clock::now())
 {
@@ -822,7 +825,7 @@ srt::CRcvFreshLoss::CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_age)
     seq[1] = seqhi;
 }
 
-srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t sequence)
+CRcvFreshLoss::Emod CRcvFreshLoss::revoke(int32_t sequence)
 {
     int32_t diffbegin = CSeqNo::seqcmp(sequence, seq[0]);
     int32_t diffend   = CSeqNo::seqcmp(sequence, seq[1]);
@@ -853,7 +856,7 @@ srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t sequence)
     return SPLIT;
 }
 
-srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t lo, int32_t hi)
+CRcvFreshLoss::Emod CRcvFreshLoss::revoke(int32_t lo, int32_t hi)
 {
     // This should only if the range lo-hi is anyhow covered by seq[0]-seq[1].
 
@@ -897,7 +900,7 @@ srt::CRcvFreshLoss::Emod srt::CRcvFreshLoss::revoke(int32_t lo, int32_t hi)
     return DELETE;
 }
 
-bool srt::CRcvFreshLoss::removeOne(std::deque<CRcvFreshLoss>& w_container, int32_t sequence, int* pw_had_ttl)
+bool CRcvFreshLoss::removeOne(std::deque<CRcvFreshLoss>& w_container, int32_t sequence, int* pw_had_ttl)
 {
     for (size_t i = 0; i < w_container.size(); ++i)
     {
@@ -946,3 +949,4 @@ bool srt::CRcvFreshLoss::removeOne(std::deque<CRcvFreshLoss>& w_container, int32
 
 }
 
+}

--- a/srtcore/list.h
+++ b/srtcore/list.h
@@ -55,7 +55,6 @@ modified by
 
 #include <deque>
 
-#include "udt.h"
 #include "common.h"
 
 namespace srt {
@@ -124,7 +123,7 @@ private:
     const int m_iSize;          // size of the static array
     int       m_iLastInsertPos; // position of last insert node
 
-    mutable srt::sync::Mutex m_ListLock; // used to synchronize list operation
+    mutable sync::Mutex m_ListLock; // used to synchronize list operation
 
 private:
     /// Inserts an element to the beginning and updates head pointer.
@@ -280,7 +279,7 @@ struct CRcvFreshLoss
 {
     int32_t                             seq[2];
     int                                 ttl;
-    srt::sync::steady_clock::time_point timestamp;
+    sync::steady_clock::time_point timestamp;
 
     CRcvFreshLoss(int32_t seqlo, int32_t seqhi, int initial_ttl);
 

--- a/srtcore/packet.h
+++ b/srtcore/packet.h
@@ -53,7 +53,6 @@ modified by
 #ifndef INC_SRT_PACKET_H
 #define INC_SRT_PACKET_H
 
-#include "udt.h"
 #include "common.h"
 #include "utilities.h"
 #include "netinet_any.h"

--- a/srtcore/packetfilter.h
+++ b/srtcore/packetfilter.h
@@ -164,7 +164,7 @@ public:
             return i->second.get();
         }
         bool ParseConfig(const std::string& s, SrtFilterConfig& out, PacketFilter::Factory** ppf = NULL);
-        bool CheckFilterCompat(srt::SrtFilterConfig& w_agent, const srt::SrtFilterConfig& peer);
+        bool CheckFilterCompat(SrtFilterConfig& w_agent, const SrtFilterConfig& peer);
     public:
         Internal();
     };

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -65,7 +65,10 @@ using namespace std;
 using namespace srt::sync;
 using namespace srt_logging;
 
-srt::CUnitQueue::CUnitQueue(int initNumUnits, int mss)
+namespace srt
+{
+
+CUnitQueue::CUnitQueue(int initNumUnits, int mss)
     : m_iNumTaken(0)
     , m_iMSS(mss)
     , m_iBlockSize(initNumUnits)
@@ -83,7 +86,7 @@ srt::CUnitQueue::CUnitQueue(int initNumUnits, int mss)
     m_iSize = m_iBlockSize;
 }
 
-srt::CUnitQueue::~CUnitQueue()
+CUnitQueue::~CUnitQueue()
 {
     CQEntry* p = m_pQEntry;
 
@@ -101,7 +104,7 @@ srt::CUnitQueue::~CUnitQueue()
     }
 }
 
-srt::CUnitQueue::CQEntry* srt::CUnitQueue::allocateEntry(const int iNumUnits, const int mss)
+CUnitQueue::CQEntry* CUnitQueue::allocateEntry(const int iNumUnits, const int mss)
 {
     CQEntry* tempq = NULL;
     CUnit* tempu   = NULL;
@@ -136,7 +139,7 @@ srt::CUnitQueue::CQEntry* srt::CUnitQueue::allocateEntry(const int iNumUnits, co
     return tempq;
 }
 
-int srt::CUnitQueue::increase_()
+int CUnitQueue::increase_()
 {
     const int numUnits = m_iBlockSize;
     HLOGC(qrlog.Debug, log << "CUnitQueue::increase: Capacity" << capacity() << " + " << numUnits << " new units, " << m_iNumTaken << " in use.");
@@ -154,7 +157,7 @@ int srt::CUnitQueue::increase_()
     return 0;
 }
 
-srt::CUnit* srt::CUnitQueue::getNextAvailUnit()
+CUnit* CUnitQueue::getNextAvailUnit()
 {
     const int iNumUnitsTotal = capacity();
     if (m_iNumTaken * 10 > iNumUnitsTotal * 9) // 90% or more are in use.
@@ -185,7 +188,7 @@ srt::CUnit* srt::CUnitQueue::getNextAvailUnit()
     return NULL;
 }
 
-void srt::CUnitQueue::makeUnitFree(CUnit* unit)
+void CUnitQueue::makeUnitFree(CUnit* unit)
 {
     SRT_ASSERT(unit != NULL);
     SRT_ASSERT(unit->m_bTaken);
@@ -194,7 +197,7 @@ void srt::CUnitQueue::makeUnitFree(CUnit* unit)
     --m_iNumTaken;
 }
 
-void srt::CUnitQueue::makeUnitTaken(CUnit* unit)
+void CUnitQueue::makeUnitTaken(CUnit* unit)
 {
     ++m_iNumTaken;
 
@@ -203,7 +206,7 @@ void srt::CUnitQueue::makeUnitTaken(CUnit* unit)
     unit->m_bTaken.store(true);
 }
 
-srt::CSndUList::CSndUList(sync::CTimer* pTimer)
+CSndUList::CSndUList(sync::CTimer* pTimer)
     : m_pHeap(NULL)
     , m_iArrayLength(512)
     , m_iLastEntry(-1)
@@ -214,13 +217,13 @@ srt::CSndUList::CSndUList(sync::CTimer* pTimer)
     m_pHeap = new CSNode*[m_iArrayLength];
 }
 
-srt::CSndUList::~CSndUList()
+CSndUList::~CSndUList()
 {
     releaseCond(m_ListCond);
     delete[] m_pHeap;
 }
 
-void srt::CSndUList::update(const CUDT* u, EReschedule reschedule, sync::steady_clock::time_point ts)
+void CSndUList::update(const CUDT* u, EReschedule reschedule, sync::steady_clock::time_point ts)
 {
     ScopedLock listguard(m_ListLock);
 
@@ -249,7 +252,7 @@ void srt::CSndUList::update(const CUDT* u, EReschedule reschedule, sync::steady_
     insert_(ts, u);
 }
 
-srt::CUDT* srt::CSndUList::pop()
+CUDT* CSndUList::pop()
 {
     ScopedLock listguard(m_ListLock);
 
@@ -265,13 +268,13 @@ srt::CUDT* srt::CSndUList::pop()
     return u;
 }
 
-void srt::CSndUList::remove(const CUDT* u)
+void CSndUList::remove(const CUDT* u)
 {
     ScopedLock listguard(m_ListLock);
     remove_(u);
 }
 
-steady_clock::time_point srt::CSndUList::getNextProcTime()
+steady_clock::time_point CSndUList::getNextProcTime()
 {
     ScopedLock listguard(m_ListLock);
 
@@ -281,7 +284,7 @@ steady_clock::time_point srt::CSndUList::getNextProcTime()
     return m_pHeap[0]->m_tsTimeStamp;
 }
 
-void srt::CSndUList::waitNonEmpty() const
+void CSndUList::waitNonEmpty() const
 {
     UniqueLock listguard(m_ListLock);
     if (m_iLastEntry >= 0)
@@ -290,13 +293,13 @@ void srt::CSndUList::waitNonEmpty() const
     m_ListCond.wait(listguard);
 }
 
-void srt::CSndUList::signalInterrupt() const
+void CSndUList::signalInterrupt() const
 {
     ScopedLock listguard(m_ListLock);
     m_ListCond.notify_one();
 }
 
-void srt::CSndUList::realloc_()
+void CSndUList::realloc_()
 {
     CSNode** temp = NULL;
 
@@ -315,7 +318,7 @@ void srt::CSndUList::realloc_()
     m_pHeap = temp;
 }
 
-void srt::CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
+void CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
 {
     // increase the heap array size if necessary
     if (m_iLastEntry == m_iArrayLength - 1)
@@ -324,7 +327,7 @@ void srt::CSndUList::insert_(const steady_clock::time_point& ts, const CUDT* u)
     insert_norealloc_(ts, u);
 }
 
-void srt::CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT* u)
+void CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const CUDT* u)
 {
     CSNode* n = u->m_pSNode;
 
@@ -365,7 +368,7 @@ void srt::CSndUList::insert_norealloc_(const steady_clock::time_point& ts, const
     }
 }
 
-void srt::CSndUList::remove_(const CUDT* u)
+void CSndUList::remove_(const CUDT* u)
 {
     CSNode* n = u->m_pSNode;
 
@@ -405,7 +408,7 @@ void srt::CSndUList::remove_(const CUDT* u)
 }
 
 //
-srt::CSndQueue::CSndQueue()
+CSndQueue::CSndQueue()
     : m_pSndUList(NULL)
     , m_pChannel(NULL)
     , m_pTimer(NULL)
@@ -413,7 +416,7 @@ srt::CSndQueue::CSndQueue()
 {
 }
 
-srt::CSndQueue::~CSndQueue()
+CSndQueue::~CSndQueue()
 {
     m_bClosing = true;
 
@@ -434,20 +437,20 @@ srt::CSndQueue::~CSndQueue()
     delete m_pSndUList;
 }
 
-int srt::CSndQueue::ioctlQuery(int type) const
+int CSndQueue::ioctlQuery(int type) const
 {
     return m_pChannel->ioctlQuery(type);
 }
-int srt::CSndQueue::sockoptQuery(int level, int type) const
+int CSndQueue::sockoptQuery(int level, int type) const
 {
     return m_pChannel->sockoptQuery(level, type);
 }
 
 #if ENABLE_LOGGING
-srt::sync::atomic<int> srt::CSndQueue::m_counter(0);
+sync::atomic<int> CSndQueue::m_counter(0);
 #endif
 
-void srt::CSndQueue::init(CChannel* c, CTimer* t)
+void CSndQueue::init(CChannel* c, CTimer* t)
 {
     m_pChannel  = c;
     m_pTimer    = t;
@@ -464,25 +467,25 @@ void srt::CSndQueue::init(CChannel* c, CTimer* t)
         throw CUDTException(MJ_SYSTEMRES, MN_THREAD);
 }
 
-int srt::CSndQueue::getIpTTL() const
+int CSndQueue::getIpTTL() const
 {
     return m_pChannel ? m_pChannel->getIpTTL() : -1;
 }
 
-int srt::CSndQueue::getIpToS() const
+int CSndQueue::getIpToS() const
 {
     return m_pChannel ? m_pChannel->getIpToS() : -1;
 }
 
 #ifdef SRT_ENABLE_BINDTODEVICE
-bool srt::CSndQueue::getBind(char* dst, size_t len) const
+bool CSndQueue::getBind(char* dst, size_t len) const
 {
     return m_pChannel ? m_pChannel->getBind(dst, len) : false;
 }
 #endif
 
 #if defined(SRT_DEBUG_SNDQ_HIGHRATE)
-static void CSndQueueDebugHighratePrint(const srt::CSndQueue* self, const steady_clock::time_point currtime)
+static void CSndQueueDebugHighratePrint(const CSndQueue* self, const steady_clock::time_point currtime)
 {
     if (self->m_DbgTime <= currtime)
     {
@@ -500,7 +503,7 @@ static void CSndQueueDebugHighratePrint(const srt::CSndQueue* self, const steady
 }
 #endif
 
-void* srt::CSndQueue::worker(void* param)
+void* CSndQueue::worker(void* param)
 {
     CSndQueue* self = (CSndQueue*)param;
 
@@ -608,7 +611,7 @@ void* srt::CSndQueue::worker(void* param)
     return NULL;
 }
 
-int srt::CSndQueue::sendto(const sockaddr_any& addr, CPacket& w_packet, const CNetworkInterface& src)
+int CSndQueue::sendto(const sockaddr_any& addr, CPacket& w_packet, const CNetworkInterface& src)
 {
     // send out the packet immediately (high priority), this is a control packet
     // NOTE: w_packet is passed by mutable reference because this function will do
@@ -619,15 +622,15 @@ int srt::CSndQueue::sendto(const sockaddr_any& addr, CPacket& w_packet, const CN
 }
 
 //
-srt::CRcvUList::CRcvUList()
+CRcvUList::CRcvUList()
     : m_pUList(NULL)
     , m_pLast(NULL)
 {
 }
 
-srt::CRcvUList::~CRcvUList() {}
+CRcvUList::~CRcvUList() {}
 
-void srt::CRcvUList::insert(const CUDT* u)
+void CRcvUList::insert(const CUDT* u)
 {
     CRNode* n        = u->m_pRNode;
     n->m_tsTimeStamp = steady_clock::now();
@@ -648,7 +651,7 @@ void srt::CRcvUList::insert(const CUDT* u)
     m_pLast          = n;
 }
 
-void srt::CRcvUList::remove(const CUDT* u)
+void CRcvUList::remove(const CUDT* u)
 {
     CRNode* n = u->m_pRNode;
 
@@ -679,7 +682,7 @@ void srt::CRcvUList::remove(const CUDT* u)
     n->m_pNext = n->m_pPrev = NULL;
 }
 
-void srt::CRcvUList::update(const CUDT* u)
+void CRcvUList::update(const CUDT* u)
 {
     CRNode* n = u->m_pRNode;
 
@@ -710,13 +713,13 @@ void srt::CRcvUList::update(const CUDT* u)
 }
 
 //
-srt::CHash::CHash()
+CHash::CHash()
     : m_pBucket(NULL)
     , m_iHashSize(0)
 {
 }
 
-srt::CHash::~CHash()
+CHash::~CHash()
 {
     for (int i = 0; i < m_iHashSize; ++i)
     {
@@ -732,7 +735,7 @@ srt::CHash::~CHash()
     delete[] m_pBucket;
 }
 
-void srt::CHash::init(int size)
+void CHash::init(int size)
 {
     m_pBucket = new CBucket*[size];
 
@@ -742,7 +745,7 @@ void srt::CHash::init(int size)
     m_iHashSize = size;
 }
 
-srt::CUDT* srt::CHash::lookup(SRTSOCKET id)
+CUDT* CHash::lookup(SRTSOCKET id)
 {
     // simple hash function (% hash table size); suitable for socket descriptors
     CBucket* b = bucketAt(id);
@@ -757,7 +760,7 @@ srt::CUDT* srt::CHash::lookup(SRTSOCKET id)
     return NULL;
 }
 
-srt::CUDT* srt::CHash::lookupPeer(SRTSOCKET peerid)
+CUDT* CHash::lookupPeer(SRTSOCKET peerid)
 {
     // Decode back the socket ID if it has that peer
     SRTSOCKET id = map_get(m_RevPeerMap, peerid, SRT_INVALID_SOCK);
@@ -766,7 +769,7 @@ srt::CUDT* srt::CHash::lookupPeer(SRTSOCKET peerid)
     return lookup(id);
 }
 
-void srt::CHash::insert(SRTSOCKET id, CUDT* u)
+void CHash::insert(SRTSOCKET id, CUDT* u)
 {
     CBucket* b = bucketAt(id);
 
@@ -780,7 +783,7 @@ void srt::CHash::insert(SRTSOCKET id, CUDT* u)
     m_RevPeerMap[u->peerID()] = id;
 }
 
-void srt::CHash::remove(SRTSOCKET id)
+void CHash::remove(SRTSOCKET id)
 {
     CBucket* b = bucketAt(id);
     CBucket* p = NULL;
@@ -806,18 +809,18 @@ void srt::CHash::remove(SRTSOCKET id)
 }
 
 //
-srt::CRendezvousQueue::CRendezvousQueue()
+CRendezvousQueue::CRendezvousQueue()
     : m_lRendezvousID()
     , m_RIDListLock()
 {
 }
 
-srt::CRendezvousQueue::~CRendezvousQueue()
+CRendezvousQueue::~CRendezvousQueue()
 {
     m_lRendezvousID.clear();
 }
 
-void srt::CRendezvousQueue::insert(const SRTSOCKET&           id,
+void CRendezvousQueue::insert(const SRTSOCKET&           id,
                               CUDT*                           u,
                               const sockaddr_any&             addr,
                               const steady_clock::time_point& ttl)
@@ -836,7 +839,7 @@ void srt::CRendezvousQueue::insert(const SRTSOCKET&           id,
               << " (total connectors: " << m_lRendezvousID.size() << ")");
 }
 
-void srt::CRendezvousQueue::remove(const SRTSOCKET& id)
+void CRendezvousQueue::remove(const SRTSOCKET& id)
 {
     ScopedLock lkv(m_RIDListLock);
 
@@ -850,7 +853,7 @@ void srt::CRendezvousQueue::remove(const SRTSOCKET& id)
     }
 }
 
-srt::CUDT* srt::CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id) const
+CUDT* CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& w_id) const
 {
     ScopedLock vg(m_RIDListLock);
 
@@ -909,7 +912,7 @@ srt::CUDT* srt::CRendezvousQueue::retrieve(const sockaddr_any& addr, SRTSOCKET& 
     return NULL;
 }
 
-void srt::CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, CUnit* unit)
+void CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst, CUnit* unit)
 {
     vector<LinkStatusInfo> toRemove, toProcess;
 
@@ -1056,7 +1059,7 @@ void srt::CRendezvousQueue::updateConnStatus(EReadStatus rst, EConnectStatus cst
     }
 }
 
-bool srt::CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
+bool CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
                                        EConnectStatus cst      SRT_ATR_UNUSED,
                                        SRTSOCKET               iDstSockID,
                                        vector<LinkStatusInfo>& toRemove,
@@ -1160,7 +1163,7 @@ bool srt::CRendezvousQueue::qualifyToHandle(EReadStatus    rst,
 }
 
 //
-srt::CRcvQueue::CRcvQueue()
+CRcvQueue::CRcvQueue()
     : m_WorkerThread()
     , m_pUnitQueue(NULL)
     , m_pRcvUList(NULL)
@@ -1179,7 +1182,7 @@ srt::CRcvQueue::CRcvQueue()
     setupCond(m_BufferCond, "QueueBuffer");
 }
 
-srt::CRcvQueue::~CRcvQueue()
+CRcvQueue::~CRcvQueue()
 {
     m_bClosing = true;
 
@@ -1208,10 +1211,10 @@ srt::CRcvQueue::~CRcvQueue()
 }
 
 #if ENABLE_LOGGING
-srt::sync::atomic<int> srt::CRcvQueue::m_counter(0);
+sync::atomic<int> CRcvQueue::m_counter(0);
 #endif
 
-void srt::CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel* cc, CTimer* t)
+void CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CChannel* cc, CTimer* t)
 {
     m_iIPversion    = version;
     m_szPayloadSize = payload;
@@ -1241,7 +1244,7 @@ void srt::CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CCh
     }
 }
 
-void* srt::CRcvQueue::worker(void* param)
+void* CRcvQueue::worker(void* param)
 {
     CRcvQueue*   self = (CRcvQueue*)param;
     sockaddr_any sa(self->getIPversion());
@@ -1374,7 +1377,7 @@ void* srt::CRcvQueue::worker(void* param)
     return NULL;
 }
 
-srt::EReadStatus srt::CRcvQueue::worker_RetrieveUnit(SRTSOCKET& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
+EReadStatus CRcvQueue::worker_RetrieveUnit(SRTSOCKET& w_id, CUnit*& w_unit, sockaddr_any& w_addr)
 {
 #if !USE_BUSY_WAITING
     // This might be not really necessary, and probably
@@ -1430,7 +1433,7 @@ srt::EReadStatus srt::CRcvQueue::worker_RetrieveUnit(SRTSOCKET& w_id, CUnit*& w_
     return rst;
 }
 
-srt::EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
+EConnectStatus CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit, const sockaddr_any& addr)
 {
     HLOGC(cnlog.Debug,
           log << "Got sockID=0 from " << addr.str() << " - trying to resolve it as a connection request...");
@@ -1489,7 +1492,7 @@ srt::EConnectStatus srt::CRcvQueue::worker_ProcessConnectionRequest(CUnit* unit,
     return worker_TryAsyncRend_OrStore(SRT_SOCKID_CONNREQ, unit, addr);
 }
 
-bool srt::CRcvQueue::worker_TryAcceptedSocket(CUnit* unit, const sockaddr_any& addr)
+bool CRcvQueue::worker_TryAcceptedSocket(CUnit* unit, const sockaddr_any& addr)
 {
     // We are working with a possibly HS packet... check that.
     CPacket& pkt = unit->m_Packet;
@@ -1539,7 +1542,7 @@ bool srt::CRcvQueue::worker_TryAcceptedSocket(CUnit* unit, const sockaddr_any& a
     return u->createSendHSResponse(kmdata, kmdatasize, pkt.udpDestAddr(), (hs));
 }
 
-srt::EConnectStatus srt::CRcvQueue::worker_ProcessAddressedPacket(SRTSOCKET id, CUnit* unit, const sockaddr_any& addr)
+EConnectStatus CRcvQueue::worker_ProcessAddressedPacket(SRTSOCKET id, CUnit* unit, const sockaddr_any& addr)
 {
     CUDT* u = m_pHash->lookup(id);
     if (!u)
@@ -1600,7 +1603,7 @@ srt::EConnectStatus srt::CRcvQueue::worker_ProcessAddressedPacket(SRTSOCKET id, 
 // This function then tries to manage the packet as a rendezvous connection
 // request in ASYNC mode; when this is not applicable, it stores the packet
 // in the "receiving queue" so that it will be picked up in the "main" thread.
-srt::EConnectStatus srt::CRcvQueue::worker_TryAsyncRend_OrStore(SRTSOCKET id, CUnit* unit, const sockaddr_any& addr)
+EConnectStatus CRcvQueue::worker_TryAsyncRend_OrStore(SRTSOCKET id, CUnit* unit, const sockaddr_any& addr)
 {
     // This 'retrieve' requires that 'id' be either one of those
     // stored in the rendezvous queue (see CRcvQueue::registerConnector)
@@ -1730,13 +1733,13 @@ srt::EConnectStatus srt::CRcvQueue::worker_TryAsyncRend_OrStore(SRTSOCKET id, CU
     return CONN_CONTINUE;
 }
 
-void srt::CRcvQueue::stopWorker()
+void CRcvQueue::stopWorker()
 {
     // We use the decent way, so we say to the thread "please exit".
     m_bClosing = true;
 
     // Sanity check of the function's affinity.
-    if (srt::sync::this_thread::get_id() == m_WorkerThread.get_id())
+    if (sync::this_thread::get_id() == m_WorkerThread.get_id())
     {
         LOGC(rslog.Error, log << "IPE: RcvQ:WORKER TRIES TO CLOSE ITSELF!");
         return; // do nothing else, this would cause a hangup or crash.
@@ -1747,7 +1750,7 @@ void srt::CRcvQueue::stopWorker()
     m_WorkerThread.join();
 }
 
-int srt::CRcvQueue::recvfrom(SRTSOCKET id, CPacket& w_packet)
+int CRcvQueue::recvfrom(SRTSOCKET id, CPacket& w_packet)
 {
     CUniqueSync buffercond(m_BufferLock, m_BufferCond);
 
@@ -1800,12 +1803,12 @@ int srt::CRcvQueue::recvfrom(SRTSOCKET id, CPacket& w_packet)
     return (int)w_packet.getLength();
 }
 
-bool srt::CRcvQueue::setListener(CUDT* u)
+bool CRcvQueue::setListener(CUDT* u)
 {
     return m_pListener.compare_exchange(NULL, u);
 }
 
-srt::CUDT* srt::CRcvQueue::getListener()
+CUDT* CRcvQueue::getListener()
 {
     SharedLock lkl (m_pListener);
     return m_pListener.get_locked(lkl);
@@ -1816,12 +1819,12 @@ srt::CUDT* srt::CRcvQueue::getListener()
 // exclusive lock on m_pListener, while keeping shared lock on
 // CUDTUnited::m_GlobControlLock in CUDTUnited::closeAllSockets.
 // As the other thread locks both as shared, this is no deadlock risk.
-bool srt::CRcvQueue::removeListener(CUDT* u)
+bool CRcvQueue::removeListener(CUDT* u)
 {
     return m_pListener.compare_exchange(u, NULL);
 }
 
-void srt::CRcvQueue::registerConnector(const SRTSOCKET&                id,
+void CRcvQueue::registerConnector(const SRTSOCKET&                id,
                                   CUDT*                           u,
                                   const sockaddr_any&             addr,
                                   const steady_clock::time_point& ttl)
@@ -1831,7 +1834,7 @@ void srt::CRcvQueue::registerConnector(const SRTSOCKET&                id,
     m_pRendezvousQueue->insert(id, u, addr, ttl);
 }
 
-void srt::CRcvQueue::removeConnector(const SRTSOCKET& id)
+void CRcvQueue::removeConnector(const SRTSOCKET& id)
 {
     HLOGC(cnlog.Debug, log << "removeConnector: removing @" << id);
     m_pRendezvousQueue->remove(id);
@@ -1852,20 +1855,20 @@ void srt::CRcvQueue::removeConnector(const SRTSOCKET& id)
     }
 }
 
-void srt::CRcvQueue::setNewEntry(CUDT* u)
+void CRcvQueue::setNewEntry(CUDT* u)
 {
     HLOGC(cnlog.Debug, log << CUDTUnited::CONID(u->m_SocketID) << "setting socket PENDING FOR CONNECTION");
     ScopedLock listguard(m_IDLock);
     m_vNewEntry.push_back(u);
 }
 
-bool srt::CRcvQueue::ifNewEntry()
+bool CRcvQueue::ifNewEntry()
 {
     ScopedLock listguard(m_IDLock);
     return !(m_vNewEntry.empty());
 }
 
-srt::CUDT* srt::CRcvQueue::getNewEntry()
+CUDT* CRcvQueue::getNewEntry()
 {
     ScopedLock listguard(m_IDLock);
 
@@ -1878,12 +1881,12 @@ srt::CUDT* srt::CRcvQueue::getNewEntry()
     return u;
 }
 
-void srt::CRcvQueue::kick()
+void CRcvQueue::kick()
 {
     CSync::lock_notify_all(m_BufferCond, m_BufferLock);
 }
 
-void srt::CRcvQueue::storePktClone(SRTSOCKET id, const CPacket& pkt)
+void CRcvQueue::storePktClone(SRTSOCKET id, const CPacket& pkt)
 {
     CUniqueSync passcond(m_BufferLock, m_BufferCond);
 
@@ -1904,7 +1907,7 @@ void srt::CRcvQueue::storePktClone(SRTSOCKET id, const CPacket& pkt)
     }
 }
 
-void srt::CMultiplexer::destroy()
+void CMultiplexer::destroy()
 {
     // Reverse order of the assigned.
     delete m_pRcvQueue;
@@ -1917,3 +1920,5 @@ void srt::CMultiplexer::destroy()
         delete m_pChannel;
     }
 }
+
+} // ns srt

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -338,7 +338,7 @@ public:
     /// @param u pointer to a corresponding CUDT instance.
     /// @param addr remote address to connect to.
     /// @param ttl timepoint for connection attempt to expire.
-    void insert(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const srt::sync::steady_clock::time_point& ttl);
+    void insert(const SRTSOCKET& id, CUDT* u, const sockaddr_any& addr, const sync::steady_clock::time_point& ttl);
 
     /// @brief Remove a socket from the connection pending list.
     /// @param id socket ID.
@@ -483,7 +483,7 @@ public:
 private:
 
 #if ENABLE_LOGGING
-    static srt::sync::atomic<int> m_counter;
+    static sync::atomic<int> m_counter;
 #endif
 
     CSndQueue(const CSndQueue&);
@@ -549,7 +549,7 @@ private:
 
     sync::atomic<bool> m_bClosing; // closing the worker
 #if ENABLE_LOGGING
-    static srt::sync::atomic<int> m_counter; // A static counter to log RcvQueue worker thread number.
+    static sync::atomic<int> m_counter; // A static counter to log RcvQueue worker thread number.
 #endif
 
 private:

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -193,8 +193,8 @@ public:
 
 struct CSrtConfig: CSrtMuxerConfig
 {
-    typedef srt::sync::steady_clock::time_point time_point;
-    typedef srt::sync::steady_clock::duration   duration;
+    typedef sync::steady_clock::time_point time_point;
+    typedef sync::steady_clock::duration   duration;
 
     static const int
         DEF_MSS = 1500,
@@ -296,7 +296,7 @@ struct CSrtConfig: CSrtMuxerConfig
         , iSndBufSize(DEF_BUFFER_SIZE)
         , iRcvBufSize(DEF_BUFFER_SIZE)
         , bRendezvous(false)
-        , tdConnTimeOut(srt::sync::seconds_from(DEF_CONNTIMEO_S))
+        , tdConnTimeOut(sync::seconds_from(DEF_CONNTIMEO_S))
         , bDriftTracer(true)
         , iSndTimeOut(-1)
         , iRcvTimeOut(-1)

--- a/srtcore/srt.h
+++ b/srtcore/srt.h
@@ -1076,7 +1076,32 @@ SRT_API SRT_SOCKGROUPCONFIG srt_prepare_endpoint(const struct sockaddr* src /*nu
 SRT_API SRTSOCKET srt_connect_group(SRTSOCKET group, SRT_SOCKGROUPCONFIG name[], int arraysize);
 
 #ifdef __cplusplus
+} // END: extern "C"
+
+// Extra C++ API
+
+namespace srt
+{
+
+SRT_API void setloglevel(srt_logging::LogLevel::type ll);
+SRT_API void addlogfa(srt_logging::LogFA fa);
+SRT_API void dellogfa(srt_logging::LogFA fa);
+SRT_API void resetlogfa(std::set<srt_logging::LogFA> fas);
+SRT_API void resetlogfa(const int* fara, size_t fara_size);
+SRT_API void setlogstream(std::ostream& stream);
+SRT_API void setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler);
+SRT_API void setlogflags(int flags);
+
+SRT_API bool setstreamid(SRTSOCKET u, const std::string& sid);
+SRT_API std::string getstreamid(SRTSOCKET u);
+
+// Namespace alias
+namespace logging {
+    using namespace srt_logging;
 }
+
+} // namespace srt
+
 #endif
 
 #endif

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -286,12 +286,12 @@ int srt_recvmsg2(SRTSOCKET u, char * buf, int len, SRT_MSGCTRL *mctrl)
     return CUDT::recvmsg2(u, buf, len, (mignore));
 }
 
-const char* srt_getlasterror_str() { return UDT::getlasterror().getErrorMessage(); }
+const char* srt_getlasterror_str() { return srt::CUDT::getlasterror().getErrorMessage(); }
 
 int srt_getlasterror(int* loc_errno)
 {
     if ( loc_errno )
-        *loc_errno = UDT::getlasterror().getErrno();
+        *loc_errno = srt::CUDT::getlasterror().getErrno();
     return CUDT::getlasterror().getErrorCode();
 }
 
@@ -305,7 +305,7 @@ const char* srt_strerror(int code, int err)
 
 void srt_clearlasterror()
 {
-    UDT::getlasterror().clear();
+    srt::CUDT::getlasterror().clear();
 }
 
 SRTSTATUS srt_bstats(SRTSOCKET u, SRT_TRACEBSTATS * perf, int clear) { return CUDT::bstats(u, perf, 0!=  clear); }
@@ -363,8 +363,8 @@ int srt_epoll_wait(
       SRTSOCKET* readfds, int* rnum, SRTSOCKET* writefds, int* wnum,
       int64_t msTimeOut,
       SYSSOCKET* lrfds, int* lrnum, SYSSOCKET* lwfds, int* lwnum)
-  {
-    return UDT::epoll_wait2(
+{
+    return srt::CUDT::epoll_wait2(
         eid,
         readfds, rnum, writefds, wnum,
         msTimeOut,
@@ -373,7 +373,7 @@ int srt_epoll_wait(
 
 int srt_epoll_uwait(int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int64_t msTimeOut)
 {
-    return UDT::epoll_uwait(
+    return srt::CUDT::epoll_uwait(
         eid,
         fdsSet,
         fdsSize,
@@ -389,32 +389,32 @@ SRTSTATUS srt_epoll_release(int eid) { return CUDT::epoll_release(eid); }
 
 void srt_setloglevel(int ll)
 {
-    UDT::setloglevel(srt_logging::LogLevel::type(ll));
+    srt::setloglevel(srt_logging::LogLevel::type(ll));
 }
 
 void srt_addlogfa(int fa)
 {
-    UDT::addlogfa(srt_logging::LogFA(fa));
+    srt::addlogfa(srt_logging::LogFA(fa));
 }
 
 void srt_dellogfa(int fa)
 {
-    UDT::dellogfa(srt_logging::LogFA(fa));
+    srt::dellogfa(srt_logging::LogFA(fa));
 }
 
 void srt_resetlogfa(const int* fara, size_t fara_size)
 {
-    UDT::resetlogfa(fara, fara_size);
+    srt::resetlogfa(fara, fara_size);
 }
 
 void srt_setloghandler(void* opaque, SRT_LOG_HANDLER_FN* handler)
 {
-    UDT::setloghandler(opaque, handler);
+    srt::setloghandler(opaque, handler);
 }
 
 void srt_setlogflags(int flags)
 {
-    UDT::setlogflags(flags);
+    srt::setlogflags(flags);
 }
 
 int srt_getsndbuffer(SRTSOCKET sock, size_t* blocks, size_t* bytes)

--- a/srtcore/sync.h
+++ b/srtcore/sync.h
@@ -229,7 +229,7 @@ private:
 };
 
 template <>
-srt::sync::Duration<srt::sync::steady_clock> srt::sync::TimePoint<srt::sync::steady_clock>::time_since_epoch() const;
+Duration<steady_clock> TimePoint<steady_clock>::time_since_epoch() const;
 
 inline Duration<steady_clock> operator*(const int& lhs, const Duration<steady_clock>& rhs)
 {

--- a/srtcore/sync_cxx11.cpp
+++ b/srtcore/sync_cxx11.cpp
@@ -39,9 +39,14 @@ int pow10()
 }
 }
 
-int srt::sync::clockSubsecondPrecision()
+namespace srt
 {
-    const int64_t ticks_per_sec = (srt::sync::steady_clock::period::den / srt::sync::steady_clock::period::num);
+namespace sync
+{
+
+int clockSubsecondPrecision()
+{
+    const int64_t ticks_per_sec = (steady_clock::period::den / steady_clock::period::num);
     const int     decimals      = pow10<ticks_per_sec>();
     return decimals;
 }
@@ -52,36 +57,36 @@ int srt::sync::clockSubsecondPrecision()
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-srt::sync::Condition::Condition() {}
+Condition::Condition() {}
 
-srt::sync::Condition::~Condition() {}
+Condition::~Condition() {}
 
-void srt::sync::Condition::init() {}
+void Condition::init() {}
 
-void srt::sync::Condition::destroy() {}
+void Condition::destroy() {}
 
-void srt::sync::Condition::wait(UniqueLock& lock)
+void Condition::wait(UniqueLock& lock)
 {
     m_cv.wait(lock);
 }
 
-bool srt::sync::Condition::wait_for(UniqueLock& lock, const steady_clock::duration& rel_time)
+bool Condition::wait_for(UniqueLock& lock, const steady_clock::duration& rel_time)
 {
     // Another possible implementation is wait_until(steady_clock::now() + timeout);
     return m_cv.wait_for(lock, rel_time) != std::cv_status::timeout;
 }
 
-bool srt::sync::Condition::wait_until(UniqueLock& lock, const steady_clock::time_point& timeout_time)
+bool Condition::wait_until(UniqueLock& lock, const steady_clock::time_point& timeout_time)
 {
     return m_cv.wait_until(lock, timeout_time) != std::cv_status::timeout;
 }
 
-void srt::sync::Condition::notify_one()
+void Condition::notify_one()
 {
     m_cv.notify_one();
 }
 
-void srt::sync::Condition::notify_all()
+void Condition::notify_all()
 {
     m_cv.notify_all();
 }
@@ -96,13 +101,15 @@ void srt::sync::Condition::notify_all()
 // with a static scope, therefore static thread_local
 static thread_local srt::CUDTException s_thErr;
 
-void srt::sync::SetThreadLocalError(const srt::CUDTException& e)
+void SetThreadLocalError(const srt::CUDTException& e)
 {
     s_thErr = e;
 }
 
-srt::CUDTException& srt::sync::GetThreadLocalError()
+srt::CUDTException& GetThreadLocalError()
 {
     return s_thErr;
 }
 
+} // ns sync
+} // ns srt

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -14,7 +14,6 @@
 #include <stdexcept>
 #include "sync.h"
 #include "utilities.h"
-#include "udt.h"
 #include "srt.h"
 #include "srt_compat.h"
 #include "logging.h"

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -135,9 +135,6 @@ const int s_clock_subsecond_precision = count_subsecond_precision(s_clock_ticks_
 
 int clockSubsecondPrecision() { return s_clock_subsecond_precision; }
 
-} // namespace sync
-} // namespace srt
-
 ////////////////////////////////////////////////////////////////////////////////
 //
 // Sync utilities section
@@ -159,84 +156,84 @@ static timespec us_to_timespec(const uint64_t time_us)
 ////////////////////////////////////////////////////////////////////////////////
 
 template <>
-srt::sync::Duration<srt::sync::steady_clock> srt::sync::TimePoint<srt::sync::steady_clock>::time_since_epoch() const
+Duration<steady_clock> TimePoint<steady_clock>::time_since_epoch() const
 {
-    return srt::sync::Duration<srt::sync::steady_clock>(m_timestamp);
+    return Duration<steady_clock>(m_timestamp);
 }
 
-srt::sync::TimePoint<srt::sync::steady_clock> srt::sync::steady_clock::now()
+TimePoint<steady_clock> steady_clock::now()
 {
     uint64_t x = 0;
     rdtsc(x);
     return TimePoint<steady_clock>(x);
 }
 
-int64_t srt::sync::count_microseconds(const steady_clock::duration& t)
+int64_t count_microseconds(const steady_clock::duration& t)
 {
     return t.count() / s_clock_ticks_per_us;
 }
 
-int64_t srt::sync::count_milliseconds(const steady_clock::duration& t)
+int64_t count_milliseconds(const steady_clock::duration& t)
 {
     return t.count() / s_clock_ticks_per_us / 1000;
 }
 
-int64_t srt::sync::count_seconds(const steady_clock::duration& t)
+int64_t count_seconds(const steady_clock::duration& t)
 {
     return t.count() / s_clock_ticks_per_us / 1000000;
 }
 
-srt::sync::steady_clock::duration srt::sync::microseconds_from(int64_t t_us)
+steady_clock::duration microseconds_from(int64_t t_us)
 {
     return steady_clock::duration(t_us * s_clock_ticks_per_us);
 }
 
-srt::sync::steady_clock::duration srt::sync::milliseconds_from(int64_t t_ms)
+steady_clock::duration milliseconds_from(int64_t t_ms)
 {
     return steady_clock::duration((1000 * t_ms) * s_clock_ticks_per_us);
 }
 
-srt::sync::steady_clock::duration srt::sync::seconds_from(int64_t t_s)
+steady_clock::duration seconds_from(int64_t t_s)
 {
     return steady_clock::duration((1000000 * t_s) * s_clock_ticks_per_us);
 }
 
-srt::sync::Mutex::Mutex()
+Mutex::Mutex()
 {
-    const int err = pthread_mutex_init(&m_mutex, 0);
+    const int err = ::pthread_mutex_init(&m_mutex, 0);
     if (err)
     {
         throw CUDTException(MJ_SYSTEMRES, MN_MEMORY, 0);
     }
 }
 
-srt::sync::Mutex::~Mutex()
+Mutex::~Mutex()
 {
-    pthread_mutex_destroy(&m_mutex);
+    ::pthread_mutex_destroy(&m_mutex);
 }
 
-int srt::sync::Mutex::lock()
+int Mutex::lock()
 {
-    return pthread_mutex_lock(&m_mutex);
+    return ::pthread_mutex_lock(&m_mutex);
 }
 
-int srt::sync::Mutex::unlock()
+int Mutex::unlock()
 {
-    return pthread_mutex_unlock(&m_mutex);
+    return ::pthread_mutex_unlock(&m_mutex);
 }
 
-bool srt::sync::Mutex::try_lock()
+bool Mutex::try_lock()
 {
-    return (pthread_mutex_trylock(&m_mutex) == 0);
+    return (::pthread_mutex_trylock(&m_mutex) == 0);
 }
 
-srt::sync::UniqueLock::UniqueLock(Mutex& m)
+UniqueLock::UniqueLock(Mutex& m)
     : m_Mutex(m)
 {
     m_iLocked = m_Mutex.lock();
 }
 
-srt::sync::UniqueLock::~UniqueLock()
+UniqueLock::~UniqueLock()
 {
     if (m_iLocked == 0)
     {
@@ -244,7 +241,7 @@ srt::sync::UniqueLock::~UniqueLock()
     }
 }
 
-void srt::sync::UniqueLock::lock()
+void UniqueLock::lock()
 {
     if (m_iLocked != -1)
         throw CThreadException(MJ_SYSTEMRES, MN_THREAD, 0);
@@ -252,7 +249,7 @@ void srt::sync::UniqueLock::lock()
     m_iLocked = m_Mutex.lock();
 }
 
-void srt::sync::UniqueLock::unlock()
+void UniqueLock::unlock()
 {
     if (m_iLocked != 0)
         throw CThreadException(MJ_SYSTEMRES, MN_THREAD, 0);
@@ -261,7 +258,7 @@ void srt::sync::UniqueLock::unlock()
     m_iLocked = -1;
 }
 
-srt::sync::Mutex* srt::sync::UniqueLock::mutex()
+Mutex* UniqueLock::mutex()
 {
     return &m_Mutex;
 }
@@ -272,10 +269,6 @@ srt::sync::Mutex* srt::sync::UniqueLock::mutex()
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace srt
-{
-namespace sync
-{
 
 Condition::Condition()
 #ifdef _WIN32
@@ -287,36 +280,36 @@ Condition::~Condition() {}
 
 void Condition::init()
 {
-    pthread_condattr_t* attr = NULL;
+    ::pthread_condattr_t* attr = NULL;
 #if SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_GETTIME_MONOTONIC && HAVE_PTHREAD_CONDATTR_SETCLOCK
-    pthread_condattr_t  CondAttribs;
-    pthread_condattr_init(&CondAttribs);
-    if (pthread_condattr_setclock(&CondAttribs, CLOCK_MONOTONIC) != 0)
+    ::pthread_condattr_t  CondAttribs;
+    ::pthread_condattr_init(&CondAttribs);
+    if (::pthread_condattr_setclock(&CondAttribs, CLOCK_MONOTONIC) != 0)
     {
-        pthread_condattr_destroy(&CondAttribs);
-        LOGC(inlog.Fatal, log << "IPE: pthread_condattr_setclock failed to set up a monotonic clock for a CV");
+        ::pthread_condattr_destroy(&CondAttribs);
+        LOGC(inlog.Fatal, log << "IPE: ::pthread_condattr_setclock failed to set up a monotonic clock for a CV");
     }
     attr = &CondAttribs;
 #endif
-    const int res = pthread_cond_init(&m_cv, attr);
+    const int res = ::pthread_cond_init(&m_cv, attr);
 #if SRT_SYNC_CLOCK == SRT_SYNC_CLOCK_GETTIME_MONOTONIC && HAVE_PTHREAD_CONDATTR_SETCLOCK
     if (attr != NULL)
     {
-        pthread_condattr_destroy(attr);
+        ::pthread_condattr_destroy(attr);
     }
 #endif
     if (res != 0)
-        throw std::runtime_error("pthread_cond_init monotonic failed");
+        throw std::runtime_error("::pthread_cond_init monotonic failed");
 }
 
 void Condition::destroy()
 {
-    pthread_cond_destroy(&m_cv);
+    ::pthread_cond_destroy(&m_cv);
 }
 
 void Condition::wait(UniqueLock& lock)
 {
-    pthread_cond_wait(&m_cv, &lock.mutex()->ref());
+    ::pthread_cond_wait(&m_cv, &lock.mutex()->ref());
 }
 
 bool Condition::wait_for(UniqueLock& lock, const steady_clock::duration& rel_time)
@@ -331,7 +324,7 @@ bool Condition::wait_for(UniqueLock& lock, const steady_clock::duration& rel_tim
     const uint64_t now_us = now.tv_sec * uint64_t(1000000) + now.tv_usec;
 #endif
     timeout = us_to_timespec(now_us + count_microseconds(rel_time));
-    return pthread_cond_timedwait(&m_cv, &lock.mutex()->ref(), &timeout) != ETIMEDOUT;
+    return ::pthread_cond_timedwait(&m_cv, &lock.mutex()->ref(), &timeout) != ETIMEDOUT;
 }
 
 bool Condition::wait_until(UniqueLock& lock, const steady_clock::time_point& timeout_time)
@@ -349,16 +342,13 @@ bool Condition::wait_until(UniqueLock& lock, const steady_clock::time_point& tim
 
 void Condition::notify_one()
 {
-    pthread_cond_signal(&m_cv);
+    ::pthread_cond_signal(&m_cv);
 }
 
 void Condition::notify_all()
 {
-    pthread_cond_broadcast(&m_cv);
+    ::pthread_cond_broadcast(&m_cv);
 }
-
-}; // namespace sync
-}; // namespace srt
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -367,26 +357,26 @@ void Condition::notify_all()
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-srt::sync::CThread::CThread()
+CThread::CThread()
 {
-    m_thread = pthread_t();
+    m_thread = ::pthread_t();
 }
 
-srt::sync::CThread::CThread(void *(*start_routine) (void *), void *arg)
+CThread::CThread(void *(*start_routine) (void *), void *arg)
 {
     create(start_routine, arg);
 }
 
 #if HAVE_FULL_CXX11
-srt::sync::CThread& srt::sync::CThread::operator=(CThread&& other)
+CThread& CThread::operator=(CThread&& other)
 #else
-srt::sync::CThread& srt::sync::CThread::operator=(CThread& other)
+CThread& CThread::operator=(CThread& other)
 #endif
 {
     if (joinable())
     {
         // If the thread has already terminated, then
-        // pthread_join() returns immediately.
+        // ::pthread_join() returns immediately.
         // But we have to check it has terminated before replacing it.
         LOGC(inlog.Error, log << "IPE: Assigning to a thread that is not terminated!");
 
@@ -394,9 +384,9 @@ srt::sync::CThread& srt::sync::CThread::operator=(CThread& other)
 #if !defined(__ANDROID__) && !defined(__OHOS__)
         // In case of production build the hanging thread should be terminated
         // to avoid hang ups and align with C++11 implementation.
-        // There is no pthread_cancel on Android. See #1476. This error should not normally
+        // There is no ::pthread_cancel on Android. See #1476. This error should not normally
         // happen, but if it happen, then detaching the thread.
-        pthread_cancel(m_thread);
+        ::pthread_cancel(m_thread);
 #endif // __ANDROID__ __OHOS__
 #else
         join();
@@ -405,48 +395,48 @@ srt::sync::CThread& srt::sync::CThread::operator=(CThread& other)
 
     // Move thread handler from other
     m_thread = other.m_thread;
-    other.m_thread = pthread_t();
+    other.m_thread = ::pthread_t();
     return *this;
 }
 
 #if !HAVE_FULL_CXX11
-void srt::sync::CThread::create_thread(void *(*start_routine) (void *), void *arg)
+void CThread::create_thread(void *(*start_routine) (void *), void *arg)
 {
     SRT_ASSERT(!joinable());
     create(start_routine, arg);
 }
 #endif
 
-bool srt::sync::CThread::joinable() const
+bool CThread::joinable() const
 {
-    return !pthread_equal(m_thread, pthread_t());
+    return !::pthread_equal(m_thread, ::pthread_t());
 }
 
-void srt::sync::CThread::join()
+void CThread::join()
 {
     void *retval;
-    const int ret SRT_ATR_UNUSED = pthread_join(m_thread, &retval);
+    const int ret SRT_ATR_UNUSED = ::pthread_join(m_thread, &retval);
     if (ret != 0)
     {
-        LOGC(inlog.Error, log << "pthread_join failed with " << ret);
+        LOGC(inlog.Error, log << "::pthread_join failed with " << ret);
     }
 #ifdef HEAVY_LOGGING
     else
     {
-        HLOGC(inlog.Debug, log << "pthread_join SUCCEEDED");
+        HLOGC(inlog.Debug, log << "::pthread_join SUCCEEDED");
     }
 #endif
     // After joining, joinable should be false
-    m_thread = pthread_t();
+    m_thread = ::pthread_t();
     return;
 }
 
-void srt::sync::CThread::create(void *(*start_routine) (void *), void *arg)
+void CThread::create(void *(*start_routine) (void *), void *arg)
 {
-    const int st = pthread_create(&m_thread, NULL, start_routine, arg);
+    const int st = ::pthread_create(&m_thread, NULL, start_routine, arg);
     if (st != 0)
     {
-        LOGC(inlog.Error, log << "pthread_create failed with " << st);
+        LOGC(inlog.Error, log << "::pthread_create failed with " << st);
         throw CThreadException(MJ_SYSTEMRES, MN_THREAD, 0);
     }
 }
@@ -457,15 +447,13 @@ void srt::sync::CThread::create(void *(*start_routine) (void *), void *arg)
 // CThreadError class - thread local storage error wrapper
 //
 ////////////////////////////////////////////////////////////////////////////////
-namespace srt {
-namespace sync {
 
 class CThreadError
 {
 public:
     CThreadError()
     {
-        pthread_key_create(&m_ThreadSpecKey, ThreadSpecKeyDestroy);
+        ::pthread_key_create(&m_ThreadSpecKey, ThreadSpecKeyDestroy);
 
         // This is a global object and as such it should be called in the
         // main application thread or at worst in the thread that has first
@@ -480,7 +468,7 @@ public:
         // doing any operations here). This will prevent SRT from running
         // into trouble while trying to operate.
         CUDTException* ne = new CUDTException();
-        pthread_setspecific(m_ThreadSpecKey, ne);
+        ::pthread_setspecific(m_ThreadSpecKey, ne);
     }
 
     ~CThreadError()
@@ -488,8 +476,8 @@ public:
         // Likely all objects should be deleted in all
         // threads that have exited, but std::this_thread didn't exit
         // yet :).
-        ThreadSpecKeyDestroy(pthread_getspecific(m_ThreadSpecKey));
-        pthread_key_delete(m_ThreadSpecKey);
+        ThreadSpecKeyDestroy(::pthread_getspecific(m_ThreadSpecKey));
+        ::pthread_key_delete(m_ThreadSpecKey);
     }
 
     void set(const CUDTException& e)
@@ -508,9 +496,9 @@ public:
         *cur = e;
     }
 
-    /*[[nullable]]*/ CUDTException* get()
+    CUDTException* /*[[nullable]]*/ get()
     {
-        if (!pthread_getspecific(m_ThreadSpecKey))
+        if (!::pthread_getspecific(m_ThreadSpecKey))
         {
             // This time if this can't be done due to memory allocation
             // problems, just allow this value to be NULL, which during
@@ -523,10 +511,10 @@ public:
             // a creation callback that would apply to every thread in
             // the application (as it is for C++11 thread_local storage).
             CUDTException* ne = new(std::nothrow) CUDTException();
-            pthread_setspecific(m_ThreadSpecKey, ne);
+            ::pthread_setspecific(m_ThreadSpecKey, ne);
             return ne;
         }
-        return (CUDTException*)pthread_getspecific(m_ThreadSpecKey);
+        return (CUDTException*)::pthread_getspecific(m_ThreadSpecKey);
     }
 
     static void ThreadSpecKeyDestroy(void* e)
@@ -535,7 +523,7 @@ public:
     }
 
 private:
-    pthread_key_t m_ThreadSpecKey;
+    ::pthread_key_t m_ThreadSpecKey;
 };
 
 // Threal local error will be used by CUDTUnited

--- a/srtcore/tsbpd_time.cpp
+++ b/srtcore/tsbpd_time.cpp
@@ -22,8 +22,6 @@ namespace srt
 #if SRT_DEBUG_TRACE_DRIFT
 class drift_logger
 {
-    typedef srt::sync::steady_clock steady_clock;
-
 public:
     drift_logger() {}
 
@@ -38,20 +36,19 @@ public:
                int64_t                                    drift_sample,
                int64_t                                    drift,
                int64_t                                    overdrift,
-               const srt::sync::steady_clock::time_point& pkt_base,
-               const srt::sync::steady_clock::time_point& tsbpd_base)
+               const steady_clock::time_point& pkt_base,
+               const steady_clock::time_point& tsbpd_base)
     {
-        using namespace srt::sync;
         ScopedLock lck(m_mtx);
         create_file();
 
-        // std::string str_tnow = srt::sync::FormatTime(steady_clock::now());
+        // std::string str_tnow = FormatTime(steady_clock::now());
         // str_tnow.resize(str_tnow.size() - 7); // remove trailing ' [STDY]' part
 
-        std::string str_tbase = srt::sync::FormatTime(tsbpd_base);
+        std::string str_tbase = FormatTime(tsbpd_base);
         str_tbase.resize(str_tbase.size() - 7); // remove trailing ' [STDY]' part
 
-        std::string str_pkt_base = srt::sync::FormatTime(pkt_base);
+        std::string str_pkt_base = FormatTime(pkt_base);
         str_pkt_base.resize(str_pkt_base.size() - 7); // remove trailing ' [STDY]' part
 
         // m_fout << str_tnow << ",";
@@ -78,8 +75,8 @@ private:
         if (m_fout.is_open())
             return;
 
-        m_start_time         = srt::sync::steady_clock::now();
-        std::string str_tnow = srt::sync::FormatTimeSys(m_start_time);
+        m_start_time         = steady_clock::now();
+        std::string str_tnow = FormatTimeSys(m_start_time);
         str_tnow.resize(str_tnow.size() - 7); // remove trailing ' [SYST]' part
         while (str_tnow.find(':') != std::string::npos)
         {
@@ -94,9 +91,9 @@ private:
     }
 
 private:
-    srt::sync::Mutex                    m_mtx;
+    Mutex                    m_mtx;
     std::ofstream                       m_fout;
-    srt::sync::steady_clock::time_point m_start_time;
+    steady_clock::time_point m_start_time;
 };
 
 drift_logger g_drift_logger;

--- a/srtcore/tsbpd_time.h
+++ b/srtcore/tsbpd_time.h
@@ -23,10 +23,10 @@ namespace srt
 /// See SRT Internet Draft Section "Timestamp-Based Packet Delivery".
 class CTsbpdTime
 {
-    typedef srt::sync::steady_clock  steady_clock;
+    typedef sync::steady_clock  steady_clock;
     typedef steady_clock::time_point time_point;
     typedef steady_clock::duration   duration;
-    typedef srt::sync::SharedMutex   SharedMutex;
+    typedef sync::SharedMutex   SharedMutex;
 
 public:
     CTsbpdTime()

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -23,8 +23,12 @@ written by
 #include "srt_attr_defs.h" // defines HAVE_CXX11
 
 // Happens that these are defined, undefine them in advance
+#ifdef min
 #undef min
+#endif
+#ifdef max
 #undef max
+#endif
 
 #include <string>
 #include <algorithm>
@@ -46,196 +50,13 @@ written by
 #include <cstring>
 #include <stdexcept>
 
+#include "byte_order.h"
+
+namespace srt {
+
 // -------------- UTILITIES ------------------------
 
-// --- ENDIAN ---
-// Copied from: https://gist.github.com/panzi/6856583
-// License: Public Domain.
-
-#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
-
-#	define __WINDOWS__
-
-#endif
-
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__GNU__) || defined(__GLIBC__)
-
-#	include <endian.h>
-
-// GLIBC-2.8 and earlier does not provide these macros.
-// See http://linux.die.net/man/3/endian
-// From https://gist.github.com/panzi/6856583
-#   if defined(__GLIBC__) \
-      && ( !defined(__GLIBC_MINOR__) \
-         || ((__GLIBC__ < 2) \
-         || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ < 9))) )
-#       include <arpa/inet.h>
-#       if defined(__BYTE_ORDER) && (__BYTE_ORDER == __LITTLE_ENDIAN)
-
-#           define htole32(x) (x)
-#           define le32toh(x) (x)
-
-#       elif defined(__BYTE_ORDER) && (__BYTE_ORDER == __BIG_ENDIAN)
-
-#           define htole16(x) ((((((uint16_t)(x)) >> 8))|((((uint16_t)(x)) << 8)))
-#           define le16toh(x) ((((((uint16_t)(x)) >> 8))|((((uint16_t)(x)) << 8)))
-
-#           define htole32(x) (((uint32_t)htole16(((uint16_t)(((uint32_t)(x)) >> 16)))) | (((uint32_t)htole16(((uint16_t)(x)))) << 16))
-#           define le32toh(x) (((uint32_t)le16toh(((uint16_t)(((uint32_t)(x)) >> 16)))) | (((uint32_t)le16toh(((uint16_t)(x)))) << 16))
-
-#       else
-#           error Byte Order not supported or not defined.
-#       endif
-#   endif
-
-#elif defined(__APPLE__)
-
-#	include <libkern/OSByteOrder.h>
-
-#	define htobe16(x) OSSwapHostToBigInt16(x)
-#	define htole16(x) OSSwapHostToLittleInt16(x)
-#	define be16toh(x) OSSwapBigToHostInt16(x)
-#	define le16toh(x) OSSwapLittleToHostInt16(x)
- 
-#	define htobe32(x) OSSwapHostToBigInt32(x)
-#	define htole32(x) OSSwapHostToLittleInt32(x)
-#	define be32toh(x) OSSwapBigToHostInt32(x)
-#	define le32toh(x) OSSwapLittleToHostInt32(x)
- 
-#	define htobe64(x) OSSwapHostToBigInt64(x)
-#	define htole64(x) OSSwapHostToLittleInt64(x)
-#	define be64toh(x) OSSwapBigToHostInt64(x)
-#	define le64toh(x) OSSwapLittleToHostInt64(x)
-
-#	define __BYTE_ORDER    BYTE_ORDER
-#	define __BIG_ENDIAN    BIG_ENDIAN
-#	define __LITTLE_ENDIAN LITTLE_ENDIAN
-#	define __PDP_ENDIAN    PDP_ENDIAN
-
-#elif defined(__OpenBSD__)
-
-#	include <sys/endian.h>
-
-#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__FreeBSD_kernel__)
-
-#	include <sys/endian.h>
-
-#ifndef be16toh
-#	define be16toh(x) betoh16(x)
-#endif
-#ifndef le16toh
-#	define le16toh(x) letoh16(x)
-#endif
-
-#ifndef be32toh
-#	define be32toh(x) betoh32(x)
-#endif
-#ifndef le32toh
-#	define le32toh(x) letoh32(x)
-#endif
-
-#ifndef be64toh
-#	define be64toh(x) betoh64(x)
-#endif
-#ifndef le64toh
-#	define le64toh(x) letoh64(x)
-#endif
-
-#elif defined(SUNOS)
-
-   // SunOS/Solaris
-
-   #include <sys/byteorder.h>
-   #include <sys/isa_defs.h>
-
-   #define __LITTLE_ENDIAN 1234
-   #define __BIG_ENDIAN 4321
-
-   # if defined(_BIG_ENDIAN)
-   #define __BYTE_ORDER __BIG_ENDIAN
-   #define be64toh(x) (x)
-   #define be32toh(x) (x)
-   #define be16toh(x) (x)
-   #define le16toh(x) ((uint16_t)BSWAP_16(x))
-   #define le32toh(x) BSWAP_32(x)
-   #define le64toh(x) BSWAP_64(x)
-   #define htobe16(x) (x)
-   #define htole16(x) ((uint16_t)BSWAP_16(x))
-   #define htobe32(x) (x)
-   #define htole32(x) BSWAP_32(x)
-   #define htobe64(x) (x)
-   #define htole64(x) BSWAP_64(x)
-   # else
-   #define __BYTE_ORDER __LITTLE_ENDIAN
-   #define be64toh(x) BSWAP_64(x)
-   #define be32toh(x) ntohl(x)
-   #define be16toh(x) ntohs(x)
-   #define le16toh(x) (x)
-   #define le32toh(x) (x)
-   #define le64toh(x) (x)
-   #define htobe16(x) htons(x)
-   #define htole16(x) (x)
-   #define htobe32(x) htonl(x)
-   #define htole32(x) (x)
-   #define htobe64(x) BSWAP_64(x)
-   #define htole64(x) (x)
-   # endif
-
-#elif defined(__WINDOWS__)
-
-#	include <winsock2.h>
-
-#	if BYTE_ORDER == LITTLE_ENDIAN
-
-#		define htobe16(x) htons(x)
-#		define htole16(x) (x)
-#		define be16toh(x) ntohs(x)
-#		define le16toh(x) (x)
- 
-#		define htobe32(x) htonl(x)
-#		define htole32(x) (x)
-#		define be32toh(x) ntohl(x)
-#		define le32toh(x) (x)
- 
-#		define htobe64(x) htonll(x)
-#		define htole64(x) (x)
-#		define be64toh(x) ntohll(x)
-#		define le64toh(x) (x)
-
-#	elif BYTE_ORDER == BIG_ENDIAN
-
-		/* that would be xbox 360 */
-#		define htobe16(x) (x)
-#		define htole16(x) __builtin_bswap16(x)
-#		define be16toh(x) (x)
-#		define le16toh(x) __builtin_bswap16(x)
- 
-#		define htobe32(x) (x)
-#		define htole32(x) __builtin_bswap32(x)
-#		define be32toh(x) (x)
-#		define le32toh(x) __builtin_bswap32(x)
- 
-#		define htobe64(x) (x)
-#		define htole64(x) __builtin_bswap64(x)
-#		define be64toh(x) (x)
-#		define le64toh(x) __builtin_bswap64(x)
-
-#	else
-
-#		error byte order not supported
-
-#	endif
-
-#	define __BYTE_ORDER    BYTE_ORDER
-#	define __BIG_ENDIAN    BIG_ENDIAN
-#	define __LITTLE_ENDIAN LITTLE_ENDIAN
-#	define __PDP_ENDIAN    PDP_ENDIAN
-
-#else
-
-#	error Endian: platform not supported
-
-#endif
+// ENDIAN-dependent array copying functions
 
 /// Hardware --> Network (big-endian) byte order conversion
 /// @param size source length in four octets
@@ -415,8 +236,6 @@ struct DynamicStruct
 
 
 /// Fixed-size array template class.
-namespace srt {
-
 template <class T, class Indexer = size_t>
 class FixedArray
 {
@@ -478,8 +297,6 @@ private:
     size_t      m_size;
     T* const    m_entries;
 };
-
-} // namespace srt
 
 // ------------------------------------------------------------
 
@@ -1215,6 +1032,17 @@ inline ValueType avg_iir_w(ValueType old_value, ValueType new_value, size_t new_
     return (old_value * (DEPRLEN - new_val_weight) + new_value * new_val_weight) / DEPRLEN;
 }
 
+template <class T>
+inline T CountIIR(T base, T newval, double factor)
+{
+    if ( base == 0.0 )
+        return newval;
+
+    T diff = newval - base;
+    return base+T(diff*factor);
+}
+
+
 // Property accessor definitions
 //
 // "Property" is a special method that accesses given field.
@@ -1258,5 +1086,7 @@ inline ValueType avg_iir_w(ValueType old_value, ValueType new_value, size_t new_
 #define SRTU_PROPERTY_RRW(type, name, field) SRTU_PROPERTY_RR(type, name, field); SRTU_PROPERTY_WO(type, name, field)
 #define SRTU_PROPERTY_RW_CHAIN(otype, type, name, field) SRTU_PROPERTY_RO(type, name, field); SRTU_PROPERTY_WO_CHAIN(otype, type, name, field)
 #define SRTU_PROPERTY_RRW_CHAIN(otype, type, name, field) SRTU_PROPERTY_RR(type, name, field); SRTU_PROPERTY_WO_CHAIN(otype, type, name, field)
+
+} // namespace srt
 
 #endif

--- a/srtcore/window.cpp
+++ b/srtcore/window.cpp
@@ -141,11 +141,10 @@ int acknowledge(Seq* r_aSeq, const size_t size, int& r_iHead, int& r_iTail, int3
 }
 
 } // namespace AckTools
-} // namespace srt
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeWindow, int* r_bytesWindow, size_t asize, size_t psize, size_t max_payload_size)
+void CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_probeWindow, int* r_bytesWindow, size_t asize, size_t psize, size_t max_payload_size)
 {
    for (size_t i = 0; i < asize; ++ i)
       r_pktWindow[i] = 1000000;   //1 sec -> 1 pkt/sec
@@ -157,13 +156,13 @@ void srt::CPktTimeWindowTools::initializeWindowArrays(int* r_pktWindow, int* r_p
       r_bytesWindow[i] = int(max_payload_size); //based on 1 pkt/sec set in r_pktWindow[i]
 }
 
-int srt::CPktTimeWindowTools::ceilPerMega(double value, double count)
+int CPktTimeWindowTools::ceilPerMega(double value, double count)
 {
     static const double MEGA = 1000.0 * 1000.0;
     return int(::ceil(MEGA / (value / count)));
 }
 
-int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, size_t hdr_size, int& w_bytesps)
+int CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica, const int* abytes, size_t asize, size_t hdr_size, int& w_bytesps)
 {
     PassFilter<int> filter = GetPeakRange(window, replica, asize);
 
@@ -188,7 +187,7 @@ int srt::CPktTimeWindowTools::getPktRcvSpeed_in(const int* window, int* replica,
     return ceilPerMega(sum, count);
 }
 
-int srt::CPktTimeWindowTools::getBandwidth_in(const int* window, int* replica, size_t psize)
+int CPktTimeWindowTools::getBandwidth_in(const int* window, int* replica, size_t psize)
 {
     PassFilter<int> filter = GetPeakRange(window, replica, psize);
 
@@ -201,3 +200,4 @@ int srt::CPktTimeWindowTools::getBandwidth_in(const int* window, int* replica, s
 }
 
 
+} // namespace srt

--- a/srtcore/window.h
+++ b/srtcore/window.h
@@ -59,7 +59,6 @@ modified by
    #include <time.h>
 #endif
 #include "packet.h"
-#include "udt.h"
 
 namespace srt
 {

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -19,6 +19,7 @@
 #include "srt.h"
 #include "sync.h"
 
+using namespace srt;
 
 
 enum PEER_TYPE

--- a/test/test_listen_callback.cpp
+++ b/test/test_listen_callback.cpp
@@ -13,6 +13,8 @@
 #include "access_control.h"
 #include "utilities.h"
 
+using namespace srt;
+
 srt_listen_callback_fn SrtTestListenCallback;
 
 class ListenerCallback

--- a/test/test_reuseaddr.cpp
+++ b/test/test_reuseaddr.cpp
@@ -9,7 +9,6 @@
 
 #include "common.h"
 #include "srt.h"
-#include "udt.h"
 
 using srt::sockaddr_any;
 

--- a/testing/srt-test-file.cpp
+++ b/testing/srt-test-file.cpp
@@ -17,6 +17,7 @@ written by
 #include <direct.h>
 #endif
 #include <iostream>
+#include <fstream>
 #include <iterator>
 #include <vector>
 #include <map>
@@ -27,7 +28,6 @@ written by
 #include <chrono>
 #include <sys/stat.h>
 #include <srt.h>
-#include <udt.h>
 #include <logging.h>
 
 #include "apputil.hpp"
@@ -49,6 +49,7 @@ static size_t g_buffer_size = 1456;
 static bool g_skip_flushing = false;
 
 using namespace std;
+using namespace srt;
 
 srt_logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-file");
 

--- a/testing/srt-test-live.cpp
+++ b/testing/srt-test-live.cpp
@@ -85,6 +85,7 @@
 #endif
 
 using namespace std;
+using namespace srt;
 
 srt_logging::Logger applog(SRT_LOGFA_APP, srt_logger_config, "srt-live");
 

--- a/testing/srt-test-multiplex.cpp
+++ b/testing/srt-test-multiplex.cpp
@@ -42,6 +42,7 @@
 
 
 using namespace std;
+using namespace srt;
 
 // The length of the SRT payload used in srt_recvmsg call.
 // So far, this function must be used and up to this length of payload.

--- a/testing/srt-test-relay.cpp
+++ b/testing/srt-test-relay.cpp
@@ -31,7 +31,6 @@ written by
 #include <csignal>
 #include <sys/stat.h>
 #include <srt.h>
-#include <udt.h>
 
 #include "testactivemedia.hpp"
 
@@ -46,6 +45,7 @@ written by
 
 
 using namespace std;
+using namespace srt;
 
 
 bool Upload(UriParser& srt, UriParser& file);
@@ -174,21 +174,21 @@ int main( int argc, char** argv )
     string loglevel = Option<OutString>(params, "error", o_loglevel);
     string logfa = Option<OutString>(params, "", o_logfa);
     srt_logging::LogLevel::type lev = SrtParseLogLevel(loglevel);
-    UDT::setloglevel(lev);
+    srt::setloglevel(lev);
     if (logfa == "")
     {
-        UDT::addlogfa(SRT_LOGFA_APP);
+        srt::addlogfa(SRT_LOGFA_APP);
     }
     else
     {
         // Add only selected FAs
         set<string> unknown_fas;
         set<srt_logging::LogFA> fas = SrtParseLogFA(logfa, &unknown_fas);
-        UDT::resetlogfa(fas);
+        srt::resetlogfa(fas);
 
         // The general parser doesn't recognize the "app" FA, we check it here.
         if (unknown_fas.count("app"))
-            UDT::addlogfa(SRT_LOGFA_APP);
+            srt::addlogfa(SRT_LOGFA_APP);
     }
 
     string verbo = Option<OutString>(params, "no", o_verbose);

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -29,7 +29,6 @@
 #include "netinet_any.h"
 #include "common.h"
 #include "api.h"
-#include "udt.h"
 #include "logging.h"
 #include "utilities.h"
 
@@ -2103,7 +2102,7 @@ void SrtModel::Establish(std::string& w_name)
         Verb() << "Accepting a client...";
         AcceptNewClient();
         // This rewrites m_sock with a new SRT socket ("accepted" socket)
-        w_name = UDT::getstreamid(m_sock);
+        w_name = srt::getstreamid(m_sock);
         Verb() << "... GOT CLIENT for stream [" << w_name << "]";
     }
 }

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -21,7 +21,6 @@
 #include "apputil.hpp"
 #include "statswriter.hpp"
 #include "testmediabase.hpp"
-#include <udt.h> // Needs access to CUDTException
 #include <netinet_any.h>
 
 extern srt_listen_callback_fn* transmit_accept_hook_fn;

--- a/testing/utility-test.cpp
+++ b/testing/utility-test.cpp
@@ -12,7 +12,6 @@
 #include <string>
 #include <iomanip>
 
-#include <udt.h>
 #include <utilities.h>
 #include <packet.h>
 #include <crypto.h>


### PR DESCRIPTION
Changes:

1. In all implementations, all freestanding method implementations with explicit `srt` namespace have been put into the scope of srt namespace.
2. Included in srt namespace also parts of internal interface of the SRT library, mainly in utilities.
3. Removed (put into a historic storage) `udt.h` header file. Parts still in use have been split into appropriate other header files.