### PR TITLE
[core] Vulnerability fixed: unchecked buffer size for KMREQ

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2184,7 +2184,7 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
         {
             uint32_t srtdata_out[SRTDATA_MAXSIZE];
             size_t   len_out = 0;
-            if (len % srtdata_out[0] == 0 && len <= sizeof srtdata_out)
+            if (len % sizeof(srtdata_out[0]) == 0 && len <= sizeof srtdata_out)
             {
                 res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4, m_uPeerSrtVersion,
                         (srtdata_out), (len_out));

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -2184,8 +2184,12 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
         {
             uint32_t srtdata_out[SRTDATA_MAXSIZE];
             size_t   len_out = 0;
-            res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4, m_uPeerSrtVersion,
-                    (srtdata_out), (len_out));
+            if (len % srtdata_out[0] == 0 && len <= sizeof srtdata_out)
+            {
+                res = m_pCryptoControl->processSrtMsg_KMREQ(srtdata, len, CUDT::HS_VERSION_UDT4, m_uPeerSrtVersion,
+                        (srtdata_out), (len_out));
+            } // On error, it will stay with NONE and reject the packet
+
             if (res == SRT_CMD_KMRSP)
             {
                 if (len_out == 1)
@@ -2208,11 +2212,11 @@ bool srt::CUDT::processSrtMsg(const CPacket *ctrlpkt)
                 }
                 sendSrtMsg(SRT_CMD_KMRSP, srtdata_out, len_out);
             }
-            // XXX Dead code. processSrtMsg_KMREQ now doesn't return any other value now.
-            // Please review later.
+            // NOTE: processSrtMsg_KMREQ doesn't return any other value now.
+            // But this may be a result of the size check EPE.
             else
             {
-                LOGC(cnlog.Warn, log << CONID() << "KMREQ failed to process the request - ignoring");
+                LOGC(cnlog.Warn, log << CONID() << "EPE: KMREQ failed to process the request - ignoring");
             }
 
             return true; // already done what's necessary


### PR DESCRIPTION
Problem: the handler for KMREQ message is copying the received message into a buffer, but the size was taken without check from the packet's length, while the contents is copied to the externally passed array of a size expected for KMREQ without checking for oversize.