### PR TITLE
[BUG] Fixed OOB read in DROPREQ payload parsing

### DIFF
--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -9325,6 +9325,14 @@ void srt::CUDT::processCtrlHS(const CPacket& ctrlpkt)
 
 void srt::CUDT::processCtrlDropReq(const CPacket& ctrlpkt)
 {
+    // dropdata[0..1] are indexed unconditionally below.
+    if (ctrlpkt.getLength() < 2 * sizeof(int32_t))
+    {
+        LOGC(inlog.Warn, log << CONID() << "DROPREQ: payload " << ctrlpkt.getLength()
+                             << " bytes < " << (2 * sizeof(int32_t)) << " - rejecting");
+        return;
+    }
+
     const int32_t* dropdata = (const int32_t*) ctrlpkt.m_pcData;
 
     {

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -307,6 +307,7 @@ class CUDT
     friend class PacketFilter;
     friend class CUDTGroup;
     friend class TestMockCUDT; // unit tests
+    friend class TestMockControlPackets; // unit tests
 
     typedef sync::steady_clock::time_point time_point;
     typedef sync::steady_clock::duration duration;

--- a/test/filelist.maf
+++ b/test/filelist.maf
@@ -7,6 +7,7 @@ test_main.cpp
 test_buffer_rcv.cpp
 test_common.cpp
 test_connection_timeout.cpp
+test_control_packets.cpp
 test_crypto.cpp
 test_cryspr.cpp
 test_enforced_encryption.cpp

--- a/test/test_control_packets.cpp
+++ b/test/test_control_packets.cpp
@@ -1,0 +1,57 @@
+#include "gtest/gtest.h"
+#include "test_env.h"
+
+#include "srt.h"
+#include "api.h"
+#include "core.h"
+#include "packet.h"
+
+using namespace srt;
+
+namespace srt {
+    // Friend wrapper for unit tests that drive private CUDT control-packet
+    // entry points. Declared as a friend in core.h.
+    class TestMockControlPackets
+    {
+    public:
+        CUDT* core;
+
+        void processCtrlDropReq(const CPacket& pkt) { core->processCtrlDropReq(pkt); }
+        int32_t rcvCurrSeqNo() const { return core->m_iRcvCurrSeqNo; }
+        void setRcvCurrSeqNo(int32_t v) { core->m_iRcvCurrSeqNo = v; }
+    };
+}
+
+// processCtrlDropReq must reject DROPREQs whose payload is smaller than two
+// seqno words; otherwise dropdata[1] reads past the wire payload.
+TEST(ControlPackets, DropReqRejectsShortPayload)
+{
+    srt::TestInit srtinit;
+
+    CUDTSocket* s1 = NULL;
+    SRTSOCKET sid1 = CUDT::uglobal().newSocket(&s1);
+    ASSERT_NE(sid1, SRT_INVALID_SOCK);
+
+    TestMockControlPackets m1;
+    m1.core = &s1->core();
+
+    const int32_t sentinel = 100;
+    m1.setRcvCurrSeqNo(sentinel);
+
+    CPacket pkt;
+    pkt.allocate(1500);
+
+    // Each of these is shorter than the 8-byte minimum and must be rejected
+    // by the guard at the top of processCtrlDropReq.
+    const size_t short_lens[] = { 0, 1, 4, 7 };
+    for (size_t i = 0; i < sizeof(short_lens) / sizeof(short_lens[0]); ++i)
+    {
+        pkt.setLength(short_lens[i]);
+        m1.processCtrlDropReq(pkt);
+        EXPECT_EQ(m1.rcvCurrSeqNo(), sentinel)
+            << "DROPREQ with payload " << short_lens[i] << " bytes must not be processed";
+    }
+
+    pkt.deallocate();
+    srt_close(sid1);
+}


### PR DESCRIPTION
processCtrlDropReq ireads dropdata[0] and dropdata[1] from the wire payload unconditionally. A well-formed DROPREQ payload is two 32-bit seqno words. The handler doesn't check that the wire payload actually contains both words. A DROPREQ message shorter than 8 bytes — e.g. 4 bytes carrying only the low seqno — causes the second indexed read to land past the end of the wire payload, into whatever leftover memory the packet slot happens to hold.
