### PR TITLE
[core] Fixed bug in srt_epoll_uwait: wrong number of sockets returned

### DIFF
--- a/srtcore/epoll.cpp
+++ b/srtcore/epoll.cpp
@@ -522,22 +522,17 @@ int srt::CEPoll::uwait(const int eid, SRT_EPOLL_EVENT* fdsSet, int fdsSize, int6
                 throw CUDTException(MJ_NOTSUP, MN_INVAL);
             }
 
-            int total = 0; // This is a list, so count it during iteration
-            CEPollDesc::enotice_t::iterator i = ed.enotice_begin();
-            while (i != ed.enotice_end())
+            CEPollDesc::enotice_t::iterator i = ed.enotice_begin(), inext;
+            int pos = 0; // This is a list, so count it during iteration
+            for (inext = i ; i != ed.enotice_end() && pos < fdsSize ; ++pos, i = inext)
             {
-                int pos = total; // previous past-the-end position
-                ++total;
-
-                if (total > fdsSize)
-                    break;
+                ++inext; // deletion-safe list loop
 
                 fdsSet[pos] = *i;
-
-                ed.checkEdge(i++); // NOTE: potentially deletes `i`
+                ed.checkEdge(i); // NOTE: potentially deletes `i`
             }
-            if (total)
-                return total;
+            if (pos) // pos is increased by 1 towards the last used position
+                return pos;
         }
 
         if ((msTimeOut >= 0) && (count_microseconds(srt::sync::steady_clock::now() - entertime) >= msTimeOut * int64_t(1000)))


### PR DESCRIPTION
The loop that was rolling over the events in the container was incorrectly increasing the total counter over the number of actually filled items in the array. The loop was refactored to return the exact number of array items filled.