### PR TITLE
[core] Restored old cookie contest. Added ignored wrong peer response on cookie collision

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4102,9 +4102,14 @@ void srt::CUDT::sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& 
     m_pSndQueue->sendto(serv_addr, r_rsppkt, m_SourceAddr);
 }
 
-#define VERSION_INITIAL 0
-#define VERSION_MAX 1
-#define VERSION_COMPARISON 0
+// NOTE: there is provided the source code for all solutions, including
+// historic and future ones. Just only one will be in use.
+//
+// Selection: either only one of these below should be 1, or all should be 0.
+#define VERSION_INITIAL 0     // Version from 1.3.0
+#define VERSION_FIXED 1       // Version from 1.4.5 (64-bit subtraction with bit 31 check)
+#define VERSION_COMPARISON 0  // 32-bit comparison version
+// IF ALL ARE 0: --------------  64-bit subtraction zero-comparison
 
 void srt::CUDT::cookieContest()
 {
@@ -4125,6 +4130,11 @@ void srt::CUDT::cookieContest()
     }
 
 #if VERSION_INITIAL
+
+    // This is the original version from 1.3.0, which contains mutliple bugs:
+    // - a small range of values that resolve differently depending on compiler options
+    // - a small range of values which result in both-side responder.
+
     int better_cookie = m_ConnReq.m_iCookie - m_ConnRes.m_iCookie;
 
     if ( better_cookie > 0 )
@@ -4160,7 +4170,11 @@ void srt::CUDT::cookieContest()
     return;
 #elif VERSION_COMPARISON
 
-    // XXX ROUND VERSION on 32-bit
+    // This is the simple version that should always work (stating that
+    // the use of operator < for 32-bit numbers handles also the overflow
+    // situation).
+
+    // ROUND VERSION on 32-bit
     if (m_ConnReq.m_iCookie < m_ConnRes.m_iCookie)
     {
         LOGC(gglog.Note, log << CONID() << hex << setfill('0') << uppercase
@@ -4239,18 +4253,35 @@ void srt::CUDT::cookieContest()
         return;
     }
 
-#if VERSION_MAX
+#if VERSION_FIXED
+    // Fixed version from 1.4.5, which renders the buggy sitaution always the
+    // same (even though wrong) way, still avoiding collision for the buggy range.
+    // There remains, however, a problem for a narrow range of cookies which
+    // have the exactly same value except bit 0x80000000.
+
     if (contest & 0x80000000)
-#else
-    if (contest < 0)
-#endif
     {
         m_SrtHsSide = HSD_RESPONDER;
         return;
     }
+#else
+    // Version prepared for 1.6.0, which solves the problem of cookie comparison
+    // for all cases, while using 64-bit subtraction. This should render the exactly
+    // same results as 32-bit simple comparison version (see VERSION_COMPARISON).
+
+    if (contest < 0)
+    {
+        m_SrtHsSide = HSD_RESPONDER;
+        return;
+    }
+#endif
 
     m_SrtHsSide = HSD_INITIATOR;
 }
+
+#undef VERSION_INITIAL
+#undef VERSION_FIXED
+#undef VERSION_COMPARISON
 
 // This function should complete the data for KMX needed for an out-of-band
 // handshake response. Possibilities are:
@@ -4385,6 +4416,51 @@ EConnectStatus srt::CUDT::processRendezvous(
                   << "processRendezvous: rejecting due to switch-state response: " << RequestTypeStr(rsp_type));
         return CONN_REJECT;
     }
+
+    // Solve the cookie collision problem.
+    //
+    // The future version 1.6.0 will have the cookie problem solved by having
+    // no possibility of cookie collision. Therefore such a situation will never
+    // happen. This version will also have added an adaptive mode when doing rendezvous
+    // with the older version.
+    //
+    // The version 1.6.0 will simultaneously introduce a problem with some ranges
+    // of cookie values that will result in a collision with the older version. The
+    // adaptive mechanism will mitigate the collision, however the problem is that
+    // if the responder site version <= 1.5.4 resolves to RESPONDER, it will just
+    // reject the handshake sent without extensions (which is a case when the responder
+    // has to send the conclusion handshake as the first one).
+    //
+    // This here fixes this problem, meaning, in such a situation the handshake will
+    // be IGNORED (instead of being rejected). If the cookie collision situation happens
+    // against this version or older, which is only a rare situation of cookie
+    // values identical except bit 0x80000000, this agent's ignored handshake will only
+    // result in timeout, instead of immediate failure. If this happens against 1.6.0
+    // version, which involves more ranges of cookies and is more probable, the result
+    // will be that the version 1.6.0 will adapt to the situation and finally the
+    // connection will be established. This fix here is required to solve a problem that
+    // results from a situation that the pre-1.6.0 version would reject the handshake
+    // without extensions and break the connection process, which would make the
+    // connection process break even though the 1.6.0 would adapt to the situation,
+    // but when sending the first conclusion handshake, version 1.6.0 was at the moment
+    // unaware of the situation.
+
+    // This situation happens if:
+    //  - agent is RESPONDER - which means, it expects CONCLUSION with HSRSP extension
+    //  - incoming handshake command is CONCLUSION (not WAVEAHAND, which is always without extensions)
+    //  - and it's without extension (CONCLUSION without extension is only possible
+    //    in rendezvous mode if peer is RESPONDER and is obliged to send CONCLUSION as first)
+    if (m_SrtHsSide == HSD_RESPONDER && m_ConnRes.m_iReqType == URQ_CONCLUSION && ext_flags == 0)
+    {
+        LOGC(cnlog.Error, log <<
+                "processRendezvous: Peer HS-noext with agent=RESPONDER: COOKIE COLLISION? - not interpreting, REQ-TIME LOW");
+
+        // Fake that no handshake has been received, simply proceed with sending
+        // YOUR handshake only.
+        rst = RST_AGAIN;
+        m_tsLastReqTime = steady_clock::time_point();
+    }
+
     checkUpdateCryptoKeyLen("processRendezvous", m_ConnRes.m_iType);
 
     // We have three possibilities here as it comes to HSREQ extensions:

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4103,8 +4103,8 @@ void srt::CUDT::sendRendezvousRejection(const sockaddr_any& serv_addr, CPacket& 
 }
 
 #define VERSION_INITIAL 0
-#define VERSION_MAX 0
-#define VERSION_COMPARISON 1
+#define VERSION_MAX 1
+#define VERSION_COMPARISON 0
 
 void srt::CUDT::cookieContest()
 {

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -294,6 +294,17 @@ public: // internal API
         return m_ConnRes.m_iVersion;
     }
 
+    int32_t handshakeCookie()
+    {
+        return m_ConnReq.m_iCookie;
+    }
+
+    static HandshakeSide handshakeSide(SRTSOCKET u);
+    HandshakeSide handshakeSide()
+    {
+        return m_SrtHsSide;
+    }
+
     std::string CONID() const
     {
 #if ENABLE_LOGGING
@@ -1247,6 +1258,16 @@ private: // for epoll
     void removeEPollEvents(const int eid);
     void removeEPollID(const int eid);
 };
+
+// DEBUG SUPPORT
+
+// The cookie is prepared basing on the target address.
+// To get the cookie with the expected value during connection,
+// simply register this address with desired cookie value and this
+// will be the cookie value of the agent when you next run srt_connect.
+int32_t RegisterCookieBase(const sockaddr_any& addr, int32_t cookieval);
+void ClearCookieBase();
+HandshakeSide getHandshakeSide(SRTSOCKET s);
 
 } // namespace srt
 

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -5,6 +5,7 @@
 #include "test_env.h"
 #include "utilities.h"
 #include "common.h"
+#include "core.h"
 
 using namespace srt;
 
@@ -70,4 +71,107 @@ TEST(CIPAddress, IPv4_in_IPv6_pton)
     const uint32_t ip[4]   = {0, 0, htobe32(0x0000FFFF), htobe32(0xC0A80001)};
 
     test_cipaddress_pton(peer_ip, AF_INET6, ip);
+}
+
+void testCookieContest(int32_t agent_cookie, int32_t peer_cookie)
+{
+    using namespace srt;
+    using namespace std;
+
+    SRTSOCKET agent = srt_create_socket(), peer = srt_create_socket();
+
+    uint16_t agent_port = 5001, peer_port = 5002;
+    cout << "TEST: Rem-addr: agent @" << agent << " PORT: " << peer_port
+        << " peer " << peer << " PORT: " << agent_port << endl;
+
+    cout << "TEST: Cookies: agent=" << hex << agent_cookie
+        << " peer=" << peer_cookie << endl << dec;
+
+
+    sockaddr_any agent_addr = srt::CreateAddr("127.0.0.1", 0, AF_INET);
+    sockaddr_any peer_addr = agent_addr;
+
+    agent_addr.hport(agent_port);
+    peer_addr.hport(peer_port);
+
+    // Bind sockets
+    srt_bind(agent, agent_addr.get(), agent_addr.size());
+    srt_bind(peer, peer_addr.get(), peer_addr.size());
+
+    // Manipulate bake process
+
+    // peer_addr will be used as target by agent and vv.
+    RegisterCookieBase(peer_addr, agent_cookie);
+    RegisterCookieBase(agent_addr, peer_cookie);
+
+    int eid = srt_epoll_create();
+    int event_connect = SRT_EPOLL_CONNECT;
+
+    srt_epoll_add_usock(eid, agent, &event_connect);
+    srt_epoll_add_usock(eid, peer, &event_connect);
+
+    bool noblock = false;
+
+    srt_setsockflag(agent, SRTO_RCVSYN, &noblock, sizeof noblock);
+    //srt_setsockflag(peer, SRTO_RCVSYN, &noblock, sizeof noblock);
+
+    bool rdv = true;
+
+    srt_setsockflag(agent, SRTO_RENDEZVOUS, &rdv, sizeof rdv);
+    srt_setsockflag(peer, SRTO_RENDEZVOUS, &rdv, sizeof rdv);
+
+    // Set 500ms timeout - rendezvous has a builtin extended 10* this
+    // time, so it will result in 5 seconds.
+    int tmo = 500;
+    srt_setsockflag(agent, SRTO_CONNTIMEO, &tmo, sizeof tmo);
+    srt_setsockflag(peer, SRTO_CONNTIMEO, &tmo, sizeof tmo);
+
+    SRTSOCKET sta = srt_connect(agent, peer_addr.get(), peer_addr.size());
+    SRTSOCKET stp = srt_connect(peer, agent_addr.get(), agent_addr.size());
+
+    cout << "Agent connect: " << sta << " Peer connect: " << stp << endl;
+
+    int epoll_table[2];
+    int epoll_table_size = 2;
+
+    int nrdy = srt_epoll_wait(eid, 0, 0, epoll_table, &epoll_table_size, 1000, 0, 0, 0, 0);
+
+    cout << "Ready sockets: " << nrdy << endl;
+
+    EXPECT_GT(nrdy, 0);
+
+    HandshakeSide agent_side = getHandshakeSide(agent), peer_side = getHandshakeSide(peer);
+
+    EXPECT_EQ(agent_side, HSD_INITIATOR);
+    EXPECT_EQ(peer_side, HSD_RESPONDER);
+
+    srt_close(agent);
+    srt_close(peer);
+
+    sync::this_thread::sleep_for(sync::seconds_from(2));
+    ClearCookieBase();
+}
+
+TEST(Common, CookieContest)
+{
+    srt::TestInit srtinit;
+    using namespace std;
+
+    srt_setloglevel(LOG_NOTICE);
+
+    cout << "TEST 1: two easy comparable values\n";
+    testCookieContest(100, 50);
+    testCookieContest(-1, -1000);
+    testCookieContest(10055, -10000);
+
+    // In this function you should pass cookies always in the order: INITIATOR, RESPONDER.
+
+    // Values from PR 1517
+    cout << "TEST 2: Values from PR 1517\n";
+    testCookieContest(811599203, -1480577720);
+    testCookieContest(2147483647, -2147483648);
+
+    cout << "TEST 3: wrong post-fix\n";
+    // NOTE: 0x80000001 is a negative number in hex
+    testCookieContest(0x00000001, 0x80000001);
 }

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -159,12 +159,15 @@ TEST(Common, CookieContest)
 
     srt_setloglevel(LOG_NOTICE);
 
+    // In this function you should pass cookies always in the order: INITIATOR, RESPONDER.
     cout << "TEST 1: two easy comparable values\n";
     testCookieContest(100, 50);
     testCookieContest(-1, -1000);
     testCookieContest(10055, -10000);
 
-    // In this function you should pass cookies always in the order: INITIATOR, RESPONDER.
+    /* XXX Blocked temporarily because in 1.5.5 they would fail,
+       and itś decided to not provide the fix, which is too
+       dangerous. The real fix will be provided in 1.6.0.
 
     // Values from PR 1517
     cout << "TEST 2: Values from PR 1517\n";
@@ -174,4 +177,5 @@ TEST(Common, CookieContest)
     cout << "TEST 3: wrong post-fix\n";
     // NOTE: 0x80000001 is a negative number in hex
     testCookieContest(0x00000001, 0x80000001);
+    */
 }

--- a/testing/testmedia.cpp
+++ b/testing/testmedia.cpp
@@ -464,6 +464,19 @@ void SrtCommon::InitParameters(string host, string path, map<string,string> par)
         par.erase("groupconfig");
     }
 
+    // Test-tentacle: cookie. Allows to enforce the cookie value.
+    // For testing rendezvous.
+    if (par.count("cookie"))
+    {
+        int32_t val = stoi(par.at("cookie"));
+        if (val == 0)
+        {
+            throw std::runtime_error("SRT/cookie: cookie value 0 is not allowed");
+        }
+        m_forced_cookie = val;
+        par.erase("cookie");
+    }
+
     // Fix Minversion, if specified as string
     if (par.count("minversion"))
     {
@@ -1323,6 +1336,12 @@ void SrtCommon::ConnectClient(string host, int port)
     if (!m_blocking_mode)
     {
         srt_connect_callback(m_sock, &TransmitConnectCallback, 0);
+    }
+
+    if (m_forced_cookie)
+    {
+        Verb("ENFORCED cookie value: ", m_forced_cookie, " for address: ", sa.str());
+        RegisterCookieBase(sa, m_forced_cookie);
     }
 
     int stat = -1;

--- a/testing/testmedia.hpp
+++ b/testing/testmedia.hpp
@@ -106,6 +106,7 @@ protected:
     std::vector<Connection> m_group_nodes;
     std::string m_group_type;
     std::string m_group_config;
+    int32_t m_forced_cookie = 0;
 #if ENABLE_BONDING
     std::vector<SRT_SOCKGROUPDATA> m_group_data;
 #ifdef SRT_OLD_APP_READER


### PR DESCRIPTION
Changes:

1. The cookie contest method was restored the version from 1.4.5, which is still buggy, but least risky.
2. Added a mechanism to enforce a cookie value, for testing and development.
3. Added a recognition of a situation when RESPONDER got a CONCLUSION handshake with no extensions.

The trick in 3 is necessary so that the version 1.6.0, where the cookie contest problem will be fixed, can connect without problems.

Version 1.3.0 has created a range of values where the overflow situation was ignored, hence the HS side was rendered the opposite way, still as two different; this algorithm was also prone to different results depending on compiler options (potentially leading to same-side rendering on both parties). In 1.4.5 a fix was provided which cleared that last problem, forcing the buggy, but still different, resolution on both sides, except a small range of values different only by 0x80000000 bit, where the subtraction results in a value with this bit set, regardless of the order.

We have then 3 ranges of cookie values, regarding how it is resolved in version up to 1.5.5:

1. Range N: the result will be the same as comparison
2. Range V: the result will be opposite towards the comparison
3. Range C: the result will be the collision (same resolution on both sides)

Range C is a small range when one cookie value A differs to B being A = B ^ 0x80000000. For example 1 and 0x80000001.

As adaptive solution would be too dangerous, this version contains a fix for the following situation:
- the other party sends the CONCLUSION handshake first, as it has resolved itself as RESPONDER, without extensions (it's the only situation when CONCLUSION can be sent without extensions)
- when THIS party receives it, while considering itself also a responder, it will reject the handshake and break the connection process

The fix: if receiving conclusion handshake without extensions, IGNORE the handshake and send your own (also CONCLUISION without extensions) to the peer. This fix is for the sake of the adaptive solution to be provided in 1.6.0 - without it, the connection would break before the 1.6.0-based side would attempt for adaptation.

With this fix, this will be the result of connecting between different versions:

1. A=1.4.5 vs. B=1.4.5: normal, except Range-C value the result will be connection failure.
2. A=1.4.5 vs. B=1.5.5: same as 1, except that B side will not break, and instead it will be trying to connect up to the timeout.
3. A=1.6.0 vs. B=1.5.5: Here both ranges C and V will result in a collision, but side A will adapt to it by turning into opposite side; as version B contains the fix, it will ignore the invalid HS request and after adaptation the HS will be this time correct for it.
4. A = 1.6.0 vs. B=1.4.5: Same as 3, except that this will result in connection failure if the layout is such that the A version starts first. This can be walked around by starting B as first.
