### PR TITLE
[core] Fixed reentrancy problem of srt_strerror

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -2841,13 +2841,13 @@ associated with the last error. The system error is:
 const char* srt_strerror(int code, int errnoval);
 ```
 
-Returns a string message that represents a given SRT error code and possibly the
-`errno` value, if not 0.
+Returns a string message that represents a given SRT error code.
 
-**NOTE:** *This function isn't thread safe. It uses a static variable to hold the
-error description. There's no problem with using it in a multithreaded environment,
-as long as only one thread in the whole application calls this function at the
-moment*
+**NOTE:** *The `errnoval` parameter is ignored. This function's old version
+was intended to get both the SRT error description and system error description,
+but this requires resolution of the reentrancy problem and dynamic strings.
+For getting the error description for a system error, you need to use the
+`strerror` function or some of its reentrant version.*
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/srtcore/srt_c_api.cpp
+++ b/srtcore/srt_c_api.cpp
@@ -26,6 +26,14 @@ written by
 using namespace std;
 using namespace srt;
 
+namespace srt
+{
+// This is provided in strerror_defs.cpp, which doesn't have
+// its header file.
+// XXX Consider adding some static function to CUDTException.
+const char* strerror_get_message(size_t major, size_t minor);
+}
+
 
 extern "C" {
 
@@ -248,11 +256,9 @@ int srt_getlasterror(int* loc_errno)
     return CUDT::getlasterror().getErrorCode();
 }
 
-const char* srt_strerror(int code, int err)
+const char* srt_strerror(int code, int /*err ignored*/)
 {
-    static srt::CUDTException e;
-    e = srt::CUDTException(CodeMajor(code/1000), CodeMinor(code%1000), err);
-    return(e.getErrorMessage());
+    return strerror_get_message(CodeMajor(code/1000), CodeMinor(code%1000));
 }
 
 


### PR DESCRIPTION
Fixes: #3184

Changes:
1. The `srt_strerror` now returns a message contained in the array of generated error messages. This is constant and reentrant.
2. The documentation was updated: the reentrancy note removed, added info about ignored parameter.