### PR TITLE
[core] Report a missing decryption key distinctly and only once

### DIFF
--- a/srtcore/crypto.cpp
+++ b/srtcore/crypto.cpp
@@ -249,6 +249,7 @@ int srt::CCryptoControl::processSrtMsg_KMREQ(
         // Since now, when CCryptoControl::decrypt() encounters an error, it will print it, ONCE,
         // until the next KMREQ is received as a key regeneration.
         m_bErrorReported = false;
+        m_bNoRcvKeyReported = false;
 
         if (rc >= HAICRYPT_OK)
         {
@@ -396,6 +397,7 @@ int srt::CCryptoControl::processSrtMsg_KMRSP(const uint32_t* srtdata, size_t len
     // Since now, when CCryptoControl::decrypt() encounters an error, it will print it, ONCE,
     // until the next KMREQ is received as a key regeneration.
     m_bErrorReported = false;
+    m_bNoRcvKeyReported = false;
 
     if (srtlen == 1) // Error report. Set accordingly.
     {
@@ -645,6 +647,7 @@ srt::CCryptoControl::CCryptoControl(SRTSOCKET id)
     , m_iCryptoMode(CSrtConfig::CIPHER_MODE_AUTO)
     , m_bUseGcm153(false)
     , m_bErrorReported(false)
+    , m_bNoRcvKeyReported(false)
 {
     m_KmSecret.len = 0;
     //send
@@ -927,11 +930,32 @@ srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNU
     }
 
     const int rc = HaiCrypt_Rx_Data(m_hRcvCrypto, ((uint8_t *)w_packet.getHeader()), ((uint8_t *)w_packet.m_pcData), w_packet.getLength());
-    if (rc <= 0)
+    if (rc == 0)
+    {
+        // HaiCrypt_Rx_Data returns 0 from exactly one place: the packet's KK flags
+        // select an SEK slot whose context is not yet keyed. This is not a decryption
+        // failure - it means the peer is encrypting with a key that was never installed
+        // here, which is what a key refresh looks like when its KMX did not complete.
+        // KMREQ travels on the control channel and is not covered by ARQ, so a lost or
+        // unsent one leaves the receiver keyed only for the previous key index.
+        //
+        // The connection stays SECURED and nothing re-requests the key, so every
+        // subsequent packet takes this same path. Report it once, and name the key
+        // index, rather than emitting one line per packet for as long as the peer
+        // keeps sending.
+        if (!m_bNoRcvKeyReported)
+        {
+            m_bNoRcvKeyReported = true;
+            LOGC(cnlog.Warn, log << "decrypt ERROR: no key for "
+                    << (w_packet.getMsgCryptoFlags() == EK_ODD ? "odd" : "even")
+                    << " key index - peer encrypts with a key this connection never received"
+                    << " (KM refresh not completed?). Further occurrences not reported.");
+        }
+        return ENCS_FAILED;
+    }
+    if (rc < 0)
     {
         LOGC(cnlog.Note, log << "decrypt ERROR: HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
-        // -1: decryption failure
-        // 0: key not received yet
         return ENCS_FAILED;
     }
     // Otherwise: rc == decrypted text length.
@@ -940,10 +964,15 @@ srt::EncryptionStatus srt::CCryptoControl::decrypt(CPacket& w_packet SRT_ATR_UNU
     // Decryption succeeded. Update flags.
     w_packet.setMsgCryptoFlags(EK_NOENC);
 
+    // Arm the report again, so that a later gap in the keying is not silently
+    // swallowed by a report made for an earlier one that has since recovered.
+    m_bNoRcvKeyReported = false;
+
     HLOGC(cnlog.Debug, log << "decrypt: successfully decrypted, resulting length=" << rc);
     return ENCS_CLEAR;
 #else
     (void)m_bErrorReported; // otherwise warning!
+    (void)m_bNoRcvKeyReported;
     return ENCS_NOTSUP;
 #endif
 }

--- a/srtcore/crypto.h
+++ b/srtcore/crypto.h
@@ -86,6 +86,10 @@ private:
     HaiCrypt_Handle m_hRcvCrypto;
 
     bool m_bErrorReported;
+    // Set when a packet selected an SEK slot that holds no key, so that this
+    // condition is reported once rather than once per packet. Cleared on the
+    // next KMX and on the first packet that decrypts again.
+    bool m_bNoRcvKeyReported;
 
 public:
     static void globalInit();


### PR DESCRIPTION
## Problem

`HaiCrypt_Rx_Data()` returns `0` from exactly one place — the KK flags of the incoming packet select an SEK slot whose context is not keyed (`haicrypt/hcrypt_rx.c`, the final `else` branch). That is a distinct condition from a decryption failure, which returns `-1`.

`CCryptoControl::decrypt()` collapses both into one branch:

```cpp
if (rc <= 0)
{
    LOGC(cnlog.Note, log << "decrypt ERROR: HaiCrypt_Rx_Data failure=" << rc << " - returning failed decryption");
    // -1: decryption failure
    // 0: key not received yet
    return ENCS_FAILED;
}
```

The comment already acknowledges the distinction; the log does not act on it.

The unkeyed-slot case is not transient. It is what a key refresh looks like when its KMX did not complete. KMREQ travels on the control channel, which is not covered by ARQ, so a lost or unsent one leaves the receiver keyed only for the previous key index. `hcryptCtx_Tx_ManageKM()` (`haicrypt/hcrypt_ctx_tx.c:343`) switches on schedule regardless of whether the peer acknowledged the new key, the connection stays `SECURED`, nothing re-requests the key, and every subsequent packet takes the same path forever.

The result is one log line per packet, at the full rate of the stream, saying only `failure=0`.

## Evidence

Observed on two live encrypted receive sessions against a commercial SRT sender, each on one unbroken connection, each under a full control-channel packet capture:

| | session A | session B |
|---|---|---|
| duration | 7 h 45 m (27,910 s) | 18 h 39 m (67,191 s) |
| rate | 6.5 Mbit/s, 601 pkt/s | 2.8 Mbit/s, 250 pkt/s |
| packets decrypted before failure | 16,778,694 | 16,776,241 |
| vs `HAICRYPT_DEF_KM_REFRESH_RATE` (2^24) | **+1,478 (+0.0088 %)** | **−975 (−0.0058 %)** |
| undecryptable packets after | 111,609 | 48,002 |
| log lines emitted | **111,609** | **48,002** |
| `UMSG_EXT` packets captured, whole session | **0** | **0** |

Both sessions bracket 2^24 from either side while differing by 2.4× in bitrate and elapsed time, so the trigger is the peer's packet count and not anything local. Both remained `SND=SECURED RCV=SECURED` and kept ACKing normally throughout — the transport was healthy in both cases and only decryption was dead.

Diagnosing that from the logs required rebuilding libsrt with the `haicrypt` FA enabled — it is off by default — and a packet capture. The line the user actually gets tells them neither which key index failed nor that a key was missing rather than wrong.

## What this changes

Diagnostics only. No packet is accepted or dropped differently; `pktRcvUndecryptTotal` is unchanged.

- split `rc == 0` from `rc < 0`
- for `rc == 0`, name the key index and state the likely cause
- report it once, through a dedicated flag, cleared on the next KMX and on the first packet that decrypts again so a later occurrence is still reported
- raise it to `Warn`: unlike a single corrupt packet, this condition does not resolve itself

Before:

```
decrypt ERROR: HaiCrypt_Rx_Data failure=0 - returning failed decryption      (x111609)
```

After:

```
decrypt ERROR: no key for odd key index - peer encrypts with a key this connection never received (KM refresh not completed?). Further occurrences not reported.   (x1)
```

## Test

Reproduced deterministically with both ends local: a sender with `kmrefreshrate=1000`, and a UDP relay between the two that forwards everything except sender→receiver `UMSG_EXT` packets (first two bytes `0xFFFF`), which is what carries `SRT_CMD_KMREQ`. The handshake is unaffected because handshake KM rides inside the HS packet, so the session establishes normally and only the later refresh is lost — the same shape as the production failure.

Same tree, same test, 45 s, encryption on (openssl):

| | `pktRcvUndecryptTotal` | decryption-failure log lines |
|---|---|---|
| before | 4004 | **4004** |
| after | 4004 | **4** |

Identical counters, so behaviour is unchanged. The four lines are four distinct episodes — the rig's sender alternates between a key the receiver holds and one it does not, and the flag re-arms whenever a packet decrypts again. In the production case, where the failure is permanent, it is one line instead of 111,609.

Builds clean with `-DENABLE_ENCRYPTION=ON -DUSE_ENCLIB=openssl` and with `-DENABLE_ENCRYPTION=OFF`.

## Note

This does not make the condition recoverable — SRT has no receiver-initiated key request, so a receiver that misses the KMREQ cannot ask for it again. It only makes the condition identifiable. #3299 already flags the reliability of KMX refresh against a lost KMREQ as untested; this is the diagnostic half of that, and the two sessions above are real-world instances of exactly the scenario that issue describes.
