### PR TITLE
suggest to run codespell before creating PRs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,28 @@ Submit a pull request at any time, whether an issue has been created or not. It 
 
 Please follow the [SRT Developer's Guide](docs/dev/developers-guide.md).
 
+## Spell Check
+
+Before submitting a pull request, we should run codespell locally to check for spelling errors.
+This helps ensure your PR passes the automated checks.
+
+```console
+# create python venv
+python3 -m venv .venv
+
+# activate venv
+source .venv/bin/activate
+
+# install codespell in venv
+pip install codespell
+
+# run codespell with config
+codespell --config scripts/codespell/codespell.cfg
+
+# deactivate venv
+deactivate
+```
+
 ## Code Style
 
 Please follow existing style.


### PR DESCRIPTION
follow up of https://github.com/Haivision/srt/pull/3263

https://github.com/Haivision/srt/pull/3263#issuecomment-3767263183 tells that user should be able to know how to run the codespell beforehand creating pull requests, so that they can fix the typos before github workflow runs. this is missing in https://github.com/Haivision/srt/pull/3263, so this PR addresses it.

> [!NOTE]
> This also should be cherri-picked after https://github.com/Haivision/srt/pull/3274 for `dev` branch.

Replaced by #3333 (partially - the script is added so that codespell is run manually; this is also part of the CI)