### PR TITLE
move examples/fork-test to examples, aligns with other test samples.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1544,6 +1544,14 @@ if (ENABLE_BONDING)
 endif()
 
 	srt_add_example(testcapi-connect.c)
+
+if (POSIX)
+	# Fork test examples require POSIX APIs (fork, pthread)
+	srt_add_example(test-fork-server.c)
+
+	srt_add_example(test-fork-client.c)
+endif()
+
 endif()
 
 

--- a/examples/fork-test/Makefile
+++ b/examples/fork-test/Makefile
@@ -1,9 +1,0 @@
-TARGETS=srt_server srt_client
-
-all: $(TARGETS)
-
-%: %.c
-	$(CC) $< `pkg-config --cflags --libs srt` -o `basename $< .c`
-
-clean:
-	rm -f $(TARGETS)

--- a/examples/fork-test/README.md
+++ b/examples/fork-test/README.md
@@ -1,7 +1,0 @@
-The `srt_server` and `srt_client` apps should be compiled using
-external installation of SRT (e.g. in the local directory), each
-one as a single program. This is not compiled as a part of SRT.
-
-If you want to use a local installation, simply set `PKG_CONFIG_PATH`
-environment variable to point to the local installation directory with
-"lib/pkgconfig" or "lib64/pkgconfig" suffix.

--- a/examples/test-fork-client.c
+++ b/examples/test-fork-client.c
@@ -1,4 +1,14 @@
-#include <srt/srt.h>
+/*
+ * SRT Fork Test - Client Example
+ *
+ * This example demonstrates an SRT client that connects to test-fork-server
+ * to verify SRT behavior with fork() system calls.
+ *
+ * See test-fork-server.c for building and running instructions.
+ */
+
+#include "srt.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/examples/test-fork-server.c
+++ b/examples/test-fork-server.c
@@ -1,4 +1,24 @@
-#include <srt/srt.h>
+/*
+ * SRT Fork Test - Server Example
+ *
+ * This example demonstrates SRT behavior with fork() system calls.
+ * The server accepts an SRT connection, receives a message, then forks
+ * a child process to execute a command while maintaining the SRT connection.
+ *
+ * Building:
+ *   These examples are built as part of the main SRT build when examples are enabled:
+ *   cmake .. -DENABLE_EXAMPLES=ON
+ *   make
+ *
+ * Running:
+ *   Start the server:
+ *     ./test-fork-server
+ *   In another terminal, run the client:
+ *     ./test-fork-client
+ */
+
+#include "srt.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
minor refactoring for the example directory structure.

The fork-test examples are isolated in their own directory with a standalone Makefile that expects an installed SRT library, while all other examples in the examples directory are built directly as part of the main CMake build system. This is indeed inconsistent.

History: brought up with https://github.com/Haivision/srt/issues/3177, and generated by https://github.com/Haivision/srt/pull/3179