### PR TITLE
Add to decumentation a list of srt-bindings

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@
 | Document Title                                     |            Folder             | File Name                                             | Description                                                  |
 | :------------------------------------------------- | :---------------------------- | :---------------------------------------------------- | :----------------------------------------------------------- |
 | [Why SRT Was Created](misc/why-srt-was-created.md) |         [misc](misc/)         | [why-srt-was-created.md](misc/why-srt-was-created.md) | Background and history of SRT. See also<br />[Section 1. Introduction][srt-internet-draft-sec-1] of the [Internet Draft][srt-internet-draft]. |
+| [Bindings / Wrappers for SRT](misc/bindings.md)    |         [misc](misc/)         | [bindings.md](misc/bindings.md)                       | Projects that offer SRT in other programming languages.   | 
 | <img width=200px height=1px/>                      | <img width=100px height=1px/> | <img width=200px height=1px/>                         | <img width=500px height=1px/>                                |
 
 

--- a/docs/misc/bindings.md
+++ b/docs/misc/bindings.md
@@ -1,0 +1,31 @@
+**Abstract:**
+This document provides a list of known SRT bindings. For issues or questions regarding a specific binding, please refer to that project's official repository
+
+The Haivision Secure Realiable Transport (SRT) protocol repository is a large project, with over 95k lines of code, primarly implemented as a C++ library, which also provides a C API for broader compatibility, and built upon many contributions.
+Such that, the open-source community has developed several bindings/wrappers that allow developers to use SRT in other programming languages.
+
+**Tanks to the efforts of many contributors**
+
+**considerations:**
+We encourage you contribute by adding your own SRT-related projects to this list or helping the existing ones.
+
+## Official Repositories
+| Language                  | Repository Name           | Description               | 
+| :------------------------ | :------------------------ | :------------------------ |  
+| go | [srtgo](https://github.com/Haivision/srtgo) | Go bindings for SRT. Advantages of SRT technology for an easy to use programming language |
+|
+
+## Unofficial Repositories
+**Disclaimer**: Please note that these projects are developed independently and are not officially supported by the Haivision.
+
+| Language                  | Repository Name           | Description               |
+| :------------------------ | :------------------------ | :------------------------ | 
+| dart / flutter | [srt_dart](https://github.com/NoachDev/srt_dart) | Bindings of Secure Reliable Transport (SRT) protocol for Dart with sugar on top |
+| go | [gosrt](https://github.com/russelltg/gosrt) | Go bindings for SRT |
+| ocaml | [ocaml-srt](https://github.com/savonet/ocaml-srt) | OCaml bindings for the Secure, Reliable, Transport protocol library |
+| node | [node-srt](https://github.com/Eyevinn/node-srt) | Nodejs bindings for Secure Reliable Transport SDK |
+| rust | [srt-rs](https://github.com/nthieu173/srt-rs) | Idiomatic rust binding to libsrt |
+| python | [Python-binding-for-libsrt](https://github.com/dazzl-tv/Python-binding-for-libsrt) | Python binding for the srt library from Haivision|
+| kotlin | [srtdroid](https://github.com/ThibaultBee/srtdroid) | Secure Reliable Transport (SRT) Protocol for Android 
+| swift | [SwiftSRT](https://github.com/unpause-live/SwiftSRT) | SRT (Secure Reliable Transport) Swift wrapper 
+|

--- a/docs/misc/bindings.md
+++ b/docs/misc/bindings.md
@@ -4,7 +4,7 @@ This document provides a list of known SRT bindings. For issues or questions reg
 The Haivision Secure Realiable Transport (SRT) protocol repository is a large project, with over 95k lines of code, primarly implemented as a C++ library, which also provides a C API for broader compatibility, and built upon many contributions.
 Such that, the open-source community has developed several bindings/wrappers that allow developers to use SRT in other programming languages.
 
-**Tanks to the efforts of many contributors**
+**Thanks to the efforts of many contributors**
 
 **considerations:**
 We encourage you contribute by adding your own SRT-related projects to this list or helping the existing ones.


### PR DESCRIPTION
Hi Haivision team,

Recently I started develop a project in Dart / Flutter in which I needed use some sockets to stream audio and video, so for that I chose to use the SRT, but in this language there was no bindings until I created one [srt dart](https://github.com/NoachDev/srt_dart). in this way, I realized that others have done the same for different languages, so I thought it was fair – for the developers who need these bindings and for those who dedicated themselves to creating them – to have a reference in the documentation.

I highly recommend append this section into main README for more visualization. 

Any necessary edits, I'll be happy to make them.