### PR TITLE
[BUG] Validate KMRSP wire length to prevent stack overflow

### DIFF
--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -370,6 +370,20 @@ HSv4_ErrorReport:
 
 int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len, unsigned srtv)
 {
+    // Validate the wire-supplied length before using it:
+    //  - oversize would overflow the fixed-size stack buffer below;
+    //  - non-word-aligned or too-small payloads are malformed by protocol and would
+    //    feed uninitialised stack into downstream key-matching logic.
+    if (len > SRT_CMD_MAXSZ
+        || len < sizeof(uint32_t)
+        || (len % sizeof(uint32_t)) != 0)
+    {
+        LOGC(cnlog.Error, log << "processSrtMsg_KMRSP: malformed len " << len
+                              << " (must be a non-zero multiple of " << sizeof(uint32_t)
+                              << ", up to " << SRT_CMD_MAXSZ << ") - rejecting");
+        return SRT_CMD_NONE;
+    }
+
     /* All 32-bit msg fields (if present) swapped on reception
      * But HaiCrypt expect network order message
      * Re-swap to cancel it.

--- a/test/test_crypto.cpp
+++ b/test/test_crypto.cpp
@@ -1,10 +1,36 @@
 #include <array>
 #include <numeric>
+#include <vector>
 
 #include "gtest/gtest.h"
 
-#if defined(SRT_ENABLE_ENCRYPTION) && defined(ENABLE_AEAD_API_PREVIEW)
 #include "crypto.h"
+#include "handshake.h"
+
+// processSrtMsg_KMRSP must reject malformed wire-supplied lengths before they
+// reach the fixed-size stack buffer / uninitialised-read paths inside the
+// function. Built into the library unconditionally, so this test runs
+// regardless of SRT_ENABLE_ENCRYPTION.
+TEST(CryptoKMRSP, RejectsMalformedLengths)
+{
+    srt::CCryptoControl crypt(0);
+    std::vector<uint32_t> garbage(SRT_CMD_MAXSZ, 0);
+    const unsigned srtv = srt::SrtVersion(1, 5, 3);
+
+    // Oversize: would overflow uint32_t srtd[SRTDATA_MAXSIZE].
+    EXPECT_EQ(crypt.processSrtMsg_KMRSP(garbage.data(), SRT_CMD_MAXSZ + sizeof(uint32_t), srtv),
+              srt::SRT_CMD_NONE);
+
+    // Non-word-aligned: silently drops bytes and risks misinterpretation.
+    EXPECT_EQ(crypt.processSrtMsg_KMRSP(garbage.data(), 7, srtv), srt::SRT_CMD_NONE);
+
+    // Empty / under-a-word: HtoNLA writes nothing and downstream code would read
+    // uninitialised stack from srtd[].
+    EXPECT_EQ(crypt.processSrtMsg_KMRSP(garbage.data(), 0, srtv), srt::SRT_CMD_NONE);
+    EXPECT_EQ(crypt.processSrtMsg_KMRSP(garbage.data(), 3, srtv), srt::SRT_CMD_NONE);
+}
+
+#if defined(SRT_ENABLE_ENCRYPTION) && defined(ENABLE_AEAD_API_PREVIEW)
 #include "hcrypt.h" // Imports the CRYSPR_HAS_AESGCM definition.
 #include "socketconfig.h"
 


### PR DESCRIPTION
[BUG] Validate KMRSP wire length to prevent stack overflow

`processSrtMsg_KMRSP` copies a wire-supplied byte count into a
fixed-size 104-byte stack buffer (`uint32_t srtd[SRTDATA_MAXSIZE]`)
without validating the length:

    uint32_t srtd[SRTDATA_MAXSIZE];
    size_t srtlen = len / sizeof(uint32_t);
    HtoNLA(srtd, srtdata, srtlen);

`len` is `ctrlpkt->getLength()` and is attacker-controllable on any
post-handshake socket. A UMSG_EXT/SRT_CMD_KMRSP with a >104-byte body
overruns `srtd` on the stack. The dispatcher in `core.cpp:2221`
accepts KMRSP unconditionally - there is no precondition that a
KMREQ was sent first - so the primitive is reachable by:

- a malicious listener against a connecting client (lured-caller);
- an attacker who has completed an unencrypted handshake, by
  replaying KMRSP post-handshake against any listener.

On stack-protector builds this is a reliable SIGABRT. Without
`-fstack-protector` the saved return address is overwritten.

Validate `len` at the top of the function and reject malformed
values before they reach the stack copy:

- `len > SRT_CMD_MAXSZ`        - the overflow case.
- `len < sizeof(uint32_t)`     - HtoNLA writes 0 words, leaving
                                 `srtd` uninitialised; downstream
                                 `getKmMsg_acceptResponse` reads it.
- `len % sizeof(uint32_t) != 0` - non-word-aligned bodies are not
                                  valid per the wire format.

All three return `SRT_CMD_NONE`, matching the function's existing
error-path convention. The caller at `core.cpp:2224` already ignores
the return value, so behaviour on a malformed KMRSP is "log and drop."

Valid KMRSPs remain accepted: 4-byte error-report variant (single
`SRT_KMR_KMSTATE` word) and the full KM-echo variant up to 104 B
regardless of key length used.

Adds `CryptoKMRSP.RejectsMalformedLengths` in test/test_crypto.cpp
exercising oversize (108 B), non-aligned (7 B), zero, and 3-byte
inputs. Test sits outside the `SRT_ENABLE_ENCRYPTION` guard since
the validator path is compiled unconditionally. Verified the test
SIGABRTs (exit 134) against the unfixed code and passes with the fix.