### PR TITLE
Old URL (404 - no longer exists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="left">
   <a href="http://srtalliance.org/">
-    <img alt="SRT" src="http://www.srtalliance.org/wp-content/uploads/SRT_text_hor_logo_grey.png" width="500"/>
+    <img alt="SRT" src="https://srtalliance.org/wp-content/uploads/2025/11/srt-long.svg" width="500"/>
   </a>
 </p>
 


### PR DESCRIPTION
The SRT Alliance website underwent a redesign (appears to have been around October 2025 based on the new image paths), and the old WordPress uploads structure was changed. The original grey horizontal logo file was either renamed, replaced, or removed during this process.