### PR TITLE
Fix int32_t-vs-int portability; align CThread assignment with std::thread

### DIFF
--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -357,6 +357,13 @@ struct EventVariant
     // Note: UNDEFINED and ARRAY don't have assignment operator.
     // For ARRAY you'll use 'set' function. For UNDEFINED there's nothing.
 
+    // For events that pass no argument (e.g. TEV_SYNC).
+    EventVariant()
+    {
+        type = UNDEFINED;
+        u.packet = NULL;
+    }
+
     explicit EventVariant(const srt::CPacket* arg)
     {
         type = PACKET;

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -361,7 +361,8 @@ struct EventVariant
     EventVariant()
     {
         type = UNDEFINED;
-        u.packet = NULL;
+        u.ptr = NULL;
+        u.len = 0;
     }
 
     explicit EventVariant(const srt::CPacket* arg)

--- a/srtcore/common.h
+++ b/srtcore/common.h
@@ -361,8 +361,8 @@ struct EventVariant
     EventVariant()
     {
         type = UNDEFINED;
-        u.ptr = NULL;
-        u.len = 0;
+        u.array.ptr = NULL;
+        u.array.len = 0;
     }
 
     explicit EventVariant(const srt::CPacket* arg)

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -929,7 +929,7 @@ private:
             return;
 
         m_pSndBuffer->setRateEstimator(rate);
-        updateCC(TEV_SYNC, EventVariant(0));
+        updateCC(TEV_SYNC, EventVariant());
     }
 
 

--- a/srtcore/socketconfig.cpp
+++ b/srtcore/socketconfig.cpp
@@ -161,7 +161,7 @@ struct CSrtConfigSetter<SRTO_UDP_SNDBUF>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.iUDPSndBufSize = std::max(co.iMSS, cast_optval<int>(optval, optlen));
+        co.iUDPSndBufSize = std::max(co.iMSS, cast_optval<int32_t>(optval, optlen));
     }
 };
 
@@ -170,7 +170,7 @@ struct CSrtConfigSetter<SRTO_UDP_RCVBUF>
 {
     static void set(CSrtConfig& co, const void* optval, int optlen)
     {
-        co.iUDPRcvBufSize = std::max(co.iMSS, cast_optval<int>(optval, optlen));
+        co.iUDPRcvBufSize = std::max(co.iMSS, cast_optval<int32_t>(optval, optlen));
     }
 };
 template<>

--- a/srtcore/socketconfig.h
+++ b/srtcore/socketconfig.h
@@ -218,7 +218,7 @@ struct CSrtConfig: CSrtMuxerConfig
     static const size_t MAX_PFILTER_LENGTH = 64;
     static const size_t MAX_CONG_LENGTH    = 16;
 
-    int    iMSS;            // Maximum Segment Size, in bytes
+    int32_t iMSS;           // Maximum Segment Size, in bytes (int32_t: matches CHandShake::m_iMSS)
     size_t zExpPayloadSize; // Expected average payload size (user option)
 
     // Options

--- a/srtcore/sync_posix.cpp
+++ b/srtcore/sync_posix.cpp
@@ -9,6 +9,7 @@
  */
 #include "platform_sys.h"
 
+#include <exception>
 #include <iomanip>
 #include <math.h>
 #include <stdexcept>
@@ -394,22 +395,11 @@ srt::sync::CThread& srt::sync::CThread::operator=(CThread& other)
 {
     if (joinable())
     {
-        // If the thread has already terminated, then
-        // pthread_join() returns immediately.
-        // But we have to check it has terminated before replacing it.
+        // Match std::thread semantics: assigning to a joinable thread
+        // terminates the program ([thread.thread.assign]). This error should
+        // not normally happen; the log line makes the abort diagnosable.
         LOGC(inlog.Error, log << "IPE: Assigning to a thread that is not terminated!");
-
-#ifndef DEBUG
-#if !defined(__ANDROID__) && !defined(__OHOS__)
-        // In case of production build the hanging thread should be terminated
-        // to avoid hang ups and align with C++11 implementation.
-        // There is no pthread_cancel on Android. See #1476. This error should not normally
-        // happen, but if it happen, then detaching the thread.
-        pthread_cancel(m_thread);
-#endif // __ANDROID__ __OHOS__
-#else
-        join();
-#endif
+        std::terminate();
     }
     // Move thread handler from other
     m_thread = other.m_thread;


### PR DESCRIPTION
## Summary

Three small portability fixes that let `libsrt` compile and run on toolchains where `int32_t` is a distinct type from `int` (e.g. the newlib `arm-none-eabi` bare-metal toolchain, where `int32_t` is `long int`) and on pthread backends without thread cancellation.

Reworked per review (see comments): the config field is typed to match the wire, `TEV_SYNC` passes no argument, and `CThread` assignment matches `std::thread` — no opt-out define needed anymore.

## Changes

**1. `CSrtConfig::iMSS` is now `int32_t`**
Matching the handshake wire field `CHandShake::m_iMSS` it is clamped against, so `std::min(m_config.iMSS, w_hs.m_iMSS)` in `acceptAndRespond()` deduces its template argument. The `SRTO_UDP_SNDBUF`/`SRTO_UDP_RCVBUF` setters that `std::max` the option value against `iMSS` read it with `cast_optval<int32_t>` for the same reason. Where `int32_t == int` this is a pure no-op.

**2. `common.h`/`core.h` — `EventVariant()` no-argument constructor**
`EventVariant(0)` at the `TEV_SYNC` call site was ambiguous between `EventVariant(int32_t)` and `EventVariant(const CPacket*)` once `int32_t` is not `int`. `TEV_SYNC` passes no argument (no slot is connected to it, and `updateCC` never reads the arg for it), so `EventVariant` now has a no-argument constructor producing `UNDEFINED`, used at that call site.

**3. `sync_posix.cpp` — `CThread` assign-to-joinable matches `std::thread`**
`CThread::operator=` called `pthread_cancel()` on a still-joinable thread — guarded out on Android/OHOS (#1476 / #1484) and missing on some RTOS pthread backends (e.g. FreeRTOS-Plus-POSIX). Per `std::thread` semantics ([thread.thread.assign]) and the `ENABLE_STDCXX_SYNC` backend, this is now `std::terminate()` after the existing IPE log line. This removes the only `pthread_cancel` call in the codebase, so no platform special-casing is needed at all.

## Testing

Built and run on bare-metal `arm-none-eabi` (Cortex-M4F) under QEMU on a FreeRTOS + lwIP substrate (pthread sync backend, `ENABLE_STDCXX_SYNC=OFF`): `libsrt` cross-compiles cleanly; an `srt_startup` → `srt_create_socket` → `srt_getsockstate` → `srt_close` → `srt_cleanup` smoke test and a caller↔listener loopback transfer over a lossy link (plain and AES-128 via mbedTLS) pass. Desktop Release build with `ENABLE_UNITTESTS=ON` compiles unchanged and the full `test-srt` suite passes (275/275).

Behavior note: the only behavior change on existing platforms is the assign-to-joinable IPE path, which now terminates — as `std::thread` and the `ENABLE_STDCXX_SYNC` build already do — instead of cancelling the live thread.