### PR TITLE
[BUG] Incorrect error code when srt_listen on closed socket

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -612,9 +612,10 @@ the listener socket to accept group connections
 | [`SRT_EINVPARAM`](#srt_einvparam)       | Value of `backlog` is 0 or negative.                                                         |
 | [`SRT_EINVSOCK`](#srt_einvsock)         | Socket [`u`](#u) indicates no valid SRT socket.                                              |
 | [`SRT_EUNBOUNDSOCK`](#srt_eunboundsock) | [`srt_bind`](#srt_bind) has not yet been called on that socket.                              |
+| [`SRT_ESCLOSED`](#srt_esclosed)         | The socket has been closed                                                                   |
 | [`SRT_ERDVNOSERV`](#srt_erdvnoserv)     | [`SRTO_RENDEZVOUS`](API-socket-options.md#SRTO_RENDEZVOUS) flag is set to true on specified socket. |
 | [`SRT_EINVOP`](#srt_einvop)             | Internal error (should not happen when [`SRT_EUNBOUNDSOCK`](#srt_eunboundsock) is reported). |
-| [`SRT_ECONNSOCK`](#srt_econnsock)       | The socket is already connected.                                                             |
+| [`SRT_ECONNSOCK`](#srt_econnsock)       | The socket is currently being used to establish a connection (like by `srt_connect`)         |
 | [`SRT_EDUPLISTEN`](#srt_eduplisten)     | The address used in [`srt_bind`](#srt_bind) by this socket is already occupied by another listening socket. <br/> Binding multiple sockets to one IP address and port is allowed, as long as <br/> [`SRTO_REUSEADDR`](API-socket-options.md#SRTO_REUSEADDRS) is set to true, but only one of these sockets can be set up as a listener.  |
 | <img width=240px height=1px/>           | <img width=710px height=1px/>                      |
 

--- a/scripts/codespell/codespell.cfg
+++ b/scripts/codespell/codespell.cfg
@@ -6,9 +6,11 @@ builtin = clear,rare,informal,code
 
 # Ignore words listed in this file.
 ignore-words = ./scripts/codespell/codespell_whitelist.txt
+ignore-regex = TEST\(.*\)
 
 # Add custom dictionary file.
 dictionary = ./scripts/codespell/codespell_dictionary.txt,-
 
 # Skip checking files or directories.
 skip = ./build/*,./.git/*
+

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1144,6 +1144,9 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
     // it could have changed the state. It could be also set listen in another
     // thread, so check it out.
 
+    if (s->core().m_config.bRendezvous)
+        throw CUDTException(MJ_NOTSUP, MN_ISRENDEZVOUS, 0);
+
     switch(s->m_Status)
     {
         case SRTS_INIT:
@@ -1168,9 +1171,6 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
             throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
             break;
     }
-
-    if (s->core().m_config.bRendezvous)
-        throw CUDTException(MJ_NOTSUP, MN_ISRENDEZVOUS, 0);
 
 
     return 0;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1144,9 +1144,23 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
     // it could have changed the state. It could be also set listen in another
     // thread, so check it out.
 
-    // do nothing if the socket is already listening
+    // do not change the state if the socket is already listening
     if (s->m_Status == SRTS_LISTENING)
+    {
+        // Although update the backlog value. NOTE: POSIX doesn't require this
+        // for the `listen` function, but in practice all Linux/Unix do so.
+        s->m_uiBackLog = backlog;
         return 0;
+    }
+
+    // Somehow we have a broken/closing socket; unlikely to be dispatched,
+    // but there are conditions when a closed socket is kept in trash for
+    // some reason, from where the GC should pick it up; report that state.
+    if (int(s->m_Status) >= SRTS_BROKEN) // BROKEN, CLOSING, CLOSED, NONEXIST
+        throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
+
+    if (int(s->m_Status) >= SRTS_CONNECTING) // CONNECTING, CONNECTED
+        throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
 
     // a socket can listen only if is in OPENED status
     if (s->m_Status != SRTS_OPENED)
@@ -1163,7 +1177,7 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
     // [[using assert(s->m_Status == OPENED)]]; // (still, unchanged)
 
     s->core().setListenState(); // propagates CUDTException,
-                                // if thrown, remains in OPENED state if so.
+                                // if thrown, remains in OPENED state
     s->m_Status = SRTS_LISTENING;
 
     return 0;

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1147,7 +1147,6 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
     switch(s->m_Status)
     {
         case SRTS_INIT:
-        case SRTS_NONEXIST:
             throw CUDTException(MJ_NOTSUP, MN_ISUNBOUND, 0);
             break;
         case SRTS_OPENED:
@@ -1165,6 +1164,7 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
         case SRTS_BROKEN:
         case SRTS_CLOSING:
         case SRTS_CLOSED:
+        case SRTS_NONEXIST:
             throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
             break;
     }

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -1144,41 +1144,34 @@ int srt::CUDTUnited::listen(const SRTSOCKET u, int backlog)
     // it could have changed the state. It could be also set listen in another
     // thread, so check it out.
 
-    // do not change the state if the socket is already listening
-    if (s->m_Status == SRTS_LISTENING)
+    switch(s->m_Status)
     {
-        // Although update the backlog value. NOTE: POSIX doesn't require this
-        // for the `listen` function, but in practice all Linux/Unix do so.
-        s->m_uiBackLog = backlog;
-        return 0;
+        case SRTS_INIT:
+        case SRTS_NONEXIST:
+            throw CUDTException(MJ_NOTSUP, MN_ISUNBOUND, 0);
+            break;
+        case SRTS_OPENED:
+            s->m_uiBackLog = backlog;
+            s->core().setListenState(); // propagates CUDTException,
+            s->m_Status = SRTS_LISTENING;
+            break;
+        case SRTS_LISTENING:
+            s->m_uiBackLog = backlog;
+            break;
+        case SRTS_CONNECTING:
+        case SRTS_CONNECTED:
+            throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
+            break;
+        case SRTS_BROKEN:
+        case SRTS_CLOSING:
+        case SRTS_CLOSED:
+            throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
+            break;
     }
 
-    // Somehow we have a broken/closing socket; unlikely to be dispatched,
-    // but there are conditions when a closed socket is kept in trash for
-    // some reason, from where the GC should pick it up; report that state.
-    if (int(s->m_Status) >= SRTS_BROKEN) // BROKEN, CLOSING, CLOSED, NONEXIST
-        throw CUDTException(MJ_SETUP, MN_CLOSED, 0);
-
-    if (int(s->m_Status) >= SRTS_CONNECTING) // CONNECTING, CONNECTED
-        throw CUDTException(MJ_NOTSUP, MN_ISCONNECTED, 0);
-
-    // a socket can listen only if is in OPENED status
-    if (s->m_Status != SRTS_OPENED)
-        throw CUDTException(MJ_NOTSUP, MN_ISUNBOUND, 0);
-
-    // [[using assert(s->m_Status == OPENED)]];
-
-    // listen is not supported in rendezvous connection setup
     if (s->core().m_config.bRendezvous)
         throw CUDTException(MJ_NOTSUP, MN_ISRENDEZVOUS, 0);
 
-    s->m_uiBackLog = backlog;
-
-    // [[using assert(s->m_Status == OPENED)]]; // (still, unchanged)
-
-    s->core().setListenState(); // propagates CUDTException,
-                                // if thrown, remains in OPENED state
-    s->m_Status = SRTS_LISTENING;
 
     return 0;
 }

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -390,4 +390,30 @@ TEST(TestConnectionAPI, Accept)
     srt_cleanup();
 }
 
+TEST(TestConnectionAPI, Listen)
+{
+    using namespace std::chrono;
+    using namespace srt;
+    srt_startup();
+
+    SRTSOCKET s = srt_create_socket();
+    int listen_stat1, listen_stat2, listen_stat3;
+
+    sockaddr_any sa = srt::CreateAddr("localhost", 5555, AF_INET);
+
+    ASSERT_NE(srt_bind(s, sa.get(), sa.size()), -1);
+    listen_stat1 = srt_listen(s, 1);
+    listen_stat2 = srt_listen(s, 5);
+    srt_close(s);
+    listen_stat3 = srt_listen(s, 5);
+
+    int err = srt_getlasterror(NULL);
+    std::cout << "Listen after close error: " << srt_strerror(err, 0) << std::endl;
+
+    EXPECT_EQ(listen_stat1, 0);
+    EXPECT_EQ(listen_stat2, 0);
+    EXPECT_EQ(listen_stat3, -1);
+
+    srt_cleanup();
+}
 


### PR DESCRIPTION
Fixes #3297

Changes:
1. The state of the socket to be set listen is reporting "closed" error if it was broken/closed
2. The ISCONNECTED error is reported if the socket is attempting to be connected
3. If LISTEN state is already, report success as before, but also UPDATE the backlog