### PR TITLE
[build] Avoid using list(PREPEND).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,7 +966,7 @@ else ()
 	message(STATUS "Pthread library: ${PTHREAD_LIBRARY}")
 endif()
 
-list(PREPEND CMAKE_REQUIRED_LIBRARIES "${PTHREAD_LIBRARY}")
+set(CMAKE_REQUIRED_LIBRARIES "${PTHREAD_LIBRARY};${CMAKE_REQUIRED_LIBRARIES}")
 unset(CMAKE_REQUIRED_QUIET)
 
 check_symbol_exists(pthread_atfork "pthread.h" HAVE_PTHREAD_ATFORK)


### PR DESCRIPTION
list(PREPEND) requires CMake version 3.15, but our project's minimum supported version is 3.5.
This PR avoids using list(PREPEND) to maintain compatibility.