### PR TITLE
[core] Reimplemented node type for HeapSet item types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,10 +309,7 @@ endif()
 
 # PKTINFO not supported on these platforms.
 seton_if(ENABLE_PKTINFO_DEFAULT        NOT (BSD OR WIN32))
-seton_if(ENABLE_STDCXX_SYNC_FORCED  DEFINED ENABLE_STDCXX_SYNC)
-
-# Default to be controlled by an environment variable HAI_BUILD_PROFILE
-seton_if(ENABLE_PROFILE_DEFAULT  ENV{HAI_BUILD_PROFILE})
+seton_if(ENABLE_STDCXX_SYNC_FORCED  DEFINED ENABLE_STDCXX_SYNC AND ENABLE_STDCXX_SYNC)
 
 # -------
 # options
@@ -339,7 +336,7 @@ option(USE_MUTEX_ATOMIC "Use srt::sync::Mutex to Implement Atomics" OFF)
 option(ENABLE_SHOW_PROJECT_CONFIG "Enable show Project Configuration" OFF)
 option(ENABLE_CLANG_TSA "Enable Clang Thread Safety Analysis" OFF)
 option(ENABLE_CODE_COVERAGE "Enable code coverage reporting" OFF)
-option(ENABLE_PROFILE "Should instrument the code for profiling. Ignored for non-GNU compiler." ${ENABLE_PROFILE_DEFAULT})
+option(ENABLE_PROFILE "Should instrument the code for profiling. Ignored for non-GNU compiler." OFF)
 option(ENABLE_TOOLS "Should the Developer Applications be Built?" OFF)
 option(ENABLE_GETNAMEINFO "In-logs sockaddr-to-string should do rev-dns" OFF)
 option(ENABLE_LOGGING "Should logging be enabled" ON)
@@ -352,6 +349,8 @@ option(ENABLE_UNITTESTS_DISCOVERY "Do unit test discovery when UT enabled" ON)
 # Built-in optional features
 option(ENABLE_BONDING "Should the bonding functionality be enabled?" ON)
 option(ENABLE_ENCRYPTION "Enable encryption in SRT" ON)
+# ENABLE_LOCALIF_WIN32 is OFF by default because iphlpapi.lib library is not
+# available on every system.
 option(ENABLE_LOCALIF_WIN32 "Enable local interface check ability on Windows (adds Iphlpapi.lib dep)" OFF)
 option(ENABLE_AEAD "Enable AEAD API preview in SRT" ON)
 option(ENABLE_MAXREXMITBW "Enable SRTO_MAXREXMITBW (limiting rexmit bandwidth)" ON)
@@ -608,7 +607,7 @@ else()
 endif()
 
 if (ENABLE_GETNAMEINFO)
-	string(APPEND FEATURE_REPORT "GETNAMEINFO ")
+	string(APPEND FEATURE_REPORT "+GETNAMEINFO ")
 	list(APPEND SRT_EXTRA_CFLAGS "-DSRT_ENABLE_GETNAMEINFO=1")
 endif()
 
@@ -617,7 +616,9 @@ if (ENABLE_PKTINFO)
 		message(FATAL_ERROR "PKTINFO is not implemented on Windows or *BSD.")
 	endif()
 	list(APPEND SRT_EXTRA_CFLAGS "-DSRT_ENABLE_PKTINFO=1")
-	string(APPEND FEATURE_REPORT "PKTINFO ")
+	string(APPEND FEATURE_REPORT "PKTINFO=*ON")
+else()
+	string(APPEND FEATURE_REPORT "PKTINFO=OFF ")
 endif()
 
 if (ENABLE_BONDING)
@@ -636,13 +637,13 @@ if (ENABLE_THREAD_CHECK)
 		-DFUGU_PLATFORM=1
 		-I${WITH_THREAD_CHECK_INCLUDEDIR}
 	)
-	string(APPEND FEATURE_REPORT "THREADCHECK ")
+	string(APPEND FEATURE_REPORT "+THREADCHECK ")
 endif()
 
 if (ENABLE_CLANG_TSA)
 	list(APPEND SRT_EXTRA_CFLAGS "-Wthread-safety -Wthread-safety-beta")
     add_definitions(-DSRT_ENABLE_CLANG_TSA=1)
-	string(APPEND FEATURE_REPORT "CLANG_TSA ")
+	string(APPEND FEATURE_REPORT "+CLANG_TSA ")
 endif()
 
 if (ENABLE_PROFILE)
@@ -650,7 +651,7 @@ if (ENABLE_PROFILE)
 		# They are actually cflags, not definitions, but CMake is stupid enough.
 		add_definitions(-g -pg)
 		link_libraries(-g -pg)
-		string(APPEND FEATURE_REPORT "GNU_PROFILER ")
+		string(APPEND FEATURE_REPORT "+GNU_PROFILER ")
 	else()
 		message(FATAL_ERROR "Profiling option is not supported on this platform")
 	endif()
@@ -660,7 +661,7 @@ if (ENABLE_CODE_COVERAGE)
 	if (HAVE_COMPILER_GNU_COMPAT)
 		add_definitions(-g -O0 --coverage)
 		link_libraries(--coverage)
-		string(APPEND FEATURE_REPORT "GNU_COVERAGE ")
+		string(APPEND FEATURE_REPORT "+GNU_COVERAGE ")
 	else()
 		message(FATAL_ERROR "ENABLE_CODE_COVERAGE: option is not supported on this platform")
 	endif()
@@ -677,7 +678,11 @@ endif()
 if (LINUX)
 # This is an option supported only on Linux
 	add_definitions(-DSRT_ENABLE_BINDTODEVICE)
-	string(APPEND FEATURE_REPORT "BINDTODEVICE=ON ")
+	string(APPEND FEATURE_REPORT "BINDTODEVICE=*ON ")
+endif()
+
+if (ENABLE_LOCALIF_WIN32)
+	string(APPEND FEATURE_REPORT "+LOCAL_IF ")
 endif()
 
 if (USE_STATIC_LIBSTDCXX)

--- a/docs/dev/utilities.md
+++ b/docs/dev/utilities.md
@@ -174,7 +174,7 @@ The NodeType should be a value through which the object in the container is
 directly reachable, so for example:
 - A pointer to the object - NULL is a trap representation
 - A positive integer index in some array - so std::string::npos is a trap
-- A list iterator - for that you need to keep some empty list for a trap
+- A wrapper with a list iterator and list pointer (no trap possible for iterator)
 - Your own wrapper for any of the above so that it can be same as AccessType
 
 The AccessType class is only required to contain several static members, which
@@ -203,14 +203,14 @@ HeapSet state attributes:
 Operations:
 
 - `find_next(key_type k)`: return the node that is the earliest element in the
-                         list, but already later than the given `k` key
+                         container, but already later than the given `k` key
                          (none() if no such element)
 - `top()` : return the element at top. Returns `none()` if the heap is empty.
 - `top_raw()` : Unchecked version of `top()`, returns the value from the first
                 element of the internal array; results in UB if it's empty.
 - pop() : same as top(), but the element is removed from the list.
 - insert() : insert the element into the heap array. The element's position
-             must be npos first. It's in two versions:
+             must be npos before the operation. It's in two versions:
            - insert(node): insert the node after you updated the key
            - insert(key, node): convenience wrapper for updating and inserting
 - erase() : removes the element from the heap array. Returns false if the

--- a/docs/dev/utilities.md
+++ b/docs/dev/utilities.md
@@ -218,15 +218,39 @@ Operations:
 - update(pos, newkey): update the node at the given position with the new
                        key and update its position accordingly
 
+6. `MaybeIterator`: The trap-representation-capable iterator wrapper
+--------------------------------------------------------------------
 
-6. `explicit_t`: Prevent C++ from using default conversion
+This type should be used as a replacement for the container's iterator in
+order to be able to use it with a trap representation. The purpose of it
+is to use it in the HeapSet, which requires that the element type be of a
+value type that can provide a trap representation, returned in a case when
+there is no element possible to be identified.
+
+This object requires a pointer to the container and the iterator that must
+be taken from this very container. The pointer can be NULL and the iterator
+in this case is allowed to have a singular value.
+
+This object can keep two kinds of values:
+
+* An empty value, where the pointer is NULL and the iterator is not being
+used in this case
+
+* A pair of pointer to a container and the iterator inside it
+
+The comparison by operator== relies on the statement: only if container
+pointers are the same, and this pointer isn't NULL, does it compare the
+iterator values. For NULL they are just always equal.
+
+
+7. `explicit_t`: Prevent C++ from using default conversion
 ----------------------------------------------------------
 
 Using `explicit_t<int>` instead of `int` as a function argument prevents
 the function from being called with any other type, like `bool` or `long`.
 
 
-7. `EqualAny`: shorthand comparison of a single value to multiple values
+8. `EqualAny`: shorthand comparison of a single value to multiple values
 ------------------------------------------------------------------------
 
 Usage example:
@@ -244,7 +268,7 @@ if (state == ST_CONNECTING || state == ST_CONNECTED || state == ST_BROKEN)
 You need to add `using namespace any_op` inside the function to enable it.
 
 
-8. Unique pointer and movable objects
+9. Unique pointer and movable objects
 -------------------------------------
 
 For C++11 these are aliases: `UniquePtr = std::unique_ptr` and `Move = std::move`.
@@ -262,7 +286,7 @@ at the back of the container:
   (returns false if the container is empty)  
 
 
-9. Map element extraction convenience functionalities
+10. Map element extraction convenience functionalities
 -----------------------------------------------------
 
 These functions do a similar thing as `m[k]` for an `m` map with given `k` key.
@@ -304,14 +328,14 @@ the map. Having that you can do:
    - p.dig() - uses `map_tryinsert` and returns its result
 
 
-10. Printable, PrintabeMod: allow formatting a container of values
+11. Printable, PrintabeMod: allow formatting a container of values
 -------------------------------------------------------------------
 
 These functions turn a container of printable values into the representing
 string with surrounding `[]` and values separated by space. Used in logging.
 
 
-11. Container utilities and algorithms
+12. Container utilities and algorithms
 --------------------------------------
 
 * `FilterIf`: a mix of `std::find_if` and `std::transform`: copies the range
@@ -345,7 +369,7 @@ string with surrounding `[]` and values separated by space. Used in logging.
    number of found occurrences of this very value
 
 
-12. CallbackHolder
+13. CallbackHolder
 ------------------
 
 A convenience wrapper for a function pointer with opaque pointer idiom.
@@ -353,7 +377,7 @@ An additional macro `CALLBACK_CALL` simplifies passing parameters to
 the call regarding the opaque pointer.
 
 
-13. Pass filter utilities
+14. Pass filter utilities
 --------------------------
 
 * GetPeakRange
@@ -403,7 +427,7 @@ position. Returned is the sum of the elements passed from the first array and
 from the `para` array, as well as the number of included elements.
 
 
-14. DriftTracer
+15. DriftTracer
 ---------------
 
 This is the utility for calculating the drift in SRT, which is measured as the
@@ -438,7 +462,7 @@ overdrift() will start from 0, but it will always keep track on any changes in
 overdrift. By manipulating the `MAX_DRIFT` parameter you can decide how high the
 drift can go relatively to stay below overdrift.
 
-15. Running Average Utilities
+16. Running Average Utilities
 -----------------------------
 
 * CountIIR(base, newval, factor)
@@ -453,7 +477,7 @@ taken by factor (use 0 - 1 range for this value).
 This uses base as if it was an average value of the previous `DLEN` values
 and adds `newval` to calculate the new average value.
 
-16. Property accessor definitions
+17. Property accessor definitions
 ---------------------------------
 
 This is a system of turning an existing field into being accessible in specific

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -8443,7 +8443,11 @@ int CUDT::sendCtrlAck(CPacket& ctrlpkt, int size)
                 // DO NOT check nor enable reading when a group member - group member sockets are never ready to read.
                 // XXX This is for the case of a group connection that is not TSBPD; the same thing
                 // should be done in the group, if this socket is a member.
-                SRT_ASSERT( bool(m_parent->m_GroupOf) != bool(m_pRcvBuffer) );
+                // SRT_ASSERT( bool(m_parent->m_GroupOf) != bool(m_pRcvBuffer) );
+                // NOTE: The situation when both Group pointer and buffer pointer are NULL is
+                // possible, when a socket is being under closing procedure; in such a situation simply
+                // assume it's not readable, that's all.
+                SRT_ASSERT( (bool(m_parent->m_GroupOf) & bool(m_pRcvBuffer)) == false );
                 const bool canread = m_pRcvBuffer != NULL;
 #else
                 const bool canread = true;

--- a/srtcore/core.h
+++ b/srtcore/core.h
@@ -993,7 +993,7 @@ private:
 
 private: // Identification
     CUDTSocket* const m_parent;                       // Temporary, until the CUDTSocket class is merged with CUDT
-    SocketHolder::sockiter_t m_MuxNode;
+    SocketHolder::sockrep_t m_MuxNode;
     SRTSOCKET m_SocketID;                     // UDT socket number
     SRTSOCKET m_PeerID;                       // Peer ID, for multiplexer
 

--- a/srtcore/queue.cpp
+++ b/srtcore/queue.cpp
@@ -451,7 +451,7 @@ void CSendOrderList::resetAtFork()
     resetCond(m_ListCond);
 }
 
-bool CSendOrderList::update(SocketHolder::sockiter_t point, SocketHolder::EReschedule reschedule, sync::steady_clock::time_point ts)
+bool CSendOrderList::update(SocketHolder::sockrep_t point, SocketHolder::EReschedule reschedule, sync::steady_clock::time_point ts)
 {
     if (point == SocketHolder::none())
     {
@@ -517,7 +517,7 @@ bool CSendOrderList::update(SocketHolder::sockiter_t point, SocketHolder::EResch
     return true;
 }
 
-SocketHolder::sockiter_t CSendOrderList::wait(UniqueLock& w_lk)
+SocketHolder::sockrep_t CSendOrderList::wait(UniqueLock& w_lk)
 {
     CSync lg (m_ListCond, (w_lk));
 
@@ -531,7 +531,7 @@ SocketHolder::sockiter_t CSendOrderList::wait(UniqueLock& w_lk)
         {
             // Have at least one element in the list.
             // Check if the ship time is in the past
-            SocketHolder::sockiter_t point = m_Schedule.top_raw();
+            SocketHolder::sockrep_t point = m_Schedule.top_raw();
             if (point->m_SendOrder.time < sync::steady_clock::now())
                 return point;
             uptime = point->m_SendOrder.time;
@@ -562,7 +562,7 @@ SocketHolder::sockiter_t CSendOrderList::wait(UniqueLock& w_lk)
     }
 }
 
-bool CSendOrderList::requeue(SocketHolder::sockiter_t point, const sync::steady_clock::time_point& uptime)
+bool CSendOrderList::requeue(SocketHolder::sockrep_t point, const sync::steady_clock::time_point& uptime)
 {
     if (point == SocketHolder::none())
     {
@@ -714,7 +714,7 @@ void CSndQueue::workerSendOrder()
 
             // NOTE: wait() unlocks lk for the stall time, then locks back on exit
             // [TSA] NOTE: m_SendOrderList.m_ExternLock = m_parent->m_SocketsLock (CSndQueue ctor)
-            SocketHolder::sockiter_t runner = m_SendOrderList.wait((lk));
+            SocketHolder::sockrep_t runner = m_SendOrderList.wait((lk));
             THREAD_RESUMED();
 
             INCREMENT_THREAD_ITERATIONS();
@@ -818,11 +818,6 @@ void CSndQueue::workerSendOrder()
 
     THREAD_EXIT();
 }
-
-// This is to satisfy the requirement of HeapSet class.
-// The values kept in HeapSet must be capable of a trap representation
-// to be returned from none(). Here it's returned as empty_list.end().
-SocketHolder::socklist_t SocketHolder::empty_list;
 
 void CMultiplexer::removeRID(const SRTSOCKET& id)
 {
@@ -1235,7 +1230,7 @@ void CMultiplexer::removeSender(CUDT* u)
 {
     ScopedLock slk (m_SocketsLock);
 
-    SocketHolder::sockiter_t pos = u->m_MuxNode;
+    SocketHolder::sockrep_t pos = u->m_MuxNode;
     if (pos == SocketHolder::none())
         return;
 
@@ -1959,7 +1954,7 @@ bool CMultiplexer::addSocket(CUDTSocket* s)
     std::list<SocketHolder>::iterator last = m_Sockets.end();
     --last; // guaranteed to be valid after push_back
     m_SocketMap[s->core().m_SocketID] = last;
-    s->core().m_MuxNode = last;
+    s->core().m_MuxNode = SocketHolder::rep(m_Sockets, last);
     ++m_zSockets;
     HLOGC(qmlog.Debug, log << "MUXER: id=" << m_iID << " added @" << s->core().m_SocketID << " (total of " << m_zSockets.load() << " sockets)");
 
@@ -2021,7 +2016,7 @@ bool CMultiplexer::setConnected(SRTSOCKET id)
     m_RevPeerMap[prid] = id;
     sh.m_State = SocketHolder::ACTIVE;
 
-    m_UpdateOrderList.insert(steady_clock::now(), point);
+    m_UpdateOrderList.insert(steady_clock::now(), SocketHolder::rep(m_Sockets, point));
 
     HLOGC(qmlog.Debug, log << "MUXER id=" << m_iID << ": connected: " << sh.report()
             << "UPDATE-LIST: pos=" << point->m_UpdateOrder.pos
@@ -2098,8 +2093,8 @@ bool CMultiplexer::deleteSocket(SRTSOCKET id)
     CUDTSocket* s = point->m_pSocket;
 
     // Remove from maps and list
-    m_UpdateOrderList.erase(point);
-    m_SndQueue.m_SendOrderList.remove(point);
+    m_UpdateOrderList.erase(SocketHolder::rep(m_Sockets, point));
+    m_SndQueue.m_SendOrderList.remove(SocketHolder::rep(m_Sockets, point));
 
     // As this is being waited for in another thread, you need to request sync.
     // It will be anyway effective only after this function exits and unlocks m_SocketsLock.
@@ -2294,7 +2289,7 @@ void CMultiplexer::rollUpdateSockets(const sync::steady_clock::time_point& curti
         for (;;)
         {
             // Guaranteed at least one element, so top() is valid.
-            sockiter_t point = m_UpdateOrderList.top();
+            SocketHolder::sockrep_t point = m_UpdateOrderList.top();
             if (point != m_UpdateOrderList.none() && point->m_UpdateOrder.time < curtime_minus_syn)
             {
                 HLOGC(qmlog.Debug, log << "UPDATE-LIST: roll: got @" << point->id() << " due in "

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -396,63 +396,13 @@ public:
 
 #endif
 
-template< template<class Value, class Alocator>class ContainerTemplate, class ValueType >
-struct MaybeIterator
-{
-    typedef ContainerTemplate< ValueType, std::allocator<ValueType> > Container;
-    Container* base;
-    typedef typename Container::iterator iterator;
-    iterator it;
-
-    // Leave the iterator empty
-    MaybeIterator() : base(NULL) {}
-    MaybeIterator(Container& b, iterator i): base(&b), it(i) {}
-
-    void reset() { base = NULL; }
-
-    bool operator==(MaybeIterator const& o) const
-    {
-        // 99% of this operator's calls will be
-        // 1. <some-valid-value> == <null-object>
-        // 2. <null-object> == <null-object>
-
-        // C 1
-        if (base != o.base)
-            return false;
-
-        // C 2
-        if (base == nullptr)
-            return true;
-
-        // C 3
-        return it == o.it;
-
-        // In this implementation, which is safest, this will take:
-        // 1. Only C 1, because NULL object is different than valid container.
-        // 2. C 1 and C 2, with the latter being a simple zero-check
-
-        // The alternative was considered, to expose a case if both are NULL first,
-        // but this will then take:
-        // 1. total NULL check and C 1, then C 2 must be done, too for safety,
-        //    and it's considered more probable to occur
-        // 2. Just total-NULL check
-    }
-
-    bool operator!=(MaybeIterator const& o) const { return !(*this == o); }
-
-    operator iterator() const { return it; }
-
-    iterator operator->() { return it; }
-};
-
-
 // NOTE: SocketHolder was moved here because it's a dependency of
 // CSendOrderList, so it must be first defined.
 struct SocketHolder
 {
     typedef std::list<SocketHolder> socklist_t;
     typedef socklist_t::iterator sockiter_t;
-    typedef MaybeIterator<std::list, SocketHolder> sockrep_t;
+    typedef MaybeIterator< std::list<SocketHolder> > sockrep_t;
     static const size_t heap_npos = std::string::npos;
     static sockrep_t none() { return sockrep_t(); }
     static sockrep_t rep(socklist_t& cont, sockiter_t iti)

--- a/srtcore/queue.h
+++ b/srtcore/queue.h
@@ -396,6 +396,55 @@ public:
 
 #endif
 
+template< template<class Value, class Alocator>class ContainerTemplate, class ValueType >
+struct MaybeIterator
+{
+    typedef ContainerTemplate< ValueType, std::allocator<ValueType> > Container;
+    Container* base;
+    typedef typename Container::iterator iterator;
+    iterator it;
+
+    // Leave the iterator empty
+    MaybeIterator() : base(NULL) {}
+    MaybeIterator(Container& b, iterator i): base(&b), it(i) {}
+
+    void reset() { base = NULL; }
+
+    bool operator==(MaybeIterator const& o) const
+    {
+        // 99% of this operator's calls will be
+        // 1. <some-valid-value> == <null-object>
+        // 2. <null-object> == <null-object>
+
+        // C 1
+        if (base != o.base)
+            return false;
+
+        // C 2
+        if (base == nullptr)
+            return true;
+
+        // C 3
+        return it == o.it;
+
+        // In this implementation, which is safest, this will take:
+        // 1. Only C 1, because NULL object is different than valid container.
+        // 2. C 1 and C 2, with the latter being a simple zero-check
+
+        // The alternative was considered, to expose a case if both are NULL first,
+        // but this will then take:
+        // 1. total NULL check and C 1, then C 2 must be done, too for safety,
+        //    and it's considered more probable to occur
+        // 2. Just total-NULL check
+    }
+
+    bool operator!=(MaybeIterator const& o) const { return !(*this == o); }
+
+    operator iterator() const { return it; }
+
+    iterator operator->() { return it; }
+};
+
 
 // NOTE: SocketHolder was moved here because it's a dependency of
 // CSendOrderList, so it must be first defined.
@@ -403,9 +452,13 @@ struct SocketHolder
 {
     typedef std::list<SocketHolder> socklist_t;
     typedef socklist_t::iterator sockiter_t;
-    static socklist_t empty_list;
+    typedef MaybeIterator<std::list, SocketHolder> sockrep_t;
     static const size_t heap_npos = std::string::npos;
-    static sockiter_t none() { return empty_list.end(); }
+    static sockrep_t none() { return sockrep_t(); }
+    static sockrep_t rep(socklist_t& cont, sockiter_t iti)
+    {
+        return sockrep_t(cont, iti);
+    }
 
     enum State
     {
@@ -443,9 +496,9 @@ struct SocketHolder
         size_t pos;
 
         // Access methods
-        static key_type& key(sockiter_t i) { return i->m_UpdateOrder.time; }
-        static size_t& position(sockiter_t i) { return i->m_UpdateOrder.pos; }
-        static sockiter_t none() { return empty_list.end(); }
+        static key_type& key(sockrep_t i) { return i->m_UpdateOrder.time; }
+        static size_t& position(sockrep_t i) { return i->m_UpdateOrder.pos; }
+        static sockrep_t none() { return sockrep_t(); }
         static bool order(key_type left, key_type right) { return left < right; }
 
         UpdateNode() : pos(heap_npos) {}
@@ -460,9 +513,9 @@ struct SocketHolder
         size_t pos;
 
         // Access methods
-        static key_type& key(sockiter_t i) { return i->m_SendOrder.time; }
-        static size_t& position(sockiter_t i) { return i->m_SendOrder.pos; }
-        static sockiter_t none() { return empty_list.end(); }
+        static key_type& key(sockrep_t i) { return i->m_SendOrder.time; }
+        static size_t& position(sockrep_t i) { return i->m_SendOrder.pos; }
+        static sockrep_t none() { return sockrep_t(); }
         static bool order(key_type left, key_type right) { return left < right; }
 
         SendNode() : pos(heap_npos) {}
@@ -578,7 +631,7 @@ public:
     /// @param [in] ts the next time to trigger sending logic on the CUDT
     /// @return True, if the socket was scheduled for given time
     SRT_TSA_NEEDS_LOCKED(m_ExternLock)
-    bool update(SocketHolder::sockiter_t point, SocketHolder::EReschedule reschedule, sync::steady_clock::time_point ts = sync::steady_clock::now());
+    bool update(SocketHolder::sockrep_t point, SocketHolder::EReschedule reschedule, sync::steady_clock::time_point ts = sync::steady_clock::now());
 
     /// Blocks until the time comes to pick up the heap top.
     /// The call remains blocked as long as:
@@ -587,17 +640,17 @@ public:
     /// - no other thread has forcefully interrupted the wait
     /// @return the node that is ready to run, or NULL on interrupt
     SRT_TSA_NEEDS_LOCKED(m_ExternLock)
-    SocketHolder::sockiter_t wait(sync::UniqueLock& lk);
+    SocketHolder::sockrep_t wait(sync::UniqueLock& lk);
 
     // This function moves the node throughout the heap to put
     // it into the right place.
     SRT_TSA_NEEDS_LOCKED(m_ExternLock)
-    bool requeue(SocketHolder::sockiter_t point, const sync::steady_clock::time_point& uptime);
+    bool requeue(SocketHolder::sockrep_t point, const sync::steady_clock::time_point& uptime);
 
     /// Remove UDT instance from the list.
     /// @param [in] u pointer to the UDT instance
     SRT_TSA_NEEDS_LOCKED(m_ExternLock)
-    void remove(SocketHolder::sockiter_t point)
+    void remove(SocketHolder::sockrep_t point)
     {
         m_Schedule.erase(point);
     }
@@ -629,7 +682,7 @@ public:
 
 private:
 
-    HeapSet<SocketHolder::sockiter_t, SocketHolder::SendNode> m_Schedule;
+    HeapSet<SocketHolder::sockrep_t, SocketHolder::SendNode> m_Schedule;
 
     friend class CSndQueue;
 
@@ -906,7 +959,7 @@ private:
     sockmap_t m_SocketMap;
 
     // Functional orders
-    HeapSet<sockiter_t, SocketHolder::UpdateNode> m_UpdateOrderList;
+    HeapSet<SocketHolder::sockrep_t, SocketHolder::UpdateNode> m_UpdateOrderList;
     // Send order is contained in the CSndQueue class.
 
     // Peer ID to Agent ID mapping

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -704,6 +704,56 @@ public:
 
 };
 
+template<class Container>
+struct MaybeIterator
+{
+    Container* base;
+    typedef typename Container::iterator iterator;
+    iterator it;
+
+    // Leave the iterator empty
+    MaybeIterator() : base(NULL) {}
+    MaybeIterator(Container& b, iterator i): base(&b), it(i) {}
+
+    void reset() { base = NULL; }
+
+    bool operator==(MaybeIterator const& o) const
+    {
+        // 99% of this operator's calls will be
+        // 1. <some-valid-value> == <null-object>
+        // 2. <null-object> == <null-object>
+
+        // C 1
+        if (base != o.base)
+            return false;
+
+        // C 2
+        if (base == nullptr)
+            return true;
+
+        // C 3
+        return it == o.it;
+
+        // In this implementation, which is safest, this will take:
+        // 1. Only C 1, because NULL object is different than valid container.
+        // 2. C 1 and C 2, with the latter being a simple zero-check
+
+        // The alternative was considered, to expose a case if both are NULL first,
+        // but this will then take:
+        // 1. total NULL check and C 1, then C 2 must be done, too for safety,
+        //    and it's considered more probable to occur
+        // 2. Just total-NULL check
+    }
+
+    bool operator!=(MaybeIterator const& o) const { return !(*this == o); }
+
+    operator iterator() const { return it; }
+
+    iterator operator->() { return it; }
+};
+
+
+
 // std::addressof in C++11, needs to be provided for C++03
 template <class RefType>
 inline RefType* AddressOf(RefType& r)

--- a/srtcore/utilities.h
+++ b/srtcore/utilities.h
@@ -728,7 +728,7 @@ struct MaybeIterator
             return false;
 
         // C 2
-        if (base == nullptr)
+        if (!base)
             return true;
 
         // C 3

--- a/test/test_connection_timeout.cpp
+++ b/test/test_connection_timeout.cpp
@@ -142,9 +142,11 @@ TEST_F(TestConnectionTimeout, Nonblocking) {
         // Check the actual timeout
         const chrono::steady_clock::time_point chrono_ts_end = chrono::steady_clock::now();
         const auto delta_ms = chrono::duration_cast<chrono::milliseconds>(chrono_ts_end - chrono_ts_start).count();
-        // Confidence interval border : +/-80 ms
-        EXPECT_LE(delta_ms, connection_timeout_ms + 80) << "Timeout was: " << delta_ms;
-        EXPECT_GE(delta_ms, connection_timeout_ms - 80) << "Timeout was: " << delta_ms;
+        // Confidence interval border : (-50 ; +120 )
+        // Too early is tolerated only if it is caused by thread layout.
+        // Longer time might happen on some machines, but that shouldn't be a problem.
+        EXPECT_LE(delta_ms, connection_timeout_ms + 120) << "Timeout was: " << delta_ms;
+        EXPECT_GE(delta_ms, connection_timeout_ms - 50) << "Timeout was: " << delta_ms;
 
         EXPECT_EQ(rlen, 1);
         EXPECT_EQ(read[0], client_sock);

--- a/test/test_enforced_encryption.cpp
+++ b/test/test_enforced_encryption.cpp
@@ -97,7 +97,18 @@ static const std::string s_pwd_a ("s!t@r#i$c^t");
 static const std::string s_pwd_b ("s!t@r#i$c^tu");
 static const std::string s_pwd_no("");
 
+void showwait_header(std::ostream& out, size_t size)
+{
+    out << "[";
+    for (size_t i = 0; i < size; ++i)
+        out << " ";
+    out << "]\r[" << std::flush;
+}
 
+void showwait_step(std::ostream& out)
+{
+    out << "." << std::flush;
+}
 
 /*
  * TESTING SCENARIO
@@ -619,10 +630,14 @@ public:
             // srt_accept() has no timeout, so we have to close the socket and wait for the thread to exit.
             // Just give it some time and close the socket.
             int accept_wait = 200;
+            showwait_header(cout, 50);
             while (--accept_wait && !accept_done)
             {
                 std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                if (accept_wait % 4 == 0)
+                    showwait_step(cout);
             }
+            ofprintl(cout);
             EXPECT_NE(srt_close(m_listener_socket), SRT_ERROR);
             m_listener_socket = SRT_INVALID_SOCK; // mark closed already
             accepting_thread.join();


### PR DESCRIPTION
The change:

List's iterator cannot be used with trap representation being another list because comparing iterators to different lists is illegal (some platofmrs in some configurations check this and cause assertion crash). The `MaybeIterator` type is provided to allow making trap rep through the pointer to a container to be kept in the `HeapSert` container.