### PR TITLE
[core] Fixes for rough cleanup actions

### DIFF
--- a/srtcore/api.cpp
+++ b/srtcore/api.cpp
@@ -451,7 +451,7 @@ int srt::CUDTUnited::cleanup()
         return 0;
 
     stopGarbageCollector();
-    closeAllSockets();
+    cleanupAllSockets();
     return 0;
 }
 

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -608,6 +608,7 @@ struct CMultiplexer
 
     ~CMultiplexer()
     {
+        stop(); // just in case
         if (m_pRcvQueue != NULL)
             delete m_pRcvQueue;
         if (m_pSndQueue != NULL)


### PR DESCRIPTION
Changes:

* Cleanup action uses `cleanupAllSockets` rather than `closeAllSockets`. This is a thread-unaware version which does the cleanup with an assumption that no other SRT threads are running
* Added `stop()` call in the CMultiplexer's destructor, as a completion for a possibly non-joined threads of the worker queues