### PR TITLE
Ubuntu 23.04 reached end-of-life in January 2024.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Build Status Linux and macOS][travis-badge]][travis]
 [![Build Status Windows][appveyor-badge]][appveyor]
 
-[![Ubuntu 23.04][Ubuntu-badge]][Ubuntu-package]
+[![Ubuntu 24.04][Ubuntu-badge]][Ubuntu-package]
 [![Fedora 37][fedora-badge]][fedora-package]
 [![Debian][debian-badge]][debian-package]
 [![Homebrew][Homebrew-badge]][Homebrew-package]
@@ -242,4 +242,4 @@ By contributing code to the SRT project, you agree to license your contribution 
 [homebrew-badge]: https://repology.org/badge/version-for-repo/homebrew/srt.svg
 
 [Ubuntu-package]: https://repology.org/project/srt/versions
-[Ubuntu-badge]: https://repology.org/badge/version-for-repo/ubuntu_23_04/srt.svg
+[Ubuntu-badge]: https://repology.org/badge/version-for-repo/ubuntu_24_04/srt.svg


### PR DESCRIPTION
updated the Ubuntu badge from version 23.04 to 24.04 (the current LTS release).
The issue was that Ubuntu 23.04 reached end-of-life in January 2024, so the Repology badge for that version wasn't rendering properly anymore.
The badge should now display correctly with Ubuntu 24.04, which is the latest LTS version and is actively maintained.