### PR TITLE
Fixed bug: interrupting a blocking connect loop must be recognized per the same condition

### DIFF
--- a/srtcore/common.cpp
+++ b/srtcore/common.cpp
@@ -67,6 +67,7 @@ modified by
 #include "logging.h"
 #include "packet.h"
 #include "threadname.h"
+#include "logger_defs.h"
 
 using namespace std;
 using namespace srt::sync;
@@ -92,6 +93,7 @@ m_iMinor(minor)
        m_iErrno = NET_ERROR;
    else
       m_iErrno = err;
+   HLOGC(aclog.Debug, log << "CREATED SRT EXCEPTION: " << (1000*major+minor) << " errno=" << m_iErrno);
 }
 
 const char* srt::CUDTException::getErrorMessage() const ATR_NOTHROW

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4068,7 +4068,7 @@ void srt::CUDT::startConnect(const sockaddr_any& serv_addr, int32_t forced_isn)
 
     if (e.getErrorCode() == 0)
     {
-        if (m_bClosing)                                    // if the socket is closed before connection...
+        if (m_bClosing || m_bBreaking)                     // if the socket is closed before connection...
             e = CUDTException(MJ_SETUP, MN_CLOSED, 0);
         else if (m_ConnRes.m_iReqType > URQ_FAILURE_TYPES) // connection request rejected
         {


### PR DESCRIPTION
Fixes #3289

The problem: the blocking connect loop should be interrupted by free break calls inside and per a flag. This must be recognized later with the "zero error" status after exitting the loop the same way as the loop condition, otherwise it may result in continuing as if the connection succeeded and possibly hit a misleading error condition.

Additionally: a log was added for a creation action for the CUDTException; this allows to track all cases when an action ends up with exception (development support only).