### PR TITLE
[MAINT] Fixes for IP Address handling in sockaddr_any and CIPAddress

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -856,7 +856,7 @@ int CUDTUnited::newConnection(const SRTSOCKET     listener,
     // - OVERWRITE just the IP address itself by a value taken from piSelfIP
     // (the family is used exactly as the one taken from what has been returned
     // by getsockaddr)
-    CIPAddress::pton((ns->m_SelfAddr), ns->core().m_piSelfIP, peer);
+    CIPAddress::decode(ns->core().m_piSelfIP, peer, (ns->m_SelfAddr));
 
     {
         // protect the m_PeerRec structure (and group existence)

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -979,11 +979,18 @@ public:
 
 struct CIPAddress
 {
-   static bool ipcmp(const struct sockaddr* addr1, const struct sockaddr* addr2, int ver = AF_INET);
-   static void ntop(const struct sockaddr_any& addr, uint32_t ip[4]);
-   static void pton(sockaddr_any& addr, const uint32_t ip[4], const sockaddr_any& peer);
-   static std::string show(const struct sockaddr* adr);
+   static void encode(const struct sockaddr_any& addr, uint32_t (&ip)[4]);
+   static void decode(const uint32_t (&ip)[4], const sockaddr_any& peer, sockaddr_any& w_addr);
 };
+
+bool checkMappedIPv4(const uint16_t* sa);
+
+inline bool checkMappedIPv4(const sockaddr_in6& sa)
+{
+    const uint16_t* addr = reinterpret_cast<const uint16_t*>(&sa.sin6_addr.s6_addr);
+    return checkMappedIPv4(addr);
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -1547,14 +1554,6 @@ inline std::string SrtVersionString(int version)
 }
 
 bool SrtParseConfig(const std::string& s, SrtConfig& w_config);
-
-bool checkMappedIPv4(const uint16_t* sa);
-
-inline bool checkMappedIPv4(const sockaddr_in6& sa)
-{
-    const uint16_t* addr = reinterpret_cast<const uint16_t*>(&sa.sin6_addr.s6_addr);
-    return checkMappedIPv4(addr);
-}
 
 std::string FormatLossArray(const std::vector< std::pair<int32_t, int32_t> >& lra);
 std::ostream& PrintEpollEvent(std::ostream& os, int events, int et_events = 0);

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3701,7 +3701,7 @@ void CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
     // SRTO_FC has been set to a less value.
     m_ConnReq.m_iFlightFlagSize = m_config.flightCapacity();
     m_ConnReq.m_iID             = m_SocketID;
-    CIPAddress::ntop(serv_addr, (m_ConnReq.m_piPeerIP));
+    CIPAddress::encode(serv_addr, (m_ConnReq.m_piPeerIP));
 
     if (forced_isn == SRT_SEQNO_NONE)
     {
@@ -5030,7 +5030,7 @@ EConnectStatus CUDT::postConnect(const CPacket* pResponse, bool rendezvous, CUDT
     // otherwise if startConnect() fails, the multiplexer cannot be located
     // by garbage collection and will cause leak
     s->m_SelfAddr = s->core().channel()->getSockAddr();
-    CIPAddress::pton((s->m_SelfAddr), s->core().m_piSelfIP, m_PeerAddr);
+    CIPAddress::decode(s->core().m_piSelfIP, m_PeerAddr, (s->m_SelfAddr));
 
     //int token = -1;
 #if SRT_ENABLE_BONDING
@@ -5898,7 +5898,7 @@ void CUDT::rewriteHandshakeData(const sockaddr_any& peer, CHandShake& w_hs)
         w_hs.m_extensionType = (m_SrtHsSide == HSD_INITIATOR) ? SRT_CMD_HSREQ : SRT_CMD_HSRSP;
     }
 
-    CIPAddress::ntop(peer, (w_hs.m_piPeerIP));
+    CIPAddress::encode(peer, (w_hs.m_piPeerIP));
 }
 
 void CUDT::acceptAndRespond(CUDTSocket* lsn, const sockaddr_any& peer, const CPacket& hspkt, CHandShake& w_hs)
@@ -5952,7 +5952,7 @@ void CUDT::acceptAndRespond(CUDTSocket* lsn, const sockaddr_any& peer, const CPa
     // get local IP address and send the peer its IP address (because UDP cannot get local IP address)
     memcpy((m_piSelfIP), w_hs.m_piPeerIP, sizeof m_piSelfIP);
     m_parent->m_SelfAddr = agent;
-    CIPAddress::pton((m_parent->m_SelfAddr), m_piSelfIP, peer);
+    CIPAddress::decode(m_piSelfIP, peer, (m_parent->m_SelfAddr));
 
     rewriteHandshakeData(peer, (w_hs));
 

--- a/srtcore/netinet_any.h
+++ b/srtcore/netinet_any.h
@@ -267,20 +267,15 @@ struct sockaddr_any
         len = size();
     }
 
-    // port is in exactly the same location in both sin and sin6
-    // and has the same size. This is actually yet another common
-    // field, just not mentioned in the sockaddr structure.
+    // NOTE: We rely on that sockaddr_in::sin_port and sockaddr_in6::sin6_port
+    // have the same offset and size. This is the current practice in every
+    // today OS, unlikely to change due to ABI compat requirements,
+    // but POSIX gives no such explicit guarantee, even though it does define
+    // these types themselves.
     uint16_t& r_port() { return sin.sin_port; }
     uint16_t r_port() const { return sin.sin_port; }
     int hport() const { return ntohs(sin.sin_port); }
-
-    void hport(int value)
-    {
-        // Port is fortunately located at the same position
-        // in both sockaddr_in and sockaddr_in6 and has the
-        // same size.
-        sin.sin_port = htons(value);
-    }
+    void hport(int value) { sin.sin_port = htons(value); }
 
     sockaddr* get() { return &sa; }
     const sockaddr* get() const { return &sa; }
@@ -387,6 +382,23 @@ struct sockaddr_any
             return "unknown:0";
 
         std::ostringstream output;
+        write_addr(output, true);
+        return output.str();
+    }
+
+    std::string str_addr() const
+    {
+        if (family() != AF_INET && family() != AF_INET6)
+            return "";
+
+        std::ostringstream output;
+        write_addr(output, false);
+        return output.str();
+    }
+
+    void write_addr(std::ostringstream& output, bool withport) const
+    {
+
         char hostbuf[1024];
         int flags;
 
@@ -396,13 +408,27 @@ struct sockaddr_any
         flags = NI_NUMERICHOST | NI_NUMERICSERV;
     #endif
 
-        if (!getnameinfo(get(), size(), hostbuf, 1024, NULL, 0, flags))
+        if (getnameinfo(get(), size(), hostbuf, 1024, NULL, 0, flags) == 0 /*success*/)
         {
-            output << hostbuf;
+            if (withport && family() == AF_INET6)
+            {
+                // For IPv6 the specification of the port is still with ":",
+                // and the standard mandates that in this situation the IP address
+                // must be in square brackets.
+                output << "[" << hostbuf << "]";
+            }
+            else
+            {
+                output << hostbuf;
+            }
+        }
+        else
+        {
+            output << "<ERROR>";
         }
 
-        output << ":" << hport();
-        return output.str();
+        if (withport)
+            output << ":" << hport();
     }
 
     bool operator==(const sockaddr_any& other) const

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -15,7 +15,7 @@
 
 using namespace srt;
 
-void test_cipaddress_pton(const char* peer_ip, int family, const uint32_t (&ip)[4])
+void test_ip_coding(const char* peer_ip, int family, const uint32_t (&ip)[4])
 {
     const int port = 4200;
 
@@ -44,7 +44,7 @@ void test_cipaddress_pton(const char* peer_ip, int family, const uint32_t (&ip)[
     sockaddr_any host(family);
     host.hport(port);
 
-    srt::CIPAddress::pton(host, ip, peer);
+    srt::CIPAddress::decode(ip, peer, (host));
     EXPECT_EQ(peer, host) << "Peer " << peer.str() << " host " << host.str();
 }
 
@@ -54,7 +54,7 @@ TEST(CIPAddress, IPv4_pton)
     srt::TestInit srtinit;
     const char*    peer_ip = "192.168.0.1";
     const uint32_t ip[4]   = {htobe32(0xC0A80001), 0, 0, 0};
-    test_cipaddress_pton(peer_ip, AF_INET, ip);
+    test_ip_coding(peer_ip, AF_INET, ip);
 }
 
 // Example IPv6 address: 2001:db8:85a3:8d3:1319:8a2e:370:7348
@@ -64,7 +64,7 @@ TEST(CIPAddress, IPv6_pton)
     const char*    peer_ip = "2001:db8:85a3:8d3:1319:8a2e:370:7348";
     const uint32_t ip[4]   = {htobe32(0x20010db8), htobe32(0x85a308d3), htobe32(0x13198a2e), htobe32(0x03707348)};
 
-    test_cipaddress_pton(peer_ip, AF_INET6, ip);
+    test_ip_coding(peer_ip, AF_INET6, ip);
 }
 
 // Example IPv4 address: 192.168.0.1
@@ -76,7 +76,7 @@ TEST(CIPAddress, IPv4_in_IPv6_pton)
     const char*    peer_ip = "::ffff:192.168.0.1";
     const uint32_t ip[4]   = {0, 0, htobe32(0x0000FFFF), htobe32(0xC0A80001)};
 
-    test_cipaddress_pton(peer_ip, AF_INET6, ip);
+    test_ip_coding(peer_ip, AF_INET6, ip);
 }
 
 TEST(SRTAPI, SyncRendezvousHangs)

--- a/test/test_ipv6.cpp
+++ b/test/test_ipv6.cpp
@@ -210,7 +210,7 @@ TEST_F(TestIPv6, v4_calls_v6_mapped)
     std::thread client(&TestIPv6::ClientThread, this, AF_INET, "127.0.0.1");
 
     const sockaddr_any sa_accepted = DoAccept();
-    EXPECT_EQ(sa_accepted.str(), "::ffff:127.0.0.1:4200");
+    EXPECT_EQ(sa_accepted.str(), "[::ffff:127.0.0.1]:4200");
 
     client.join();
 }
@@ -229,7 +229,7 @@ TEST_F(TestIPv6, v6_calls_v6_mapped)
     std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "::1");
 
     const sockaddr_any sa_accepted = DoAccept();
-    EXPECT_EQ(sa_accepted.str(), "::1:4200");
+    EXPECT_EQ(sa_accepted.str(), "[::1]:4200");
 
     client.join();
 }
@@ -251,7 +251,7 @@ TEST_F(TestIPv6, v6_calls_v6)
     std::thread client(&TestIPv6::ClientThread, this, AF_INET6, "::1");
 
     const sockaddr_any sa_accepted = DoAccept();
-    EXPECT_EQ(sa_accepted.str(), "::1:4200");
+    EXPECT_EQ(sa_accepted.str(), "[::1]:4200");
 
     client.join();
 }


### PR DESCRIPTION
Changes:
1. In `CIPAddress`, removed unused `ipcmp` and `show`, and `ntop`/`pton` changed into `encode`/`decode`. The "coding" is understand here as creating the SRT-encoding address using an 4-element 32-bit integer array. The array is passed also by reference in order to prevent using an array of different size.
2. Fixed buggy `str()` specification in `sockaddr_any`, which didn't respect the standard rule that IPv6 address must be in square brackets if it occurs together with port separated by a colon.
3. Added `str_addr()` method to `sockaddr_any` in order to print only the address itself, disregarding the port.