### PR TITLE
[dev] Added BSTOW tool: generate live-planning transmission

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1627,6 +1627,9 @@ if (ENABLE_APPS)
 		srt_add_testprogram(srt-test-multiplex)
 		srt_make_application(srt-test-multiplex)
 
+		srt_add_testprogram(srt-test-stow)
+		srt_make_application(srt-test-stow)
+
 		if (ENABLE_BONDING)
 			srt_add_testprogram(srt-test-mpbond)
 			srt_make_application(srt-test-mpbond)

--- a/scripts/codespell/codespell.cfg
+++ b/scripts/codespell/codespell.cfg
@@ -15,4 +15,6 @@ ignore-regex = ^\s*(TEST|TEST_F)\([^\)]*\)
 dictionary = ./scripts/codespell/codespell_dictionary.txt,-
 
 # Skip checking files or directories.
-skip = ./build/*,./_build/*,./.git/*
+# (Skipping tcl because this tool is stupid and reports "spell errors"
+# also in variable names).
+skip = ./build/*,./_build/*,./.git/*,*.tcl

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,5 +1,5 @@
-Testing
-=======
+Tools
+=====
 
 This directory contains applications used for testing and development only.
 
@@ -8,3 +8,30 @@ They may contain experimental versions or not fully functioning features.
 Every application has its own individual Manifest file (`*.maf`), which defines
 of which source files particular application comprises. They may be contained
 either in the same directory, or in any other subproject.
+
+
+Tools applications:
+===================
+
+
+* srt-test-file: File transmission testing tool. Corresponds to
+[../docs/apps/srt-file-transmit.md](`srt-file-transmit`) in the apps.
+
+* srt-test-live: Live transmission testing tool. Corresponds to
+[../docs/apps/srt-live-transmit.md](`srt-live-transmit`) in the apps.
+
+* srt-test-mpbond: Testing tool for live transmission with redundancy.
+Allows to set up a service on multiple listeners in order to test
+the functionality of multiple listeners accepting connections for
+the same group
+
+* srt-test-multiplex: The application that allows to send multiple
+streams at once over one SRT connection (see
+[../docs/apps/srt-test-multiplex.md](Documentation)).
+
+* srt-test-relay: The bidirectional sending testing application.
+For the specified SRT connection there is used both input and
+output (see [../docs/apps/srt-test-relay.md](Documentation)).
+
+* srt-test-stow: The BSTOW reader testing application. See the
+[bstow.md](BSTOW documentation) for more details.

--- a/tools/bstow-log.cpp
+++ b/tools/bstow-log.cpp
@@ -1,0 +1,64 @@
+#include "bstow-log.hpp"
+#include "utilities.h"
+
+namespace bstow
+{
+std::string ExtractFunctionName(const char* fnspec)
+{
+    using namespace std;
+    using namespace srt;
+
+    string id = fnspec;
+
+    // First find the first space that is not within parents
+    int ipos = 0;
+    int depth = 0;
+    for (size_t i = 0; i < id.size(); ++i)
+    {
+        // Fortunately we don't have initial spaces.
+        // The first space means end of the type specification
+        if (id[i] == '(')
+        {
+            ++depth;
+        }
+        else if (id[i] == ')')
+            --depth;
+        else if (id[i] == ' ' && depth == 0)
+        {
+            ipos = i;
+            break;
+        }
+    }
+    if (ipos == 0)
+    {
+        id = "UNKNOWN";
+    }
+    else
+    {
+        id = id.substr(ipos + 1);
+        size_t op = id.find('(');
+        if (op != string::npos)
+            id = id.substr(0, op);
+
+        if (id.find(':') != string::npos)
+        {
+            vector<string> parts;
+            Split(id, ':', back_inserter(parts));
+            if (parts.size() < 3)
+                id = parts.back();
+            else
+            {
+                size_t last = parts.size() - 1;
+                size_t from = parts.size() - 3;
+                id = parts[from] + "." + parts[last];
+            }
+        }
+    }
+
+    return id;
+}
+
+std::ostream* g_logstream = &std::cerr;
+int g_loglevel = LL_ERROR;
+
+}

--- a/tools/bstow-log.hpp
+++ b/tools/bstow-log.hpp
@@ -1,0 +1,30 @@
+#ifndef INC_BSTOW_LOG_H
+#define INC_BSTOW_LOG_H
+
+#include <string>
+
+#include "ofmt_iostream.h"
+
+namespace bstow
+{
+std::string ExtractFunctionName(const char* fnspec);
+const int LL_ERROR = 0, LL_WARN = 1, LL_DEBUG = 2;
+extern std::ostream* g_logstream;
+extern int g_loglevel;
+
+template<class... Args>
+inline void LogLine(int lev, const std::string& func, const Args&... args)
+{
+    if (lev <= g_loglevel)
+        hvu::ofprintl(*g_logstream, func, ": ", args...);
+}
+}
+
+
+#if defined(BSLOG_ENABLED) && (BSLOG_ENABLED == 1)
+#define BSLOG(level_suf, ...) bstow::LogLine(bstow::LL_##level_suf, bstow::ExtractFunctionName(__PRETTY_FUNCTION__), __VA_ARGS__)
+#else
+#define BSLOG(...) (void)0
+#endif
+
+#endif

--- a/tools/bstow-read.cpp
+++ b/tools/bstow-read.cpp
@@ -1,0 +1,874 @@
+///
+//
+///
+
+#include "bstow-read.hpp"
+
+#include <string>
+#include <fstream>
+#include <set>
+#include <exception>
+#include <chrono>
+#include <thread> // for sleep
+
+#include "hvu_compat.h"
+#include "hvu_bigendian.h"
+
+#define BSLOG_ENABLED 1
+#include "bstow-log.hpp"
+
+//#define BSTOW_ENABLE_VERBOSE 1
+
+using namespace std;
+using namespace hvu;
+
+typedef std::chrono::steady_clock ClockType;
+typedef ClockType::time_point ClockTime;
+typedef ClockType::duration Duration;
+
+inline int64_t count_microseconds(const Duration& dur)
+{
+    return chrono::duration_cast<chrono::microseconds>(dur).count();
+}
+
+struct TimeConverter
+{
+    ClockTime base_local;
+    std::chrono::system_clock::time_point base_system;
+
+    TimeConverter()
+    {
+        base_local = ClockType::now();
+        base_system = std::chrono::system_clock::now();
+    }
+
+    std::chrono::system_clock::time_point ToSystem(const ClockTime& steady)
+    {
+        Duration sep = steady - base_local;
+        return base_system + sep;
+    }
+
+    template<class Clock>
+    static int64_t SinceEpoch(const Clock& val)
+    {
+        return val.time_since_epoch().count();
+    }
+
+} g_time_converter;
+
+inline std::tm SystemTM(ClockTime time)
+{
+    using namespace std;
+    using namespace std::chrono;
+    using namespace hvu;
+
+    auto systime = g_time_converter.ToSystem(time);
+
+    const time_t time_epoch = std::chrono::system_clock::to_time_t(systime);
+
+    ofmt_bufs output;
+
+    // SysLocalTime returns zeroed tm_now on failure, which is ok for put_time.
+    const tm tm_now = sys_localtime(time_epoch);
+    return tm_now;
+}
+
+enum eDurationUnit {DUNIT_S, DUNIT_MS, DUNIT_US};
+
+template <eDurationUnit u>
+struct DurationUnitName;
+
+template<>
+struct DurationUnitName<DUNIT_US>
+{
+    static const char* name() { return "us"; }
+    static double count(const Duration& dur) { return static_cast<double>(count_microseconds(dur)); }
+};
+
+template<>
+struct DurationUnitName<DUNIT_MS>
+{
+    static const char* name() { return "ms"; }
+    static double count(const Duration& dur) { return static_cast<double>(count_microseconds(dur))/1000.0; }
+};
+
+template<>
+struct DurationUnitName<DUNIT_S>
+{
+    static const char* name() { return "s"; }
+    static double count(const Duration& dur) { return static_cast<double>(count_microseconds(dur))/1000000.0; }
+};
+
+template<eDurationUnit UNIT>
+inline std::string FormatDuration(const Duration& dur, bool plus = false)
+{
+    using namespace hvu;
+    double val = DurationUnitName<UNIT>::count(dur);
+    return ofcat(plus && val >= 0 ? OFMT_SV("+") : OFMT_SV(""), fmtm(val, std::fixed), DurationUnitName<UNIT>::name());
+}
+
+inline std::string FormatDuration(const Duration& dur)
+{
+    return FormatDuration<DUNIT_US>(dur);
+}
+std::string FormatDurationAuto(const Duration& dur, bool plus = false)
+{
+    int64_t value = count_microseconds(dur);
+
+    if (value < 1000)
+        return FormatDuration<DUNIT_US>(dur, plus);
+
+    if (value < 1000000)
+        return FormatDuration<DUNIT_MS>(dur, plus);
+
+    return FormatDuration<DUNIT_S>(dur, plus);
+}
+
+
+
+namespace hvu
+{
+namespace internal
+{
+struct snd_steadyclock
+{
+    bool daytime = false;
+    bool timezone = false;
+
+    snd_steadyclock(const char* spec)
+    {
+        if (!spec)
+            return;
+        while (char c = *spec)
+        {
+            if (c == 'z')
+                timezone = true;
+            else if (c == 'd')
+                daytime = true;
+        }
+    }
+
+    template <class Value, class OutStream>
+    void format_send(const Value& val, OutStream& os) const
+    {
+        using namespace std::chrono;
+
+        struct std::tm systime = SystemTM(val);
+
+        if (daytime)
+            os << fmt(systime, "%FT%T.");
+        else
+            os << fmt(systime, "%T.");
+
+        // Fraction of a second part
+        const auto us_now = duration_cast<microseconds>(val.time_since_epoch());
+        const auto us_rem = us_now - duration_cast<seconds>(us_now);
+        os << fmt(us_rem.count(), hvu::fmtc().fillzero().width(6));
+
+        // Timezone
+        if (timezone)
+            os << fmt(systime, "%z");
+    }
+};
+}
+
+inline auto fmt(const std::chrono::steady_clock::time_point& tim, const char* spec = nullptr)
+// NOTE: `auto` as return type would work, but only in C++17
+// The `decltype` could be tried, but the declaration wouldn't be less complicated
+            -> internal::fmt_proxy_template<
+                std::chrono::steady_clock::time_point,
+                internal::snd_steadyclock>
+{
+    return fmt_make_proxy(tim, internal::snd_steadyclock(spec));
+}
+
+}
+
+
+
+namespace bstow
+{
+
+struct PacketReader::PIMP
+{
+    std::istream& m_Datastream;
+
+    // BSTOW stream structure:
+    //
+    // SERIES {
+    //     BLOCK {
+    //         PACKET <---------- INITIAL PACKET; TS > 0; TD = 0 {
+    //              Very first packet, so
+    //               - m_Checkpoint.series_duration_us = 0
+    //               - m_Checkpoint.playtime_us = TS
+    //               - m_Checkpoint.basetime_us = 0 // will be always used as relative time
+    //               - m_Checkpoint.tdSendTime = NOW
+    //
+    //               - m_Last.tdPacketDuration_us = 0 (unknown)
+    //               - m_Last.tdPacketTimeStride_us = 0 (initial)
+    //               - m_Last.tdSendTime = NOW
+    //         }
+    //         PACKET ; TD>0 {
+    //               At lest one packet is there, so
+    //               - m_Last.tdPacketDuration_us = TD - m_Last.tdPacketTimeStride_us
+    //               - m_Last.tdPacketTimeStride_us = m_Checkpoint.basetime_us + TD
+    //               - m_Last.tdSendTime = NOW
+    //         }
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //     }
+    //     BLOCK {
+    //         PACKET ; TS > 0, TD > 0
+    //         PACKET
+    //         PACKET
+    //     }
+    //     BLOCK {
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //     }
+    // }
+    // SERIES {
+    //     BLOCK {
+    //         PACKET <---------- CHECKPOINT PACKET; TS > 0; TD = 0 {
+    //              Next series first:
+    //               - m_Checkpoint.series_duration_us = TS - m_Checkpoint.playtime_us
+    //               - m_Checkpoint.playtime_us = TS
+    //               - NEW_BASETIME = m_Checkpoint.(basetime_us + series_duration_us)
+    //               - m_Checkpoint.basetime_us = NEW_BASETIME
+    //               - m_Checkpoint.tdSendTime = m_Checkpoint.tdSendTime + m_Checkpoint.series_duration_us
+    //
+    //               - m_Last.tdPacketDuration_us = UNCHANGED (remains with previous value)
+    //               - m_Last.tdPacketTimeStride_us = m_Checkpoint.basetime_us
+    //               - m_Last.tdSendTime = NOW
+    //         }
+    //         PACKET ; TD>0
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //         PACKET
+    //     }
+    //     BLOCK {
+    //         PACKET ; TS > 0, TD > 0
+    //         PACKET
+    //         PACKET
+    //     }
+    //     BLOCK {
+    //         PACKET {
+    //            PREV PACKET SENDTIME = NOW SEND TIME  
+    //         }
+    //         PACKET {  --- DATA AT THIS POSITION
+    //            m_Checkpoint.playtime_us = TS from the CKECHPOINT PACKET
+    //            m_Checkpoint.sendtime = [now] when CHECKPOINT PACKET was sent
+    //            m_tsLastSendTime = NOW SEND TIME
+    //            m_tsBasetime_us = [user time] representing ZERO SEND TIME
+    //            m_tdLastPacketTimeStride_us = NOW SEND TIME - ZERO SEND TIME
+    //            m_tdLastPacketDuration = NOW SEND TIME - PREV PACKET SENDTIME
+    //         }
+    //         PACKET
+    //     }
+    // }
+    //
+    // SENDING INITIAL PACKET:
+    //
+    // - send it now, immediately
+    // - packet timestamp = m_tsBasetime_us (in ms)
+    //
+    // SENDING CHECKPOINT PACKET:
+    //
+    //   FIRST: HANDLE CHECKPOINT :
+    //       - NOW TIME - m_tsZeroSendtime -> SEND DURATION
+    //       - incooming timestmp - m_tsZeroPlaytime_us -> PLAY DURATION
+    //       - PLAY DURATION - SEND DURATION -> TIME SKEW
+    //
+    // - m_tsLastSendTime + m_tdLastPacketDuration + FIX
+    //     where FIX:
+    //        - < 0: borrow from the future sending time
+    //        - > 0: add the value to the sending time
+    //
+
+    struct Header
+    {
+        // Updated with Refill(). If it's 0 after Refill, it's EOF.
+        size_t packet_size = 0;
+
+        // Last received media timestamp - remains unchanged as the
+        // further units come in, until the next unit with timestamp
+        int64_t media_timestamp_us = 0;
+
+        // Last read packet timestamp, in the source version
+        int64_t packet_timestride_us = 0;
+
+        void Reset()
+        {
+            packet_size = 0;
+            media_timestamp_us = 0;
+            packet_timestride_us = 0;
+        }
+    } m_Header;
+
+    struct Zero
+    {
+        // Initial value read from the timestamp in the begingging
+        // or at the last checkpoint.
+        int64_t playtime_us = 0;
+
+        // The base time value since which the values of the timestamp
+        // will be set to the outgoing packets. This value is initially 0
+        // and updated with every checkpoint; the app should treat it as
+        // relative time towards the beginning.
+        int64_t basetime_us = 0;
+
+        int64_t series_duration_us = 0;
+
+        // Time recorded when sending the initial packet from the series.
+        // NOTE: realtime doesn't follow any data, it's only used for
+        // applying a wait time.
+        ClockTime sendtime;
+
+        int64_t diff_playtime(int64_t new_playtime)
+        {
+            return playtime_us == 0 ? 0 : new_playtime - playtime_us;
+        }
+
+        bool update(int64_t new_playtime)
+        {
+            bool following;
+            if (playtime_us)
+            {
+                // FIRST SERIES packet already in-transmission.
+                int64_t diff = diff_playtime(new_playtime);
+                series_duration_us = diff;
+                int64_t newbase = basetime_us + diff;
+                auto newsend = sendtime + chrono::microseconds(diff);
+                following = true;
+                BSLOG(DEBUG, "NEXT packet; send time: ", fmt(sendtime), " STEP: ", diff,
+                        " BASE: ", basetime_us, " -> ", newbase,
+                        " SEND: ", fmt(sendtime), " -> ", fmt(newsend));
+                basetime_us = newbase;
+                sendtime = newsend;
+            }
+            else
+            {
+                // VERY FIRST packet
+                sendtime = ClockType::now();
+                following = false;
+                BSLOG(DEBUG, "FIRST packet; send time: ", fmt(sendtime));
+            }
+            playtime_us = new_playtime;
+            return following;
+        }
+
+        // This function is to be run with every block that provides the
+        // block timestamp; this should confront it with the series-initial
+        // timestamp (playtime_us) and the sendtime latched at the same time.
+        ClockTime expectedReceiveTime(int64_t new_playtime)
+        {
+            return sendtime + chrono::microseconds(diff_playtime(new_playtime));
+        }
+
+        // NOTE: ZERO PACKET TIME IS ALWAYS ZERO.
+    } m_Checkpoint;
+
+    struct Last
+    {
+        ClockTime tsSendtime;
+
+        // TimeStride from the packet that was sent as the last one. The packet
+        // with that time stride was sent at the time recorded in tsSendtime.
+        int64_t tdPacketTimeStride_us = 0;
+
+        // Updated with every packet with TD > 0; distance between
+        // incoming TD and previous TD (can be remembered in a local variable)
+        int64_t tdPacketDuration_us = 0;
+
+        // This represents the value of m_Header.packet_timestride_us in
+        // case when this value as last read from BSTOW was 0.
+        int next_stride() const
+        {
+            return tdPacketTimeStride_us + tdPacketDuration_us;
+        }
+
+        // Called only during the checkpoint, after checkpoint update
+        void checkpoint(int64_t new_basetime_us, bool renew = true)
+        {
+            if (renew)
+            {
+                // Set this to 0 because after checkpoint you'll be getting
+                // packet stride value relative to the last checkpoint
+                new_basetime_us = 0;
+            }
+            BSLOG(DEBUG, "last/checkpoint: new pacekt stride: ", new_basetime_us, " - override ", tdPacketTimeStride_us);
+            tdPacketTimeStride_us = new_basetime_us;
+
+        }
+
+        void update(int64_t packet_timestride_us)
+        {
+            tdPacketDuration_us = packet_timestride_us - tdPacketTimeStride_us;
+            BSLOG(DEBUG, "last/update: stride ", tdPacketTimeStride_us, " -> ", packet_timestride_us,
+                    " duration ", tdPacketDuration_us);
+            tdPacketTimeStride_us = packet_timestride_us;
+        }
+
+    } m_Last;
+
+    // XXX This should track bigger differences between the time distance resulting
+    // from the packet time strides and series timestamps. Not in use yet.
+    int64_t m_tdTimeSkew = 0;
+
+    // Called with every packet after the whole header was read and interpreted,
+    // just at the moment of DATA command (before giving up to reading a payload).
+    // ONLY the payload size is set directly.
+    // XXX Consider making the payload size also a parameter.
+    void InterpretTS(int64_t media_timestamp, int packet_timestride)
+    {
+        // NOTE: possible cases are:
+        // ONLY packet_timestride == 0, media_timestamp specified
+        // - INITIAL packet of the series, CHECKPOINT.
+        // ONLY media_timestamp == 0, packet_timestride specified
+        // - SUBSEQUENT packet of the block
+        // BOTH specified
+        // - FIRST packet of the block, but subsequent block in the series
+        BSLOG(DEBUG, "TS.media=", media_timestamp, " .packet=", packet_timestride);
+
+        m_Header.packet_timestride_us = packet_timestride;
+
+        if (packet_timestride == 0)
+        {
+            return Checkpoint(media_timestamp);
+        }
+
+        m_Last.update(packet_timestride);
+    }
+
+    // TNEN: after reading was done:
+    void RecordSendTime()
+    {
+        m_Last.tsSendtime = ClockType::now();
+        if (m_Checkpoint.sendtime == ClockTime()) // INITIAL setting
+            m_Checkpoint.sendtime = m_Last.tsSendtime;
+    }
+
+    void Checkpoint(int64_t play_timestamp)
+    {
+        using namespace std::chrono;
+
+        if (m_Checkpoint.update(play_timestamp))
+        {
+            // One checkpoing was made already, estimate the passed time
+
+            //  LAST DISTANCE: --------------/-\..... == m_Last.tdPacketDuration_us
+            // [I] [P] [P] [P] [P] [P] [P] [P] [P] [I]
+            //  \-----------------------------------/ == m_Checkpoint.series_duration_us
+            //                                      |
+            // HERE -------------------------------/
+            // We have last frame's packet time + duration
+            int64_t packet_order_time = m_Last.next_stride();
+            int64_t playout_order_time = m_Checkpoint.basetime_us;
+            //
+            // Skew is positive if we spent more time to send than we should.
+            // We need to decrease the spending time, if so.
+            //
+            int64_t skew = m_tdTimeSkew + (packet_order_time - playout_order_time);
+            int64_t borrow_skew = m_Last.tdPacketDuration_us * 0.75;
+
+            BSLOG(DEBUG, "Checkpoint: playTS=", playout_order_time, " sendTS=", packet_order_time, " skew=", skew);
+
+            if (skew < borrow_skew)
+            {
+                packet_order_time = playout_order_time;
+                m_tdTimeSkew = 0;
+            }
+            else
+            {
+                // First time after checkpoint, but also with every next packet
+                m_tdTimeSkew = skew - borrow_skew;
+                packet_order_time -= borrow_skew;
+            }
+
+            m_Last.checkpoint(packet_order_time);
+            BSLOG(DEBUG, "...BASE: playTS=", playout_order_time, " sendTS=", packet_order_time, " remain-skew=", m_tdTimeSkew);
+        }
+        else
+        {
+            BSLOG(DEBUG, "Checkpoint: first");
+        }
+    }
+
+    int64_t GetUnitTimestamp_us()
+    {
+        return m_Checkpoint.basetime_us + m_Last.tdPacketTimeStride_us;
+    }
+
+    PIMP(std::istream& src): m_Datastream(src) {}
+
+    bool PIMP_Prepare(int64_t basetime);
+    MediaPacket PIMP_Read();
+    bool PIMP_End() const;
+
+    bool Refill();
+
+    bool ReadCheckHeader();
+
+    // Done initially or after getting a bigger portion
+    void ResetState();
+
+    // TRIGGERED WHEN: payload notch reaches payload size
+    void Trigger_full_notch();
+    // TRIGGERED WHEN: updated play rate is higher than previous play rate
+    void Trigger_high_spike();
+
+    std::string last_error;
+
+    virtual bool TestRead(char matrix[4]) = 0;
+    virtual std::string type() const = 0;
+};
+
+bool PacketReader::PIMP::ReadCheckHeader()
+{
+    char matrix[4];
+
+    if (!TestRead((matrix)))
+        return false;
+
+    int dif = memcmp(matrix, g_header, 4);
+    if (dif != 0)
+    {
+        last_error = "No 4-byte BSTOW signature found";
+        return false;
+    }
+
+    return true;
+}
+
+PacketReader::PacketReader(const string& spec): pimp(NULL)
+{
+    pimp = Factory(spec);
+}
+
+bool PacketReader::Prepare(int64_t basetime) { return pimp->PIMP_Prepare(basetime); }
+MediaPacket PacketReader::Read() { return pimp->PIMP_Read(); }
+bool PacketReader::End() const { return pimp->PIMP_End(); }
+std::string PacketReader::ErrorStr() const { return pimp->last_error; }
+std::string PacketReader::type() const { return pimp->type(); }
+
+template<class IntType>
+inline IntType TryData(const vector<unsigned char>& data, IntType value)
+{
+    if (data.empty())
+        return value;
+
+    return hvu::ParseBE(data.data(), data.size());
+}
+
+// XXX Put this into a separate file of "bstow-format" module or something
+static int Extract(const unsigned char* data, int& w_lab, int& w_val)
+{
+    int val3 = data[0];
+    if ( (val3 & 0x80) == 0 )
+    {
+        w_lab = val3;
+        w_val = (data[1] << 16) | (data[2] << 8) | data[3];
+        return 0;
+    }
+    const unsigned char* udata = reinterpret_cast<const unsigned char*>(data);
+
+    w_lab = ((udata[0] & 0x7F) << 8) | udata[1];
+    int length = (udata[2] << 8) | udata[3];
+    w_val = 0;
+    return length;
+}
+
+struct ConsoleReader: public PacketReader::PIMP
+{
+    std::string type() const { return "file"; }
+
+    ConsoleReader(): PacketReader::PIMP(std::cin) {}
+
+    // For console reader, read explicitly since the beginning, with blocking.
+    bool TestRead(char matrix[4]) override
+    {
+        m_Datastream.read(matrix, 4);
+        if (m_Datastream.eof())
+        {
+            last_error = "Unexpected EOF when reading";
+            return false;
+        }
+
+        return true;
+    }
+};
+
+struct FileReader: public PacketReader::PIMP
+{
+    std::string type() const { return "file"; }
+    ifstream ifile;
+    FileReader(const string& path): PacketReader::PIMP(ifile)
+    {
+        ifile.exceptions(ios::failbit | ios::badbit);
+        ifile.open(path);
+
+        // Turn off after correctly open
+        ifile.exceptions(ios::goodbit);
+    }
+
+    bool TestRead(char matrix[4]) override
+    {
+        // First 4 bytes expected to be a header
+        m_Datastream.read(matrix, 4);
+        if (m_Datastream.eof())
+        {
+            // You can't get EOF even if there's nothing more to read from the file.
+            // If you really have nothing more to read, it's EOF + 0 bytes read.
+            if (m_Datastream.gcount() != 0)
+                last_error = "Unexpected EOF when reading";
+            return false;
+        }
+
+        return true;
+    }
+
+};
+
+PacketReader::PIMP* PacketReader::Factory(const string& spec)
+{
+    UriParser u (spec, UriParser::EXPECT_FILE);
+
+    if (u.type() != UriParser::FILE)
+        throw std::invalid_argument("Invalid specification");
+
+    if (u.host() == "con")
+    {
+        return new ConsoleReader();
+    }
+    if (u.host() == "" && u.path() != "")
+    {
+        return new FileReader(u.path());
+    }
+
+    throw std::invalid_argument("Invalid specification");
+}
+
+// This must be called initially to refill the containers.
+// This will be chain-called from PIMP_Read once it has extracted
+// everything from the container
+bool PacketReader::PIMP::PIMP_Prepare(int64_t basetime)
+{
+    if (!Refill())
+        return false;
+
+    // Extra initial settings?
+    m_Checkpoint.basetime_us = basetime;
+    BSLOG(DEBUG, "PREPARE: initial TS=", basetime);
+    return true;
+}
+
+static map<int, string> g_parameter_names {
+#define MAPNAME(name) { DEF_##name, #name }
+    MAPNAME(LENGTH),
+    MAPNAME(PLAYTIME),
+    MAPNAME(SENDTIME),
+    MAPNAME(DATA)
+#undef MAPNAME
+};
+
+// Reads the next unit's data and updates things as needed.
+bool PacketReader::PIMP::Refill()
+{
+    using namespace hvu;
+
+    char matrix[4];
+
+    if (!ReadCheckHeader())
+        return false;
+
+    int64_t block_timestamp_us = 0;
+    int64_t packet_timestamp_us = 0;
+
+    set<int> expected { DEF_LENGTH, DEF_PLAYTIME, DEF_SENDTIME };
+
+    // Ok, now read by 4 portions until you get all data
+    for (;;)
+    {
+        m_Datastream.read(matrix, 4);
+        if (m_Datastream.eof())
+        {
+            last_error = "No 4-byte data available while parameters expected";
+            return false;
+        }
+
+        int label, value;
+        int xsize = Extract((const unsigned char*)matrix, (label), (value));
+        if (xsize < 0)
+            return false;
+
+        // This should appear when all data are already read.
+        // (We don't check for the value at all - it should be 0)
+        if (label == DEF_DATA)
+        {
+            if (!expected.empty())
+            {
+                last_error = "DATA parameter found while not all parameters specified yet";
+                return false;
+            }
+
+            if (packet_timestamp_us == 0 && block_timestamp_us == 0)
+            {
+                last_error = "TIMESTAMP/TIMESTRIDE not provided in this block";
+                return false;
+            }
+
+            ClockTime wait_time;
+            if (block_timestamp_us)
+                wait_time = m_Checkpoint.expectedReceiveTime(block_timestamp_us);
+
+            InterpretTS(block_timestamp_us, packet_timestamp_us);
+
+            // XXX Controversial - might be that for console reading pace control
+            // should not be done.
+            if (wait_time != ClockTime())
+            {
+                // Can be in the past - if so it will simply do nothing.
+                BSLOG(DEBUG, "Simulate non-encoder-ready: SLEEP FOR: ", FormatDurationAuto(wait_time - ClockType::now()));
+                this_thread::sleep_until(wait_time);
+            }
+
+#ifdef BSTOW_ENABLE_VERBOSE
+            static int64_t last_packet_timestamp_us = 0;
+            if (block_timestamp_us)
+            {
+                ofprint(cerr, "\nF PTS=", fmtm(block_timestamp_us/1000000.0, std::fixed), " ");
+                ofprint(cerr, "[", m_Header.packet_size, "]@{", packet_timestamp_us, "} ");
+                last_packet_timestamp_us = packet_timestamp_us;
+            }
+            else
+            {
+                ofprint(cerr, "[", m_Header.packet_size, "]+", packet_timestamp_us - last_packet_timestamp_us, " ");
+            }
+#endif
+
+            return true;
+        }
+
+        if (expected.empty()) // too early
+        {
+            hvu::ofmt_bufs out;
+            out.print("Excessive parameters while all specified: ",
+                    srt::map_get(g_parameter_names, label, hvu::ofcat("UNKNOWN:", label)));
+            last_error = out.str();
+            return false;
+        }
+
+        vector<unsigned char> databuffer;
+        if (xsize)
+        {
+            databuffer.resize(xsize);
+            m_Datastream.read((char*)databuffer.data(), databuffer.size());
+            if (m_Datastream.eof())
+            {
+                last_error = hvu::ofcat("Error reading extended length of ", xsize, " for label=",
+                        srt::map_get(g_parameter_names, label, "?"));
+                return false;
+            }
+        }
+
+        if (label == DEF_LENGTH)
+        {
+            // Theoretically to stay universal, it should do TryData<int64_t>,
+            // but this is a size for a single network packet, so a 24-bit integer
+            // should suffice.
+            m_Header.packet_size = value;
+            BSLOG(DEBUG, "... specified LENGTH:", value);
+        }
+        else if (label == DEF_PLAYTIME)
+        {
+            block_timestamp_us = TryData<int64_t>(databuffer, value);
+            BSLOG(DEBUG, "... specified PLAYTIME:", block_timestamp_us, " removed also SENDTIME");
+
+            // If PLAYTIME is specified, we allow SENDTIME to be not specified.
+            expected.erase(DEF_SENDTIME);
+        }
+        else if (label == DEF_SENDTIME)
+        {
+            packet_timestamp_us = TryData<int64_t>(databuffer, value);
+            BSLOG(DEBUG, "... specified SENDTIME:", packet_timestamp_us, " removed also PLAYTIME");
+
+            expected.erase(DEF_PLAYTIME);
+        }
+
+        expected.erase(label);
+    }
+}
+
+
+MediaPacket PacketReader::PIMP::PIMP_Read()
+{
+    MediaPacket mp;
+    static int readcounter = 0;
+
+    // NOTE: If you didn't call Prepare first, this will behave as EOF.
+    if (m_Header.packet_size == 0)
+        return mp;
+
+    size_t takesize = m_Header.packet_size;
+
+    // This call also does updates
+    int64_t based_packettime_us = GetUnitTimestamp_us();
+
+    // NOTE: Reading is done once and directly to the output.
+    // XXX Consider any kind of alloc-uninitialized-and-read method
+    mp.payload.resize(takesize);
+    m_Datastream.read(mp.payload.data(), takesize);
+    size_t nread = m_Datastream.gcount();
+    mp.time = based_packettime_us;
+    RecordSendTime();
+    ++readcounter;
+
+    // Just formally - this should be impossible
+    if (nread > takesize)
+    {
+        throw std::runtime_error("Read more than requested");
+    }
+    if (nread != takesize)
+    {
+        // Likely unexpected EOF. Report whatever you have
+        mp.payload.resize(nread);
+    }
+    if (m_Datastream.eof())
+    {
+        // Do nothing else. It's useless to make it retry reading.
+        m_Header.packet_size = 0;
+    }
+    else
+    {
+        m_Header.packet_size -= nread;
+        if (m_Header.packet_size == 0)
+        {
+            if (!Refill())
+            {
+                if (last_error != "")
+                    hvu::ofprintl(cerr, "PacketReader::Refill: ERROR: ", last_error);
+                return MediaPacket();
+            }
+            BSLOG(DEBUG, "# ", readcounter, " xp.{ play=", m_Checkpoint.playtime_us,
+                    " base=", m_Checkpoint.basetime_us, " sdur=", m_Checkpoint.series_duration_us, " }",
+                    " last.{ stride=", m_Last.tdPacketTimeStride_us,
+                    " dur=", m_Last.tdPacketDuration_us, " }");
+        }
+    }
+
+    return mp;
+}
+
+bool PacketReader::PIMP::PIMP_End() const
+{
+    return m_Header.packet_size == 0;
+}
+
+}
+

--- a/tools/bstow-read.cpp
+++ b/tools/bstow-read.cpp
@@ -282,7 +282,7 @@ struct PacketReader::PIMP
     //
     //   FIRST: HANDLE CHECKPOINT :
     //       - NOW TIME - m_tsZeroSendtime -> SEND DURATION
-    //       - incooming timestmp - m_tsZeroPlaytime_us -> PLAY DURATION
+    //       - incooming timestamp - m_tsZeroPlaytime_us -> PLAY DURATION
     //       - PLAY DURATION - SEND DURATION -> TIME SKEW
     //
     // - m_tsLastSendTime + m_tdLastPacketDuration + FIX
@@ -460,7 +460,7 @@ struct PacketReader::PIMP
 
         if (m_Checkpoint.update(play_timestamp))
         {
-            // One checkpoing was made already, estimate the passed time
+            // One checkpoint was made already, estimate the passed time
 
             //  LAST DISTANCE: --------------/-\..... == m_Last.tdPacketDuration_us
             // [I] [P] [P] [P] [P] [P] [P] [P] [P] [I]

--- a/tools/bstow-read.hpp
+++ b/tools/bstow-read.hpp
@@ -1,0 +1,77 @@
+#ifndef INC_BSTOW_READ_H
+#define INC_BSTOW_READ_H
+
+#include "testmediabase.hpp"
+
+namespace bstow
+{
+
+
+static const char g_header[4] = { char(0xbe), 0x57, 0x08, char(0x88) };
+
+// STRUCTURE:
+// HEADER: in the beginning of the file or first 4 bytes of transmission
+// PROPERTIES:
+// - {A, B, C, D}, where
+//   - A & ~0x7F == 0 - label, B:C:D - value
+//   - A & 0x80 == 0x80:
+//         A:B & 0x7F - label
+//         C:D  - length
+//         followed by value of this length
+//
+// LABELS:
+//
+// - DEF_LENGTH:  = length of the payload
+// - DEF_PLAYTIME: = time distance between packets in us
+// - DEF_SENDTIME = relative timestamp of this unit
+// - DEF_DATA: 0x7F (value: 0) = last property field, followed by data
+//
+// Single reading reports a UNIT. There are two types of units:
+//
+// - PUSI unit: first one; defines DEF_PLAYTIME (which is media timestamp)
+// - TAIL unit: following;
+//      - DEF_PLAYTIME is same as before or not specified,
+//      - DEF_SENDTIME defines the relative value since previous one; 0 to guess the previous
+
+const int
+      // Length of the current piece, in bytes
+      // ASSUMED: the size fits in one SRT packet (up to 1444 bytes)
+      DEF_LENGTH = 1,
+      // Datastream timestamp. Shall never be 0. OPTIONAL (if continued)
+      DEF_PLAYTIME = 2,
+      // Packet's timestamp delta (or, how fast this
+      // packet should be sent after sending the previos one)
+      DEF_SENDTIME = 3,
+      // 
+      DEF_DATA = 0x7F;
+
+// Expected exactly 4 bytes in the array.
+// Returns:
+// -1 : invalid specification
+// 0: w_val contains the value and nothing more to be extracted
+// 1+: w_val == 0 and the actual value is following the array of this size
+int Extract(const char* data, int& w_lab, int& w_val);
+
+class PacketReader
+{
+    struct PIMP;
+    PIMP* pimp;
+    static PIMP* Factory(const std::string& spec);
+    friend class ConsoleReader;
+    friend class FileReader;
+
+public:
+
+    PacketReader(const std::string& spec);
+
+    bool Prepare(int64_t basetime);
+    MediaPacket Read();
+    bool End() const;
+
+    std::string ErrorStr() const;
+    std::string type() const;
+};
+
+}
+
+#endif

--- a/tools/bstow-read.hpp
+++ b/tools/bstow-read.hpp
@@ -40,7 +40,7 @@ const int
       // Datastream timestamp. Shall never be 0. OPTIONAL (if continued)
       DEF_PLAYTIME = 2,
       // Packet's timestamp delta (or, how fast this
-      // packet should be sent after sending the previos one)
+      // packet should be sent after sending the previous one)
       DEF_SENDTIME = 3,
       // 
       DEF_DATA = 0x7F;

--- a/tools/bstow-test/Silverball
+++ b/tools/bstow-test/Silverball
@@ -1,0 +1,24 @@
+
+# TEMPORARY build file - development only.
+
+ag-profile gcc-native
+
+pinit DEBUG 1
+
+if {$DEBUG} {
+	ag-profile c++ -D _DEBUG -cflags -- -g3 -O0
+}
+
+ag-profile c++ -std c++17
+ag-profile general -depspec cached
+
+ag-profile c++ -incdir ../../srtcore ../../build-debug ../../logging ../../apps ../
+
+set t test-packetreader
+ag $t -type program -s $t.cpp ../../apps/uriparser.cpp ../../apps/options.cpp ../bstow-read.cpp ../bstow-log.cpp
+
+set g bstow-generate
+
+ag $g -type program -s $g.cpp ../bstow-log.cpp
+
+

--- a/tools/bstow-test/bstow-generate.cpp
+++ b/tools/bstow-test/bstow-generate.cpp
@@ -1,0 +1,758 @@
+// This application should generate the bstow data.
+
+// The source file *.bsrc has the following format:
+
+// First line:
+//  :<PARAMETERS>
+// Every next line:
+//  <SIZE>[ i]
+//
+// where:
+// <PARAMETERS> are space separated KEY=VALUE pairs. Available keys:
+//
+// U: unit size - multiplier for the frame sizes (if 1, <SIZE> is in bytes)
+// P: packet size - maximum payload size for a single packet, must be aligned to U.
+// F: framerate - divisor of 1 for the DTS distance between frames
+// T: timestamp - the DTS of the very first frame
+//
+// For following frames, <SIZE> declares a single frame of given size
+// multiplied by the unit size (U). Optionally followed by a frame type
+// declarator; if this is "i", it's an I-Frame, or otherwise the required
+// synchronization point.
+//
+// The generated BSTOW (*.bs) file will contain the correctly determined
+// bitrate and will be split into single packets. The I-Frame is considered
+// as the checkpoint when the sending time based on the bitrate is synchronized
+// with the DTS.
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <deque>
+#include <map>
+#include <tuple>
+#include <iterator>
+#include "ofmt.h"
+#include "utilities.h" // from srt
+#include "hvu_bigendian.h"
+
+#include "bstow-read.hpp"
+
+#define BSLOG_ENABLED 1
+#include "bstow-log.hpp"
+
+namespace bstow
+{
+    template<class IntType>
+    inline void WriteValue(std::ostream& out, int label, IntType value)
+    {
+        int32_t cutval = (value & 0x00FFFFFF);
+
+        if (cutval == value)
+        {
+            // Usual 24-bit encoding.
+            unsigned char data[4];
+            data[0] = label & 0x7F;
+            data[1] = (value >> 16) & 0xFF;
+            data[2] = (value >> 8) & 0xFF;
+            data[3] = value & 0xFF;
+            out.write((char*)data, 4);
+            return;
+        }
+
+        // Encode a greater value: [LA][BEL][LEN][GTH][payload-of-that-length]
+        unsigned char data[4+8];
+        unsigned short labform = unsigned(label) | 0x8000;
+        unsigned char* p = data;
+        hvu::FormatBE<2>(labform, (p));
+        p += 2;
+        // We'd ignore zero-skipping for now, just write out a 64-bit value
+        hvu::FormatBE<2>(sizeof(IntType), (p));
+        p += 2;
+        hvu::FormatBE<sizeof(IntType)>(value, (p));
+
+        out.write((char*)data, sizeof data);
+    }
+}
+
+using namespace std;
+using namespace hvu;
+
+struct General
+{
+    int64_t bitrate = 0;
+    size_t unitsize = 1;
+    size_t packetsize = 1444;
+    int64_t timestamp_base = 1000;
+    size_t framerate = 0;
+
+    std::string show() const
+    {
+        return ofcat("CONFIG: br=", bitrate, " size.{u=", unitsize, ", p=", packetsize,
+                "} ts.base=", timestamp_base, " fps=", framerate);
+    }
+
+    // XXX Here you can add some information how to
+    // generate data
+};
+
+struct Payload
+{
+    size_t length = 0;
+    int64_t timestamp = 0;
+    int flags = 0;
+
+    enum Flags { I = 1 };
+
+    bool operator & (Flags f) const
+    {
+        return (flags & int(f)) == int(f);
+    }
+
+    bool Interpret(const std::string& line)
+    {
+        using namespace std;
+
+        deque<string> parts;
+        srt::Split(line, ' ', back_inserter(parts));
+        for (;;)
+        {
+            if (parts.empty())
+                break;
+
+            if (parts[0] == "")
+                parts.pop_front();
+            else
+                break;
+        }
+        if (parts.empty())
+            return false;
+
+        // Very first must be a number
+        length = stoi(parts[0]);
+        parts.pop_front();
+
+        for (auto& s: parts)
+        {
+            if (s == "")
+                continue;
+            InterpretFlag(s);
+        }
+
+        return true;
+    }
+
+    void InterpretFlag(const std::string& f)
+    {
+        if (f == "i")
+        {
+            flags |= Flags::I;
+            return;
+        }
+
+        // XXX Here you might also interpret a timestamp, for example.
+
+        hvu::ofprintl(std::cerr, "WARNING: unknown flag: ", f);
+    }
+};
+
+struct Config
+{
+    General general;
+    std::vector<Payload> payloads;
+
+    void FixMissing();
+    int64_t EstimateBitrate();
+    void DefineTimestamps();
+
+    size_t payloadSize(size_t ix) const
+    {
+        return general.unitsize * payloads[ix].length;
+    }
+};
+
+int64_t SendPeriod(const General& gen, size_t bytes)
+{
+    size_t nbits_micro = bytes * 8 * 1000000;
+
+    // size [Mega-bits] / rate [Bits / s]
+    // -> 1s * (size[Mb] / Bits
+    // -> 1s * 1000000 * (size[B] / factor[B])
+
+    return nbits_micro / gen.bitrate;
+}
+
+class Extractor
+{
+    // Constants
+    vector<string> m_prefix;
+    string m_line;
+
+    // Variable state
+    struct State
+    {
+        size_t linepos = 0;
+        string value;
+    } m_state;
+
+public:
+    static const size_t npos = string::npos;
+
+    Extractor(const vector<string>& prefixes, const string& line): m_prefix(prefixes), m_line(line) {}
+
+    tuple<size_t, string> next()
+    {
+        // At first, starting from linepos, skip all space characters.
+        // Exit with nothing if reached the end.
+        for (;;)
+        {
+            if (m_state.linepos >= m_line.size())
+                return make_tuple(+npos, string());
+
+            if (m_line[m_state.linepos] == ' ')
+            {
+                ++m_state.linepos;
+                continue;
+            }
+
+            break;
+        }
+
+        string::iterator line_start = m_line.begin() + m_state.linepos;
+        size_t line_size = m_line.size() - m_state.linepos;
+        for (size_t i = 0; i < m_prefix.size(); ++i)
+        {
+            auto& p = m_prefix[i];
+            if (line_size <= p.size())
+                continue;
+
+            if (std::mismatch(p.begin(), p.end(), line_start).first == p.end())
+            {
+                // We have a match
+                size_t valpos = m_state.linepos + p.size();
+                string value;
+                size_t earg = m_line.find(' ', valpos);
+                if (earg == string::npos)
+                {
+                    m_state.value = m_line.substr(valpos);
+                    m_state.linepos = m_line.size();
+                }
+                else
+                {
+                    size_t nchars = earg - valpos;
+                    m_state.value = m_line.substr(valpos, nchars);
+                    m_state.linepos = earg + 1;
+                }
+                return make_tuple(i, m_state.value);
+            }
+        }
+
+        return make_tuple(string::npos, string("Unknown prefix"));
+    }
+};
+
+static const vector<string> g_prefixes = {
+    "F=",
+    "U=",
+    "P=",
+    "T="
+};
+
+enum Arg: size_t
+{
+    FRAMERATE = 0,
+    UNITSIZE,
+    PACKETSIZE,
+    TIMESTAMP,
+
+    UNKNOWN = std::string::npos
+};
+
+bool InterpretParameters(const string& line, Config& config)
+{
+    Extractor ex (g_prefixes, line);
+
+    try
+    {
+        for (;;)
+        {
+            auto [index, value] = ex.next();
+
+            if (index == Arg::UNKNOWN)
+            {
+                // empty string means end. Otherwise it's an error message
+                if (value != "")
+                {
+                    ofprintl(cerr, "Error reading parameters: ", value);
+                    return false;
+                }
+                break;
+            }
+
+            switch (index)
+            {
+            case Arg::FRAMERATE:
+                config.general.framerate = stoi(value);
+                break;
+
+            case Arg::UNITSIZE:
+                config.general.unitsize = stoi(value);
+                break;
+
+            case Arg::PACKETSIZE:
+                config.general.packetsize = stoi(value);
+                break;
+
+            case Arg::TIMESTAMP:
+                config.general.timestamp_base = stoi(value);
+                break;
+            }
+        }
+    }
+    catch (std::exception& e)
+    {
+        ofprintl(cerr, "ERROR: ", e.what());
+        return false;
+    }
+
+    // HERE you should verify if all args were checked.
+    return true;
+}
+
+bool InterpretFile(const string& infile, Config& config)
+{
+    std::ifstream ifile (infile);
+
+    bool have_parameters = false;
+
+    string line;
+    while (getline(ifile, (line)))
+    {
+        // Skip empties and commetns
+        if (line == "" || line[0] == '#')
+            continue;
+        if (line[0] == ':')
+        {
+            if (have_parameters)
+            {
+                ofprintl(cerr, "ERROR: Parameters specified twice");
+                return false;
+            }
+            size_t i = 0;
+            while (line[i] == ':' || line[i] == ' ')
+            {
+                ++i;
+                if (i == line.size())
+                {
+                    ofprintl(cerr, "No parameters in parameters line: '", line, "' - bailing out");
+                    return false;
+                }
+            }
+            // Interpret parameters
+            // Skip that initial :
+            if (!InterpretParameters(line.substr(i), (config)))
+                return false;
+
+            have_parameters = true;
+
+            // Do this update every time the settings come in.
+            continue;
+        }
+        if (!have_parameters)
+        {
+            ofprintl(cerr, "ERROR: Parameters not specified");
+            return false;
+        }
+
+        size_t size = 0;
+        int64_t ts = -1;
+
+        Payload pay;
+        if (pay.Interpret(line))
+            config.payloads.push_back(pay);
+    }
+
+    return true;
+}
+
+void Config::DefineTimestamps()
+{
+    int64_t timestamp_track = 0;
+    int64_t timestamp_zero_align_s = 0;
+    size_t timestamp_track_frames = 0;
+
+    int64_t resolution = 1000000; // ms
+
+    // BSLOG(DEBUG, "WILL DEFINE TIMESTAMPS:");
+
+    for (auto& p : payloads)
+    {
+        double tval = timestamp_track_frames * double(resolution) / general.framerate;
+        int64_t ival = tval;
+        double fracval = tval - ival;
+        int postfix = 2*fracval;
+
+        p.timestamp = general.timestamp_base + ival + postfix;
+
+        // BSLOG(DEBUG, "FRAME #", timestamp_track_frames, " tval=", tval, " TS=", p.timestamp);
+
+        ++timestamp_track_frames;
+    }
+}
+
+bool InterpretArgs(const vector<string>& args, Config& config)
+{
+    if (args.size() == 1)
+        return InterpretFile(args[0], (config));
+    string last;
+    size_t nexp = 0;
+    int ipayload = -1;
+
+    // PROGRAM PARAMETERS:
+    //
+    // SINGLE PARAMETERS:
+    // BITRATE = x bps
+    // TIMESTAMP_BASE [optional = 1000] = FIRST portion timestamp
+    // TIMESTAMP_STRIDE [optional = 0] = shift to add to next payloads
+    // UNITSIZE [optional = 1] = size of payload alignment
+    //
+    // MULTIPLE PARAMETERS
+    // LENGTH = total length of the payload divided by UNITSIZE
+    // TIMESTAMP [optional = 0]
+
+    auto& gen = config.general;
+    auto& pay = config.payloads;
+
+    try
+    {
+        for (int i = 0; i < args.size(); ++i)
+        {
+            if (nexp)
+            {
+                // Handles the -p case
+                if (ipayload > -1)
+                {
+                    if (last == "-s" || last == "-size" || last == "-length")
+                    {
+                        pay[ipayload].length = stoi(args[i]);
+                    }
+                    else if (last == "-ts" || last == "-timestamp")
+                    {
+                        pay[ipayload].timestamp = stoll(args[i]);
+                    }
+                    else
+                    {
+                        throw std::invalid_argument(ofcat("Invalid parameter (payload): ", last, " value:", args[i]));
+                    }
+                }
+                else if (last == "-b" || last == "-bitrate")
+                {
+                    gen.bitrate = stoi(args[i]);
+                }
+                else if (last == "-tb" || last == "-timestamp-base")
+                {
+                    gen.timestamp_base = stoll(args[i]);
+                }
+                else if (last == "-fps" || last == "-framerate")
+                {
+                    gen.framerate = stoi(args[i]);
+                }
+                else if (last == "-u" || last == "-unitsize")
+                {
+                    gen.unitsize = stoi(args[i]);
+                }
+                else
+                {
+                    throw std::invalid_argument(ofcat("Invalid parameter (general): ", last, " value:", args[i]));
+                }
+
+                last = "";
+                nexp = 0;
+                continue;
+            }
+
+            string arg = args[i];
+            if (arg[0] == '-')
+            {
+                if (arg == "-p" || arg == "-payload")
+                {
+                    // Special handling
+                    ++ipayload;
+                    pay.push_back(Payload());
+                    continue;
+                }
+
+                last = arg;
+                nexp = 1;
+                continue;
+            }
+
+            ofprintl(cout, "Unordered argument: ", arg);
+            break;
+        }
+    }
+    catch (std::invalid_argument& e)
+    {
+        ofprintl(cerr, "ERROR: ", e.what(), " last arg=", last, " payload=", ipayload);
+        return false;
+    }
+
+    for (int i = 0; i < pay.size(); ++i)
+    {
+        if (pay[i].length == 0)
+        {
+            ofprintl(cerr, "ZERO length at payload #", i);
+            return false;
+        }
+
+        if (pay[i].timestamp == 0 && gen.framerate == 0)
+        {
+            ofprintl(cerr, "ZERO timestamp (with no framerate specified) at payload #", i);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void GenerateRandomData(ostream& out, size_t ndata)
+{
+    // Currently we just create a payload of EE hex value
+    for (size_t i = 0; i < ndata; ++i)
+    {
+        out.put(0xEE);
+    }
+}
+
+size_t avg_tracked_plsize = 0;
+
+void WritePayload(ostream& out, const Config& cf, size_t ix, const vector<char>& payload_data, int64_t& w_timestride_us)
+{
+    using namespace bstow;
+    auto& pl = cf.payloads[ix];
+    auto& gen = cf.general;
+
+    // This should be split here into smaller pieces.
+    // Rely on the timestamp defined in the payload.
+    // General is necessary only for unit size and bitrate.
+
+    size_t takesize = (gen.packetsize / gen.unitsize) * gen.unitsize;
+
+    size_t remain = payload_data.size();
+
+    if (::avg_tracked_plsize == 0)
+        ::avg_tracked_plsize = remain;
+    else
+    {
+        ::avg_tracked_plsize = srt::avg_iir<5>(::avg_tracked_plsize, remain);
+    }
+
+    // Determine the checkpoint
+    if (pl & Payload::Flags::I)
+    {
+        w_timestride_us = 0;
+        ::avg_tracked_plsize = 0;
+    }
+
+    BSLOG(DEBUG, "size=", remain, " avg=", ::avg_tracked_plsize, " STS=", w_timestride_us);
+
+    bool first = true;
+
+    while (remain)
+    {
+        // Signature first
+        out.write(g_header, 4);
+
+        string timelog = "UNSPEC";
+        if (first)
+        {
+            WriteValue(out, DEF_PLAYTIME, pl.timestamp);
+            timelog = fmts(pl.timestamp);
+        }
+
+        if (w_timestride_us)
+        {
+            WriteValue(out, DEF_SENDTIME, w_timestride_us);
+        }
+
+        first = false;
+
+        size_t pktsize = std::min(takesize, remain);
+        WriteValue(out, DEF_LENGTH, pktsize);
+
+        size_t notch = payload_data.size() - remain;
+
+        WriteValue(out, DEF_DATA, 0);
+        out.write(payload_data.data() + notch, pktsize);
+
+        remain -= pktsize;
+
+        BSLOG(DEBUG, "packet size=", pktsize, " PTS=", timelog, " STS=", w_timestride_us);
+
+        w_timestride_us += SendPeriod(gen, pktsize);
+    }
+}
+
+vector<char> GeneratePayloadData(const Config& config, size_t ix)
+{
+    // NOTE: length defines the number of units
+
+    vector<char> out;
+
+    for (size_t l = 0; l < config.payloads[ix].length; ++l)
+    {
+        // A single unit is filled by subsequent numbers up to the
+        // end of unit. The next unit will start from 1. If the unit
+        // is larger than 255, it will just overflow.
+        uint8_t b = 1;
+        for (size_t i = 0; i < config.general.unitsize; ++i)
+        {
+            out.push_back(b++);
+        }
+    }
+
+    return out;
+}
+
+int64_t Config::EstimateBitrate()
+{
+    size_t i;
+    int64_t timestamp_begin = -1;
+
+    // Search for the first I-Frame
+    for (i = 0; i < payloads.size(); ++i)
+    {
+        if (srt::IsSet(payloads[i].flags, Payload::Flags::I))
+        {
+            timestamp_begin = payloads[i].timestamp;
+            break;
+        }
+        BSLOG(DEBUG, "# ", i, " still no I-Frame");
+    }
+    if (timestamp_begin == -1)
+        throw std::runtime_error("No I-frame found");
+
+    size_t collected_size = payloadSize(i);
+
+    int64_t avg_rate = 0; // Prevent it from being 0
+
+    // BSLOG(DEBUG, "START: size=", collected_size);
+
+    size_t prev_size = collected_size;
+
+    BSLOG(DEBUG, "# ", i, ": [FIRST I-Frame] p.size=", payloadSize(i));
+
+    // Continue from next frame until the next I-Frame.
+    for (++i; i < payloads.size(); ++i)
+    {
+        int64_t dur = payloads[i].timestamp - payloads[i-1].timestamp;
+        int64_t tdur = payloads[i].timestamp - timestamp_begin;
+        size_t prev_col_size = collected_size;
+        collected_size += payloadSize(i);
+
+        int64_t irate = payloadSize(i) * 8 * 1000000 / dur;
+        int64_t trate = collected_size * 8 * 1000000 / tdur;
+
+        BSLOG(DEBUG, "# ", i, ": flags=", payloads[i].flags, " p.size=", payloadSize(i),
+                " GOP.size=", collected_size, " p.dur=", dur, " GOP.dur=", tdur, " p.rate=", irate, " GOP.rate=", trate);
+
+        if (srt::IsSet(payloads[i].flags, Payload::Flags::I))
+        {
+            break;
+        }
+        avg_rate = collected_size * 8 * 1000000 / (tdur + dur);
+        prev_size = payloadSize(i);
+    }
+
+    return avg_rate;
+}
+
+void Config::FixMissing()
+{
+    if (payloads.empty())
+        throw std::runtime_error("No payloads");
+
+    // This means we haven't specified timestamps for every payload,
+    // so construct the timestamps using the base and framerate.
+    if (payloads[0].timestamp == 0)
+    {
+        DefineTimestamps();
+    }
+
+    // NOTE: timestamps are required to estimate the bitrate!
+    if (general.bitrate == 0)
+    {
+        general.bitrate = EstimateBitrate();
+        ofprintl(cerr, "BITRATE CALCULATED: ", general.bitrate);
+    }
+}
+
+int main( int argc, char** argv )
+{
+    using namespace std;
+    using namespace bstow;
+
+    // CHECK 1: Either TIMESAMP_STRIDE must be specified
+    // or TIMESTAMP must be specified for every payload
+
+    string filename;
+    if (argc < 2 || (filename = argv[1]) == "--help")
+    {
+        ofprintl(cerr, "Usage: ", argv[0], " <filename> <generation parameters...>");
+        ofprintl(cerr, "  where <generation parameters...> is a *.bsrc filename or options.");
+        ofprintl(cerr, "Options:");
+        ofprintl(cerr, "  -b\tbitrate [bps]");
+        ofprintl(cerr, "  -tb\tTimestamp base [us]");
+        ofprintl(cerr, "  -td\tTimestamp stride [us]");
+        ofprintl(cerr, "  -u\tUnit size (size alignment for reading payloads)");
+        ofprintl(cerr, "  -p: Specify further payload data:");
+        ofprintl(cerr, "    -s: Payload size");
+        ofprintl(cerr, "    -ts: Payload timestamp (if not specified by -tb/-td)");
+        return 1;
+    }
+
+    vector<string> args(argv + 2, argv + argc);
+    Config config;
+
+    if (args.empty())
+    {
+        ofprintl(cerr, "After <filename> at least <source-file> or <generation-options> expected");
+        return 1;
+    }
+
+    if (!InterpretArgs(args, (config)))
+    {
+        ofprintl(cerr, "Usage error, bailing out");
+        return 1;
+    }
+
+    config.FixMissing();
+
+    try
+    {
+        ofstream out;
+        out.exceptions(ios::failbit | ios::badbit);
+        out.open(filename, ios::out | ios::binary);
+
+        // XXX set no buffering to see the file immediately
+        out.setf(ios::unitbuf);
+        out.rdbuf()->pubsetbuf(0, 0);
+
+        // sendtime tracker - will get reset at the checkpoint
+        int64_t timestride_us = 0;
+
+        for (int i = 0; i < config.payloads.size(); ++i)
+        {
+            // BSLOG(DEBUG, "WRITE PAYLOAD #", i, " TS=", config.payloads[i].timestamp);
+            vector<char> data = GeneratePayloadData(config, i);
+            WritePayload((out), config, i, data, (timestride_us));
+        }
+    }
+    catch (std::exception& e)
+    {
+        ofprintl(cerr, "ERROR: ", e.what(), " -- interrupted by exception");
+    }
+
+    return 0;
+}

--- a/tools/bstow-test/bstow-test-src.tcl
+++ b/tools/bstow-test/bstow-test-src.tcl
@@ -1,0 +1,175 @@
+#!/usr/bin/tclsh
+
+set confobj ""
+
+set frametime 0.0
+set frame_timestride 0
+
+set frames {}
+
+proc print_line {size} {
+	# State you already have config data, but
+	# play times are set initially to 0.
+
+	puts "FRAME \[[format {% 5d} $size]\] PLAY=$::frametime"
+	set ::frametime [expr {$::frametime + $::frame_timestride}]
+
+	# DISPLAY PAKCETS!
+}
+
+proc readfile {filename} {
+	global confobj
+	set fd [open $filename r]
+
+	set have_param no
+
+	while { [gets $fd line] != -1 } {
+		if { [string index $line 0] == ":" } {
+			# Header with config data
+			set confdata [string range $line 1 end]
+			foreach d $confdata {
+				lassign [split $d =] lab val
+				switch -- $lab {
+					F {dict set confobj framerate $val}
+					U {dict set confobj unitsize $val}
+					P {dict set confobj packetsize $val}
+					default {
+						error "Unknown config parameter '$lab'"
+					}
+				}
+			}
+			set have_param yes
+			set ::frame_timestride [expr {1.0/[dict get $confobj framerate]}]
+			continue
+		}
+
+		if {!$have_param} {
+			error "Parameters not specified"
+		}
+
+		# Line with packet size
+		lappend ::frames $line
+	}
+
+	close $fd
+}
+
+proc round {value unitsize} {
+	return [expr {($value/$unitsize)*$unitsize}]
+}
+
+proc updiv {size unit} {
+	set ov [expr {$size % $unit ? 1 : 0}]
+	set div [expr {$size / $unit + $ov}]
+	return $div
+}
+
+readfile [lindex $argv 0]
+
+# Ok, read a single GOP to calculate the average rate.
+
+set avg 0
+
+set begin_time 0
+set end_time 0
+
+#set time 0
+set time $::frame_timestride
+set total_size 0
+set nf 0
+set nf_next 0
+set end_size 0
+
+set packetsize [round 1500 [dict get $confobj unitsize]]
+
+proc EstimateBitrate {frames} {
+
+
+set npackets 0
+
+set insync no
+
+foreach ef $frames {
+	set flags [lassign $ef fram]
+	set nf $nf_next
+	incr nf_next
+
+	if {!$insync} {
+		if {"i" ni $flags} {
+			puts "FRAME #$nf: NO I-Frame yet, skipping"
+			continue
+		}
+		set insync yes
+	} else {
+		if {"i" in $flags} {
+			puts "Frame #$nf: NEXT I-Frame, STOPPED"
+			break
+		}
+	}
+
+	set f [expr {$fram * [dict get $confobj unitsize]}]
+	incr total_size $f
+	set time [expr {$time + $::frame_timestride}]
+
+	set crate [expr {$f / $::frame_timestride}]
+	set trate [expr {$total_size / ($time - $begin_time)}]
+	set end_time $time
+
+	set avg $trate
+	set end_size $total_size
+
+	puts "FRAME #$nf: $fram size=$f playtime=$time SELF RATE:$crate AVG RATE:$trate"
+	incr npackets [updiv $f $packetsize]
+}
+
+incr nf
+# Total playtime: TOTAL_FRAMES / FPS
+set total_playtime_us [expr {($nf) * 1000000 / [dict get $confobj framerate]}]
+
+set packet_playtime_us [expr {$total_playtime_us / $npackets}]
+
+puts "OVERALL: GOP=$nf SIZE=$end_size PKTS=$npackets*$packetsize TIME=[expr {$total_playtime_us/1000000.0}]s RATE\[B/s\]=$avg"
+puts "OVERALL RATE: $avg = [expr {$avg*8}]bps FRAME PERIOD: $frame_timestride PACKET PERIOD: $packet_playtime_us us"
+
+
+
+
+puts "PACKET DISTRIBUTION: size=$packetsize "
+
+set playtime_duration_us [expr 1000000 / [dict get $confobj framerate]]
+
+
+#set time 0
+set time $playtime_duration_us
+set send_time 0
+set send_time_global_base $playtime_duration_us
+
+proc glob-sendtime {} {
+	global send_time
+	global send_time_global_base
+	return [expr {$send_time_global_base + $send_time}]
+}
+
+set px 0
+set nf 0
+
+foreach ef $frames {
+	set flags [lassign $ef fram]
+	if {"i" in $flags} {
+		incr send_time_global_base $send_time
+		set send_time 0
+	}
+	set size [expr {$fram * [dict get $confobj unitsize]}]
+	puts "FRAME #$nf: u=$fram size=$size playtime=[expr {$time / 1000000.0}]"
+
+	set remain $size
+	while {$remain} {
+		set takesize [expr {min($packetsize, $remain)}]
+		puts " --- PACKET #$px: size=$takesize sendtime=[expr $send_time/1000000.0] globsend=[expr [glob-sendtime]/1000000.0]"
+		set send_time [expr {$send_time + $packet_playtime_us}]
+		incr remain -$takesize
+		incr px
+	}
+	incr time $playtime_duration_us
+	incr nf
+}

--- a/tools/bstow-test/bstow-test-src.tcl
+++ b/tools/bstow-test/bstow-test-src.tcl
@@ -14,7 +14,7 @@ proc print_line {size} {
 	puts "FRAME \[[format {% 5d} $size]\] PLAY=$::frametime"
 	set ::frametime [expr {$::frametime + $::frame_timestride}]
 
-	# DISPLAY PAKCETS!
+	# DISPLAY PACKETS!
 }
 
 proc readfile {filename} {

--- a/tools/bstow-test/test-packetreader.cpp
+++ b/tools/bstow-test/test-packetreader.cpp
@@ -1,0 +1,118 @@
+
+#include <vector>
+#include <string>
+#include <chrono>
+#include <csignal>
+#include <fstream>
+
+#include "ofmt.h"
+#include "options.hpp"
+
+#include "bstow-read.hpp"
+#include "bstow-log.hpp"
+#include "hvu_debug.h"
+
+using namespace std;
+using namespace hvu;
+
+int64_t TimeNow()
+{
+    using namespace std::chrono;
+    auto epoch_now = steady_clock::now().time_since_epoch();
+
+    return duration_cast<microseconds>(epoch_now).count();
+}
+
+int g_interrupt_at = 0;
+
+int main( int argc, char** argv )
+{
+    OptionHandler ops;
+
+    // The only sensible setting for free options
+    ops.default_arg(OptionScheme::ARG_VAR);
+
+    ops.process(argv, argc);
+
+    vector<string> args = ops[""];
+
+    if (args.size() < 1)
+    {
+        ofprintl(cout, "Usage: ", argv[0], " <bstow URI> [options]");
+        ofprintl(cout, "Options: -v (verbose), -t <time[us]|now>, -l <loglevel>, -lf <logfile>, -I <interrupt-at>");
+        return 1;
+    }
+
+    bstow::PacketReader r (args[0]);
+
+    int64_t base_ts = 0;
+
+    string timesp = ops["t"];
+    if (timesp != "")
+    {
+        if (isdigit(timesp[0]))
+            base_ts = stoi(timesp);
+        else if (timesp == "now")
+            base_ts = TimeNow();
+        else
+        {
+            ofprintl(cerr, "ERROR: -t <time|'now'> expected");
+            return -1;
+        }
+    }
+
+    int logl = ops.getfree(-1, "l");
+    if (logl != -1)
+        bstow::g_loglevel = logl;
+
+    vector<string> logfile_spec = ops["lf"];
+    std::ofstream out_logger;
+    if (!logfile_spec.empty())
+    {
+        if (logfile_spec.size() > 1)
+        {
+            ofprintl(cerr, "OPTION: -lf requires one filename argument");
+            return -1;
+        }
+        string logfile = logfile_spec[0];
+        out_logger.open(logfile, ios::out | ios::trunc);
+        if (!out_logger.good())
+        {
+            ofprintl(cerr, "ERROR OPENING FILE for logs: ", logfile);
+            return -1;
+        }
+        bstow::g_logstream = &out_logger;
+    }
+
+    g_interrupt_at = ops.getfree(0, "I");
+
+    if (!r.Prepare(base_ts))
+    {
+        ofprintl(cerr, "PREPARE FAILED: ", r.ErrorStr());
+        return -1;
+    }
+
+    bool verbose = ops["v"];
+
+    if (verbose)
+        ofprintl(cout, "READING. FIRST TS=", base_ts);
+
+    int npacket = 1;
+    for (;;)
+    {
+        if (g_interrupt_at && npacket == g_interrupt_at)
+            HVU_DEBUG_BREAK()
+                ;
+
+        MediaPacket p = r.Read();
+        if (r.End())
+            break;
+
+        if (verbose)
+            ofprintl(cout, fmt(ofcat("# ", npacket), fmtc().left().width(8)),
+                    " [", fmt(p.payload.size(), fmtc().fillzero().width(4)), "] TS=", fmt(p.time, fmtc().width(8).fillzero()));
+        ++npacket;
+    }
+
+    return 0;
+}

--- a/tools/bstow-test/ts-extract-info.tcl
+++ b/tools/bstow-test/ts-extract-info.tcl
@@ -1,0 +1,232 @@
+#!/usr/bin/tclsh
+
+# This script is required to parse the output of ts_analyuzer, which should
+# be run with the MPEG-TS file with predefined bitrate. This script analyzes
+# the "default text" output of this file and produces the *.bsrc file.
+
+# Next the *.bsrc file can be used with `bstow-generate` application.
+
+set fd [open [lindex $argv 0]]
+
+set total ""
+set current ""
+
+proc foreach-i {r_index r_element slist block} {
+	set size [llength $slist]
+	upvar $r_index index
+	upvar $r_element element
+
+	for {set index 0} {$index < $size} {incr index} {
+		set element [lindex $slist $index]
+
+		set es [catch {uplevel $block} res]
+		#puts stderr "DEBUG: EVAL result=$es return=$res"
+		if {$es == 0 || $es == 4} {
+			continue
+		}
+		break
+	}
+
+	switch -- $es {
+		1 {
+			error $res
+		}
+
+		2 {
+			return -code return $res
+		}
+
+		default {
+			return -code $es $res
+		}
+	}
+}
+
+proc flush-ts {} {
+	global current
+	global total
+
+	if {$current == ""} {
+		return
+	}
+
+	set part [lindex $current 0]
+	lassign [split $part :] type spec
+
+	# Collect the number of TS packets of the same type.
+	set follow $type
+
+	set count 0
+	set lastx -1
+	#puts stderr "DEBUG: checking series starting with $part"
+	foreach-i i e $current {
+		set part [lindex $current 0]
+		set type [lindex [split $part :] 0]
+		if {$type != $follow} {
+			puts stderr "DEBUG: after $follow caught $type: total of $count"
+			break
+		}
+		incr count
+		set lastx $i
+	}
+
+	if {$i + 1 == [llength $current]} {
+		set current ""
+	} else {
+		set current [lrange $current [expr {$i+1}] end]
+	}
+
+	set out $count
+	if {$spec == "I"} {
+		lappend out i
+	}
+	lappend total $out
+}
+
+# First find the PAT entry.
+
+puts stderr "Finding PAT..."
+while { [gets $fd line] } {
+	if { [string range $line 0 2] != "I: " } {
+		continue
+	}
+
+	if { [string first "pid=0000" $line] == -1 } {
+		continue
+	}
+
+	break
+}
+
+if { [eof $fd] } {
+	error "PAT not found"
+}
+
+# Read the next line; should specify the PMT PID
+set line ""
+gets $fd line
+
+lassign $line number pmtpid
+
+# Expected is only one program, so identify and find the PMT
+
+lassign [split $pmtpid =] label pmtpid
+if {$label != "PID"} {
+	error "Wrong PAT entry: $line"
+}
+
+lappend current "T:PAT"
+
+puts stderr "PMT PID = $pmtpid"
+
+set pmtline ""
+
+while { [gets $fd line] } {
+	if { [string range $line 0 2] != "I: " } {
+		continue
+	}
+
+	if { [string first "pid=$pmtpid" $line] == -1 } {
+		continue
+	}
+
+	break
+}
+
+# Found PMT PID entry. Read next line - should be PMT
+set pmtline $line
+
+if {$pmtline == ""} {
+	error "PMT NOT FOUND"
+}
+
+gets $fd pmtline
+
+if {$pmtline != "PMT"} {
+	error "Wrong PMT"
+}
+
+lappend current "T:PMT"
+
+set pmtmap ""
+
+dict set pmtmap 0000 T:PAT
+dict set pmtmap $pmtpid T:PMT
+
+while { [gets $fd line] } {
+	set line [string trim $line]
+	if {$line == ""} {
+		break
+	}
+
+	set rest [lassign $line pidspec typespec typedesc]
+
+	lassign [split $pidspec =] lab pidval
+	if {$lab != "PID"} {
+		error "Wrong PMT entry line: $line"
+	}
+	
+	set pos [string first | $typedesc]
+	if {$pos == -1 } {
+		error "Wrong PMT entry typedesc: $typedesc"
+	}
+
+	set mediatype [string range $typedesc 1 $pos-1]
+	dict set pmtmap $pidval $mediatype
+}
+
+# XXX Here you can try to read the remaining parts of PMT
+# if it is split into multiple TS packets, possibly interleft
+# by TS packets of other streams. Here we state that it fits
+# in one TS packet.
+
+puts stderr mappings:
+foreach {key val} $pmtmap {
+	puts stderr " - $val: pid=$key"
+}
+
+flush-ts
+
+# Ok, now read the file and collect them
+
+while { [gets $fd line] != -1 } {
+	set line [string trim $line]
+
+	if { [string range $line 0 2] != "I: " } {
+		continue
+	}
+
+	set pos [string first "pid=" $line]
+	if {$pos == -1} {
+		error "Wrong stream line: $line"
+	}
+
+	set uline [string range $line $pos end-1]
+	set flags [lassign $uline pidspec kind type media]
+	lassign [split $pidspec =] lab pidval
+
+	if {![dict exists $pmtmap $pidval] } {
+		error "Unknown PID $pidval"
+	}
+
+	set pusi [expr {"PUSI" in $flags}]
+	set rai [expr {"RAI" in $flags}]
+	if {$pusi} {
+		flush-ts
+	}
+	
+	set frame [dict get $pmtmap $pidval]
+	if {$pusi && $rai} {
+		append frame ":I"
+	}
+
+	lappend current $frame
+}
+
+flush-ts
+
+puts stderr "----------------------"
+foreach l $total {
+	puts $l
+}
+

--- a/tools/bstow.md
+++ b/tools/bstow.md
@@ -1,0 +1,233 @@
+BSTOW
+=====
+
+This is a simulation development tool for sending the live stream using the
+stow mode.
+
+The BSTOW name stands for "binary stow" and it's a binary data container that
+provides payloads with associated parameters. It's a medium security format
+(less than the one with MPEG-TS) and it's intended to keep all the data in a
+file.
+
+A possible extension is to make it an index file to another file in the same
+directory, where instead of physical payload, there is only declared numeric
+offset of the beginning of the payload.
+
+
+Motivation
+==========
+
+The stow mode is a sending mode for a live stream, where packets still do
+have their smoothly distributed time gaps between single network packets,
+but the real time when the packet is sent is allowed to be earlier than
+at this very time.
+
+However, there are not many existing software solution that can work this
+way. Testing with `ffmpeg -re` is pointless - even if you can use a different
+time proportion between stream time and sending time than 1:1 using the
+`-readrate X` option (allowing to use X:1 proportion), it will speed up the
+right way only if you have a real live encoder (and for that case it could be
+adjusted to the needs) or when the reading application causes appropriate
+blocking while tracing the stream's times by itself.
+
+What really is needed is a situation that the frame is available as a whole
+at once (or at least a bigger portion of it), data are delivered with time gaps
+that correspond to the framerate, and even if the data are split into single
+packets that fit in a network packet with their defined sending time, the whole
+series of packets that carry a single frame are all available at once. It would
+be then up to the decision of the application whether to send the packet
+physically at the declared time, or earlier.
+
+
+BSTOW format
+============
+
+The general format is the following:
+
+* The 4-byte constant header
+* The parameter with the value
+* The payload (if required by the parameter)
+
+The header consists of 4 bytes, in HEX: `BE 57 08 88`.
+
+The parameter uses special value-length encoding:
+
+1. 4 bytes are read as A, B, C, D.
+2. If byte A has the 0x80 bit clear, the format is: A[label], B:C:D[value]
+3. If byte A has the 0x80 bit set, then:
+   * A:B & 0x7F : label
+   * C:D : length
+   * Further bytes of that length: value
+
+All of values, labels and length specifications are encoded as Big Endian.
+
+So, for example:
+
+* 01 03 AB 02 - LABEL=1, VALUE=0x03AB02
+* 80 02 00 04 DE AD BE EF - LABEL=2 VALUE=0xDEADBEEF
+
+Parameters are the following:
+
+* LENGTH: 1 : length of the payload
+* PLAYTIME: 2 : block's timestamp (DTS in video terms)
+* SENDTIME: 3 : packet's timestamp (smooth-scaled bitrate)
+* DATA : 0x7F : end of parameters, start of the payload
+
+Parameters should be specified in total as first and the DATA parameter
+should be the last one, with just 0 value, followed by the payload. The
+payload should have the length as declared in the LENGTH parameter. The
+PLAYTIME and SENDTIME parameters' values and presence depend on the
+position of the payload in the structure.
+
+
+The BSTOW file structure
+========================
+
+The BSTOW file consists of single packet declarations, that is, payloads
+with attached parameters, but the shape of the parameters define also the
+structure.
+
+The BSTOW system consists of 3 layers of information:
+
+1. Series
+2. Block
+3. Packet
+
+Meaning, Series contains multiple Blocks, and a Block contains multiple
+Packets.
+
+To help you imagine how it maps to real MPEG-TS structure:
+
+* Packet is one portion of data that can be sent over network at once.
+
+* Block is a portion of data representing a single frame. This need not
+be just the video frame, it can be also additional data, and also not only
+audio data, but audio data happen to be also "attached" to the corresponding
+frame and gets completed together of the particular video frame data.
+
+* Series collects blocks that belong to one GOP. In other words, it's a series
+of blocks that start with the I-Frame and ends before the next I-Frame.
+
+Now that the structure is explained, the PLAYTIME and SENDTIME parameters
+can be explained with more precision:
+
+* PLAYTIME corresponds to the video frame's DTS, and it's only specified in
+the first Packet of the Block. Playtime is monotonic; it can be generated
+basing on the timestamp read from the video frame in MPEG-TS, but discontinuity
+must be detected and handled when translating the timestamps.
+
+* SENDTIME is specified in every packet in the series, except the first one
+(or the first one has simply the 0 value). The value should designate the time
+when the packet has to be send according to the smooth time distribution rules
+of the live stream, expressed as the time distance between this packet and the
+first packet of the series. Note that even though the first pakcet of a block
+does define its PLAYTIME, the SENDTIME is still defined according to this rule.
+
+As an example how this might be distributed, a list of packets:
+
+* 0001: (series: 1) (block: 1) PLAYTIME=1000
+* 0002: SENDTIME=3
+* 0003: SENDTIME=6
+* 0004: SENDTIME=9
+* 0005: SENDTIME=12
+* 0006: SENDTIME=15
+* 0007: SENDTIME=18
+* 0008: (block: 2) PLAYTIME=1020 SENDTIME=21
+* 0009: SENDTIME=24
+* 0010: SENDTIME=27
+* 0011: SENDTIME=30
+* 0012: SENDTIME=33
+* 0013: SENDTIME=36
+* 0014: (series: 2) (block: 1) PLAYTIME=1040
+* 0015: SENDTIME=3
+* 0016: SENDTIME=6
+
+The reading rules are the following:
+
+1. The reading starts with the packet that declares the first in the series.
+Sending time should be immediate and the application should use this as a base
+time for any further sendings. The playtime should be remembered for next
+calculations as well, and also the time when sending of the first packet happened.
+
+2. Reading the next packet gets the sendtime and the value should be translated
+to the sending time in the application by adding this value to the base value.
+
+3. Reading the first packet of the next block in the series should read the
+playtime, but it's not significant for any data. This is only to allow for
+simulation of the live encoder: the current time should be decreased by the
+time of sending the first packet of the previous block, and if the distance
+is different than the distance of the playtime declared in these packets, the
+application should simulate non-readiness of the frame by sleeping for the
+remaining time.
+
+4. Reading the first packet of the next series should do the following:
+
+   * Determine the alleged sendtime for this packet from the distance from
+the last packet of the previous series
+
+   * Calculate the the distance between this value and the send time base.
+
+   * Compare this distance with the distance between the playtime values of
+this one and the first packet of the previous series
+
+   * Prepare compensation for the difference between these two values:
+
+      - if sending was too fast, simply add the difference to the send time
+of the first pakcet
+
+      - if sending was too slow, remember the difference in the compensation
+register and distribute it with the next sent packets as much as possible
+
+Example reading session for the above packet example:
+
+Initial playtime: 1000
+Initial sendtime: 10000
+
+Sending times with comments:
+
+* 0001: 10000 (taking initial)
+* 0002: 10003
+* 0003: 10006
+* 0004: 10009
+* 0005: 10012
+* 0006: 10015
+* 0007: 10018
+* 0008: 10021 (pause for up to 20ms before delivery)
+* 0009: 10024
+* 0010: 10027
+* 0011: 10030
+* 0012: 10033
+* 0013: 10036
+* 0014: [calculations (see below)] : 10040
+* 0015: 10043
+* 0016: 10046
+
+Calculations:
+
+* PLAYTIME distance: 40
+* Last send gap: 10036-10033 = 3
+* New packet sendtime = last packet + last gap = 10036+3 = 10039
+* SENDTIME distance: 10039 - 10000 = 39
+* DEVIATION = PLAYTIME distance - SENDTIME distance = 1
+* Compensation method:
+   - One shot fix for sendtime: +1
+   - SENDTIME = 10039 + 1 = 10040
+
+
+Testing with SRT
+================
+
+For SRT there's a specific application prepared: `srt-test-stow`, which uses
+the BSTOW file as the source and SRT endpoint for sending.
+
+The `senmode` option should be configured by the user - default options remain
+default, so the default mode is live: packets are sent immediately upon arrival.
+The application obtains the sendtime directly from the BSTOW reader and sets it
+into the packet's timestamp; sleeps between sending is another matter.
+
+Amont the sendmode values there are 3 possibilities:
+
+* 0 (default): live mode (send immediately upon arrival)
+* 1: eager mode - send with speedup and controlled speed
+* 2: planned mode - send the packets exactly according to the declared sendtime
+

--- a/tools/bstow.md
+++ b/tools/bstow.md
@@ -120,7 +120,7 @@ must be detected and handled when translating the timestamps.
 (or the first one has simply the 0 value). The value should designate the time
 when the packet has to be send according to the smooth time distribution rules
 of the live stream, expressed as the time distance between this packet and the
-first packet of the series. Note that even though the first pakcet of a block
+first packet of the series. Note that even though the first packet of a block
 does define its PLAYTIME, the SENDTIME is still defined according to this rule.
 
 As an example how this might be distributed, a list of packets:
@@ -173,7 +173,7 @@ this one and the first packet of the previous series
    * Prepare compensation for the difference between these two values:
 
       - if sending was too fast, simply add the difference to the send time
-of the first pakcet
+of the first packet
 
       - if sending was too slow, remember the difference in the compensation
 register and distribute it with the next sent packets as much as possible
@@ -225,7 +225,7 @@ default, so the default mode is live: packets are sent immediately upon arrival.
 The application obtains the sendtime directly from the BSTOW reader and sets it
 into the packet's timestamp; sleeps between sending is another matter.
 
-Amont the sendmode values there are 3 possibilities:
+Among the sendmode values there are 3 possibilities:
 
 * 0 (default): live mode (send immediately upon arrival)
 * 1: eager mode - send with speedup and controlled speed

--- a/tools/bstow.md
+++ b/tools/bstow.md
@@ -53,20 +53,20 @@ The header consists of 4 bytes, in HEX: `BE 57 08 88`.
 The parameter uses special value-length encoding:
 
 1. 4 bytes are read as A, B, C, D.
-2. If byte A has the 0x80 bit clear, the format is: A[label], B:C:D[value]
+2. If byte A has the 0x80 bit clear, the format is: LABEL = A, VALUE = B:C:D
 3. If byte A has the 0x80 bit set, then:
-   * A:B & 0x7F : label
-   * C:D : length
-   * Further bytes of that length: value
+   * LABEL = A:B & 0x7FFF
+   * LENGTH = C:D
+   * VALUE = Further bytes of that LENGTH
 
-All of values, labels and length specifications are encoded as Big Endian.
+All multi-byte values are encoded as Big Endian.
 
 So, for example:
 
 * 01 03 AB 02 - LABEL=1, VALUE=0x03AB02
 * 80 02 00 04 DE AD BE EF - LABEL=2 VALUE=0xDEADBEEF
 
-Parameters are the following:
+Parameters use the following LABELs:
 
 * LENGTH: 1 : length of the payload
 * PLAYTIME: 2 : block's timestamp (DTS in video terms)
@@ -144,7 +144,7 @@ As an example how this might be distributed, a list of packets:
 
 The reading rules are the following:
 
-1. The reading starts with the packet that declares the first in the series.
+1. The reading starts with the packet declared as the first in the series.
 Sending time should be immediate and the application should use this as a base
 time for any further sendings. The playtime should be remembered for next
 calculations as well, and also the time when sending of the first packet happened.
@@ -180,12 +180,11 @@ register and distribute it with the next sent packets as much as possible
 
 Example reading session for the above packet example:
 
-Initial playtime: 1000
-Initial sendtime: 10000
+Initial playtime = 1000, sendtime = 10000
 
 Sending times with comments:
 
-* 0001: 10000 (taking initial)
+* 0001: 10000 (taking initial, sendtime base = 10000)
 * 0002: 10003
 * 0003: 10006
 * 0004: 10009
@@ -198,7 +197,7 @@ Sending times with comments:
 * 0011: 10030
 * 0012: 10033
 * 0013: 10036
-* 0014: [calculations (see below)] : 10040
+* 0014: 10040 (see Calculations below, new sendtime base = 10040)
 * 0015: 10043
 * 0016: 10046
 

--- a/tools/hvu_bigendian.h
+++ b/tools/hvu_bigendian.h
@@ -1,0 +1,210 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2027 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+#ifndef INC_HVU_BIGENDIAN_H
+#define INC_HVU_BIGENDIAN_H
+
+#include <cstdint>
+#include <cstring>
+
+namespace hvu
+{
+
+template <size_t LEN>
+struct BECodec
+{
+    static void parse(const uint8_t* buffer, uint64_t& out)
+    {
+        out = (out << 8) | *buffer;
+        BECodec<LEN-1>::parse(buffer+1, (out));
+    }
+
+    // This is more universal, but it's clumsy to use as an
+    // API so it's for internal purposes for ParseBE_Set.
+    template <class Integer>
+    static void parse_type(const uint8_t* buffer, Integer& out)
+    {
+        out = (out << 8) | *buffer;
+        BECodec<LEN-1>::parse_type(buffer+1, (out));
+    }
+
+    template <class Integer>
+    static void format(Integer value, void* buffer)
+    {
+        uint8_t* real_buffer = (uint8_t*)buffer;
+        BECodec<LEN-1>::format(value >> 8, real_buffer);
+        real_buffer[LEN-1] = value & 0xFF;
+    }
+};
+
+template <>
+struct BECodec<0>
+{
+    static void parse(const uint8_t* /*buffer*/, uint64_t& /*out*/)
+    {
+        // Do nothing to close the tail.
+    }
+
+    template <class Integer>
+    static void parse_type(const uint8_t* , Integer& )
+    {
+        // Do nothing to close the tail.
+    }
+
+    template <class Integer>
+    static void format(Integer /*value*/, void* /*buffer*/)
+    {
+        // Do nothing to close the tail.
+    }
+};
+
+// Compile-time Big Endian parsing.
+// The declared LEN will be used from the buffer.
+
+template<size_t LEN>
+inline uint64_t ParseBE(const void* buffer)
+{
+    const uint8_t* real_buffer = (const uint8_t*)buffer;
+    uint64_t ret = 0;
+    BECodec<LEN>::parse(real_buffer, (ret));
+    return ret;
+}
+
+// Simpler version that takes the type of the output integer
+// as a good deal for the size.
+// Recommended for signed integers, as it doesn't align the
+// type to uint64_t so that it can be returned.
+template<class Integer>
+inline void ParseBE_Set(Integer& w_out, const void* buffer)
+{
+    const uint8_t* real_buffer = (const uint8_t*)buffer;
+    static const size_t LEN = sizeof (Integer);
+    w_out = Integer(); // Zero the value first
+    BECodec<LEN>::parse_type(real_buffer, (w_out));
+}
+
+// Compile-time Big Endian formatter.
+// The declared LEN of the buffer will be written to.
+// Note that you can use any integer and any target type.
+template <size_t N, class Integer>
+inline void FormatBE(Integer value, void* buffer)
+{
+    BECodec<N>::template format<Integer>(value, buffer);
+}
+
+
+// Runtime versions
+inline uint64_t ParseBE(const uint8_t* buffer, size_t len)
+{
+    uint64_t out = 0;
+    for (size_t i = 0; i < len; ++i)
+    {
+        out = (out << 8) | buffer[i];
+    }
+    return out;
+}
+
+// This function stores the 64-bit integer value into the given buffer
+// in the Big Endian order. As per 64-bit, it uses the maximum of 8
+// bytes of the buffer (if a bigger buffer is supplied, the parts over
+// 8 bytes are never filled). The supplied buffer is allowed to be less than
+// 8 bytes, but it must be big enough to accomodate the value or otherwise
+// the value 0 is returned as error.
+//
+// With the right alignment, the whole 8-byte result is copied to the
+// supplied buffer, with skipped the leftmost 0 bytes if the buffer is
+// smaller. The number of filled bytes is the size of the buffer or 8
+// if the buffer size was greater. The returned size is the number of
+// significant bytes, not the number of filled buffer bytes.
+//
+// With left alignment, only since the first nonzero byte the value is
+// copied to the supplied buffer. The returned value is the number of
+// written bytes into the buffer (the remaining space of the buffer is
+// untouched).
+//
+// Not exactly a good idea to have a boolean argument, but seems well to have
+// LEFT : false, RIGHT : true.
+inline size_t FormatBE(uint64_t value, uint8_t* pw_buffer, size_t bufsize, bool align_right = true)
+{
+    uint8_t buffer[8];
+    buffer[0] = uint8_t(value >> 56);
+    buffer[1] = uint8_t(value >> 48);
+    buffer[2] = uint8_t(value >> 40);
+    buffer[3] = uint8_t(value >> 32);
+    buffer[4] = uint8_t(value >> 24);
+    buffer[5] = uint8_t(value >> 16);
+    buffer[6] = uint8_t(value >> 8);
+    buffer[7] = uint8_t(value >> 0);
+
+    size_t size = 8;
+    while (buffer[8 - size] == 0)
+    {
+        --size;
+
+        // If size reached 1, there still can be 0 at the [7]
+        // position and pass the next check. If that happens,
+        // we just have the zero value that can be encoded on 1 byte.
+        if (size == 1)
+            break;
+    }
+
+    const size_t zpos = 8 - size;
+
+    // Buffer size can be less than 8, but
+    // it must be capable of accommodating the
+    // resulting value.
+    if (size > bufsize)
+        return 0;
+
+    // Example:
+    // bufsize = 3
+    // zpos = 6 (all are zeros except last 2 bytes) [0 0 0 0 0 0 X Y]
+    // size = 8 - 6 = 2                                          | |
+
+    if (align_right)
+    {
+        // Copy the whole buffer, just skip zeros                | |
+        // that don't fit in the target buffer
+
+        // Continued example:                                    | |
+        // startpos = 3 - 2 = 1
+        // memcpy(pw_buffer, buffer + 1, 3); -------->        [0 X Y]
+
+        // 
+        size_t startpos;
+        if (bufsize < 8)
+        {
+            // Skip so many initial zeros as needed to
+            // only leave the zero-filling for the unused
+            // part of the buffer
+            startpos = 8 - bufsize;
+        }
+        else
+        {
+            startpos = 0;
+            bufsize = 8; // Copy maximum 8 bytes
+        }
+
+        memcpy(pw_buffer, buffer + startpos, bufsize); //        | |
+        return size;
+    }
+
+    // In the example:
+    // zspace = 3 - 2 = 1                                        | |
+    // memcpy(pw_buffer, buffer + 6, 2);  ------------------>   [X Y _]
+
+    memcpy(pw_buffer, buffer + zpos, size);
+
+    return size;
+}
+
+}
+
+#endif

--- a/tools/hvu_bigendian.h
+++ b/tools/hvu_bigendian.h
@@ -115,7 +115,7 @@ inline uint64_t ParseBE(const uint8_t* buffer, size_t len)
 // in the Big Endian order. As per 64-bit, it uses the maximum of 8
 // bytes of the buffer (if a bigger buffer is supplied, the parts over
 // 8 bytes are never filled). The supplied buffer is allowed to be less than
-// 8 bytes, but it must be big enough to accomodate the value or otherwise
+// 8 bytes, but it must be big enough to accommodate the value or otherwise
 // the value 0 is returned as error.
 //
 // With the right alignment, the whole 8-byte result is copied to the

--- a/tools/hvu_debug.h
+++ b/tools/hvu_debug.h
@@ -1,0 +1,23 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2027 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+#ifndef INC_HVU_DEBUG_H
+#define INC_HVU_DEBUG_H
+
+#if defined(__x86_64__) || defined(__i386__)
+    #define HVU_DEBUG_BREAK() __asm__ volatile("int $3")
+#elif defined(__aarch64__) || defined(__arm__)
+    #define HVU_DEBUG_BREAK() __asm__ volatile("brk #0")
+#else
+    #include <signal.h>
+    #define HVU_DEBUG_BREAK() raise(SIGTRAP) // Fallback for other architectures
+#endif
+
+#endif

--- a/tools/srt-test-stow.cpp
+++ b/tools/srt-test-stow.cpp
@@ -1,0 +1,290 @@
+/*
+ * SRT - Secure, Reliable, Transport
+ * Copyright (c) 2018 Haivision Systems Inc.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * 
+ */
+
+// NOTE: This application uses C++11.
+
+#include <csignal>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <iterator>
+
+#include "hvu_compat.h"
+#include "apputil.hpp"
+#include "uriparser.hpp"  // UriParser
+#include "socketoptions.hpp"
+#include "testmedia.hpp" // requires access to SRT-dependent globals
+#include "verbose.hpp"
+#include "bstow-read.hpp"
+
+#include "ofmt.h"
+
+// NOTE: This is without "srt/" because it uses an internal path
+// to the library. Application using the "installed" library should
+// use <srt/srt.h>
+#include <srt.h>
+#include <access_control.h>
+#include <logging.h>
+#include <logger_fas.h>
+
+using namespace std;
+using namespace srt;
+
+hvu::logging::Logger applog("app", srt::logging::logger_config(), true, "srt-stow");
+
+void OnINT_ForceExit(int)
+{
+    cerr << "\n-------- REQUESTED INTERRUPT!\n";
+    transmit_int_state = true;
+}
+
+
+int main( int argc, char** argv )
+{
+    // This is mainly required on Windows to initialize the network system,
+    // for a case when the instance would use UDP. SRT does it on its own, independently.
+    if ( !SysInitializeNetwork() )
+        throw std::runtime_error("Can't initialize network!");
+
+    srt_startup();
+
+    // Symmetrically, this does a cleanup; put into a local destructor to ensure that
+    // it's called regardless of how this function returns.
+    struct NetworkCleanup
+    {
+        ~NetworkCleanup()
+        {
+            SysCleanupNetwork();
+            srt_cleanup();
+        }
+    } cleanupobj;
+
+    signal(SIGINT, OnINT_ForceExit);
+    signal(SIGTERM, OnINT_ForceExit);
+
+    OptionHandler optargs;
+
+    OptionName
+        o_timeout   ((optargs), "<timeout[s]=0> Data transmission timeout", "t",   "to", "timeout" ),
+        o_loglevel  ((optargs), "<severity> Minimum severity for logs (see --help logging)", "ll",  "loglevel"),
+        o_logfa     ((optargs), "<FA=FA-list...> Enabled Functional Areas (see --help logging)", "lfa", "logfa"),
+        o_logfile   ((optargs), "<filepath> File to send logs to", "lf",  "logfile"),
+        o_verbose   ((optargs), OptionScheme::ARG_OPT(1), "Print size of every packet transferred on stdout", "v",   "verbose"),
+        o_help      ((optargs), "[special=logging] This help", "?",   "help", "-help")
+            ;
+
+    OptionStatus ost = optargs.process(argv, argc);
+
+    bool need_help = optargs.exists(o_help);
+
+    vector<string> args = optargs[""];
+
+    if (!ost)
+    {
+        ofprintl(cerr, "ERROR: -", ost.error_option, ": ", ost.error_code_str());
+        need_help = true;
+    }
+
+    if (args.size() != 2)
+    {
+        need_help = true;
+    }
+
+    if (need_help)
+    {
+        ofprintl(cerr, "Usage: ", argv[0], " <BSTOW data URI> <SRT target>");
+        for (auto os: optargs.options())
+            cout << os.helpitem() << endl;
+        return 1;
+    }
+
+    // This is set always in the STOW application.
+    transmit_use_sourcetime = 1;
+    Verbose::on = optargs.exists(o_verbose);
+    if (Verbose::on)
+    {
+        int verbchan = optargs.get(o_verbose);
+        if (verbchan)
+        {
+            if (verbchan == 1)
+                Verbose::cverb = &std::cout;
+            else if (verbchan == 2)
+                Verbose::cverb = &std::cerr;
+            else
+            {
+                ofprintl(cerr, "OPTION: -v requires optionally 1 (stdout) or 2 (stderr)");
+                return -1;
+            }
+        }
+    }
+
+    string loglevel = optargs.get(o_loglevel, "error");
+    vector<string> logfa = optargs.get(o_logfa);
+
+    srt_setloglevel(hvu::logging::parse_level(loglevel));
+    string logfa_on, logfa_off;
+    ParseLogFASpec(logfa, (logfa_on), (logfa_off));
+
+    set<int> fasoff = hvu::logging::parse_fa(srt::logging::logger_config(), logfa_off);
+    set<string> missing_on;
+    set<int> fason = hvu::logging::parse_fa(srt::logging::logger_config(), logfa_on, &missing_on);
+
+    auto fa_del = [fasoff]() {
+        for (set<int>::iterator i = fasoff.begin(); i != fasoff.end(); ++i)
+            srt_dellogfa(*i);
+    };
+
+    auto fa_add = [fason]() {
+        for (set<int>::iterator i = fason.begin(); i != fason.end(); ++i)
+            srt_addlogfa(*i);
+    };
+
+    if (logfa_off == "all")
+    {
+        // If the spec is:
+        //     -lfa ~all control app
+        // then we first delete all, then enable given ones
+        fa_del();
+        fa_add();
+    }
+    else
+    {
+        // Otherwise we first add all those that have to be added,
+        // then delete those unwanted. This embraces both
+        //   -lfa control app ~cc
+        // and
+        //   -lfa all ~cc
+        fa_add();
+        fa_del();
+    }
+
+    if (!missing_on.empty())
+    {
+        cerr << "WARNING: unknown logging FA: ";
+        copy(missing_on.begin(), missing_on.end(), ostream_iterator<string>(cerr, " "));
+        cerr << endl;
+    }
+
+    std::ofstream logfile_stream; // leave unused if not set
+    string logfile = optargs.get(o_logfile);
+    if (logfile != "")
+    {
+        logfile_stream.open(logfile.c_str());
+        if ( !logfile_stream )
+        {
+            cerr << "ERROR: Can't open '" << logfile << "' for writing - fallback to cerr\n";
+        }
+        else
+        {
+            srt::setlogstream(logfile_stream);
+        }
+    }
+
+    // In this application you can only have a source file
+    // and target SRT.
+    // File will be accessed specific way, so don't use FileSource,
+    // just directly ifstream.
+
+    ifstream src;
+    unique_ptr<SrtTarget> tar;
+
+    int app_result = 0;
+    try
+    {
+        // Ok, now file
+
+        string srcname = args[0];
+        if (srcname.find("file://") == 0)
+        {
+            srcname = srcname.substr(7);
+            if (srcname == "con")
+            {
+                ofprintl(cerr, "Console input (stdin) not supported. Use file path");
+                throw TransmissionError("Can't open file");
+            }
+        }
+
+        bstow::PacketReader r(args[0]);
+        UriParser u = args[1];
+
+        if (u.type() != UriParser::SRT)
+        {
+            ofprintl(cerr, "Target URI: '", args[1], "' not supported - SRT only");
+            throw TransmissionError("Wrong target medium");
+        }
+
+        tar.reset( new SrtTarget(u.host(), u.portno(), u.path(), u.parameters()) );
+
+        // Default transmitmedia settings
+        ::transmit_use_sourcetime = true;
+
+        // XXX  TESTING
+        ofprintl(cout, "SOURCE FILE: ", srcname);
+        ofprintl(cout, "OUTPUT: ", u.uri());
+
+        if (!r.Prepare(srt_time_now()))
+        {
+            ofprintl(cerr, "TS file indexing failed");
+            throw TransmissionError("Wrong source medium");
+        }
+
+        // XXX LOOP, END.
+        for (;;)
+        {
+            Verb("[.", VerbNoEOL);
+
+            // This call will block by sleeping up to the time
+            // designated as the timestamp of the next frame.
+            Verb(", ... ", VerbNoEOL);
+            const MediaPacket data = r.Read();
+            Verb(", ", data.payload.size(),
+                    " T=", data.time,
+                    "  ->  ", VerbNoEOL);
+            if (data.payload.empty() && r.End())
+            {
+                Verb("EOS");
+                throw Source::ReadEOF("EOS");
+            }
+
+            tar->Write(data);
+            Verb(".] ", VerbNoEOL);
+            if (tar->Broken())
+                break;
+            if (::transmit_int_state)
+            {
+                Verror("\n (interrupted on request)");
+                break;
+            }
+            Verb("sent");
+        }
+    }
+    catch (TransmissionError& e)
+    {
+        ofprintl(cerr, "ERROR: ", e.what());
+        app_result = 1;
+    }
+    catch (ios::failure&)
+    {
+        ofprintl(cerr, "Source file '", args[0], "' not found");
+        app_result = 1;
+    }
+    // Do cleanup manually to avoid destructor-based calls prematurely.
+    srt_cleanup();
+
+    // Unregister the file if it was used as logging target to prevent
+    // accessing a deleted file in logs called in the destructor.
+    srt::setlogstream(cerr);
+
+    return app_result;
+}
+
+

--- a/tools/srt-test-stow.maf
+++ b/tools/srt-test-stow.maf
@@ -1,0 +1,12 @@
+
+SOURCES
+srt-test-stow.cpp
+testmedia.cpp
+bstow-read.cpp
+bstow-log.cpp
+../apps/apputil.cpp
+../apps/options.cpp
+../apps/statswriter.cpp
+../apps/verbose.cpp
+../apps/socketoptions.cpp
+../apps/uriparser.cpp


### PR DESCRIPTION
BSTOW: A binary file format and reading system for the data stream split into data portions of various sizes, intended to be sent with smoothly distributed time, like in the live stream.

The general idea for generation is based on "frame" distribution, where every frame is a portion of data to be then sent over the network, so the data have to be split into smaller portions, each one sendable through a single UDP or SRT packet.

The generation rules: The input file *.bsrc should define initial parameters with the unit size (188 for TS), framerate (DTS distance between two consecutive frames, inverted), and intended bitrate. Following lines declare the frame size (in units of unit size), optionally followed by markers, currently only "i", which means the first frame of the series. The bitrate will be used for time distribution throughout the while GOP and the sendnig time will be synchronized at the edge of the "i"-frame.

The *.bs file, which is the BSTOW file, should contain a header, followed finally by the payload; the header defines the data size and other parameters, such as play-timestamp and packet-timestride. The BSTOW file contains blocks split into the size bearable by UDP, so there are 3 levels of containment:

* SERIES (GOP otherwise),
* FRAMES (one represented by a single line in *.bsrc file)
* PACKETS (a single unit that can be sent over the network)

The play-timestamp parameter is provided with every first packet of the FRAME. The packet-timestride is a relative time value that defines the sending time distance towards the first packet of the SERIES (it is not declared and it's always 0 for this very packet).

Finally, the tool that would like to send the data from the *.bs file over the live streaming network should read them using the bstow reader API. This API will be then simulating the real-world encoder that provides a single frame only if it's currently available. Therefor it will be providing packets of the frame, together with their sending time, however all packets of a single frame will be available to read, as long as this frame becomes available. It is then up to the application if it wants to send these packets immediately, or according to the declared send time, or will control the sending speed by itself.

The `srt-test-stow` application has been designed to send the contents of the *.bs file over the SRT connection.