### PR TITLE
Fix group data length check in handshake processing

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -3080,11 +3080,10 @@ bool srt::CUDT::interpretSrtHandshake(const CHandShake& hs,
                     LOGC(cnlog.Error, log << CONID() << "PEER'S GROUP wrong size: " << (bytelen/GRPD_FIELD_SIZE));
                     return false;
                 }
-                if (bytelen > sizeof(groupdata))
-                    bytelen = sizeof(groupdata);
-                size_t groupdata_size = bytelen / GRPD_FIELD_SIZE;
+                size_t used_bytelen = std::min(bytelen, sizeof(groupdata));
+                size_t groupdata_size = used_bytelen / GRPD_FIELD_SIZE;
 
-                memcpy(groupdata, begin+1, bytelen);
+                memcpy(groupdata, begin+1, used_bytelen);
                 if (!interpretGroup(groupdata, groupdata_size, hsreq_type_cmd) )
                 {
                     // m_RejectReason handled inside interpretGroup().


### PR DESCRIPTION
Seems like groupdata array could be overflown if bytelen is too big. 