### PR TITLE
[core][test] Fixed potential crash and wrong buffer state through outdated positionals

### DIFF
--- a/srtcore/buffer_rcv.cpp
+++ b/srtcore/buffer_rcv.cpp
@@ -252,7 +252,11 @@ std::pair<int, int> CRcvBuffer::dropUpTo(int32_t seqno)
         updateNonreadPos();
     }
     if (!m_tsbpd.isEnabled() && m_bMessageAPI)
+    {
+        if (!isInRange(m_iStartPos, m_iMaxPosOff, m_szSize, m_iFirstReadableOutOfOrder))
+            m_iFirstReadableOutOfOrder = -1; // reset if outdated
         updateFirstReadableOutOfOrder();
+    }
     return std::make_pair(iNumDropped, iNumDiscarded);
 }
 
@@ -478,13 +482,21 @@ int CRcvBuffer::readMessage(char* data, size_t len, SRT_MSGCTRL* msgctrl)
     if (!isInRange(m_iStartPos, m_iMaxPosOff, m_szSize, m_iFirstNonreadPos))
     {
         m_iFirstNonreadPos = m_iStartPos;
-        //updateNonreadPos();
+        updateNonreadPos();
     }
 
-    if (!m_tsbpd.isEnabled())
-        // We need updateFirstReadableOutOfOrder() here even if we are reading inorder,
-        // in case readable inorder packets are all read out.
-        updateFirstReadableOutOfOrder();
+    if (!m_tsbpd.isEnabled() && m_bMessageAPI) // ONLY in strict message mode
+    {
+        if (!isInRange(m_iStartPos, m_iMaxPosOff, m_szSize, m_iFirstReadableOutOfOrder))
+            m_iFirstReadableOutOfOrder = -1; // reset if outdated
+
+        if (m_iFirstReadableOutOfOrder == -1)
+        {
+            // We need updateFirstReadableOutOfOrder() here even if we are reading inorder,
+            // in case readable inorder packets are all read out.
+            updateFirstReadableOutOfOrder();
+        }
+    }
 
     const int bytes_read = int(dst - data);
     if (bytes_read < bytes_extracted)
@@ -614,6 +626,19 @@ int CRcvBuffer::readBufferToFile(fstream& ofs, int len)
 bool CRcvBuffer::hasAvailablePackets() const
 {
     return hasReadableInorderPkts() || (m_numOutOfOrderPackets > 0 && m_iFirstReadableOutOfOrder != -1);
+}
+
+// Specialization for testing. Returns:
+// -1: No available packets to read
+// 0: Next available packet is the first in the buffer
+// 1+: Next available packet is out-of-order (returns number of avail packets)
+int CRcvBuffer::readablePacketsState() const
+{
+    if (hasReadableInorderPkts())
+        return 0;
+    if (m_numOutOfOrderPackets > 0 && m_iFirstReadableOutOfOrder != -1)
+        return m_numOutOfOrderPackets;
+    return -1;
 }
 
 int CRcvBuffer::getRcvDataSize() const

--- a/srtcore/buffer_rcv.h
+++ b/srtcore/buffer_rcv.h
@@ -254,6 +254,8 @@ public: // Used for testing
     /// Peek unit in position of seqno
     const CUnit* peek(int32_t seqno);
 
+    int readablePacketsState() const;
+
 private:
     inline int incPos(int pos, int inc = 1) const { return (pos + inc) % m_szSize; }
     inline int decPos(int pos) const { return (pos - 1) >= 0 ? (pos - 1) : int(m_szSize - 1); }

--- a/test/test_buffer_rcv.cpp
+++ b/test/test_buffer_rcv.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <numeric>
+#include <iostream>
 #include "gtest/gtest.h"
 #include "buffer_rcv.h"
 
@@ -19,6 +20,48 @@ protected:
     virtual ~CRcvBufferReadMsg()
     {
         // cleanup any pending stuff, but no exceptions allowed
+    }
+
+    struct Message
+    {
+        size_t m_npackets = 0;
+        size_t m_nmissing = 0;
+        int32_t m_msgno = 1;
+        int32_t m_start_seqno = -1;
+        bool m_unordered = false;
+        int64_t m_ts = 0;
+        bool m_recovered = false;
+
+        Message() {}
+        Message(size_t size): m_npackets(size) {}
+
+#define PARAM(type, name, body) Message& name(type par) { body; return *this; }
+        PARAM(size_t, npackets, m_npackets = par);
+        PARAM(size_t, nmissing, m_nmissing = par);
+        PARAM(int32_t, msgno, m_msgno = par);
+        PARAM(int32_t, isn, m_start_seqno = par);
+        PARAM(int64_t, ts, m_ts = par);
+        Message& nonorder(bool par = true) { m_unordered = par; return *this; };
+        Message& recovered(bool par = true) { m_recovered = par; return *this; };
+#undef PARAM
+
+    };
+
+    // Private utility
+    void pcout() {}
+
+    template<class Arg1, class... Args>
+    void pcout(const Arg1& arg1, const Args&... args)
+    {
+        std::cout << arg1;
+        return pcout(args...);
+    }
+
+    template<class... Args>
+    void pcoutl(const Args&... args)
+    {
+        pcout(args...);
+        std::cout << std::endl;
     }
 
 protected:
@@ -82,11 +125,19 @@ public:
     /// @returns 0 on success, the result of rcv_buffer::insert(..) once it failed
     int addMessage(size_t msg_len_pkts, int msgno, int start_seqno, bool out_of_order = false, int ts = 0)
     {
-        for (size_t i = 0; i < msg_len_pkts; ++i)
+        return add(Message(msg_len_pkts).msgno(msgno).isn(start_seqno).nonorder(out_of_order).ts(ts));
+    }
+
+    int add(const Message& m)
+    {
+        if (m.m_npackets == 0 || m.m_start_seqno == -1 || m.m_nmissing >= m.m_npackets)
+            throw std::invalid_argument("Wrong usage of add(Message)");
+
+        for (size_t i = 0; i < m.m_npackets - m.m_nmissing; ++i)
         {
-            const bool pb_first = (i == 0);
-            const bool pb_last = (i == (msg_len_pkts - 1));
-            const int res = addPacket(start_seqno + int(i), msgno, pb_first, pb_last, out_of_order, ts);
+            const bool pb_first = (i == 0 && !m.m_recovered);
+            const bool pb_last = (i == (m.m_npackets - 1));
+            const int res = addPacket(CSeqNo::incseq(m.m_start_seqno, i), m.m_msgno, pb_first, pb_last, m.m_unordered, m.m_ts);
 
             if (res != 0)
                 return res;
@@ -121,7 +172,7 @@ public:
 
     int readMessage(char* data, size_t len)
     {
-        return m_rcv_buffer->readMessage(data, len);
+        return m_rcv_buffer->readMessage(data, len, &m_readctrl);
     }
 
     bool hasAvailablePackets()
@@ -137,6 +188,7 @@ protected:
     int m_first_unack_seqno = m_init_seqno;
     static const size_t m_payload_sz = 1456;
     const bool m_use_message_api;
+    SRT_MSGCTRL m_readctrl;
 
     const sync::steady_clock::time_point m_tsbpd_base = sync::steady_clock::now(); // now() - HS.timestamp, microseconds
     const sync::steady_clock::duration m_delay = sync::milliseconds_from(200);
@@ -155,7 +207,12 @@ TEST_F(CRcvBufferReadMsg, Destroy)
     // Add a number of units (packets) to the buffer
     // equal to the buffer size in packets
     for (int i = 0; i < getAvailBufferSize(); ++i)
-        EXPECT_EQ(addMessage(1, i + 1, CSeqNo::incseq(m_init_seqno, i)), 0);
+        EXPECT_EQ(
+                add(
+                    Message(1)
+                        .msgno(i + 1)
+                        .isn(CSeqNo::incseq(m_init_seqno, i))),
+                0);
 
     m_rcv_buffer.reset();
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
@@ -485,6 +542,106 @@ TEST_F(CRcvBufferReadMsg, SmallReadBuffer)
     EXPECT_EQ(getAvailBufferSize(), m_buff_size_pkts - 1);
     EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
 }
+
+TEST_F(CRcvBufferReadMsg, SmallNonOrderReadBuffer)
+{
+    // Message structure will be:
+    // 0-0:[<1>]
+    // 1-3:[<2.][.2.][*] (expected .2>)
+    // 4-5:[<3.][.3>] (out-of-order allowed)
+
+    add(Message(1).msgno(1).isn(m_init_seqno + 0));
+    add(Message(3).msgno(2).isn(m_init_seqno + 1).nmissing(1));
+    add(Message(2).msgno(3).isn(m_init_seqno + 4).nonorder());
+    add(Message(2).msgno(4).isn(m_init_seqno + 6).nonorder());
+    add(Message(2).msgno(5).isn(m_init_seqno + 8));
+
+    pcoutl("INITIAL STATE:");
+    pcoutl(m_rcv_buffer->strFullnessState(m_init_seqno, srt::sync::steady_clock::now()));
+
+    array<char, 4 * 4 * m_payload_sz> buff;
+
+    // Now the whole message can be read.
+    EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
+    EXPECT_TRUE(hasAvailablePackets());
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), 0 ); // avail regular
+
+    pcoutl("READING MESSAGE 1:");
+    // Ok, first read the 1-packet ready message
+    EXPECT_EQ( readMessage(buff.data(), m_payload_sz), int(m_payload_sz) ); // msgno == 1
+    pcoutl("MESSAGE: ", m_readctrl.msgno, " INORDER ", m_readctrl.inorder);
+
+    EXPECT_EQ( m_readctrl.msgno, 1 );
+    // XXX BUG: EXPECT_EQ( m_readctrl.inorder, 1);
+
+    // Following are two out-of-order messages waiting, 2 packets each
+    EXPECT_TRUE(hasAvailablePackets());
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), 4 ); // avail 2 packets OOO, plus one more OOO
+
+    // Check reading into an insufficient size buffer.
+    // The old buffer extracts the whole message, but copies only
+    // the number of bytes provided in the 'len' argument.
+    pcoutl("READING MESSAGE 3 (out of order):");
+    EXPECT_EQ( readMessage(buff.data(), m_payload_sz), int(m_payload_sz) ); // msgno = 3, OOO
+    pcoutl("MESSAGE: ", m_readctrl.msgno, " INORDER ", m_readctrl.inorder);
+    EXPECT_EQ( m_readctrl.msgno, 3 );
+    // XXX BUG: EXPECT_EQ( m_readctrl.inorder, 0 );
+
+    // AFTER extraction, we should have RIGHT NOW one more OOO message available - #4
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), 2 );
+
+    // But WE DO NOT read it, instead we complete the missing packet in message #2
+    add(Message(1).recovered().isn(m_init_seqno + 3));
+
+    // Now we have in-order packets available
+    EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
+    EXPECT_TRUE(hasAvailablePackets());
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), 0 );
+
+    // The 3-packet message should be read as second
+    pcoutl("READING MESSAGE 2 (lately completed):");
+    EXPECT_EQ( readMessage(buff.data(), m_payload_sz * 2), int(m_payload_sz * 2)); // msgno = 2
+    pcoutl("MESSAGE: ", m_readctrl.msgno, " INORDER ", m_readctrl.inorder);
+    EXPECT_EQ( m_readctrl.msgno, 2 );
+    // XXX EXPECT_EQ( m_readctrl.inorder, 1 );
+
+    // And now we have the message that was previously OOO, but now it
+    // should be available as regular
+    EXPECT_TRUE(m_rcv_buffer->isRcvDataReady());
+    EXPECT_TRUE(hasAvailablePackets());
+
+    // Ok, so we have read message 1, then 3 out-of-order, with 4 waiting as out-of-order,
+    // but then completed message 2, so next message 2 has been read.
+    //
+    // Waiting is: message #4, which still has an out-of-order status, and #5, in order.
+    // HOWEVER #4 is now the newest message, even though it's out-of-order eligible.
+
+    // Therefore the availability status is 0 - the first to read message is available.
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), 0 );
+
+    pcoutl("READING MESSAGE 4 (out-of-order but read in order):");
+    EXPECT_EQ( readMessage(buff.data(), m_payload_sz * 2), int(m_payload_sz * 2)); // msgno = 4
+    pcoutl("MESSAGE: ", m_readctrl.msgno, " INORDER ", m_readctrl.inorder);
+    EXPECT_EQ( m_readctrl.msgno, 4 );
+
+    // And remaining is message #5, in order, still newest and complete.
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), 0 );
+
+    pcoutl("READING MESSAGE 5 (in order):");
+    EXPECT_EQ( readMessage(buff.data(), m_payload_sz * 2), int(m_payload_sz * 2));
+    pcoutl("MESSAGE: ", m_readctrl.msgno, " INORDER ", m_readctrl.inorder);
+    EXPECT_EQ( m_readctrl.msgno, 5 );
+
+    // No more messages should be now available.
+    EXPECT_EQ( m_rcv_buffer->readablePacketsState(), -1 );
+
+    // No more messages to read
+    EXPECT_FALSE(m_rcv_buffer->isRcvDataReady());
+    EXPECT_FALSE(hasAvailablePackets());
+    EXPECT_EQ(getAvailBufferSize(), m_buff_size_pkts - 1);
+    EXPECT_EQ(m_unit_queue->size(), m_unit_queue->capacity());
+}
+
 
 // BUG!!!
 // Checks signaling of read-readiness of a half-acknowledged message.


### PR DESCRIPTION
The problem:

The `m_iFirstNonreadPos` and `m_iFirstReadableOutOfOrder` fields were at risk of keeping the position values that after shifting `m_iStartPos` forwards could remain in the past. This may potentially result in pointing to the wrong packet cell, including an empty cell, and also blindly accessing the pUnit pointer in the entry.

This was also causing misfunctionality in a specific corner case, when once found out-of-order message covered suddenly by completed earlier message will be returned to the user suddenly in order. In such a situation the misupdated end pointers make the receiver buffer no more readable from, possibly until some next packet comes in.

The reason:

After every operation, which potentially shifts `m_iStartPos` forwards, these fields should be checked. The problem is that normally there's no reliable function that can check if the position value is in the past towards `m_iStartPos` (`offPos` assumes that its parameters are in "earlier, later" order). In case when the out-of-order detected packet gets somehow extracted in order, because the incomplete blocking packet was completed in the meantime, the out-of-order positional was remaining with non-negative value, understood then as a legitimate position, being simultaneously in the past towards `m_iStartPos`.

Fixes:

1. Made sure that after every call to `releaseNextFillerEntries()`, which is the last function that could potentially shift the start position (which might as well be also shifted earlier), the value of `m_iFirstNonreadPos` is checked if it's in the past using `isInRange`, and if it is, it's set to `m_iStartPos` with searching for the end of first message.
2. Also, after this is done, check if `m_iFirstReadableOutOfOrder` is outdated, and if so, it's set to -1. This allows for searching further for a new out-of-order packet.

Tests:

A new test is added that implements this corner scenario.