### PR TITLE
[core] Removed unnecessary post-cleaning of closed socket in the cleanup.

### DIFF
--- a/docs/API/API-functions.md
+++ b/docs/API/API-functions.md
@@ -269,14 +269,24 @@ exiting the application that uses the SRT library. This cleanup function will st
 be called from the C++ global destructor, if not called by the application, although
 relying on this behavior is strongly discouraged.
 
+**IMPORTANT NOTES**:
+
+1. This function must be called from within `main()`, preferably at the end.
+Calling it from any C++ global destructor is pointless, as SRT does it by
+itself. But relying on it is strongly discouraged - at best only if you are
+completely certain that all resources in the application are maintained in the
+strict creation-destruction order, including threads. If this condition isn't
+satisfied, then the behavior of the cleanup outside of `main()` is undefined.
+
+2. The startup/cleanup calls have an instance counter.  This means that if you
+call [`srt_startup`](#srt_startup) multiple times, you need to call the
+`srt_cleanup` function exactly the same number of times.
+
 |      Returns                  |                                                                 |
 |:----------------------------- |:--------------------------------------------------------------- |
 |         0                     | A possibility to return other values is reserved for future use |
 | <img width=240px height=1px/>       | <img width=710px height=1px/>                      |
 
-**IMPORTANT**: Note that the startup/cleanup calls have an instance counter.
-This means that if you call [`srt_startup`](#srt_startup) multiple times, you need to call the
-`srt_cleanup` function exactly the same number of times.
 
 
 [:arrow_up: &nbsp; Back to List of Functions & Structures](#srt-api-functions)

--- a/scripts/win-installer/build-win-installer.ps1
+++ b/scripts/win-installer/build-win-installer.ps1
@@ -177,7 +177,10 @@ Write-Output "NSIS: $NSIS"
 #-----------------------------------------------------------------------------
 
 if (-not $NoBuild) {
-	Write-Output "BUILD ENABLED - configuring build; LIMIT TO PLATFORM: $OnlyPlatform"
+	Write-Output "BUILD ENABLED - configuring build"
+	if ($OnlyPlatform -ne "") {
+		Write-Output "LIMIT TO PLATFORM: $OnlyPlatform"
+	}
     foreach ($Platform in $ARCH.Keys) {
 		if ($OnlyPlatform -ne "" -and $Platform -ne $OnlyPlatform) {
 			Write-Output "Skipping platform $Platform."
@@ -198,7 +201,7 @@ if (-not $NoBuild) {
 					"-DOPENSSL_INCLUDE_DIR=$(ssl-include $Platform)",
 					"-DOPENSSL_ROOT_DIR=$(ssl-libdir $Platform Release)"
 					)
-		Write-Output "Running cmake $params"
+		Write-Output "Running: cmake $params"
         & $CMake $params
         # Patch version string in version.h
         Get-Content "$BuildDir\version.h" |

--- a/scripts/win-installer/build-win-installer.ps1
+++ b/scripts/win-installer/build-win-installer.ps1
@@ -37,7 +37,8 @@
 param(
     [string]$Version = "",
     [switch]$NoBuild = $false,
-    [switch]$NoPause = $false
+    [switch]$NoPause = $false,
+	[string]$OnlyPlatform = ""
 )
 Write-Output "Building the SRT static libraries installer for Windows"
 
@@ -113,6 +114,9 @@ function ssl-lib($pf, $conf, $lib) { return "$(ssl-libdir $pf $conf)\$($LIBFILE.
 Write-Output "Searching OpenSSL libraries ..."
 $Missing = 0
 foreach ($Platform in $SSL.Keys) {
+	if ($OnlyPlatform -ne "" -and $Platform -ne $OnlyPlatform) {
+		continue
+	}
     if (-not (Test-Path -PathType Container $(ssl-include $Platform))) {
         Write-Output "**** Missing $(ssl-include $Platform)"
         $Missing = $Missing + 1
@@ -173,7 +177,13 @@ Write-Output "NSIS: $NSIS"
 #-----------------------------------------------------------------------------
 
 if (-not $NoBuild) {
+	Write-Output "BUILD ENABLED - configuring build; LIMIT TO PLATFORM: $OnlyPlatform"
     foreach ($Platform in $ARCH.Keys) {
+		if ($OnlyPlatform -ne "" -and $Platform -ne $OnlyPlatform) {
+			Write-Output "Skipping platform $Platform."
+			continue
+		}
+		Write-Output "Preparing platform $Platform."
         # Build directory. Cleanup to force a fresh cmake config.
         $BuildDir = "$TmpDir\build.$Platform"
         Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $BuildDir
@@ -181,11 +191,15 @@ if (-not $NoBuild) {
 
         # Run CMake.
         Write-Output "Configuring build for platform $Platform ..."
-        & $CMake -S $RepoDir -B $BuildDir -A $Platform `
-            -DENABLE_STDCXX_SYNC=ON `
-            -DOPENSSL_INCLUDE_DIR="$(ssl-include $Platform)" `
-            -DOPENSSL_ROOT_DIR="$(ssl-libdir $Platform Release)"
-
+		$params = @("-S", "$RepoDir",
+					"-B", "$BuildDir",
+					"-A", "$Platform",
+					"-DENABLE_STDCXX_SYNC=ON",
+					"-DOPENSSL_INCLUDE_DIR=$(ssl-include $Platform)",
+					"-DOPENSSL_ROOT_DIR=$(ssl-libdir $Platform Release)"
+					)
+		Write-Output "Running cmake $params"
+        & $CMake $params
         # Patch version string in version.h
         Get-Content "$BuildDir\version.h" |
             ForEach-Object {
@@ -197,7 +211,17 @@ if (-not $NoBuild) {
         # Compile SRT.
         Write-Output "Building for platform $Platform ..."
         foreach ($Conf in $LIBDIR.Keys) {
-            & $MSBuild "$BuildDir\SRT.sln" /nologo /maxcpucount /property:Configuration=$Conf /property:Platform=$Platform /target:srt_static
+           # The solution file format depends on the CMake version.
+           # Try new XML solution file format first.
+           $SolFile = "$BuildDir\SRT.slnx"
+           if (-not (Test-Path $SolFile)) {
+               # Try legacy solution file format.
+               $SolFile = "$BuildDir\SRT.sln"
+           }
+           if (-not (Test-Path $SolFile)) {
+               Exit-Script "Solution file $BuildDir\SRT.sln[x] not found, check CMake output"
+           }
+           & $MSBuild $SolFile /nologo /maxcpucount /property:Configuration=$Conf /property:Platform=$Platform /target:srt_static
         }
     }
 }
@@ -207,6 +231,9 @@ Write-Output "Checking compiled libraries ..."
 $Missing = 0
 foreach ($Conf in $LIBDIR.Keys) {
     foreach ($Platform in $SSL.Keys) {
+		if ($OnlyPlatform -ne "" -and $Platform -ne $OnlyPlatform) {
+			continue
+		}
         $Path = "$TmpDir\build.$Platform\$Conf\srt_static.lib"
         if (-not (Test-Path $Path)) {
             Write-Output "**** Missing $Path"

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2901,7 +2901,7 @@ void srt::CUDTUnited::checkBrokenSockets()
         // The GC thread should have deleted all sockets by now; if there
         // are any left, then likely the GC was interrupted before it could
         // finish the job. We assume then that all threads have been wiped,
-        // so all we can do is to delete all threads forcefully.
+        // so all we can do is to delete all sockets forcefully.
 
         for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
         {

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -224,7 +224,7 @@ srt::CUDTUnited::~CUDTUnited()
     leaveCS(m_InitLock);
 
     // DO NOT call closeAllSockets() here; instead rely on that
-    // all sockets have been closed when exitting the GC.
+    // all sockets have been closed when exiting the GC.
     releaseMutex(m_GlobControlLock);
     releaseMutex(m_IDLock);
     releaseMutex(m_InitLock);

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -2896,54 +2896,84 @@ void srt::CUDTUnited::checkBrokenSockets()
         leaveCS(ls->second->m_AcceptLock);
     }
 
-    for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
+    if (!m_bGCStatus)
     {
-        CUDTSocket* ps = j->second;
+        // The GC thread should have deleted all sockets by now; if there
+        // are any left, then likely the GC was interrupted before it could
+        // finish the job. We assume then that all threads have been wiped,
+        // so all we can do is to delete all threads forcefully.
 
-        // NOTE: There is still a hypothetical risk here that ps
-        // was made busy while the socket was already moved to m_ClosedSocket,
-        // if the socket was acquired through CUDTUnited::acquireSocket (that is,
-        // busy flag acquisition was done through the CUDTSocket* pointer rather
-        // than through the numeric ID). Therefore this way of busy acquisition
-        // should be done only if at the moment of acquisition there are certainly
-        // other conditions applying on the socket that prevent it from being deleted.
-        if (ps->isStillBusy())
+        for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
         {
-            HLOGC(smlog.Debug, log << "checkBrokenSockets: @" << ps->m_SocketID << " is still busy, SKIPPING THIS CYCLE.");
-            continue;
-        }
+            CUDTSocket* ps = j->second;
+            CUDT* pu = &ps->core();
+            CRNode* rnode = pu->m_pRNode;
 
-        CUDT& u = ps->core();
+            // Ignore BUSY flag.
+            // Ignore Linger.
+            // Regard CRcvUList membership.
 
-        // HLOGC(smlog.Debug, log << "checking CLOSED socket: " << j->first);
-        if (!is_zero(u.m_tsLingerExpiration))
-        {
-            // asynchronous close:
-            if ((!u.m_pSndBuffer) || (0 == u.m_pSndBuffer->getCurrBufSize()) ||
-                (u.m_tsLingerExpiration <= steady_clock::now()))
+            if (rnode && rnode->m_bOnList)
             {
-                HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << ps->m_SocketID);
-                u.m_tsLingerExpiration = steady_clock::time_point();
-                u.m_bClosing           = true;
-                ps->m_tsClosureTimeStamp        = steady_clock::now();
+                // Unstable rnode membership.
+                pu->m_pRcvQueue->forceRemove(pu);
             }
+
+            tbr.push_back(j->first);
         }
 
-        // timeout 1 second to destroy a socket AND it has been removed from
-        // RcvUList
-        const steady_clock::time_point now        = steady_clock::now();
-        const steady_clock::duration   closed_ago = now - ps->m_tsClosureTimeStamp.load();
-        if (closed_ago > seconds_from(1))
+    }
+    else
+    {
+        for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
         {
-            CRNode* rnode = u.m_pRNode;
-            if (!rnode || !rnode->m_bOnList)
-            {
-                HLOGC(smlog.Debug,
-                      log << "checkBrokenSockets: @" << ps->m_SocketID << " closed "
-                          << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
+            CUDTSocket* ps = j->second;
 
-                // HLOGC(smlog.Debug, log << "will unref socket: " << j->first);
-                tbr.push_back(j->first);
+            // NOTE: There is still a hypothetical risk here that ps
+            // was made busy while the socket was already moved to m_ClosedSocket,
+            // if the socket was acquired through CUDTUnited::acquireSocket (that is,
+            // busy flag acquisition was done through the CUDTSocket* pointer rather
+            // than through the numeric ID). Therefore this way of busy acquisition
+            // should be done only if at the moment of acquisition there are certainly
+            // other conditions applying on the socket that prevent it from being deleted.
+            if (ps->isStillBusy())
+            {
+                HLOGC(smlog.Debug, log << "checkBrokenSockets: @" << ps->m_SocketID << " is still busy, SKIPPING THIS CYCLE.");
+                continue;
+            }
+
+            CUDT& u = ps->core();
+
+            // HLOGC(smlog.Debug, log << "checking CLOSED socket: " << j->first);
+            if (!is_zero(u.m_tsLingerExpiration))
+            {
+                // asynchronous close:
+                if ((!u.m_pSndBuffer) || (0 == u.m_pSndBuffer->getCurrBufSize()) ||
+                        (u.m_tsLingerExpiration <= steady_clock::now()))
+                {
+                    HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << ps->m_SocketID);
+                    u.m_tsLingerExpiration = steady_clock::time_point();
+                    u.m_bClosing           = true;
+                    ps->m_tsClosureTimeStamp        = steady_clock::now();
+                }
+            }
+
+            // timeout 1 second to destroy a socket AND it has been removed from
+            // RcvUList
+            const steady_clock::time_point now        = steady_clock::now();
+            const steady_clock::duration   closed_ago = now - ps->m_tsClosureTimeStamp.load();
+            if (closed_ago > seconds_from(1))
+            {
+                CRNode* rnode = u.m_pRNode;
+                if (!rnode || !rnode->m_bOnList)
+                {
+                    HLOGC(smlog.Debug,
+                            log << "checkBrokenSockets: @" << ps->m_SocketID << " closed "
+                            << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
+
+                    // HLOGC(smlog.Debug, log << "will unref socket: " << j->first);
+                    tbr.push_back(j->first);
+                }
             }
         }
     }

--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -222,7 +222,9 @@ srt::CUDTUnited::~CUDTUnited()
     enterCS(m_InitLock);
     stopGarbageCollector();
     leaveCS(m_InitLock);
-    closeAllSockets();
+
+    // DO NOT call closeAllSockets() here; instead rely on that
+    // all sockets have been closed when exitting the GC.
     releaseMutex(m_GlobControlLock);
     releaseMutex(m_IDLock);
     releaseMutex(m_InitLock);
@@ -2896,84 +2898,54 @@ void srt::CUDTUnited::checkBrokenSockets()
         leaveCS(ls->second->m_AcceptLock);
     }
 
-    if (!m_bGCStatus)
+    for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
     {
-        // The GC thread should have deleted all sockets by now; if there
-        // are any left, then likely the GC was interrupted before it could
-        // finish the job. We assume then that all threads have been wiped,
-        // so all we can do is to delete all sockets forcefully.
+        CUDTSocket* ps = j->second;
 
-        for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
+        // NOTE: There is still a hypothetical risk here that ps
+        // was made busy while the socket was already moved to m_ClosedSocket,
+        // if the socket was acquired through CUDTUnited::acquireSocket (that is,
+        // busy flag acquisition was done through the CUDTSocket* pointer rather
+        // than through the numeric ID). Therefore this way of busy acquisition
+        // should be done only if at the moment of acquisition there are certainly
+        // other conditions applying on the socket that prevent it from being deleted.
+        if (ps->isStillBusy())
         {
-            CUDTSocket* ps = j->second;
-            CUDT* pu = &ps->core();
-            CRNode* rnode = pu->m_pRNode;
-
-            // Ignore BUSY flag.
-            // Ignore Linger.
-            // Regard CRcvUList membership.
-
-            if (rnode && rnode->m_bOnList)
-            {
-                // Unstable rnode membership.
-                pu->m_pRcvQueue->forceRemove(pu);
-            }
-
-            tbr.push_back(j->first);
+            HLOGC(smlog.Debug, log << "checkBrokenSockets: @" << ps->m_SocketID << " is still busy, SKIPPING THIS CYCLE.");
+            continue;
         }
 
-    }
-    else
-    {
-        for (sockets_t::iterator j = m_ClosedSockets.begin(); j != m_ClosedSockets.end(); ++j)
+        CUDT& u = ps->core();
+
+        // HLOGC(smlog.Debug, log << "checking CLOSED socket: " << j->first);
+        if (!is_zero(u.m_tsLingerExpiration))
         {
-            CUDTSocket* ps = j->second;
-
-            // NOTE: There is still a hypothetical risk here that ps
-            // was made busy while the socket was already moved to m_ClosedSocket,
-            // if the socket was acquired through CUDTUnited::acquireSocket (that is,
-            // busy flag acquisition was done through the CUDTSocket* pointer rather
-            // than through the numeric ID). Therefore this way of busy acquisition
-            // should be done only if at the moment of acquisition there are certainly
-            // other conditions applying on the socket that prevent it from being deleted.
-            if (ps->isStillBusy())
+            // asynchronous close:
+            if ((!u.m_pSndBuffer) || (0 == u.m_pSndBuffer->getCurrBufSize()) ||
+                (u.m_tsLingerExpiration <= steady_clock::now()))
             {
-                HLOGC(smlog.Debug, log << "checkBrokenSockets: @" << ps->m_SocketID << " is still busy, SKIPPING THIS CYCLE.");
-                continue;
+                HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << ps->m_SocketID);
+                u.m_tsLingerExpiration = steady_clock::time_point();
+                u.m_bClosing           = true;
+                ps->m_tsClosureTimeStamp        = steady_clock::now();
             }
+        }
 
-            CUDT& u = ps->core();
-
-            // HLOGC(smlog.Debug, log << "checking CLOSED socket: " << j->first);
-            if (!is_zero(u.m_tsLingerExpiration))
+        // timeout 1 second to destroy a socket AND it has been removed from
+        // RcvUList
+        const steady_clock::time_point now        = steady_clock::now();
+        const steady_clock::duration   closed_ago = now - ps->m_tsClosureTimeStamp.load();
+        if (closed_ago > seconds_from(1))
+        {
+            CRNode* rnode = u.m_pRNode;
+            if (!rnode || !rnode->m_bOnList)
             {
-                // asynchronous close:
-                if ((!u.m_pSndBuffer) || (0 == u.m_pSndBuffer->getCurrBufSize()) ||
-                        (u.m_tsLingerExpiration <= steady_clock::now()))
-                {
-                    HLOGC(smlog.Debug, log << "checkBrokenSockets: marking CLOSED qualified @" << ps->m_SocketID);
-                    u.m_tsLingerExpiration = steady_clock::time_point();
-                    u.m_bClosing           = true;
-                    ps->m_tsClosureTimeStamp        = steady_clock::now();
-                }
-            }
+                HLOGC(smlog.Debug,
+                      log << "checkBrokenSockets: @" << ps->m_SocketID << " closed "
+                          << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
 
-            // timeout 1 second to destroy a socket AND it has been removed from
-            // RcvUList
-            const steady_clock::time_point now        = steady_clock::now();
-            const steady_clock::duration   closed_ago = now - ps->m_tsClosureTimeStamp.load();
-            if (closed_ago > seconds_from(1))
-            {
-                CRNode* rnode = u.m_pRNode;
-                if (!rnode || !rnode->m_bOnList)
-                {
-                    HLOGC(smlog.Debug,
-                            log << "checkBrokenSockets: @" << ps->m_SocketID << " closed "
-                            << FormatDuration(closed_ago) << " ago and removed from RcvQ - will remove");
-
-                    // HLOGC(smlog.Debug, log << "will unref socket: " << j->first);
-                    tbr.push_back(j->first);
-                }
+                // HLOGC(smlog.Debug, log << "will unref socket: " << j->first);
+                tbr.push_back(j->first);
             }
         }
     }

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1350,10 +1350,7 @@ void* srt::CRcvQueue::worker(void* param)
             {
                 HLOGC(qrlog.Debug,
                       log << CUDTUnited::CONID(u->m_SocketID) << " SOCKET broken, REMOVING FROM RCV QUEUE/MAP.");
-                // the socket must be removed from Hash table first, then RcvUList
-                self->m_pHash->remove(u->m_SocketID);
-                self->m_pRcvUList->remove(u);
-                u->m_pRNode->m_bOnList = false;
+                self->forceRemove(u);
             }
 
             ul = self->m_pRcvUList->m_pUList;
@@ -1840,6 +1837,14 @@ void srt::CRcvQueue::storePktClone(int32_t id, const CPacket& pkt)
 
         i->second.push(pkt.clone());
     }
+}
+
+void srt::CRcvQueue::forceRemove(CUDT* u)
+{
+    // the socket must be removed from Hash table first, then RcvUList
+    m_pHash->remove(u->m_SocketID);
+    m_pRcvUList->remove(u);
+    u->m_pRNode->m_bOnList = false;
 }
 
 void srt::CMultiplexer::resetAtFork()

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1333,7 +1333,6 @@ void* srt::CRcvQueue::worker(void* param) ATR_NOEXCEPT
             // sockets are removed from the multiplexer. Alternatively you can forcefully
             // remove all sockets from the receive U list.
             continue;
-            // break;
         }
         // OTHERWISE: this is an "AGAIN" situation. No data was read, but the process should continue.
 
@@ -1355,7 +1354,7 @@ void* srt::CRcvQueue::worker(void* param) ATR_NOEXCEPT
             {
                 HLOGC(qrlog.Debug,
                       log << CUDTUnited::CONID(u->m_SocketID) << " SOCKET broken, REMOVING FROM RCV QUEUE/MAP.");
-                self->forceRemove(u);
+                self->removeFromLists(u);
             }
 
             ul = self->m_pRcvUList->m_pUList;
@@ -1844,7 +1843,7 @@ void srt::CRcvQueue::storePktClone(int32_t id, const CPacket& pkt)
     }
 }
 
-void srt::CRcvQueue::forceRemove(CUDT* u)
+void srt::CRcvQueue::removeFromLists(CUDT* u)
 {
     // the socket must be removed from Hash table first, then RcvUList
     m_pHash->remove(u->m_SocketID);

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -1251,7 +1251,7 @@ void srt::CRcvQueue::init(int qsize, size_t payload, int version, int hsize, CCh
     }
 }
 
-void* srt::CRcvQueue::worker(void* param)
+void* srt::CRcvQueue::worker(void* param) ATR_NOEXCEPT
 {
     CRcvQueue*   self = (CRcvQueue*)param;
     sockaddr_any sa(self->getIPversion());
@@ -1328,7 +1328,12 @@ void* srt::CRcvQueue::worker(void* param)
                          << "CChannel reported ERROR DURING TRANSMISSION - IPE. INTERRUPTING worker anyway.");
             }
             cst = CONN_REJECT;
-            break;
+
+            // DO NOT interrupt though - the worker thread must run until all
+            // sockets are removed from the multiplexer. Alternatively you can forcefully
+            // remove all sockets from the receive U list.
+            continue;
+            // break;
         }
         // OTHERWISE: this is an "AGAIN" situation. No data was read, but the process should continue.
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -517,7 +517,7 @@ public:
 
     int getIPversion() { return m_iIPversion; }
 
-    void forceRemove(CUDT* u);
+    void removeFromLists(CUDT* u);
 
     void stop();
 private:

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -519,7 +519,7 @@ public:
 
     void stop();
 private:
-    static void*  worker(void* param);
+    static void*  worker(void* param) ATR_NOEXCEPT;
     sync::CThread m_WorkerThread;
     // Subroutines of worker
     EReadStatus    worker_RetrieveUnit(int32_t& id, CUnit*& unit, sockaddr_any& sa);

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -517,6 +517,8 @@ public:
 
     int getIPversion() { return m_iIPversion; }
 
+    void forceRemove(CUDT* u);
+
     void stop();
 private:
     static void*  worker(void* param);

--- a/test/test_bonding.cpp
+++ b/test/test_bonding.cpp
@@ -530,7 +530,7 @@ TEST(Bonding, Options)
 
 #if SRT_ENABLE_ENCRYPTION
 
-    uint32_t kms = -1;
+    int32_t kms = -1;
 
     EXPECT_NE(srt_getsockflag(grp, SRTO_KMSTATE, &kms, &optsize), SRT_ERROR);
     EXPECT_EQ(optsize, (int) sizeof kms);


### PR DESCRIPTION
The problem:

After the proper cleanup has been added to handle the fork case, the cleanup function, which also executes from the global destructor, does a usual socket cleanup, which was so far done only inside the GC thread, and it doesn't remove a socket that is still in the `CRcvUList` because that's a marker that the `CRcvQueue::worker` thread is still using it. In case when in a single snapshot of the library state all threads suddenly disappear - which may happen under certain circumstances - the cleanup function catches a situation of a stuck socket, for which there's no one left to free it.

We state that as long as the GC thread is running, it takes care of all sockets. When it is asked to quit by the `stopGarbageCollector()` call, it should completely close and delete all sockets. The `closeAllSockets()` then is run only "just in case", but in this situation it won't work properly if there are any sockets left that somehow the GC thread didn't delete.

Solution:

The post-cleanup of the sockets has been removed. For SRT library it is believed that if the GC thread has been joined, all sockets have been deleted and there's no need to do any post-checks here. If anything is still not cleaned up at that point, it simply means that there is some data corruption caused by the misuse of the library rules, so any kind of action would end up with even worse kind of undefined behavior - hence it's best and safest to do nothing in this situation.

There's also more explanations added in the documentation to the necessary call to `srt_cleanup()` and the cleanup facility done in the global destructor.